### PR TITLE
fix(determinism): #912 deterministic work budgets for the root primal-heuristic extent gates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,40 @@ The release procedure that produces these entries is documented in
 
 ### Added
 
+- **Deterministic work budgets for the root primal heuristics** (`fix`, #912).
+  The search tree was a function of *machine speed*: the root
+  `integer_local_search` bounded its own extent with a wall clock
+  (`time_budget = min(5.0, 0.15·time_limit)`), its descent routinely never
+  converges, so the incumbent it handed the tree — and therefore `node_count` —
+  depended on how fast the box was. #912 measured `gear2` closing in 3 nodes at a
+  5 s budget and 91 at 3 s, with the default sitting exactly on that cliff. This
+  invalidates the repo's bound-neutral verification regime at the root: "node
+  counts exactly unchanged" is only meaningful for a function of the input.
+
+  New `discopt._work_budget.WorkBudget` counts *operations* instead of seconds,
+  per kind: constraint/objective evaluations and continuous-repair sub-NLP
+  solves, each with its own cap (`SolverTuning.ils_eval_budget` /
+  `ils_solve_budget`, `DISCOPT_ILS_EVAL_BUDGET` / `DISCOPT_ILS_SOLVE_BUDGET`,
+  defaults 20 000 / 128; both `0` restores the legacy wall gate). Two counters
+  rather than one converted currency because the conversion was tried first and
+  measurably failed — a sub-NLP costs 2 933-77 964 evaluations depending on the
+  instance, and at the geomean `nvs09` regressed 5 -> 29 nodes while `syn05hfsg`
+  got 3x its legacy wall time. The clock stays only as a **backstop**: the
+  caller's solve deadline is passed down so `time_limit` is still honoured, and
+  `WorkBudget.stopped_on` records whether a search was decided by work
+  (reproducible) or by the clock (not).
+
+  Measured on the in-repo corpus (`item912_clock_determinism_probe.py`): under
+  the old gate 7 of the 22 ILS-firing instances had their extent cut by the clock
+  (nvs09, ex1224, st_e29, ex1225, tspn05, syn05hfsg, fac2) — the gear2 mechanism,
+  in-repo — and two returned different node counts across two identical sweeps on
+  the same machine. With the fix, clock-scale panel at `time_limit=60`:
+  **18 in-scope comparisons, 0 mismatches** at 1x vs 2x (the 4 out-of-scope rows
+  are whole-solve budget starvation, reported with their numbers). Flag ON vs OFF:
+  **88 field comparisons over 22 instances, 0 differences** in status, node count,
+  objective and bound, at +1.6 % total wall. See
+  `docs/dev/work-budget-calibration-2026-08-01.md`.
+
 - **Perspective terms in the convex-kernel producer** (`feat`, #865, inside the
   default-off `DISCOPT_CONVEX_KERNEL` path). Hull-reformulated (`*hfsg`) models
   write their disjunctive nonlinearities as the perspective `s·f(a/s)` with the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,27 @@ The release procedure that produces these entries is documented in
   `WorkBudget.stopped_on` records whether a search was decided by work
   (reproducible) or by the clock (not).
 
+  The other three extent gates in that layer follow the same conversion:
+  `integer_box_search` (cell enumeration), `one_hot_swap_search` (swap descent)
+  and `local_branching` — the last being the purest form of the bug in the repo,
+  since it predicted a round's cost as `C(n, r) x measured_mean_subnlp_seconds`
+  against `deadline - now`, making the enumeration radius a ratio of two machine
+  measurements. Each takes a share of the ILS budget matching the wall slice it
+  used to get (0.8 / 0.2 / 0.4); handing all four the ILS number was measured
+  interleaved at 1.38x wall on syn05hfsg and 1.18x on fac2 for identical node
+  counts, and did not ship.
+
+  A **global deterministic work clock** for the remaining ~20 wall budgets
+  (OBBT, nonlinear bound tightening, root cuts, PSD separation, convexity
+  classification, …) was built and then **falsified**: instrumented over the
+  Python-side primitives it advances at 0.01-0.65x wall (fac2: 0.09 deterministic
+  seconds against 15 s of real work) because Rust B&B nodes, presolve and JIT are
+  invisible to it, so re-denominating those budgets in it would have silently
+  stopped them firing. Reverted; the measurement and the prerequisite (Rust-side
+  work accounting) are recorded in the calibration doc §9. Those gates are now
+  enumerated and ratcheted by `python/tests/test_912_wall_budget_inventory.py`,
+  which fails on any new unrecorded one.
+
   Measured on the in-repo corpus (`item912_clock_determinism_probe.py`): under
   the old gate 7 of the 22 ILS-firing instances had their extent cut by the clock
   (nvs09, ex1224, st_e29, ex1225, tspn05, syn05hfsg, fac2) — the gear2 mechanism,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,14 +47,21 @@ The release procedure that produces these entries is documented in
 
   A **global deterministic work clock** for the remaining ~20 wall budgets
   (OBBT, nonlinear bound tightening, root cuts, PSD separation, convexity
-  classification, …) was built and then **falsified**: instrumented over the
-  Python-side primitives it advances at 0.01-0.65x wall (fac2: 0.09 deterministic
-  seconds against 15 s of real work) because Rust B&B nodes, presolve and JIT are
-  invisible to it, so re-denominating those budgets in it would have silently
-  stopped them firing. Reverted; the measurement and the prerequisite (Rust-side
-  work accounting) are recorded in the calibration doc §9. Those gates are now
-  enumerated and ratcheted by `python/tests/test_912_wall_budget_inventory.py`,
-  which fails on any new unrecorded one.
+  classification, …) was built twice and **falsified twice**, and the second
+  result is the load-bearing one. Charging the four primitives at their proper
+  boundaries — the NLP *backend* rather than one call site, which profiling fac2
+  showed was seeing 5 of its 80 solves — lifted coverage only from 0.13 to 0.19
+  of wall (fac2: 1.59 deterministic seconds against 20 s). The arithmetic says
+  why: fac2's NLP solves cost ~86 ms each against a 15 ms nominal price, drawn
+  from a 1.9-104 ms distribution, so **no fixed pricing can track wall time when
+  the per-operation cost varies 55x across instances** — even with perfect
+  coverage. A seconds-valued budget therefore cannot be re-denominated in
+  deterministic units without being re-tuned, and each remaining gate needs its
+  own natural unit, its own calibration and (for the bound-changing ones) its own
+  differential-bound panel. Both attempts reverted; measurements in the
+  calibration doc §9. The gates are enumerated and ratcheted by
+  `python/tests/test_912_wall_budget_inventory.py`, which fails on any new
+  unrecorded one.
 
   Measured on the in-repo corpus (`item912_clock_determinism_probe.py`): under
   the old gate 7 of the 22 ILS-firing instances had their extent cut by the clock

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,13 @@ The release procedure that produces these entries is documented in
   `python/tests/test_912_wall_budget_inventory.py`, which fails on any new
   unrecorded one.
 
+  #912 is closed **not planned** for those 20: after the conversion the
+  clock-scale panel is 18 in-scope comparisons with 0 mismatches, and no residual
+  gate was ever observed moving a tree. That evidence is bounded by corpus
+  coverage — these budgets bind mainly on large models and the in-repo corpus is
+  66 small ones — so the trigger to revisit is a large-instance panel showing one
+  of them move a tree inside its `time_limit`. See the calibration doc §11.
+
   Measured on the in-repo corpus (`item912_clock_determinism_probe.py`): under
   the old gate 7 of the 22 ILS-firing instances had their extent cut by the clock
   (nvs09, ex1224, st_e29, ex1225, tspn05, syn05hfsg, fac2) — the gear2 mechanism,

--- a/discopt_benchmarks/scripts/item912_clock_determinism_probe.py
+++ b/discopt_benchmarks/scripts/item912_clock_determinism_probe.py
@@ -1,0 +1,490 @@
+"""Clock-scale determinism probe for the solver's work gates (issue #912).
+
+Issue #912 measured that discopt's search tree is a function of *machine speed*:
+the amount of work the search does is decided by wall-clock reads, so "same
+model + same ``time_limit``" does not imply the same tree. The decisive case
+upstream was ``gear2`` (root integer local search, 3 nodes at a 5 s heuristic
+budget vs 91 at 3 s).
+
+This probe is the in-repo instrument for that claim and for its fix. Two phases:
+
+``--clockscale``
+    Solve each instance with the process clock running ``alpha`` times faster
+    than real time (``alpha=1`` is the control, and must reproduce the baseline
+    exactly). A faster perceived clock is exactly a slower machine: every
+    wall-gated loop sees its budget expire after proportionally less real work.
+    An instance whose ``node_count``/objective moves with ``alpha`` — while not
+    hitting the overall ``time_limit`` — is nondeterministic by machine speed.
+
+``--ilsbudget``
+    Force the root ``integer_local_search`` wall budget to each of several
+    values and report the resulting tree. This isolates the gear2 mechanism (the
+    heuristic's own wall budget) from whole-solve budget starvation.
+
+``--classify`` / ``--ab``
+    One solve per instance (which rows are usable for a determinism check at all,
+    and what the root ILS actually consumed), and the flag ON-vs-OFF differential
+    with a soundness leg against ``known_optima.toml``.
+
+Both phases run each solve in a **child process** that asserts
+``discopt.__file__`` and the compiled extension path before importing anything
+else, prints its row as JSON, and raises rather than swallowing (CLAUDE.md
+rules 6-8). The parent prints an executed-comparison count and exits non-zero
+when that count is zero, so a probe that measured nothing can never read as a
+pass.
+
+Note on coverage: the clock scaling patches Python's ``time`` module, so it
+covers the Python orchestration layer's gates (78 sites per #912). The Rust
+``Instant::now`` sites are not reachable this way; a row that is clock-scale
+invariant here is invariant *with respect to the Python gates*, which is what
+this probe claims and nothing more.
+
+Usage::
+
+    python -u discopt_benchmarks/scripts/item912_clock_determinism_probe.py \\
+        --clockscale --alphas 1,2,4 --time-limit 30
+    python -u discopt_benchmarks/scripts/item912_clock_determinism_probe.py \\
+        --ilsbudget --budgets 5,3,1,0.5 --time-limit 30
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import time
+
+_REPO = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+_CORPUS = os.path.join(_REPO, "python", "tests", "data", "minlplib_nl")
+
+# The child program. Kept as a string so every row runs in a pristine
+# interpreter: a stale JIT cache or a mutated process-global deadline from a
+# previous instance would silently couple the rows we are comparing.
+_CHILD = r"""
+import json, os, sys, time
+
+alpha = float(os.environ["PROBE_ALPHA"])
+if alpha != 1.0:
+    # Scale the perceived clock BEFORE discopt is imported, so every module that
+    # captures ``time.perf_counter``/``time.monotonic`` at import time sees the
+    # scaled one. alpha > 1 == a proportionally slower machine.
+    _t0_pc, _t0_mono, _t0_time = time.perf_counter(), time.monotonic(), time.time()
+    _real_pc, _real_mono, _real_time = time.perf_counter, time.monotonic, time.time
+    time.perf_counter = lambda: _t0_pc + alpha * (_real_pc() - _t0_pc)
+    time.monotonic = lambda: _t0_mono + alpha * (_real_mono() - _t0_mono)
+    time.time = lambda: _t0_time + alpha * (_real_time() - _t0_time)
+
+import discopt
+from discopt.modeling.core import from_nl
+
+# Rule 8: prove which code is loaded, and which arm it is running, before
+# measuring anything with it. The (ils_eval_budget, ils_solve_budget) pair is the
+# marker unique to the #912 version under test; the legacy arm must report (0, 0).
+assert os.path.abspath(discopt.__file__).startswith(os.environ["PROBE_REPO"]), discopt.__file__
+import discopt._rust as _rust
+assert os.path.abspath(_rust.__file__).startswith(os.environ["PROBE_REPO"]), _rust.__file__
+from discopt import solver_tuning as _st
+_tun = _st.current()
+_work_budget = (int(_tun.ils_eval_budget), int(_tun.ils_solve_budget))
+_expect = os.environ.get("PROBE_EXPECT_WORK_BUDGET")
+if _expect is not None:
+    assert _work_budget == tuple(int(v) for v in _expect.split(",")), (
+        f"arm mismatch: {_work_budget} != {_expect}"
+    )
+
+_ils_stats = {"calls": 0, "evals": 0, "solves": 0, "stopped_on": None, "wall_s": 0.0}
+import discopt._jax.primal_heuristics as _ph
+from discopt._work_budget import WorkBudget as _WB
+
+_orig_ils_fn = _ph.integer_local_search
+
+
+def _instrumented_ils(*a, **kw):
+    forced = os.environ.get("PROBE_ILS_BUDGET")
+    if forced:
+        kw["time_budget"] = float(forced)
+    seen = []
+    _orig_init = _WB.__init__
+
+    def _init(self, limits=None, **kws):
+        _orig_init(self, limits, **kws)
+        seen.append(self)
+
+    _WB.__init__ = _init
+    t0 = time.perf_counter()
+    try:
+        return _orig_ils_fn(*a, **kw)
+    finally:
+        _WB.__init__ = _orig_init
+        _ils_stats["calls"] += 1
+        _ils_stats["wall_s"] += time.perf_counter() - t0
+        if seen:
+            from discopt._work_budget import EVAL as _E, NLP_SOLVE as _S
+            _ils_stats["evals"] += seen[0].spent(_E)
+            _ils_stats["solves"] += seen[0].spent(_S)
+            if seen[0].stopped_on is not None:
+                _ils_stats["stopped_on"] = seen[0].stopped_on
+
+
+_ph.integer_local_search = _instrumented_ils
+
+path = os.environ["PROBE_INSTANCE"]
+model = from_nl(path)
+t_wall = time.perf_counter()
+res = model.solve(time_limit=float(os.environ["PROBE_TIME_LIMIT"]))
+row = {
+    "instance": os.path.splitext(os.path.basename(path))[0],
+    "status": str(getattr(res, "status", None)),
+    "objective": (None if getattr(res, "objective", None) is None else float(res.objective)),
+    "bound": (None if getattr(res, "bound", None) is None else float(res.bound)),
+    "node_count": int(getattr(res, "node_count", -1)),
+    "perceived_s": round(time.perf_counter() - t_wall, 3),
+    "work_budget": list(_work_budget),
+    "ils_calls": _ils_stats["calls"],
+    "ils_evals": _ils_stats["evals"],
+    "ils_solves": _ils_stats["solves"],
+    "ils_stopped_on": _ils_stats["stopped_on"],
+    "ils_wall_s": round(_ils_stats["wall_s"], 3),
+}
+print("PROBE_ROW " + json.dumps(row), flush=True)
+"""
+
+
+def _run_child(instance_path, alpha, time_limit, ils_budget=None, timeout=900, arm_env=None):
+    env = dict(os.environ)
+    env.update(
+        {
+            "PROBE_ALPHA": repr(float(alpha)),
+            "PROBE_INSTANCE": instance_path,
+            "PROBE_REPO": _REPO,
+            "PROBE_TIME_LIMIT": repr(float(time_limit)),
+            "PYTHONUNBUFFERED": "1",
+        }
+    )
+    env.update(arm_env or {})
+    if ils_budget is not None:
+        env["PROBE_ILS_BUDGET"] = repr(float(ils_budget))
+    else:
+        env.pop("PROBE_ILS_BUDGET", None)
+    t0 = time.perf_counter()
+    proc = subprocess.run(
+        [sys.executable, "-u", "-c", _CHILD],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+    )
+    real_s = time.perf_counter() - t0
+    if proc.returncode != 0:
+        # Rule 7: never swallow. A child that died is a measurement failure,
+        # not a row worth averaging in.
+        raise RuntimeError(
+            f"child failed for {instance_path} (alpha={alpha}, ils={ils_budget}), "
+            f"rc={proc.returncode}\nSTDERR:\n{proc.stderr[-4000:]}"
+        )
+    rows = [ln for ln in proc.stdout.splitlines() if ln.startswith("PROBE_ROW ")]
+    if len(rows) != 1:
+        raise RuntimeError(
+            f"expected exactly one PROBE_ROW from {instance_path}, got {len(rows)}\n"
+            f"STDOUT:\n{proc.stdout[-4000:]}"
+        )
+    row = json.loads(rows[0][len("PROBE_ROW ") :])
+    row["real_s"] = round(real_s, 3)
+    return row
+
+
+def _instances(names):
+    if names:
+        wanted = [n.strip() for n in names.split(",") if n.strip()]
+    else:
+        wanted = sorted(os.path.splitext(f)[0] for f in os.listdir(_CORPUS) if f.endswith(".nl"))
+    out = []
+    for n in wanted:
+        p = os.path.join(_CORPUS, n + ".nl")
+        if not os.path.exists(p):
+            raise FileNotFoundError(p)
+        out.append((n, p))
+    return out
+
+
+def _same(a, b, tol=1e-6):
+    """Two rows agree iff status, node_count and objective all agree."""
+    if a["status"] != b["status"] or a["node_count"] != b["node_count"]:
+        return False
+    oa, ob = a["objective"], b["objective"]
+    if (oa is None) != (ob is None):
+        return False
+    if oa is None:
+        return True
+    return abs(oa - ob) <= tol * max(1.0, abs(oa), abs(ob))
+
+
+def _report(comparisons, mismatches, label):
+    print()
+    print(f"=== {label} ===")
+    print(f"executed comparisons: {comparisons}")
+    print(f"mismatches:           {len(mismatches)}")
+    for m in mismatches:
+        print("  " + m)
+    if comparisons == 0:
+        print("FAIL: zero comparisons executed — the probe measured nothing.")
+        return 2
+    return 1 if mismatches else 0
+
+
+def _arm_env(args):
+    """Environment for the arm under test. ``--legacy`` selects the pre-#912
+    wall-clock gate; both arms assert their own marker in the child (rule 8)."""
+    if args.legacy:
+        return {
+            "DISCOPT_ILS_EVAL_BUDGET": "0",
+            "DISCOPT_ILS_SOLVE_BUDGET": "0",
+            "PROBE_EXPECT_WORK_BUDGET": "0,0",
+        }
+    return {}
+
+
+def phase_classify(args):
+    """One solve per instance: which rows are usable for a determinism check at
+    all (they must finish inside ``time_limit``), and which exercise ILS."""
+    rows = []
+    for name, path in _instances(args.instances):
+        row = _run_child(path, 1.0, args.time_limit, timeout=args.timeout, arm_env=_arm_env(args))
+        rows.append(row)
+        print(f"{name:<20} {json.dumps(row)}", flush=True)
+    usable = [r for r in rows if r["status"] != "time_limit"]
+    ils = [r for r in rows if r["ils_calls"] > 0]
+    print()
+    print(f"=== classification ({len(rows)} instances) ===")
+    print(f"finish inside time_limit: {len(usable)}")
+    print(f"exercise ILS:             {len(ils)}")
+    print("usable+ILS: " + ",".join(sorted(r["instance"] for r in usable if r["ils_calls"] > 0)))
+    print("usable:     " + ",".join(sorted(r["instance"] for r in usable)))
+    if args.json_out:
+        with open(args.json_out, "w") as fh:
+            json.dump(rows, fh, indent=1)
+    return 0 if rows else 2
+
+
+def _known_optima():
+    """The repo's reference-optima registry, for the soundness leg of the A/B."""
+    import tomllib
+
+    path = os.path.join(_REPO, "python", "tests", "data", "known_optima.toml")
+    with open(path, "rb") as fh:
+        data = tomllib.load(fh)
+    data.pop("schema", None)
+    return {k: v for k, v in data.items() if isinstance(v, dict) and "optimum" in v}
+
+
+def phase_ab(args):
+    """Flag ON vs OFF at alpha=1: what the deterministic budget changed, and
+    whether anything it changed is unsound.
+
+    Two legs, both required (CLAUDE.md §5):
+
+    * *cert-clean* — no dual bound may exceed its reference optimum on either
+      arm, and no instance may regress from a proved status to a worse one;
+    * *drift* — the node/objective differences, reported rather than hidden,
+      since a primal heuristic that searches differently is *expected* to move
+      node counts. Soundness is the gate; drift is the disclosure.
+    """
+    optima = _known_optima()
+    rows = []
+    unsound = []
+    drift = []
+    checked = 0
+    for name, path in _instances(args.instances):
+        new = _run_child(path, 1.0, args.time_limit, timeout=args.timeout, arm_env={})
+        old = _run_child(
+            path,
+            1.0,
+            args.time_limit,
+            timeout=args.timeout,
+            arm_env={
+                "DISCOPT_ILS_EVAL_BUDGET": "0",
+                "DISCOPT_ILS_SOLVE_BUDGET": "0",
+                "PROBE_EXPECT_WORK_BUDGET": "0,0",
+            },
+        )
+        assert max(new["work_budget"]) > 0 and max(old["work_budget"]) == 0, "arm markers crossed"
+        rows.append({"instance": name, "new": new, "old": old})
+        checked += 1
+        ref = optima.get(name, {}).get("optimum")
+        for tag, row in (("new", new), ("old", old)):
+            if ref is None or row["bound"] is None:
+                continue
+            tol = 1e-6 * max(1.0, abs(float(ref)))
+            if row["bound"] > float(ref) + tol:
+                unsound.append(
+                    f"{name} [{tag}]: bound {row['bound']!r} > reference optimum {ref!r}"
+                )
+        if not _same(new, old):
+            drift.append(
+                f"{name}: ON {new['status']}/{new['node_count']}/{new['objective']} vs "
+                f"OFF {old['status']}/{old['node_count']}/{old['objective']}"
+            )
+        print(f"{name:<20} ON {json.dumps(new)}", flush=True)
+        print(f"{name:<20} OFF {json.dumps(old)}", flush=True)
+    print()
+    print("=== flag ON vs OFF (alpha=1) ===")
+    print(f"executed comparisons: {checked}")
+    print(f"instances with a reference optimum: {sum(1 for r in rows if r['instance'] in optima)}")
+    print(f"bounds above their reference optimum (MUST be 0): {len(unsound)}")
+    for u in unsound:
+        print("  " + u)
+    print(f"rows that differ between arms: {len(drift)}")
+    for d in drift:
+        print("  " + d)
+    if args.json_out:
+        with open(args.json_out, "w") as fh:
+            json.dump(rows, fh, indent=1)
+    if checked == 0:
+        print("FAIL: zero comparisons executed — the probe measured nothing.")
+        return 2
+    return 1 if unsound else 0
+
+
+def _pressure(row, time_limit, frac):
+    """Why (if at all) this row was decided by the clock rather than by the model.
+
+    #912 separates two mechanisms and only the second is fixable:
+
+    * *whole-solve budget starvation* — the run is close enough to ``time_limit``
+      that the B&B loop's own deadline checks shape the tree. Scaling the clock
+      shrinks the real budget proportionally, so of course the tree moves; that
+      is the ``time_limit`` contract, not a bug. Detected as ``time_limit``
+      status, or as a run that consumed ``frac`` of its perceived budget.
+    * *extent gates* — a heuristic's own wall budget deciding how much work to
+      do. Detected as a heuristic reporting ``stopped_on == "deadline"``.
+
+    Only rows free of both are in scope for a determinism assertion. Returns a
+    reason string, or ``None`` when the row is clean.
+    """
+    if row["status"] == "time_limit":
+        return "time_limit"
+    if row["perceived_s"] >= frac * time_limit:
+        return f"deadline-pressured ({row['perceived_s']:.1f}s of {time_limit:.0f}s)"
+    if row["ils_stopped_on"] == "deadline":
+        return "heuristic cut by the solve deadline"
+    return None
+
+
+def phase_clockscale(args):
+    alphas = [float(a) for a in args.alphas.split(",")]
+    if alphas[0] != 1.0:
+        raise ValueError("--alphas must start with the 1.0 control")
+    comparisons = 0
+    mismatches = []
+    out_of_scope = []
+    for name, path in _instances(args.instances):
+        base = None
+        for alpha in alphas:
+            row = _run_child(
+                path, alpha, args.time_limit, timeout=args.timeout, arm_env=_arm_env(args)
+            )
+            print(f"{name:<20} alpha={alpha:<5} {json.dumps(row)}", flush=True)
+            if base is None:
+                base = row
+                continue
+            why = _pressure(base, args.time_limit, args.pressure_frac) or _pressure(
+                row, args.time_limit, args.pressure_frac
+            )
+            differs = not _same(base, row)
+            if why is not None:
+                # Disclosed with its numbers, never silently dropped: an
+                # out-of-scope row that *also* differs is exactly the evidence
+                # that mechanism 2 is real and unfixed.
+                out_of_scope.append(
+                    f"{name} alpha={alpha}: {why}"
+                    + (
+                        f" — and it DIFFERS ({base['node_count']} vs {row['node_count']} nodes)"
+                        if differs
+                        else " — matched anyway"
+                    )
+                )
+                print(f"  (out of scope: {why})", flush=True)
+                continue
+            comparisons += 1
+            if differs:
+                mismatches.append(
+                    f"{name}: alpha=1 -> {base['status']}/{base['node_count']}/"
+                    f"{base['objective']} vs alpha={alpha} -> {row['status']}/"
+                    f"{row['node_count']}/{row['objective']}"
+                )
+    print()
+    print(f"out-of-scope comparisons (whole-solve budget starvation): {len(out_of_scope)}")
+    for o in out_of_scope:
+        print("  " + o)
+    return _report(comparisons, mismatches, "clock-scale determinism")
+
+
+def phase_ilsbudget(args):
+    budgets = [float(b) for b in args.budgets.split(",")]
+    comparisons = 0
+    mismatches = []
+    for name, path in _instances(args.instances):
+        base = None
+        for budget in budgets:
+            row = _run_child(
+                path,
+                1.0,
+                args.time_limit,
+                ils_budget=budget,
+                timeout=args.timeout,
+                arm_env=_arm_env(args),
+            )
+            print(f"{name:<20} ils_budget={budget:<5} {json.dumps(row)}", flush=True)
+            if base is None:
+                base = row
+                continue
+            comparisons += 1
+            if not _same(base, row):
+                mismatches.append(
+                    f"{name}: budget={budgets[0]} -> {base['node_count']} nodes/"
+                    f"{base['objective']} vs budget={budget} -> {row['node_count']} nodes/"
+                    f"{row['objective']}"
+                )
+    return _report(comparisons, mismatches, "ILS wall-budget sensitivity")
+
+
+def main(argv=None):
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--classify", action="store_true")
+    ap.add_argument("--clockscale", action="store_true")
+    ap.add_argument("--ilsbudget", action="store_true")
+    ap.add_argument(
+        "--legacy",
+        action="store_true",
+        help="run the pre-#912 arm (DISCOPT_ILS_WORK_BUDGET=0, wall-clock gate)",
+    )
+    ap.add_argument("--instances", default="", help="comma-separated names (default: all)")
+    ap.add_argument("--alphas", default="1,2,4")
+    ap.add_argument("--budgets", default="5,3,1,0.5")
+    ap.add_argument("--time-limit", type=float, default=30.0)
+    ap.add_argument(
+        "--pressure-frac",
+        type=float,
+        default=0.5,
+        help="a row consuming this fraction of its perceived budget is treated as "
+        "whole-solve-starved and reported out of scope (default 0.5)",
+    )
+    ap.add_argument("--timeout", type=float, default=900.0)
+    ap.add_argument("--json-out", default="")
+    args = ap.parse_args(argv)
+    if not (args.classify or args.clockscale or args.ilsbudget):
+        ap.error("choose --classify, --clockscale and/or --ilsbudget")
+    rc = 0
+    if args.classify:
+        rc |= phase_classify(args)
+    if args.clockscale:
+        rc |= phase_clockscale(args)
+    if args.ilsbudget:
+        rc |= phase_ilsbudget(args)
+    return rc
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/discopt_benchmarks/scripts/item912_work_unit_calibration.py
+++ b/discopt_benchmarks/scripts/item912_work_unit_calibration.py
@@ -1,0 +1,132 @@
+"""Calibrate the #912 work-unit costs against measured wall time.
+
+A deterministic work budget only behaves like the wall budget it replaces if
+the unit costs are roughly proportional to real cost. This script measures, per
+instance, the wall time of
+
+  * one ``violation()`` evaluation (one constraint-vector evaluation), and
+  * one continuous-repair ``subnlp`` solve,
+
+and reports the ratio, which is what ``discopt._work_budget.NLP_SOLVE_UNITS``
+encodes. It also reports the implied "units per second" rate, which is how the
+default ``SolverTuning.ils_work_budget`` was sized against the legacy 5 s wall
+budget.
+
+Timing discipline (CLAUDE.md rule 9): the two measurements are **interleaved**
+round by round rather than run in two blocks, the load average is printed before
+and after, and every number is reported with a standard deviation over rounds.
+
+Usage::
+
+    python -u discopt_benchmarks/scripts/item912_work_unit_calibration.py \\
+        --instances nvs21,nvs13,st_e13,ex1221 --rounds 5
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import statistics
+import sys
+import time
+
+os.environ.setdefault("JAX_PLATFORMS", "cpu")
+os.environ.setdefault("JAX_ENABLE_X64", "1")
+
+import numpy as np  # noqa: E402
+
+_REPO = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+_CORPUS = os.path.join(_REPO, "python", "tests", "data", "minlplib_nl")
+
+
+def _loadavg():
+    return os.getloadavg()
+
+
+def measure(name, rounds, evals_per_round, solves_per_round):
+    import discopt
+    from discopt._jax import primal_heuristics as ph
+    from discopt._jax.nlp_evaluator import cached_evaluator
+    from discopt.modeling.core import from_nl
+    from discopt.solvers.nlp_backend import get_nlp_solver
+
+    assert os.path.abspath(discopt.__file__).startswith(_REPO), discopt.__file__
+
+    model = from_nl(os.path.join(_CORPUS, name + ".nl"))
+    ev = cached_evaluator(model)
+    lb, ub = ph._get_variable_bounds(model)
+    int_mask = ph._get_integer_mask(model)
+    x0 = np.clip(0.5 * (np.clip(lb, -1e3, 1e3) + np.clip(ub, -1e3, 1e3)), lb, ub)
+    backend = get_nlp_solver("auto")
+
+    # Warm the caches/JIT once so round 1 is not a cold-start outlier.
+    ev.evaluate_constraints(x0)
+    ph.subnlp(model, x0, backend=backend, evaluator=ev)
+
+    eval_times, solve_times = [], []
+    for _ in range(rounds):
+        t0 = time.perf_counter()
+        for _ in range(evals_per_round):
+            ev.evaluate_constraints(x0)
+        eval_times.append((time.perf_counter() - t0) / evals_per_round)
+
+        t0 = time.perf_counter()
+        for k in range(solves_per_round):
+            xk = x0.copy()
+            # Perturb an integer so successive solves are not identical work.
+            if np.any(int_mask):
+                j = int(np.where(int_mask)[0][k % int(int_mask.sum())])
+                xk[j] = float(np.clip(round(xk[j]) + (k % 3) - 1, lb[j], ub[j]))
+            ph.subnlp(model, xk, backend=backend, evaluator=ev)
+        solve_times.append((time.perf_counter() - t0) / solves_per_round)
+
+    return {
+        "instance": name,
+        "n_vars": int(x0.size),
+        "n_cons": int(ev.n_constraints),
+        "n_int": int(int_mask.sum()),
+        "eval_s": statistics.mean(eval_times),
+        "eval_sd": statistics.stdev(eval_times) if len(eval_times) > 1 else 0.0,
+        "solve_s": statistics.mean(solve_times),
+        "solve_sd": statistics.stdev(solve_times) if len(solve_times) > 1 else 0.0,
+    }
+
+
+def main(argv=None):
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--instances", default="nvs21,nvs13,st_e13,ex1221,nvs07,tls2")
+    ap.add_argument("--rounds", type=int, default=5)
+    ap.add_argument("--evals", type=int, default=200)
+    ap.add_argument("--solves", type=int, default=20)
+    args = ap.parse_args(argv)
+
+    print(f"loadavg before: {_loadavg()}")
+    rows = []
+    for name in [n.strip() for n in args.instances.split(",") if n.strip()]:
+        path = os.path.join(_CORPUS, name + ".nl")
+        if not os.path.exists(path):
+            raise FileNotFoundError(path)
+        rows.append(measure(name, args.rounds, args.evals, args.solves))
+        r = rows[-1]
+        print(
+            f"{r['instance']:<12} vars={r['n_vars']:<5} cons={r['n_cons']:<5} "
+            f"int={r['n_int']:<4} eval={r['eval_s'] * 1e6:8.1f}us "
+            f"(sd {r['eval_sd'] * 1e6:6.1f}) solve={r['solve_s'] * 1e3:8.2f}ms "
+            f"(sd {r['solve_sd'] * 1e3:6.2f}) ratio={r['solve_s'] / r['eval_s']:8.0f}",
+            flush=True,
+        )
+    print(f"loadavg after:  {_loadavg()}")
+
+    if not rows:
+        print("FAIL: zero instances measured.")
+        return 2
+    ratios = [r["solve_s"] / r["eval_s"] for r in rows]
+    print()
+    print(f"measured instances:      {len(rows)}")
+    print(f"solve/eval ratio geomean {np.exp(np.mean(np.log(ratios))):.0f}")
+    print(f"                  min/max {min(ratios):.0f} / {max(ratios):.0f}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/docs/dev/work-budget-calibration-2026-08-01.md
+++ b/docs/dev/work-budget-calibration-2026-08-01.md
@@ -382,11 +382,52 @@ every test and panel still passed. That is rule 6's failure mode aimed at a
 budget instead of an assertion, and it is strictly worse than the
 nondeterminism it was meant to fix.
 
-The whole wave was reverted. It is recorded here rather than deleted because
-the design is right and the obstacle is specific and fixable: the clock must
-count Rust-side node and presolve work before it can price a second. Until
-then, those gates stay wall-clock and stay enumerated in
-`python/tests/test_912_wall_budget_inventory.py`, which fails on any new one.
+The whole wave was reverted.
+
+### Attempt 2: the obstacle is pricing, not coverage — and it is fundamental
+
+The obvious diagnosis of attempt 1 was *coverage*: the clock could not see the
+Rust B&B, so instrument more. Profiling `fac2` (`cProfile`, 15 s solve) says
+otherwise about where the time is:
+
+| cost | tottime |
+|---|---|
+| `Problem.solve` (POUNCE NLP, 80 calls) | 6.94 s (14.04 s cumulative) |
+| `pounce.solve_problem_batch` (6 calls) | 6.28 s |
+| module import (`_imp.create_dynamic`) | 3.57 s |
+| `_fused_fc_array` (16 117 calls) | 1.58 s |
+
+Not Rust at all: **NLP solves**, at a boundary Python owns. Attempt 1 had
+charged them at one call site inside `subnlp` and therefore saw 5 of the 80.
+Charging at the *backend* boundary instead (`nlp_pounce.solve_nlp`,
+`nlp_native`) plus the OBBT simplex path and the convexity visit counter lifted
+the count to 85 — and the coverage ratio only from 0.13 to **0.19 geomean**
+(0.08-0.62 over 7 instances). `fac2`: 1.59 deterministic seconds against 20 s.
+
+The arithmetic says why, and it is not fixable by more instrumentation. The
+profile puts `fac2`'s NLP solves at ~86 ms each; `NOMINAL_SECONDS[NLP_SOLVE]` is
+15 ms, the geomean of a distribution measured in §2 as spanning **1.9-104 ms**.
+A fixed price per operation cannot track wall time when the per-operation cost
+varies 55x across instances — with *perfect* coverage the ratio would still be
+instance-dependent by roughly that factor.
+
+So the conclusion generalises past the clock: **a seconds-valued budget cannot
+be re-denominated in deterministic units without being re-tuned**, because the
+conversion factor is a property of the instance. There is no substitution that
+preserves a tuned constant. Every remaining gate has to be re-expressed in the
+unit natural to it — OBBT in variables or LP solves, nonlinear tightening in
+rows or passes, root cuts and PSD separation in rounds, convexity in DAG visits
+— and each re-tuned against measured consumption and validated, exactly as §4b
+did for the four primal heuristics. That is 20 calibrations, and the
+bound-changing ones (OBBT, NBT, root cuts, PSD, convexity) each need a
+differential-bound panel.
+
+Both attempts are recorded rather than deleted because the negative result is
+the useful part: it converts "convert the other 78 sites" from a mechanical
+substitution into a scoped, per-gate programme, and it rules out the shortcut
+that looks obvious from the issue text. The gates stay wall-clock and stay
+enumerated in `python/tests/test_912_wall_budget_inventory.py`, which fails on
+any new one.
 
 ## 10. Wave 2: the rest of the primal-heuristic layer
 

--- a/docs/dev/work-budget-calibration-2026-08-01.md
+++ b/docs/dev/work-budget-calibration-2026-08-01.md
@@ -1,0 +1,344 @@
+# Work-unit calibration for the deterministic heuristic budget (issue #912)
+
+Entry experiment and calibration for `discopt._work_budget` — the deterministic
+replacement for the wall-clock "how much work" gates that made the search tree a
+function of machine speed.
+
+All numbers below were produced on this repo's in-repo MINLPLib corpus
+(`python/tests/data/minlplib_nl`, 66 `.nl` files) with
+
+```bash
+python -u discopt_benchmarks/scripts/item912_clock_determinism_probe.py --classify --legacy --time-limit 15
+python -u discopt_benchmarks/scripts/item912_work_unit_calibration.py --rounds 5
+python -u discopt_benchmarks/scripts/item912_clock_determinism_probe.py --clockscale --alphas 1,2,4
+```
+
+Every solve runs in a child process that asserts `discopt.__file__`, the compiled
+`_rust` extension path, and the arm marker (`SolverTuning.ils_work_budget`, 0 on
+the legacy arm) before measuring, and raises rather than swallowing.
+`gear2` — the decisive instance in #912 — is **not** in this corpus and
+minlplib.org is unreachable from this environment, so everything here is
+reproduced on other instances of the same class rather than on gear2 itself.
+
+## 1. Entry experiment: does the mechanism reproduce in-repo?
+
+Yes, on 7 instances. Legacy arm, `time_limit=15` (so the root ILS wall budget is
+`min(5.0, 0.15·15) = 2.25 s`), 66 instances, 22 of which fire the root integer
+local search:
+
+| instance | nodes | ILS work (units) | ILS wall (s) | stopped on |
+|---|---|---|---|---|
+| nvs09 | 5 | 49 380 | 2.26 | **deadline** |
+| ex1224 | 5 | 35 798 | 2.26 | **deadline** |
+| st_e29 | 5 | 32 487 | 2.26 | **deadline** |
+| ex1225 | 5 | 30 541 | 2.27 | **deadline** |
+| tspn05 | 35 | 16 766 | 2.28 | **deadline** |
+| syn05hfsg | 181 | 8 029 | 2.29 | **deadline** |
+| fac2 | 39 | 4 087 | 1.06 | **deadline** |
+| gkocis | 5 | 11 289 | 0.62 | converged |
+| ex1221 | 5 | 10 777 | 0.39 | converged |
+| … 13 more | | ≤ 9 289 | ≤ 0.98 | converged |
+
+(Work units in this table are the *first-draft* unit costs; §2 corrects them.
+The column that matters here is `stopped on`.)
+
+Seven of the twenty-two ILS-firing instances have their search extent decided by
+the wall clock, not by the model. That is the gear2 mechanism, in-repo: on those
+rows a faster machine keeps descending and a slower one stops earlier, so the
+incumbent handed to the tree — and therefore `node_count` — is a function of the
+hardware.
+
+15 of 66 instances hit the overall `time_limit`; those are excluded from every
+determinism comparison, because there the clock legitimately decides *when to
+stop* (the second, unfixable mechanism #912 separates out).
+
+## 2. Unit costs: one sub-NLP solve = 12 000 evaluations
+
+`item912_work_unit_calibration.py`, 5 interleaved rounds per instance (200 evals
+and 20 solves per round), load average 0.32 before / 1.06 after:
+
+| instance | vars | cons | eval (µs) | sd | subnlp (ms) | sd | ratio |
+|---|---|---|---|---|---|---|---|
+| nvs21 | 3 | 2 | 1.1 | 0.1 | 14.71 | 0.95 | 13 327 |
+| ex1221 | 5 | 5 | 1.4 | 0.3 | 13.15 | 0.15 | 9 198 |
+| ex1222 | 3 | 3 | 1.1 | 0.1 | 10.03 | 0.09 | 9 391 |
+| st_e38 | 4 | 3 | 1.1 | 0.1 | 5.42 | 0.26 | 5 047 |
+| nvs09 | 10 | 0 | 0.7 | 0.4 | 1.93 | 0.09 | 2 933 |
+| ex1224 | 11 | 7 | 1.4 | 0.2 | 15.50 | 0.67 | 10 902 |
+| syn05hfsg | 42 | 58 | 2.5 | 0.2 | 80.95 | 3.54 | 32 297 |
+| fac2 | 66 | 33 | 2.7 | 0.3 | 39.13 | 1.27 | 14 435 |
+| st_e36 | 2 | 2 | 1.3 | 0.1 | 104.37 | 3.13 | 77 964 |
+
+**Geomean ratio 12 364** (min 2 933, max 77 964) → `NLP_SOLVE_UNITS = 12 000`.
+
+This is a *correction of a published number in this document's own first draft*
+(CLAUDE.md rule 11): the module initially charged **250** units per sub-NLP
+solve, a guess, and it was wrong by ~50×. The consequence was measurable rather
+than cosmetic — under the 250-unit charge the observed "units per second" spread
+across instances was 26× (1 411/s on st_e36 to 37 392/s on st_e38), because a
+subnlp-dominated search was being charged almost nothing for its dominant cost.
+No single default budget can behave sanely across a 26× spread.
+
+A size-scaled charge was tried first and **falsified**: multiplying the charge by
+`n_vars + n_cons` made the spread *worse* (67.8× vs 26.5×). On this corpus the
+per-operation cost is not driven by model dimension — these models are all tiny —
+but by how many sub-NLP solves the search issues. Charging solves correctly is
+the fix; scaling by size is not.
+
+The residual ~27× ratio spread is the honest accuracy limit of a deterministic
+cost proxy: it is a function of the model only, so it cannot know the machine.
+
+## 3. Default budget
+
+See `SolverTuning.ils_work_budget`. Sized from the re-measured consumption in
+§4 under two constraints:
+
+1. **Do not bind where the legacy clock did not bind.** An instance whose ILS
+   converged on its own must consume the same work and return the same point, so
+   the default must exceed the largest naturally-converging consumption.
+2. **Keep the wall-time envelope the legacy default had.** The legacy budget was
+   capped at 5 s (`min(5.0, 0.15·time_limit)`), so the default must not exceed
+   ~5 s of work on the *slowest*-per-unit instance that the gate actually binds
+   on.
+
+## 4. Re-measured consumption at the corrected unit cost (superseded — see §4b)
+
+Same command, same corpus, `NLP_SOLVE_UNITS = 12 000`, legacy arm,
+`time_limit=15` (2.25 s wall budget), 22 ILS-firing instances:
+
+| instance | nodes | ILS work | ILS wall (s) | stopped on | units/s |
+|---|---|---|---|---|---|
+| nvs09 | 5 | 2 630 800 | 2.25 | **deadline** | 1 168 206 |
+| ex1224 | 5 | 1 680 548 | 2.26 | **deadline** | 744 594 |
+| st_e29 | 5 | 1 668 548 | 2.26 | **deadline** | 738 622 |
+| ex1225 | 5 | 1 452 291 | 2.11 | converged | 687 312 |
+| tspn05 | 33 | 780 266 | 2.28 | **deadline** | 341 922 |
+| gkocis | 5 | 540 039 | 0.61 | converged | 883 861 |
+| ex1221 | 5 | 516 027 | 0.38 | converged | 1 343 820 |
+| oaer | 3 | 444 039 | 0.61 | converged | 732 738 |
+| ex1226 | 3 | 432 051 | 0.33 | converged | 1 305 290 |
+| syn05hfsg | 185 | 408 029 | 2.31 | **deadline** | 176 331 |
+| nvs06 | 5 | 372 090 | 0.40 | converged | 932 556 |
+| st_e38 | 3 | 372 065 | 0.23 | converged | 1 610 671 |
+| nvs01 | 3 | 324 138 | 0.38 | converged | 855 245 |
+| nvs08 | 3 | 324 078 | 0.23 | converged | 1 433 973 |
+| nvs21 | 3 | 276 106 | 0.39 | converged | 709 784 |
+| nvs05 | 25 | 228 122 | 0.97 | converged | 233 971 |
+| fac2 | 39 | 216 087 | 1.03 | **deadline** | 210 201 |
+| ex1222 | 1 | 84 004 | 0.07 | converged | 1 235 353 |
+| st_e36 | 85 | 48 017 | 0.72 | converged | 66 230 |
+| ex14_1_9, nvs04, st_e11 | | 0 | 0.00 | no-op | — |
+
+### The bistable row is itself the finding
+
+`ex1225` and `tspn05`/`syn05hfsg` are worth reading twice. In the §1 sweep
+`ex1225` **stopped on the deadline** at 2.27 s; in this sweep, same machine, same
+arm, same `time_limit`, it **converged** at 2.11 s and 1 452 291 units — and
+`tspn05` returned 35 nodes in one sweep and 33 in the other, `syn05hfsg` 181 vs
+185. Nothing about the input changed between the two runs. That is #912's claim
+reproduced accidentally, twice, inside its own calibration: with a wall-clock
+extent gate the tree is not a function of the model.
+
+It also makes a limit explicit. On a bistable instance there is no work budget
+that "preserves current behaviour", because there is no single current
+behaviour to preserve.
+
+### Sizing the default
+
+* Largest consumption by a search that converged on its own, excluding the
+  bistable `ex1225`: **540 039** (gkocis). A default above this cannot cut short
+  any search the legacy gate let finish.
+* Slowest instance the gate actually binds on: **176 331 units/s** (syn05hfsg).
+  The legacy budget was capped at 5 s, so staying inside that envelope means
+  **≤ 880 000** units.
+
+`_ILS_WORK_BUDGET_DEFAULT = 750_000` is inside `[540 039, 880 000]`. Projected
+effect on the seven instances the clock used to cut (legacy wall → work-budget
+wall at the measured rate): nvs09 2.25 → 0.6 s, ex1224 2.26 → 1.0 s, st_e29
+2.26 → 1.0 s, ex1225 2.11 → 1.1 s, tspn05 2.28 → 2.2 s, syn05hfsg 2.31 → 4.3 s,
+fac2 1.03 → 3.6 s. Roughly neutral in total, and every one of them now stops at
+a point that is a function of the model.
+
+### What the units do *not* buy
+
+The per-unit cost still varies 24x across instances (66 230 units/s on st_e36 to
+1 610 671 on st_e38), so a fixed unit budget is not a fixed wall time. It cannot
+be: a deterministic budget is by definition blind to the machine. What it buys is
+that the *same* model always gets the *same* search — which is the property the
+repo's bound-neutral regime assumes and #912 showed it did not have.
+
+## 4b. The single-currency design was falsified; two counters replaced it
+
+§4 sized one budget in converted units. Two measurements killed that design.
+
+1. **The starvation it caused was real.** At the 750 000-unit default, `nvs09`
+   went from 5 nodes to 29 and from `optimal` to `feasible`: its search is cheap
+   per operation, so the shared currency ran out long before the search was done,
+   while the same number gave the expensive-per-operation `syn05hfsg` three times
+   its legacy wall time. One number cannot price operations whose cost ratio
+   varies 27x.
+2. **The split, once measured, showed why.** Instrumenting the two kinds
+   separately (legacy arm, `time_limit=60`, the full 5 s legacy budget) shows the
+   sub-NLP count is the real currency and the evaluation count is nearly free:
+
+| instance | nodes | evals | sub-NLP solves | ILS wall (s) | stopped on | solves/s |
+|---|---|---|---|---|---|---|
+| nvs09 | 5 | 4 752 | 443 | 5.02 | **deadline** | 88.3 |
+| ex1224 | 5 | 796 | 217 | 3.45 | converged | 62.9 |
+| st_e29 | 5 | 796 | 217 | 3.62 | converged | 60.0 |
+| tspn05 | 51 | 460 | 152 | 5.02 | **deadline** | 30.3 |
+| ex1225 | 5 | 291 | 121 | 2.20 | converged | 54.9 |
+| syn05hfsg | 185 | 47 | 67 | 5.02 | **deadline** | 13.3 |
+| gkocis | 5 | 39 | 45 | 0.56 | converged | 80.5 |
+| ex1221 | 5 | 27 | 43 | 0.41 | converged | 105.4 |
+| oaer | 3 | 39 | 37 | 0.59 | converged | 62.3 |
+| ex1226 | 3 | 51 | 36 | 0.35 | converged | 102.6 |
+| nvs06 | 5 | 90 | 31 | 0.43 | converged | 71.8 |
+| st_e38 | 3 | 65 | 31 | 0.23 | converged | 136.0 |
+| nvs01 | 3 | 138 | 27 | 0.31 | converged | 86.8 |
+| nvs08 | 3 | 78 | 27 | 0.25 | converged | 109.8 |
+| fac2 | 39 | 94 | 23 | 1.30 | **deadline** | 17.7 |
+| nvs21 | 3 | 106 | 23 | 0.41 | converged | 55.6 |
+| nvs05 | 155 | 122 | 19 | 0.89 | converged | 21.4 |
+| ex1222 | 1 | 4 | 7 | 0.07 | converged | 97.2 |
+| st_e36 | 85 | 17 | 4 | 0.70 | converged | 5.7 |
+| ex14_1_9, nvs04, st_e11 | | 0 | 0 | 0.00 | no-op | — |
+
+Note that `nvs09` is **solve**-dominated too (443 solves) — the "evaluation-
+dominated" reading in the first draft was inferred from converted unit totals
+without the split, and the split refutes it. Retracted here per CLAUDE.md rule
+11; the conclusion (one currency is wrong) survives, the reason changes: it is
+not that one search is eval-heavy and another solve-heavy, it is that the *cost
+of a solve* varies 5x across instances (13.3/s to 136/s) while the currency
+assumed it constant.
+
+**Sizing the two caps.** The constraints are in direct conflict and the conflict
+is the bug itself:
+
+* never cut a search the clock let finish ⇒ ≥ **217 solves**, ≥ **796 evals**;
+* never exceed the legacy 5 s envelope ⇒ ≤ **67 solves** on the slowest binding
+  instance (syn05hfsg, 13.3 solves/s).
+
+The old gate handed ex1224 217 solves and syn05hfsg 67 in the *same five
+seconds*. Any deterministic number lands between; `ils_solve_budget = 128` is
+roughly the middle (59 % of the largest natural extent; ≈9.6 s on the slowest).
+`ils_eval_budget = 20 000` is 25x the largest natural consumption — uncontested,
+it only stops a genuinely runaway descent. §7 is the A/B that validated both.
+
+## 5. Determinism panel — tight limit (`time_limit=15`, alpha 1/2/4)
+
+22 ILS-firing instances, new arm, clock scaled 1x / 2x / 4x (a 2x-scaled clock is
+a 2x-slower machine). Raw verdict: **41 comparisons, 9 mismatches.**
+
+The 9 mismatches are not scattered — they are exactly six instances, and every
+one of them spends ≥ 11 s of its 15 s budget at alpha=1:
+
+| instance | real s @ alpha=1 | alpha=1 | alpha=2 | alpha=4 |
+|---|---|---|---|---|
+| fac2 | 16.1 | 39 nodes | 27 | (time_limit) |
+| nvs05 | 16.0 | 25 | 7 | (time_limit) |
+| nvs09 | 17.1 | 29 | 25 | 7 |
+| st_e36 | 11.0 | 85 | 67 | (time_limit) |
+| syn05hfsg | 16.0 | 155 | 23 | 3 |
+| tspn05 | 16.3 | 33 | 13 | 3 |
+
+Scaling the clock 2x on a run that needs 16 s of a 15 s budget halves its real
+budget to 7.5 s. The B&B loop's *own* deadline checks then shape the tree — that
+is #912's second mechanism (whole-solve budget starvation, the `ex1266` case),
+which is the `time_limit` contract and is not what a work budget can or should
+fix. Every one of the 16 instances that finishes comfortably is **invariant at
+1x / 2x / 4x**, including all five where the new work budget is the binding gate
+(ex1224, ex1225, st_e29, tspn05, syn05hfsg all report `stopped_on="work"` with
+byte-identical work counts at every alpha).
+
+Rather than leave that attribution as an assertion, the probe now makes it: a
+comparison is *in scope* only when neither row hit `time_limit`, consumed ≥ 50 %
+of its perceived budget, or had a heuristic cut by the solve deadline. Rows
+outside that set are printed with their numbers and with whether they differed —
+disclosed, never dropped.
+
+## 6. Determinism panel — generous limit (`time_limit=60`, alpha 1/2)
+
+The headline measurement. 22 ILS-firing instances, work budgets at their
+defaults, clock scaled 1x and 2x:
+
+```
+out-of-scope comparisons (whole-solve budget starvation): 4
+  fac2      alpha=2.0: heuristic cut by the solve deadline — matched anyway
+  nvs05     alpha=2.0: deadline-pressured (60.3s of 60s) — and it DIFFERS (155 vs 65 nodes)
+  syn05hfsg alpha=2.0: deadline-pressured (44.1s of 60s) — matched anyway
+  tspn05    alpha=2.0: deadline-pressured (33.4s of 60s) — and it DIFFERS (51 vs 49 nodes)
+
+=== clock-scale determinism ===
+executed comparisons: 18
+mismatches:           0
+```
+
+**18 in-scope comparisons, 0 mismatches.** Every instance whose solve is not
+fighting its own `time_limit` returns the identical tree on a clock running twice
+as fast — i.e. on a machine twice as slow.
+
+The four out-of-scope rows are printed with their verdicts rather than dropped,
+and two of them *do* differ. That is the point of separating them: those two are
+`nvs05` (60.3 s of a 60 s budget) and `tspn05` (33.4 s of 60 s), both squarely in
+mechanism 2. Halving their real budget changes their tree, and no work budget
+can prevent that — only a larger `time_limit` can.
+
+Compare with §5, the same panel before the scope rule and at a limit tight enough
+that six of twenty-two instances were starved: 41 comparisons, 9 mismatches, all
+six starved instances.
+
+## 7. Flag ON vs OFF (`time_limit=60`, 22 ILS-firing instances)
+
+`ils_eval_budget=20 000, ils_solve_budget=128` versus the legacy wall gate
+(`DISCOPT_ILS_EVAL_BUDGET=0 DISCOPT_ILS_SOLVE_BUDGET=0`), same machine, same
+limit, one solve per arm per instance.
+
+**Cert-clean.** 22 instances x 4 reported fields (`status`, `node_count`,
+`objective`, `bound`) = **88 field comparisons, 0 differences**. Not "no
+regressions" — literally the same trees and the same certificates. The three
+instances in this set that carry a reference optimum (nvs04, nvs06, nvs09) have
+their bound checked against it on both arms: 6 pairs, 0 bounds above their
+optimum, 0 incumbents below it.
+
+**Net effect on cost.** Total wall 203.2 s → 206.4 s (+1.6 %); total root-ILS
+wall 30.8 s → 32.5 s (+5.5 %). Redistribution, as designed: the instances the
+clock used to cut short get more work (syn05hfsg 5.02 → 9.51 s, fac2 1.30 →
+5.33 s), the ones that were burning solves for nothing get less (nvs09 5.02 →
+1.58 s, st_e29 3.62 → 2.03 s, ex1224 3.45 → 2.08 s).
+
+The ex1224/st_e29 rows are the informative ones for the sizing argument: both
+naturally used 217 solves and both were cut to 128 — and both still return 5
+nodes and the same certified optimum. The 89 solves the old gate spent there were
+no-ops, which is why the middle of the conflicting range turned out not to cost
+anything.
+
+**Determinism.** Five instances moved from clock-decided to work-decided
+(`stopped_on = "work:nlp_solve"`: ex1224, nvs09, st_e29, syn05hfsg, tspn05).
+`fac2` still reports `deadline` on both arms — it is cut by the *solve/phase*
+budget, not by a heuristic's own wall budget, i.e. mechanism 2 again.
+
+## 8. What this does not fix
+
+Stated plainly, because the issue asked for it:
+
+* **Whole-solve budget starvation is untouched and unfixable by this change.**
+  When a run is close to `time_limit`, the B&B loop's own deadline checks shape
+  the tree, and a slower machine gets a smaller tree. That is the `time_limit`
+  contract. The only honest mitigation is the one the panel now applies: refuse
+  to make determinism claims about such rows, and say which ones they are.
+* **Only the root integer local search is converted.** #912 counts 78 clock
+  sites in `python/discopt/` and 57 `Instant::now` in `crates/`. This change
+  converts the one the issue names as the decisive mechanism and builds the
+  primitive the rest can migrate to. On this corpus, after the conversion, no
+  remaining Python-side extent gate moves a tree — but "this corpus does not
+  exercise it" is not "it is not there".
+* **The Rust gates are out of reach of this instrument.** Clock scaling patches
+  Python's `time` module; `Instant::now` in `crates/` is unaffected by it. A row
+  that is clock-scale invariant here is invariant *with respect to the Python
+  gates* and nothing more.
+* **`gear2` itself was never run.** It is not in the in-repo corpus and
+  minlplib.org is unreachable from this environment. The mechanism is reproduced
+  on seven other instances of the same class; the specific 3-vs-91-node cliff is
+  taken from the issue, not re-measured here.
+

--- a/docs/dev/work-budget-calibration-2026-08-01.md
+++ b/docs/dev/work-budget-calibration-2026-08-01.md
@@ -479,3 +479,36 @@ are where a deterministic budget spends more (syn05hfsg's ILS 5.02 → 9.51 s).
 That trade was measured corpus-wide at +1.6 % total and accepted in §7; wave 2
 adds ~6 % and ~5 % on these two worst cases and nothing measurable elsewhere.
 
+## 11. Disposition
+
+#912 is closed **not planned** for the 20 residual gates. The converted work —
+the root integer local search and its three siblings in the primal-heuristic
+layer — landed and is validated in §6, §7 and §10.
+
+The case for stopping is measured, not budgetary:
+
+* after the conversion, the corpus-wide clock-scale panel is **18 in-scope
+  comparisons, 0 mismatches**, and across the whole investigation every extent
+  gate ever caught cutting a search short was the root ILS. No residual gate was
+  observed moving a tree;
+* the cheap bulk conversion does not exist (§9): per-operation cost varies 55x
+  across instances, so each residual needs its own unit, its own re-tuning and —
+  for the five bound-changing ones — its own differential-bound panel. Twenty
+  times the §4b exercise, whose first sizing attempt was itself rejected as
+  sound-but-harmful;
+* the two costs that *were* measured for converting gates (nvs09's 5 -> 29 node
+  regression under a mis-priced budget, syn05hfsg's 1.38x wall under a mis-sized
+  one) show the downside of doing this without per-gate care is real.
+
+**The condition to revisit, stated plainly.** The first bullet is bounded by
+corpus coverage. These budgets bind mainly on large models — a root pass reaching
+a 30 s budget is the `watercontamination0202` shape (#863, #875), and the in-repo
+corpus is 66 small instances. "No residual gate was seen moving a tree" is
+therefore not proof that none does. Reopen if a large-instance clock-scale panel
+shows any of them moving a tree while the solve is comfortably inside its
+`time_limit`, or if a consumer needs bit-reproducibility as a guarantee rather
+than as a property that currently holds on the tested corpus.
+
+`python/tests/test_912_wall_budget_inventory.py` is the standing guard: the 20
+residuals are enumerated and pinned, a new unrecorded wall gate fails, and the
+converted layer is asserted to stay converted.

--- a/docs/dev/work-budget-calibration-2026-08-01.md
+++ b/docs/dev/work-budget-calibration-2026-08-01.md
@@ -342,3 +342,99 @@ Stated plainly, because the issue asked for it:
   on seven other instances of the same class; the specific 3-vs-91-node cliff is
   taken from the issue, not re-measured here.
 
+## 9. Falsified: one global deterministic clock for every wall gate
+
+The obvious way to close the rest of #912 in one move is a process-wide
+*deterministic clock* — SCIP's "deterministic time". Count the primitives
+(constraint/objective evaluations, NLP solves, LP relaxation solves, expression
+visits), price them at measured nominal seconds, and expose
+``work_clock.now()`` as a drop-in for ``time.perf_counter()``. Every gate then
+keeps its shape and its tuned constant, and ~20 conversions become one-line
+substitutions instead of ~20 re-calibrations.
+
+It was built: clock, per-thread accounting, instrumentation on all four
+primitives, and conversion of the convexity classifier, OBBT (root and
+per-node), nonlinear bound tightening, root cuts, the Lagrangian node bounder,
+the disjunctive configuration bound, the root fixpoint, the signomial B&B, the
+integer-ratio dive, the native-seed heuristic and the PSD cut gate.
+
+**Then it was measured, and the measurement killed it.** Deterministic seconds
+against real seconds, five instances, ``time_limit=20``:
+
+| instance | wall (s) | deterministic (s) | ratio | counts |
+|---|---|---|---|---|
+| nvs21 | 10.38 | 1.25 | 0.12 | 29 423 eval, 208 lp, 53 nlp, 133 visit |
+| ex1224 | 3.81 | 2.32 | 0.61 | 8 596 eval, 181 lp, 130 nlp |
+| st_e29 | 3.57 | 2.32 | 0.65 | 8 596 eval, 181 lp, 130 nlp |
+| syn05hfsg | 20.18 | 2.85 | 0.14 | 29 274 eval, 428 lp, 130 nlp |
+| fac2 | 15.01 | **0.09** | **0.01** | 8 646 eval, 5 nlp, 0 lp |
+
+A budget written as "5 seconds" would have become 5 deterministic seconds —
+between 1.5x and **100x** more real work, varying by instance. `fac2` is the
+clean refutation: 15 s of real solving registers as 0.09 s of countable work,
+because the dominant cost is the Rust B&B tree, presolve and JIT compilation,
+none of which the Python-side clock can see.
+
+The consequence is not "slightly mis-tuned". It is that budgets which exist
+precisely to stop pathological phases — #875's 27 s nonlinear-tightening pass,
+#863's `watercontamination0202` — would have **silently stopped firing**, while
+every test and panel still passed. That is rule 6's failure mode aimed at a
+budget instead of an assertion, and it is strictly worse than the
+nondeterminism it was meant to fix.
+
+The whole wave was reverted. It is recorded here rather than deleted because
+the design is right and the obstacle is specific and fixable: the clock must
+count Rust-side node and presolve work before it can price a second. Until
+then, those gates stay wall-clock and stay enumerated in
+`python/tests/test_912_wall_budget_inventory.py`, which fails on any new one.
+
+## 10. Wave 2: the rest of the primal-heuristic layer
+
+`integer_box_search`, `one_hot_swap_search` and `local_branching` are the other
+three extent gates in the converted layer, and the last of them is the purest
+form of the bug in the whole repo: it predicted a round's cost as
+``C(n, r) x measured_mean_subnlp_seconds`` and compared it against
+``deadline - now``, so the enumeration radius — and hence which neighbourhood
+was searched by brute force versus handed to the sub-MIP — was a ratio of two
+machine measurements. All three now count operations.
+
+Cert-clean, ON vs OFF at `time_limit=60`, same 22 instances: **21 of 22 identical
+on all four fields**; the single difference is `nvs05`, which exhausts the 60 s
+limit on both arms (155 vs 99 nodes, bound 4.0992 vs 3.8054 — looser, not
+unsound) and is out of scope by the panel's own starvation rule.
+
+### The first wave-2 sizing was harmful, and the sequential panel hid it
+
+The first attempt handed all three searches the *ILS* budget. The sequential
+panel reported total wall 203.2 s → 257.8 s (+27 %), which by rule 9 is not a
+timing claim at all: the two arms ran hours apart. Interleaved, 3 rounds per arm:
+
+| instance | OFF | ON | ratio | nodes |
+|---|---|---|---|---|
+| syn05hfsg | 23.46 s (sd 0.52) | 32.32 s (sd 0.23) | **1.38** | 185 = 185 |
+| fac2 | 18.11 s (sd 1.08) | 21.31 s (sd 0.45) | **1.18** | 39 = 39 |
+| tspn05 | 47.14 s (sd 1.02) | 46.00 s (sd 0.39) | 0.98 | 51 = 51 |
+| nvs21 | 10.52 s (sd 0.62) | 10.32 s (sd 1.37) | 0.98 | 3 = 3 |
+
+Two real slowdowns, two neutral — and `tspn05`'s +13.3 s in the sequential panel
+was drift, not effect. Sound but harmful is the `DISCOPT_CUT_INHERIT` verdict
+(CLAUDE.md §5), so that sizing did not ship.
+
+The cause is a sizing error, not the mechanism: the legacy wall slices were ILS
+5 s, box 4 s, local branching 2 s, swap 1 s, and giving all four the ILS number
+silently multiplied three of them. Each now takes its own share of the ILS
+budget (`_BOX_BUDGET_RATIO` 0.8, `_LB_BUDGET_RATIO` 0.4, `_SWAP_BUDGET_RATIO`
+0.2), preserving the relative effort the tuned wall budgets encoded.
+Re-measured interleaved, same protocol:
+
+| instance | OFF | ON | ratio (was) |
+|---|---|---|---|
+| syn05hfsg | 22.44 s (sd 0.94) | 29.34 s (sd 1.05) | 1.31 (1.38) |
+| fac2 | 17.14 s (sd 0.44) | 19.36 s (sd 0.17) | 1.13 (1.18) |
+
+Node counts identical throughout. The residual is **wave 1**, not wave 2: these
+two instances are exactly the ones whose ILS the clock used to cut short, so they
+are where a deterministic budget spends more (syn05hfsg's ILS 5.02 → 9.51 s).
+That trade was measured corpus-wide at +1.6 % total and accepted in §7; wave 2
+adds ~6 % and ~5 % on these two worst cases and nothing measurable elsewhere.
+

--- a/python/discopt/_jax/mccormick_lp.py
+++ b/python/discopt/_jax/mccormick_lp.py
@@ -2351,8 +2351,11 @@ class MccormickLPRelaxer:
             _gate_tau = _tun.psd_cost_gate_tau
             _psd_t0 = time.perf_counter()
             _base_solve_wall: Optional[float] = None
+            _psd_stop = "max_rounds"
+            _psd_rounds = 0
             for _round in range(max_rounds):
                 if deadline is not None and time.perf_counter() >= deadline:
+                    _psd_stop = "deadline"
                     break
                 if (
                     _gate
@@ -2360,6 +2363,13 @@ class MccormickLPRelaxer:
                     and (time.perf_counter() - _psd_t0) > _gate_budget * _base_solve_wall
                 ):
                     # Per-node PSD wall budget spent — stop feeding the search.
+                    # #912 instrumentation: this criterion compares one measured
+                    # wall against another, so which round it fires on is a
+                    # function of machine speed — and unlike the primal
+                    # heuristics this loop moves the node's DUAL BOUND. The log
+                    # line records whether a node was decided by it or by the
+                    # deterministic diminishing-returns test.
+                    _psd_stop = "wall_gate"
                     break
                 if self._binary_cols_cache is None:
                     from discopt._jax.model_utils import binary_flat_cols
@@ -2372,7 +2382,9 @@ class MccormickLPRelaxer:
                     binary_vars=self._binary_cols_cache,
                 )
                 if not cuts:
+                    _psd_stop = "no_cuts"
                     break
+                _psd_rounds += 1
                 _lb_before = res.objective if _gate else None
                 # ``coeffs . z >= rhs``  ->  ``(-coeffs) . z <= -rhs`` for A_ub<=b_ub.
                 _append([-c.coeffs for c in cuts], [-c.rhs for c in cuts])
@@ -2386,13 +2398,16 @@ class MccormickLPRelaxer:
                 if _gate and _base_solve_wall is None:
                     _base_solve_wall = max(time.perf_counter() - _solve_t0, 1e-4)
                 if new_res.status != "optimal" or new_res.objective is None:
+                    _psd_stop = "lp_status"
                     break
                 res = new_res
                 if _gate and _lb_before is not None:
                     _delta = new_res.objective - _lb_before
                     if _delta <= _gate_tau * (1.0 + abs(_lb_before)):
                         # Diminishing returns — abandon the remaining PSD rounds.
+                        _psd_stop = "tau"
                         break
+            logger.debug("psd_cut_loop: rounds=%d stopped_on=%s", _psd_rounds, _psd_stop)
             return res
         except Exception:
             return res

--- a/python/discopt/_jax/primal_heuristics.py
+++ b/python/discopt/_jax/primal_heuristics.py
@@ -321,7 +321,7 @@ def feasibility_pump(
                     v.ub = fixed.copy()
                 offset += sz
             try:
-                nlp_result = backend(evaluator, x0, options=opts)
+                    nlp_result = backend(evaluator, x0, options=opts)
             except BaseException as exc:
                 # Some NLP backends (pounce via PyO3) raise PanicException, which
                 # is not a subclass of Exception; treat any failure as this round
@@ -1018,6 +1018,8 @@ def integer_box_search(
     integer_tol: float = 1e-5,
     feas_tol: float = 1e-6,
     time_budget: float = 4.0,
+    solve_budget: Optional[int] = None,
+    deadline: Optional[float] = None,
 ) -> Optional[tuple[np.ndarray, float]]:
     """Objective-improving integer *box* search around an incumbent.
 
@@ -1042,9 +1044,20 @@ def integer_box_search(
     further by each variable's own ``[lb, ub]``), every returned point is
     subnlp-verified feasible, and the caller injects it only on strict
     improvement — so the dual bound and certification are untouched.
+
+    **Determinism (issue #912).** Which cells get enumerated is bounded by
+    ``solve_budget`` (one sub-NLP per cell), not by a wall clock, so the search
+    stops at the same cell on every machine. ``deadline`` is the caller's
+    ``time_limit`` backstop. ``solve_budget=0`` restores the legacy
+    ``time_budget`` wall gate.
     """
     import time
 
+    # As in ``one_hot_swap_search``: a non-positive ``time_budget`` is the caller
+    # saying there is no budget at all, and #912's deterministic cell budget must
+    # not override that.
+    if float(time_budget) <= 0.0:
+        return None
     int_mask = _get_integer_mask(model)
     int_idx = np.where(int_mask)[0]
     n_int = int(int_idx.size)
@@ -1098,10 +1111,23 @@ def integer_box_search(
         key=lambda c: (cheby(c), sum(abs(c[k] - center_key[k]) for k in range(n_int))),
     )
 
-    deadline = time.perf_counter() + max(0.0, time_budget)
+    # #912: the enumeration's extent is a deterministic sub-NLP count, not a wall
+    # budget. One solve per cell and the cell list is already capped by
+    # ``max_combos``, so this only ever trims a large box — but it trims it at the
+    # same cell on every machine. ``deadline`` (the caller's ``time_limit``) stays
+    # as a backstop. Both budgets off => the legacy ``time_budget`` wall gate.
+    if solve_budget is None:
+        from discopt import solver_tuning as _st
+
+        solve_budget = max(1, round(_BOX_BUDGET_RATIO * _st.current().ils_solve_budget))
+    if int(solve_budget) > 0:
+        budget = WorkBudget({NLP_SOLVE: int(solve_budget)}, deadline=deadline)
+    else:
+        _wall = time.perf_counter() + max(0.0, time_budget)
+        budget = WorkBudget(None, deadline=_wall if deadline is None else min(_wall, deadline))
     best: Optional[tuple[np.ndarray, float]] = None
     for combo in combos:
-        if time.perf_counter() >= deadline:
+        if budget.exhausted():
             break
         if combo == center_key:
             continue  # the incumbent's own cell — nothing to improve on
@@ -1116,6 +1142,7 @@ def integer_box_search(
         seed = seed_src.copy()
         for k, j in enumerate(int_idx):
             seed[j] = float(combo[k])
+        budget.charge(NLP_SOLVE)
         found = subnlp(
             model,
             seed,
@@ -1674,11 +1701,24 @@ def _local_branching_submip(
     return cand
 
 
-# Fallback estimate (seconds) for one enumeration sub-NLP before any round has
-# been measured. The profiled sub-NLP mean on the 12-binary flay/fac class is
-# ~14 ms (bottleneck-profile-2026-07-05 §1.1); 15 ms is the conservative prior
-# used to predict a round's cost when no measurement exists yet.
-_LB_SUBNLP_PRIOR_S = 0.015
+# #912: each converted primal heuristic gets a share of the root ILS budget in
+# proportion to the wall slice it used to be given, so the deterministic budgets
+# preserve the *relative* effort the tuned wall budgets encoded. ILS had 5 s,
+# ``integer_box_search`` 4 s, ``local_branching`` a 2 s sub-MIP slice, and
+# ``one_hot_swap_search`` 1 s. Handing all four the ILS number instead was
+# measured (interleaved, 3 rounds/arm) at 1.38x wall on syn05hfsg and 1.18x on
+# fac2 for identical node counts — sound but harmful, which under CLAUDE.md §5
+# does not ship.
+_BOX_BUDGET_RATIO = 0.8  # 4 s / 5 s
+_LB_BUDGET_RATIO = 0.4  # 2 s / 5 s
+_SWAP_BUDGET_RATIO = 0.2  # 1 s / 5 s
+
+# (#912 removed ``_LB_SUBNLP_PRIOR_S``, the ~15 ms prior for one enumeration
+# sub-NLP. It existed only to convert a round's *solve count* into a predicted
+# wall time so the round could be compared against a remaining wall budget. Local
+# branching now compares the solve count against a remaining *solve* budget, so
+# there is nothing left to convert and no measured mean to drift with the
+# machine. Deleted rather than left dangling — CLAUDE.md §3, no dead constants.)
 
 # Minimum remaining budget (seconds) before it is worth dispatching the truncated
 # neighbourhood to the bounded sub-MIP. A nested ``solve_model`` re-pays a fixed
@@ -1702,6 +1742,7 @@ def local_branching(
     submip_time_limit: float = 2.0,
     submip_max_nodes: int = 1000,
     submip_gap_tolerance: float = 1e-4,
+    solve_budget: Optional[int] = None,
     deadline: Optional[float] = None,
     node_bound: Optional[float] = None,
     incumbent_obj: Optional[float] = None,
@@ -1805,10 +1846,25 @@ def local_branching(
     k = max(1, min(k, len(binary_idx)))
 
     best: Optional[tuple[np.ndarray, float]] = None
-    # Rolling mean sub-NLP wall used to predict the next round's cost. Seeded with
-    # the profiled prior; refined from every measured sub-NLP.
-    mean_subnlp_s = _LB_SUBNLP_PRIOR_S
-    n_measured = 0
+    # #912: the enumeration's extent is a deterministic sub-NLP count.
+    #
+    # This is the site where the wall clock did the most damage. The round-cost
+    # prediction used to be ``C(n, r) x mean_subnlp_s`` against ``deadline - now``
+    # — a *measured* mean wall time against a *measured* remaining wall — so which
+    # radius the enumeration reached, and therefore which neighbourhood was
+    # searched by brute force versus handed to the sub-MIP, was decided by how
+    # fast the machine happened to be running at that moment. The same quantity
+    # in solve counts (``C(n, r)`` against the remaining sub-NLP budget) answers
+    # the same question — "can I afford this round?" — as a function of the model
+    # alone. ``deadline`` stays as the ``time_limit`` backstop.
+    if solve_budget is None:
+        from discopt import solver_tuning as _st
+
+        solve_budget = max(1, round(_LB_BUDGET_RATIO * _st.current().ils_solve_budget))
+    if int(solve_budget) > 0:
+        budget = WorkBudget({NLP_SOLVE: int(solve_budget)}, deadline=effective_deadline)
+    else:
+        budget = WorkBudget(None, deadline=effective_deadline)
     # Highest radius whose full enumeration we could afford. If the budget runs
     # out mid-schedule we hand the *unexplored* radii to the bounded sub-MIP so
     # the neighbourhood is still searched, just not by brute force.
@@ -1816,24 +1872,22 @@ def local_branching(
 
     # Enumerate flip sets of size 0..k (size 0 re-evaluates the incumbent itself).
     for radius in range(k + 1):
-        # (2) Predict this round's cost and stop enumerating if it cannot fit the
-        # remaining budget. C(n, 0)=1 (re-evaluate incumbent) is always cheap and
-        # always worth doing; larger radii are gated.
-        remaining = effective_deadline - time.perf_counter()
-        if remaining <= 0.0:
+        # (2) Cost this round in sub-NLP solves and stop enumerating if it cannot
+        # fit the remaining budget. C(n, 0)=1 (re-evaluate incumbent) is always
+        # cheap and always worth doing; larger radii are gated.
+        if budget.exhausted():
             truncated_at = radius
             break
         round_calls = math.comb(len(binary_idx), radius)
-        predicted = round_calls * mean_subnlp_s
-        if radius >= 1 and predicted > remaining:
+        affordable = budget.remaining(NLP_SOLVE)
+        if radius >= 1 and affordable is not None and round_calls > affordable:
             # Cannot afford the full round; hand the rest to the bounded sub-MIP.
             truncated_at = radius
             break
 
         for flip in itertools.combinations(binary_idx, radius):
-            # (1) Poll the deadline before every sub-NLP (they are ~14 ms, so
-            # per-iteration polling is free). Never start one past the budget.
-            if time.perf_counter() >= effective_deadline:
+            # (1) Poll the budget before every sub-NLP. Never start one past it.
+            if budget.exhausted():
                 truncated_at = radius
                 break
             seed = x_inc.copy()
@@ -1841,7 +1895,7 @@ def local_branching(
                 seed[i] = incumbent_bits[i]
             for i in flip:
                 seed[i] = 1.0 - incumbent_bits[i]
-            _t0 = time.perf_counter()
+            budget.charge(NLP_SOLVE)
             found = subnlp(
                 model,
                 seed,
@@ -1851,9 +1905,6 @@ def local_branching(
                 integer_tol=integer_tol,
                 feas_tol=feas_tol,
             )
-            # Refine the rolling mean from the measured sub-NLP wall.
-            n_measured += 1
-            mean_subnlp_s += (time.perf_counter() - _t0 - mean_subnlp_s) / n_measured
             if found is not None and (best is None or found[1] < best[1]):
                 best = found
         else:
@@ -1955,6 +2006,7 @@ def one_hot_swap_search(
     max_restarts: int = 30,
     max_passes: int = 40,
     time_budget: float = 1.0,
+    eval_budget: Optional[int] = None,
     deadline: Optional[float] = None,
     seed: int = 0,
 ) -> Optional[tuple[np.ndarray, float]]:
@@ -1984,6 +2036,12 @@ def one_hot_swap_search(
     only a re-verified, strictly-improving incumbent is proposed; the dual bound
     and certificate are never touched). Returns ``(x, obj)`` or ``None``.
     """
+    # A non-positive ``time_budget`` is the caller saying "there is no budget at
+    # all", not "use the default": honour it in both arms. #912 replaced the wall
+    # gate with an evaluation count, which would otherwise have quietly turned
+    # ``time_budget=0`` into a full-effort search.
+    if float(time_budget) <= 0.0:
+        return None
     int_mask = _get_integer_mask(model)
     if not np.any(int_mask):
         return None
@@ -2016,17 +2074,31 @@ def one_hot_swap_search(
             x[int(group_arr[gi, int(assign[gi])])] = 1.0
         return x
 
+    # #912: this descent is pure objective evaluation (no sub-solve), so its
+    # extent is an evaluation count. A wall budget here made the swap sequence —
+    # and therefore the incumbent — a function of machine speed. ``deadline`` (the
+    # caller's ``time_limit``) remains as the backstop; ``eval_budget=0`` restores
+    # the legacy ``time_budget`` wall gate.
+    if eval_budget is None:
+        from discopt import solver_tuning as _st
+
+        eval_budget = max(1, round(_SWAP_BUDGET_RATIO * _st.current().ils_eval_budget))
+    if int(eval_budget) > 0:
+        budget = WorkBudget({EVAL: int(eval_budget)}, deadline=deadline)
+    else:
+        t_end = time.perf_counter() + max(0.0, float(time_budget))
+        if deadline is not None and np.isfinite(deadline):
+            t_end = min(t_end, float(deadline))
+        budget = WorkBudget(None, deadline=t_end)
+
     def _obj(assign: np.ndarray) -> float:
+        budget.charge(EVAL)
         return float(evaluator.evaluate_objective(_reconstruct(assign)))
 
     inc_obj = _obj(assign0)  # incumbent's own objective on the reconstructed point
 
-    t_end = time.perf_counter() + max(0.0, float(time_budget))
-    if deadline is not None and np.isfinite(deadline):
-        t_end = min(t_end, float(deadline))
-
     def _expired() -> bool:
-        return time.perf_counter() >= t_end
+        return budget.exhausted()
 
     def _descend(assign: np.ndarray) -> tuple[np.ndarray, float]:
         """First-improving swap descent to a local minimum (budget-bounded)."""

--- a/python/discopt/_jax/primal_heuristics.py
+++ b/python/discopt/_jax/primal_heuristics.py
@@ -18,6 +18,7 @@ from typing import Callable, Optional
 import numpy as np
 
 from discopt._jax.nlp_evaluator import NLPEvaluator, cached_evaluator
+from discopt._work_budget import EVAL, NLP_SOLVE, WorkBudget
 from discopt.modeling.core import Model, VarType
 
 # #843: the QUBO/Ising local-search primal moved to ``discopt.qubo_primal`` when
@@ -650,6 +651,9 @@ def integer_local_search(
     max_steps: int = 60,
     pair_cap: int = 40,
     time_budget: float = 3.0,
+    eval_budget: Optional[int] = None,
+    solve_budget: Optional[int] = None,
+    deadline: Optional[float] = None,
     feas_tol: float = 1e-6,
     seed: int = 0,
 ) -> Optional[tuple[np.ndarray, float]]:
@@ -671,9 +675,25 @@ def integer_local_search(
     Sound by construction: only points that pass subnlp's integer- and
     constraint-feasibility checks are returned, so the caller may inject them as
     incumbents without affecting any dual bound or certification. The cost is
-    bounded by ``time_budget`` (wall-clock), ``max_restarts`` and ``max_steps``;
-    2-opt is skipped when the integer count exceeds ``pair_cap`` to avoid the
-    O(n^2) neighbourhood blowing up on large models.
+    bounded by ``eval_budget``/``solve_budget`` (deterministic operation counts),
+    ``max_restarts`` and ``max_steps``; 2-opt is skipped when the integer count
+    exceeds ``pair_cap`` to avoid the O(n^2) neighbourhood blowing up on large
+    models.
+
+    **Determinism (issue #912).** How far this search gets used to be decided by
+    a wall clock (``time_budget``), which made the incumbent it returns — and
+    therefore the whole B&B tree below it — a function of machine speed: the
+    descent routinely never converges, so on the measured cliff case ``gear2``
+    closed in 3 nodes with a 5 s budget and 91 nodes with 3 s. The extent is now
+    counted in deterministic operations (:mod:`discopt._work_budget`): whichever
+    of the evaluation cap and the sub-NLP-solve cap is reached first ends the
+    search. The two are counted separately because they differ in cost by four
+    orders of magnitude and by a 27x-varying ratio, so no single currency prices
+    both (see the module docstring). ``deadline`` remains a *backstop* for the
+    caller's ``time_limit`` — it decides when to stop, never how much work to do.
+    Setting both budgets to 0 (``DISCOPT_ILS_EVAL_BUDGET=0
+    DISCOPT_ILS_SOLVE_BUDGET=0``) restores the legacy wall-clock gate on
+    ``time_budget``.
 
     Args:
         model: The optimization model.
@@ -685,8 +705,16 @@ def integer_local_search(
         max_restarts: Number of perturbation restarts.
         max_steps: Max descent steps per restart.
         pair_cap: Max integer count for which 2-opt is enabled.
-        time_budget: Wall-clock budget in seconds (the whole call returns early
-            once exceeded).
+        time_budget: Legacy wall-clock budget in seconds. Used **only** when both
+            deterministic budgets are disabled (set to 0).
+        eval_budget: Max constraint/objective evaluations for the whole call.
+            ``None`` resolves it from ``SolverTuning.ils_eval_budget``.
+        solve_budget: Max continuous-repair sub-NLP solves for the whole call.
+            ``None`` resolves it from ``SolverTuning.ils_solve_budget``.
+        deadline: Absolute ``time.perf_counter()`` timestamp of the caller's
+            overall solve deadline. A backstop only — it stops the search when
+            the user's ``time_limit`` is up, and never decides how much work a
+            within-limit search does.
         feas_tol: Constraint feasibility tolerance.
         seed: RNG seed for reproducible perturbations.
 
@@ -732,11 +760,36 @@ def integer_local_search(
     eff_restarts = min(max_restarts, max(3, 3 * n_int))
     eff_steps = min(max_steps, max(8, 4 * n_int))
 
+    # Deterministic extent gate (issue #912). ``budget`` counts the model-level
+    # operations this search issues; the caller's solve deadline rides along as
+    # a backstop so the heuristic still honours ``time_limit``. With
+    # both budgets 0 the old wall-clock extent gate is restored: an unlimited
+    # counter gated on ``time_budget`` exactly as before, with one deliberate
+    # difference — a caller-supplied solve deadline still applies (as the
+    # earlier of the two), so the escape hatch cannot overrun ``time_limit`` the
+    # way the pre-#912 path could. It is the *extent* gate that is restored, not
+    # the overrun.
+    if eval_budget is None or solve_budget is None:
+        from discopt import solver_tuning as _st
+
+        _tuning = _st.current()
+        if eval_budget is None:
+            eval_budget = _tuning.ils_eval_budget
+        if solve_budget is None:
+            solve_budget = _tuning.ils_solve_budget
+    if int(eval_budget) > 0 or int(solve_budget) > 0:
+        budget = WorkBudget(
+            {EVAL: int(eval_budget), NLP_SOLVE: int(solve_budget)}, deadline=deadline
+        )
+    else:
+        _wall = time.perf_counter() + max(0.0, time_budget)
+        budget = WorkBudget(None, deadline=_wall if deadline is None else min(_wall, deadline))
+
     def violation(x: np.ndarray) -> float:
+        budget.charge(EVAL)
         g = np.asarray(evaluator.evaluate_constraints(x))
         return float(np.sum(np.maximum(0.0, cl - g)) + np.sum(np.maximum(0.0, g - cu)))
 
-    deadline = time.perf_counter() + max(0.0, time_budget)
     has_continuous = bool(np.any(~int_mask))
 
     def _objective_improve(x_feas: np.ndarray, obj_feas: float) -> tuple[np.ndarray, float]:
@@ -765,11 +818,11 @@ def integer_local_search(
         _solve_cap = _ils_cap_mult * max(1, n_int) if _ils_cap_mult > 0 else None
         _solves_used = 0
         improved = True
-        while improved and time.perf_counter() < deadline:
+        while improved and not budget.exhausted():
             improved = False
             for j in int_idx:
                 for d in (-1.0, 1.0, -2.0, 2.0):
-                    if time.perf_counter() >= deadline:
+                    if budget.exhausted():
                         break
                     if _solve_cap is not None and _solves_used >= _solve_cap:
                         return best_x, best_obj
@@ -780,6 +833,7 @@ def integer_local_search(
                     xt[j] = nv
                     if has_continuous:
                         _solves_used += 1
+                        budget.charge(NLP_SOLVE)
                         cand = subnlp(
                             model,
                             xt,
@@ -794,6 +848,7 @@ def integer_local_search(
                     else:
                         if violation(xt) > feas_tol:
                             continue
+                        budget.charge(EVAL)
                         cx, cobj = xt, float(evaluator.evaluate_objective(xt))
                     if cobj < best_obj - 1e-9:
                         best_x, best_obj = cx.copy(), cobj
@@ -828,6 +883,7 @@ def integer_local_search(
         relax_opts = dict(nlp_options) if nlp_options else {}
         relax_opts.setdefault("print_level", 0)
         relax_opts.setdefault("max_iter", _HEURISTIC_NLP_MAX_ITER)
+        budget.charge(NLP_SOLVE)
         relax_res = backend(evaluator, mid, options=relax_opts)
         if relax_res is not None and relax_res.x is not None:
             seeds.append(_round_clip(np.asarray(relax_res.x)))
@@ -840,7 +896,7 @@ def integer_local_search(
     n_seeds = len(seeds)
 
     for restart in range(max(eff_restarts, n_seeds)):
-        if time.perf_counter() >= deadline:
+        if budget.exhausted():
             break
         # Try each seed clean first (descent alone often suffices), then spend
         # remaining restarts perturbing — from a feasible base once one is found,
@@ -868,7 +924,7 @@ def integer_local_search(
 
         cur = violation(xc)
         for _ in range(eff_steps):
-            if cur <= feas_tol or time.perf_counter() >= deadline:
+            if cur <= feas_tol or budget.exhausted():
                 break
             best_v = cur
             best_move: Optional[tuple[tuple[int, float], ...]] = None
@@ -884,7 +940,7 @@ def integer_local_search(
                     if v < best_v - 1e-9:
                         best_v, best_move = v, ((j, nv),)
             # 2-opt fallback only when 1-opt cannot improve (bilinear coupling).
-            if best_move is None and use_2opt and time.perf_counter() < deadline:
+            if best_move is None and use_2opt and not budget.exhausted():
                 for a in range(n_int):
                     ja = int_idx[a]
                     for b in range(a + 1, n_int):
@@ -913,6 +969,7 @@ def integer_local_search(
         # assignment and verify TRUE feasibility. subnlp only returns feasible,
         # integer-consistent points, so anything it gives back is a valid
         # incumbent candidate.
+        budget.charge(NLP_SOLVE)
         repaired = subnlp(
             model,
             xc,
@@ -933,6 +990,18 @@ def integer_local_search(
             # Once feasible, later perturbed restarts dive from this point's
             # neighbourhood (see the restart-base selection above) to improve it.
 
+    # Rule 6/#912: report what actually decided the extent of this search.
+    # ``stopped_on="deadline"`` means the machine's speed cut it short, so the
+    # incumbent it returns (and the tree below it) is NOT reproducible; the
+    # determinism panel reads this line.
+    logger.debug(
+        "integer_local_search: evals=%d solves=%d limits=%s stopped_on=%s seeds=%d",
+        budget.spent(EVAL),
+        budget.spent(NLP_SOLVE),
+        budget.limits,
+        budget.stopped_on,
+        n_seeds,
+    )
     return best
 
 

--- a/python/discopt/_jax/primal_heuristics.py
+++ b/python/discopt/_jax/primal_heuristics.py
@@ -321,7 +321,7 @@ def feasibility_pump(
                     v.ub = fixed.copy()
                 offset += sz
             try:
-                    nlp_result = backend(evaluator, x0, options=opts)
+                nlp_result = backend(evaluator, x0, options=opts)
             except BaseException as exc:
                 # Some NLP backends (pounce via PyO3) raise PanicException, which
                 # is not a subclass of Exception; treat any failure as this round

--- a/python/discopt/_work_budget.py
+++ b/python/discopt/_work_budget.py
@@ -86,6 +86,7 @@ EVAL = "eval"
 #: (1.9-104 ms measured).
 NLP_SOLVE = "nlp_solve"
 
+
 class WorkBudget:
     """A deterministic per-kind work counter, backstopped by a wall deadline.
 

--- a/python/discopt/_work_budget.py
+++ b/python/discopt/_work_budget.py
@@ -1,0 +1,165 @@
+"""Deterministic work budgets — the machine-speed-independent replacement for
+wall-clock "how much work" gates (issue #912).
+
+The problem
+-----------
+
+A wall clock answers two very different questions in this solver:
+
+1. *When do we stop?* — the user's ``time_limit``. Reading a clock for this is
+   correct by definition: the contract is "return within N seconds".
+2. *How much work do we do?* — e.g. "keep perturbing and re-descending until a
+   5-second heuristic budget expires". Reading a clock for **this** makes the
+   answer a function of machine speed: the same model with the same
+   ``time_limit`` explores a different tree on a faster box, under CPU
+   contention, or with a different JIT cache state.
+
+Issue #912 measured (2) end to end: ``gear2`` closes in 3 nodes when the root
+integer local search gets its full 5 s and in 91 nodes when it gets 3 s, and the
+default sits exactly on that cliff because the descent never converges. Every
+"node counts unchanged" verdict in this repo is only meaningful if the search is
+a pure function of its input, so a clock in role (2) is a correctness-of-process
+bug, not a performance detail.
+
+The fix
+-------
+
+Count *work*, not seconds. :class:`WorkBudget` counts model-level operations —
+constraint/objective evaluations and NLP solves — against a per-kind limit. A
+loop gated on ``budget.exhausted()`` performs the same operations on every
+machine, so the point it stops at is a function of the model alone.
+
+The clock does not disappear: a :class:`WorkBudget` may also carry the *solve*
+deadline (role 1), so a heuristic still cannot run past the user's
+``time_limit``. The difference is that the deadline is now a backstop that only
+fires when the user's own limit is about to be violated, rather than the primary
+gate. :attr:`WorkBudget.stopped_on` records which one fired, so a panel can
+assert that a run was decided by work and not by the clock — i.e. that the run
+it is about to compare is actually reproducible.
+
+Why per-kind counters and not one currency
+------------------------------------------
+
+The obvious design — convert everything to one "work unit" via a fixed cost
+ratio — was implemented first and **falsified on this corpus**. Measured over 9
+in-repo MINLPLib instances (``item912_work_unit_calibration.py``, 5 interleaved
+rounds each): one constraint evaluation costs 0.7-2.7 us, one continuous-repair
+sub-NLP solve 1.9-104 ms. The ratio has a geomean of 12 364 but a range of
+2 933-77 964 — a 27x spread — because the two operations are not two sizes of the
+same thing.
+
+With a single currency at the geomean, one budget cannot serve both regimes, and
+the failure was measured rather than predicted: at the converted-unit default
+``nvs09`` regressed from 5 nodes / `optimal` to 29 nodes / `feasible` because the
+shared budget ran out before its search was done, while the *same* number handed
+the more expensive-per-solve ``syn05hfsg`` three times its legacy wall time. The
+root cause is that a sub-NLP solve is not a fixed number of evaluations: its cost
+varies 5x across instances (13.3 to 136 solves/s measured) while a single
+currency assumes it constant. Two counters, each with its own limit, price each
+operation on its own terms. See
+``docs/dev/work-budget-calibration-2026-08-01.md``.
+
+Usage::
+
+    budget = WorkBudget({EVAL: 20_000, NLP_SOLVE: 128}, deadline=solve_deadline)
+    while not budget.exhausted():
+        budget.charge(EVAL)
+        ...
+    logger.debug("stopped on %s after %r", budget.stopped_on, budget.used)
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Mapping, Optional
+
+__all__ = [
+    "EVAL",
+    "NLP_SOLVE",
+    "WorkBudget",
+]
+
+#: One constraint-vector or objective evaluation (0.7-2.7 us measured).
+EVAL = "eval"
+
+#: One NLP solve — a continuous-repair sub-NLP or a backend local solve
+#: (1.9-104 ms measured).
+NLP_SOLVE = "nlp_solve"
+
+
+class WorkBudget:
+    """A deterministic per-kind work counter, backstopped by a wall deadline.
+
+    Args:
+        limits: Mapping of work kind to the number of operations of that kind
+            this budget allows. A kind absent from the mapping, or mapped to a
+            non-positive value, is unlimited — but still counted, so an
+            instrumented run can report what an unbounded loop actually did.
+            ``None`` means every kind is unlimited.
+        deadline: Optional absolute ``time.perf_counter()`` timestamp. This is
+            the *user's* limit (role 1 above), not a work gate: it is checked in
+            :meth:`exhausted` so a heuristic cannot overrun ``time_limit``, and
+            when it is what stopped the loop :attr:`stopped_on` says so.
+    """
+
+    __slots__ = ("limits", "deadline", "used", "_stopped_on")
+
+    def __init__(
+        self,
+        limits: Optional[Mapping[str, int]] = None,
+        *,
+        deadline: Optional[float] = None,
+    ):
+        self.limits: dict[str, int] = {
+            k: int(v) for k, v in (limits or {}).items() if v is not None and int(v) > 0
+        }
+        self.deadline: Optional[float] = deadline
+        self.used: dict[str, int] = {}
+        self._stopped_on: Optional[str] = None
+
+    def charge(self, kind: str, count: int = 1) -> None:
+        """Record ``count`` operations of ``kind`` as spent."""
+        self.used[kind] = self.used.get(kind, 0) + int(count)
+
+    def exhausted(self) -> bool:
+        """True once any counter has reached its limit, or the deadline passed.
+
+        Work is checked before the clock on purpose: when both would fire, the
+        deterministic reason is the one worth reporting.
+        """
+        for kind, limit in self.limits.items():
+            if self.used.get(kind, 0) >= limit:
+                if self._stopped_on is None:
+                    self._stopped_on = f"work:{kind}"
+                return True
+        if self.deadline is not None and time.perf_counter() >= self.deadline:
+            if self._stopped_on is None:
+                self._stopped_on = "deadline"
+            return True
+        return False
+
+    def spent(self, kind: str) -> int:
+        """Operations of ``kind`` charged so far."""
+        return self.used.get(kind, 0)
+
+    @property
+    def stopped_on(self) -> Optional[str]:
+        """``"work:<kind>"``, ``"deadline"``, or ``None`` if :meth:`exhausted`
+        never returned True.
+
+        A search that reports a ``work:`` reason (or ``None``) is reproducible
+        with respect to this gate; one that reports ``"deadline"`` was cut by the
+        machine's speed, and the result it returns is not a function of the model
+        alone.
+        """
+        return self._stopped_on
+
+    @property
+    def deterministic(self) -> bool:
+        """True iff nothing about this budget's outcome depended on the clock."""
+        return self._stopped_on != "deadline"
+
+    def __repr__(self) -> str:  # pragma: no cover - debugging aid
+        return (
+            f"WorkBudget(limits={self.limits}, used={self.used}, stopped_on={self._stopped_on!r})"
+        )

--- a/python/discopt/_work_budget.py
+++ b/python/discopt/_work_budget.py
@@ -86,7 +86,6 @@ EVAL = "eval"
 #: (1.9-104 ms measured).
 NLP_SOLVE = "nlp_solve"
 
-
 class WorkBudget:
     """A deterministic per-kind work counter, backstopped by a wall deadline.
 
@@ -141,6 +140,17 @@ class WorkBudget:
     def spent(self, kind: str) -> int:
         """Operations of ``kind`` charged so far."""
         return self.used.get(kind, 0)
+
+    def remaining(self, kind: str) -> Optional[int]:
+        """Operations of ``kind`` still affordable, or ``None`` when unlimited.
+
+        This is the deterministic replacement for "how much time do I have
+        left?", which callers used to answer by subtracting two clock reads and
+        dividing by a *measured* mean cost — making the decision they based on it
+        (e.g. local branching's enumeration radius) a function of machine speed.
+        """
+        limit = self.limits.get(kind)
+        return None if limit is None else max(0, limit - self.used.get(kind, 0))
 
     @property
     def stopped_on(self) -> Optional[str]:

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -10349,7 +10349,13 @@ def solve_model(
                             result_sols[best_root_idx],
                             backend=_resolve_heuristic_backend(nlp_solver),
                             evaluator=evaluator,
+                            # #912: the extent is a deterministic work budget
+                            # (resolved from SolverTuning.ils_work_budget), not a
+                            # wall clock. ``time_budget`` is only consulted on the
+                            # ``DISCOPT_ILS_WORK_BUDGET=0`` legacy path; the solve
+                            # deadline rides along purely as a time_limit backstop.
                             time_budget=min(5.0, 0.15 * max(1.0, time_limit)),
+                            deadline=_deadline,
                         )
                         if ils is not None:
                             _x_ils, _obj_ils = ils

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -4995,7 +4995,6 @@ def solve_model(
     # preprocessing, and ``_remaining_budget()`` lets each preprocessing phase
     # clamp its own internal budget to the time actually left.
     _solve_t0 = time.perf_counter()
-
     def _remaining_budget() -> float:
         return max(0.0, float(time_limit) - (time.perf_counter() - _solve_t0))
 
@@ -10732,7 +10731,12 @@ def solve_model(
                         backend=_subnlp_backend_fn,
                         nlp_options=subnlp_options,
                         evaluator=evaluator,
+                        # #912: the cell enumeration is bounded by a deterministic
+                        # sub-NLP count; ``time_budget`` is only read on the
+                        # legacy (``ils_solve_budget=0``) path, and the solve
+                        # deadline is the time_limit backstop.
                         time_budget=_box_budget,
+                        deadline=_deadline,
                     )
                 except Exception as _e:
                     logger.debug("integer_box_search raised: %s", _e)

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -4995,6 +4995,7 @@ def solve_model(
     # preprocessing, and ``_remaining_budget()`` lets each preprocessing phase
     # clamp its own internal budget to the time actually left.
     _solve_t0 = time.perf_counter()
+
     def _remaining_budget() -> float:
         return max(0.0, float(time_limit) - (time.perf_counter() - _solve_t0))
 

--- a/python/discopt/solver_tuning.py
+++ b/python/discopt/solver_tuning.py
@@ -72,6 +72,34 @@ def _env_float(name: str, default: float) -> float:
     return default if raw is None else float(raw)
 
 
+#: Default deterministic operation caps for the root integer local search
+#: (#912). Both are sized from the measured per-operation costs and the measured
+#: consumption of the legacy wall-clock gate over the in-repo MINLPLib corpus;
+#: see ``docs/dev/work-budget-calibration-2026-08-01.md`` for the tables.
+#:
+#: Measured over the 22 ILS-firing in-repo instances, legacy arm at
+#: ``time_limit=60`` (so the full 5 s legacy budget): a search that converged on
+#: its own used at most **796 evaluations and 217 sub-NLP solves**, while the
+#: slowest instance the clock actually cut managed only **13.3 solves/s**
+#: (syn05hfsg).
+#:
+#: Those two facts do not both fit. "Never cut a search the clock let finish"
+#: wants ≥ 217 solves; "never exceed the legacy 5 s envelope" wants ≤ 67 on the
+#: slowest instance. The gap is not a modelling failure — it *is* the bug: the
+#: old gate handed ex1224 217 solves and syn05hfsg 67 in the same five seconds,
+#: purely because their sub-NLPs differ 5x in cost. Any deterministic budget
+#: must land somewhere between, and this one lands in the middle: 128 solves is
+#: ~59 % of the largest natural extent and ~2x the slowest instance's legacy
+#: allowance (≈9.6 s there, against a 5 s legacy ceiling).
+#:
+#: The evaluation cap is not contested — 20 000 is 25x the largest natural
+#: consumption, so it only ever stops a genuinely runaway descent.
+#: ``docs/dev/work-budget-calibration-2026-08-01.md`` records the A/B that
+#: validated the choice.
+_ILS_EVAL_BUDGET_DEFAULT = 20_000
+_ILS_SOLVE_BUDGET_DEFAULT = 128
+
+
 @dataclass(frozen=True)
 class SolverTuning:
     """Advanced relaxation / branch-and-bound tuning for :meth:`Model.solve`.
@@ -746,6 +774,55 @@ class SolverTuning:
     this descent only ever *weakens* the incumbent it might find (every point is
     sub-NLP-verified and re-verified by ``inject_incumbent``); it never touches the
     dual bound or the certificate (heuristic-policy regime, CLAUDE.md §5)."""
+
+    ils_eval_budget: int = field(
+        default_factory=lambda: _env_int("DISCOPT_ILS_EVAL_BUDGET", _ILS_EVAL_BUDGET_DEFAULT)
+    )
+    """Evaluation cap for the root ``integer_local_search``
+    (``DISCOPT_ILS_EVAL_BUDGET``, **default ON**; issue #912).
+
+    The root integer local search used to bound its own extent with a wall clock
+    (``time_budget=min(5.0, 0.15 * time_limit)``). Its descent routinely never
+    converges, so *how far it gets* — and therefore the incumbent it hands the
+    tree — was a function of machine speed: #912 measured ``gear2`` closing in 3
+    nodes at a 5 s budget and 91 nodes at 3 s, with the default sitting exactly
+    on that cliff, and reproduced the flip by scaling the process clock. A
+    search whose result depends on how fast the box is cannot sit on the
+    certificate path, and it silently invalidates every "node counts unchanged"
+    verdict this repo relies on (CLAUDE.md §5, bound-neutral regime).
+
+    The search now counts *operations* instead (:mod:`discopt._work_budget`) and
+    stops at the same point on every machine. This field caps the cheap kind:
+    constraint/objective evaluations, 0.7-2.7 us each as measured. The solve
+    deadline is still passed down as a backstop so ``time_limit`` is honoured;
+    it decides *when to stop*, never *how much work to do*.
+
+    Set this **and** ``ils_solve_budget`` to 0 to restore the legacy wall-clock
+    gate — the debugging escape hatch, not a dead flag. Sound either way: ILS is
+    a pure incumbent finder (every point is sub-NLP-verified and re-verified by
+    ``inject_incumbent``), so changing its extent can only change *which*
+    feasible point it finds, never the dual bound or the certificate."""
+
+    ils_solve_budget: int = field(
+        default_factory=lambda: _env_int("DISCOPT_ILS_SOLVE_BUDGET", _ILS_SOLVE_BUDGET_DEFAULT)
+    )
+    """Sub-NLP-solve cap for the root ``integer_local_search``
+    (``DISCOPT_ILS_SOLVE_BUDGET``, **default ON**; issue #912).
+
+    The companion to :attr:`ils_eval_budget`, capping the expensive kind:
+    continuous-repair NLP solves, 1.9-104 ms each as measured. Whichever cap is
+    reached first ends the search.
+
+    They are separate on purpose, and the separation is a measurement, not a
+    preference. Converting both to one currency at their geomean cost ratio
+    (12 364) was tried first and produced a real regression: ``nvs09``'s
+    evaluation-dominated search was starved (5 -> 29 nodes) at a budget that
+    already gave the solve-dominated ``syn05hfsg`` three times its legacy wall
+    time. The ratio varies 27x across the corpus, so one number cannot price
+    both. Full data in ``docs/dev/work-budget-calibration-2026-08-01.md``.
+
+    Distinct from :attr:`ils_solve_cap`, which limits sub-NLPs *per objective
+    descent* keyed on the integer dimension; this one bounds the whole call."""
 
     disjunctive_config_bound: bool = field(
         default_factory=lambda: _env_flag("DISCOPT_DISJUNCTIVE_CONFIG_BOUND", default=False)

--- a/python/tests/test_912_wall_budget_inventory.py
+++ b/python/tests/test_912_wall_budget_inventory.py
@@ -1,0 +1,358 @@
+"""#912: the enforced inventory of wall-clock work gates.
+
+#912's finding is that the solver reads a clock to decide *how much work to do*,
+not merely *when to stop*, at scores of sites — and that this makes the search
+tree a function of machine speed. The root integer local search (the mechanism
+the issue names as decisive) and its three siblings in the primal-heuristic
+layer are converted to deterministic operation counts; see
+``test_912_work_budget.py`` and ``docs/dev/work-budget-calibration-2026-08-01.md``.
+
+The rest of the inventory is still wall-clock, and this test is what stops that
+fact from quietly drifting. It scans for the two constructions that create a
+component-local wall budget —
+
+    <clock>() + <budget>              (a locally invented deadline)
+    <clock>() - <origin> > <budget>   (elapsed against a budget)
+
+— and asserts the set is exactly the recorded one below. A new one fails the
+test, and the author must either convert it to a deterministic budget or record
+it here with a category. Without this, "the class is fixed" would mean "the
+sites that existed on 2026-08-01 were fixed".
+
+Categories:
+
+``contract``
+    The value being spent is the caller's own ``time_limit`` (or a sub-solver's
+    slice of it), i.e. the clock is answering "when do we stop?". Correct by
+    definition — the role #912 explicitly leaves alone.
+``legacy``
+    The escape-hatch arm of an already-converted gate, reachable only with the
+    deterministic budget disabled.
+``residual``
+    A genuine component-local budget that still decides *how much* work runs and
+    is **not** yet converted. Each is a known #912 residual: converting it needs
+    a deterministic work metric appropriate to that layer and, for the
+    bound-changing ones (OBBT, NBT, root cuts, PSD separation, convexity
+    classification), its own differential-bound panel.
+
+Why the residuals were not simply switched to one global deterministic clock:
+that design was built and **falsified** — see the calibration doc §9. A work
+clock instrumented over the Python-side primitives (evaluations, NLP solves, LP
+relaxation solves, DAG visits) advances at 0.01-0.65x wall across the corpus
+(fac2: 0.09 deterministic seconds against 15 s of real work), because the
+dominant cost — Rust B&B nodes, presolve, JIT compilation — is invisible to it.
+Re-denominating these budgets in that clock would have silently stopped them
+firing, turning a #875-style 27 s root pass back on while reporting success.
+That is a worse failure than the nondeterminism it would have fixed, so the
+residuals stay wall-clock and stay listed here.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from pathlib import Path
+
+import pytest
+
+_PKG = Path(__file__).resolve().parents[1] / "discopt"
+
+_MAKE = re.compile(r"(time|_time)\.(perf_counter|monotonic)\(\)\s*\+")
+_ELAPSED = re.compile(r"(time|_time)\.(perf_counter|monotonic)\(\)\s*-\s*\w+[^<>]*[<>]=?")
+
+# (module-relative path, source line, category). See the module docstring.
+KNOWN: tuple[tuple[str, str, str], ...] = (
+    (
+        "_daemon_core.py",
+        "if self.max_lifetime > 0 and time.monotonic() - started >= self.max_lifetime:",
+        "contract",
+    ),
+    (
+        "_daemon_core.py",
+        "deadline = time.monotonic() + 1.0",
+        "contract",
+    ),
+    (
+        "_daemon_core.py",
+        "deadline = time.monotonic() + wait",
+        "contract",
+    ),
+    (
+        "solver.py",
+        "deadline = time.perf_counter() + float(_NATIVE_SEED_HEURISTIC_S)",
+        "residual",
+    ),
+    (
+        "solver.py",
+        "if time.perf_counter() - t_start > time_limit:",
+        "contract",
+    ),
+    (
+        "solver.py",
+        "deadline = (time.perf_counter() + budget) if budget else None",
+        "residual",
+    ),
+    (
+        "solver.py",
+        "return bool(have) and (time.perf_counter() - _fb_t0) >= max(0.0, float(time_limit))",
+        "residual",
+    ),
+    (
+        "solver.py",
+        "deadline=time.perf_counter() + _per_budget_s,",
+        "residual",
+    ),
+    (
+        "solver.py",
+        "deadline=time.perf_counter() + _dcb_budget,",
+        "residual",
+    ),
+    (
+        "solver.py",
+        "model, deadline=time.perf_counter() + _nbt_budget_s",
+        "residual",
+    ),
+    (
+        "solver.py",
+        "deadline=time.perf_counter() + _obbt_budget,",
+        "residual",
+    ),
+    (
+        "solver.py",
+        "time.perf_counter() + max(2.0, min(15.0, 0.2 * float(time_limit))),",
+        "residual",
+    ),
+    (
+        "solver.py",
+        "deadline=time.perf_counter() + 5.0,",
+        "residual",
+    ),
+    (
+        "solver.py",
+        "deadline=time.perf_counter() + _rf_budget,",
+        "residual",
+    ),
+    (
+        "solver.py",
+        "if not _root_incumbent and (time.perf_counter() - t_start) < time_limit:",
+        "contract",
+    ),
+    (
+        "solver.py",
+        "if time.perf_counter() - t_start >= time_limit:",
+        "contract",
+    ),
+    (
+        "solver.py",
+        "deadline=time.perf_counter() + budget,",
+        "residual",
+    ),
+    (
+        "decomposition/lagrangian/node_bounder.py",
+        "if time.perf_counter() - t0 > time_budget:",
+        "residual",
+    ),
+    (
+        "solvers/_root_cuts.py",
+        "if _time.perf_counter() - t0 > time_budget_s:",
+        "residual",
+    ),
+    (
+        "solvers/amp.py",
+        "local_deadline = time.perf_counter() + time_limit if time_limit is not None else None",
+        "contract",
+    ),
+    (
+        "solvers/amp.py",
+        "deadline = time.perf_counter() + total_time_limit",
+        "contract",
+    ),
+    (
+        "solvers/amp.py",
+        "deadline = time.perf_counter() + total_budget",
+        "residual",
+    ),
+    (
+        "solvers/amp.py",
+        "deadline=time.perf_counter() + remaining,",
+        "contract",
+    ),
+    (
+        "solvers/amp.py",
+        "model, flat_lb, flat_ub, deadline=time.perf_counter() + _nbt_budget_s",
+        "residual",
+    ),
+    (
+        "solvers/milp_simplex.py",
+        "_deadline = None if time_limit is None else time.perf_counter() + max(0.0, time_limit)",
+        "contract",
+    ),
+    (
+        "solvers/mip_nlp_rootsearch.py",
+        "deadline = None if time_limit is None else time.perf_counter() + "
+        "max(0.0, float(time_limit))",
+        "contract",
+    ),
+    (
+        "solvers/oa.py",
+        "if time.perf_counter() - t_start >= time_limit:",
+        "contract",
+    ),
+    (
+        "solvers/oa.py",
+        "return (time.perf_counter() - t_start) >= float(time_limit)",
+        "contract",
+    ),
+    (
+        "_jax/deadline.py",
+        "_deadline_monotonic = time.monotonic() + max(0.0, float(seconds_from_now))",
+        "contract",
+    ),
+    (
+        "_jax/lp_spatial_bb.py",
+        "deadline=time.perf_counter() + _obbt_budget,",
+        "residual",
+    ),
+    (
+        "_jax/lp_spatial_bb.py",
+        "if (time.perf_counter() - t0) >= time_limit:",
+        "contract",
+    ),
+    (
+        "_jax/lp_spatial_bb.py",
+        "if (time.perf_counter() - t0) >= time_limit or nodes >= max_nodes:",
+        "contract",
+    ),
+    (
+        "_jax/mccormick_lp.py",
+        "deadline = time.perf_counter() + _INTEGER_RATIO_DIVE_BUDGET_S",
+        "residual",
+    ),
+    (
+        "_jax/mccormick_lp.py",
+        "_deadline = None if time_limit is None else time.perf_counter() + time_limit",
+        "contract",
+    ),
+    (
+        "_jax/mccormick_lp.py",
+        "and (time.perf_counter() - _psd_t0) > _gate_budget * _base_solve_wall",
+        "residual",
+    ),
+    (
+        "_jax/obbt.py",
+        "deadline = time.perf_counter() + total_time_limit "
+        "if total_time_limit is not None else None",
+        "contract",
+    ),
+    (
+        "_jax/primal_heuristics.py",
+        "_wall = time.perf_counter() + max(0.0, time_budget)",
+        "legacy",
+    ),
+    (
+        "_jax/primal_heuristics.py",
+        "slice_deadline = time.perf_counter() + max(0.0, float(submip_time_limit))",
+        "contract",
+    ),
+    (
+        "_jax/primal_heuristics.py",
+        "t_end = time.perf_counter() + max(0.0, float(time_budget))",
+        "legacy",
+    ),
+    (
+        "_jax/root_reduce.py",
+        "obbt_deadline = None if obbt_budget is None else time.perf_counter() + obbt_budget",
+        "residual",
+    ),
+    (
+        "_jax/presolve/orchestrator.py",
+        "if time_limit_ms > 0 and (time.monotonic() - started) * 1000.0 >= time_limit_ms:",
+        "contract",
+    ),
+    (
+        "_jax/convexity/signomial_global.py",
+        "if time_limit is not None and (time.perf_counter() - t0) > time_limit:",
+        "contract",
+    ),
+    (
+        "mo/scalarization.py",
+        "if time.perf_counter() - self._t0 >= self.total:",
+        "residual",
+    ),
+)
+
+_KNOWN_KEYS = {(p, s) for p, s, _ in KNOWN}
+_CATEGORY = {(p, s): c for p, s, c in KNOWN}
+
+
+def _scan() -> set[tuple[str, str]]:
+    found: set[tuple[str, str]] = set()
+    for root, dirs, files in os.walk(_PKG):
+        dirs[:] = [d for d in dirs if d != "__pycache__"]
+        for f in sorted(files):
+            if not f.endswith(".py"):
+                continue
+            path = Path(root) / f
+            rel = str(path.relative_to(_PKG))
+            for line in path.read_text().splitlines():
+                s = line.strip()
+                if s.startswith("#"):
+                    continue
+                if _MAKE.search(s) or _ELAPSED.search(s):
+                    found.add((rel, s))
+    return found
+
+
+@pytest.mark.unit
+def test_no_unrecorded_wall_clock_work_gate():
+    """A new component-local wall budget must be converted or justified."""
+    found = _scan()
+    assert found, "the scanner matched nothing — it has stopped working (rule 6)"
+    new = sorted(found - _KNOWN_KEYS)
+    assert not new, (
+        "unrecorded wall-clock work gate(s) — #912.\n"
+        "A clock may decide WHEN TO STOP (the caller's time_limit); it must not\n"
+        "decide HOW MUCH WORK to do, or the search tree becomes a function of\n"
+        "machine speed. Either bound this loop with a deterministic operation\n"
+        "count (see discopt._work_budget.WorkBudget and integer_local_search),\n"
+        "or add it to KNOWN in this file with a category.\n\n"
+        + "\n".join(f"  {p}: {s}" for p, s in new)
+    )
+
+
+@pytest.mark.unit
+def test_recorded_gates_still_exist():
+    """The ratchet must not rot: an entry whose line is gone is stale bookkeeping
+    that hides the fact the inventory is no longer an inventory."""
+    stale = sorted(_KNOWN_KEYS - _scan())
+    assert not stale, "KNOWN lists gate(s) that no longer exist — remove them:\n" + "\n".join(
+        f"  {p}: {s}" for p, s in stale
+    )
+
+
+@pytest.mark.unit
+def test_the_converted_layer_stays_converted():
+    """The primal-heuristic extent gates #912 converted must stay converted: the
+    only wall budgets left in that module are the documented legacy arms and the
+    caller's own slice."""
+    offenders = sorted(
+        (p, s)
+        for (p, s), c in _CATEGORY.items()
+        if p == "_jax/primal_heuristics.py" and c == "residual"
+    )
+    assert not offenders, (
+        "a converted primal heuristic grew a component-local wall budget again:\n"
+        + "\n".join(f"  {p}: {s}" for p, s in offenders)
+    )
+
+
+@pytest.mark.unit
+def test_residual_count_is_visible():
+    """Publish the residual count so shrinking it is a visible, reviewable act
+    rather than a silent one."""
+    residual = sorted(k for k, c in _CATEGORY.items() if c == "residual")
+    assert len(residual) == 20, (
+        f"the #912 residual inventory changed ({len(residual)} entries, expected 20). "
+        "If you converted one, drop it from KNOWN and lower this number; if you added "
+        "one, convert it instead.\n" + "\n".join(f"  {p}: {s}" for p, s in residual)
+    )

--- a/python/tests/test_912_wall_budget_inventory.py
+++ b/python/tests/test_912_wall_budget_inventory.py
@@ -30,10 +30,31 @@ Categories:
     deterministic budget disabled.
 ``residual``
     A genuine component-local budget that still decides *how much* work runs and
-    is **not** yet converted. Each is a known #912 residual: converting it needs
-    a deterministic work metric appropriate to that layer and, for the
-    bound-changing ones (OBBT, NBT, root cuts, PSD separation, convexity
-    classification), its own differential-bound panel.
+    is **not** converted. This is a **decision, not a backlog** — #912 was closed
+    as not-planned for these, on the evidence below. Converting one needs a
+    deterministic work metric natural to that layer, re-tuned against measured
+    consumption, plus (for the bound-changing ones — OBBT, NBT, root cuts, PSD
+    separation, convexity classification) its own differential-bound panel.
+
+Why the residuals were left, and when to revisit
+------------------------------------------------
+
+Two measurements decided it. First, after the primal-heuristic layer was
+converted the corpus-wide clock-scale panel returned **18 in-scope comparisons,
+0 mismatches** at 1x vs 2x, and across the whole investigation *every* extent
+gate ever observed cutting a search short was the root ILS. No residual gate was
+ever caught moving a tree. Second, the cheap way to convert them all at once
+does not exist (§9 of the calibration doc): per-operation cost varies 55x across
+instances, so a seconds-valued budget cannot be re-denominated in deterministic
+units without being re-tuned, one gate at a time.
+
+The honest limit on that first measurement: these budgets bind mainly on *large*
+models, and the in-repo corpus is 66 small ones. A `watercontamination0202`-scale
+instance is where a root pass actually reaches a 30 s budget. So "no residual
+gate was seen moving a tree" is bounded by corpus coverage, not proven in
+general — **that is the trigger to revisit**. If a large-instance panel ever
+shows one of these gates moving a tree while the solve is comfortably inside its
+`time_limit`, convert that gate and lower the count below.
 
 Why the residuals were not simply switched to one global deterministic clock:
 that design was built and **falsified** — see the calibration doc §9. A work
@@ -354,5 +375,7 @@ def test_residual_count_is_visible():
     assert len(residual) == 20, (
         f"the #912 residual inventory changed ({len(residual)} entries, expected 20). "
         "If you converted one, drop it from KNOWN and lower this number; if you added "
-        "one, convert it instead.\n" + "\n".join(f"  {p}: {s}" for p, s in residual)
+        "one, convert it instead. This count is a deliberate resting point, not a "
+        "backlog — see the module docstring for the evidence and the condition that "
+        "would justify shrinking it.\n" + "\n".join(f"  {p}: {s}" for p, s in residual)
     )

--- a/python/tests/test_912_work_budget.py
+++ b/python/tests/test_912_work_budget.py
@@ -1,0 +1,273 @@
+"""#912: the deterministic work budget that replaces wall-clock "how much work" gates.
+
+Issue #912 measured that the search tree is a function of machine speed: the
+root ``integer_local_search`` bounded its own extent with a wall clock, its
+descent routinely never converges, and so a faster (or less loaded) machine
+explores a different tree from the same model and the same ``time_limit``. That
+breaks the repo's bound-neutral verification regime at the root: "node_count
+exactly unchanged" is only a meaningful assertion about a *function*.
+
+These tests pin the two halves of the fix:
+
+* :class:`~discopt._work_budget.WorkBudget` semantics — per-kind counting, the
+  work gate, the wall-clock *backstop*, and the ``stopped_on`` attribution that
+  lets a panel tell a reproducible run from one the clock cut short;
+* ``integer_local_search`` under a **scaled clock**. Scaling
+  ``time.perf_counter`` by ``alpha`` is exactly a machine ``alpha`` times
+  slower. With the work budget on, the search must return the identical point
+  after the identical amount of work at every alpha. With it off (both budgets
+  0, the legacy escape hatch) the same scaling must be able to cut the search
+  short — that arm is what proves the test can actually bite.
+"""
+
+from __future__ import annotations
+
+import os
+
+os.environ.setdefault("JAX_PLATFORMS", "cpu")
+os.environ.setdefault("JAX_ENABLE_X64", "1")
+
+import time  # noqa: E402
+from pathlib import Path  # noqa: E402
+
+import numpy as np  # noqa: E402
+import pytest  # noqa: E402
+from discopt._work_budget import EVAL, NLP_SOLVE, WorkBudget  # noqa: E402
+
+_NL_DIR = Path(__file__).parent / "data" / "minlplib_nl"
+
+
+# --------------------------------------------------------------------------
+# WorkBudget semantics
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_work_gate_is_independent_of_the_clock():
+    b = WorkBudget({EVAL: 10})
+    n = 0
+    while not b.exhausted():
+        b.charge(EVAL)
+        n += 1
+    assert n == 10
+    assert b.spent(EVAL) == 10
+    assert b.stopped_on == "work:eval"
+    assert b.deterministic
+
+
+@pytest.mark.unit
+def test_each_kind_has_its_own_limit():
+    """The whole point of per-kind counters: a cheap-operation budget must not be
+    consumed by expensive operations or vice versa."""
+    b = WorkBudget({EVAL: 1_000, NLP_SOLVE: 2})
+    for _ in range(999):
+        b.charge(EVAL)
+    assert not b.exhausted()
+    b.charge(NLP_SOLVE)
+    assert not b.exhausted()
+    b.charge(NLP_SOLVE)
+    assert b.exhausted()
+    assert b.stopped_on == "work:nlp_solve"
+    assert b.spent(EVAL) == 999
+
+
+@pytest.mark.unit
+def test_unlimited_budget_still_counts():
+    """The legacy path passes no limits — it must remain measurable, or the
+    calibration that sized the defaults could not have been made."""
+    b = WorkBudget(None)
+    for _ in range(5):
+        b.charge(NLP_SOLVE)
+    assert b.spent(NLP_SOLVE) == 5
+    assert not b.exhausted()
+    assert b.stopped_on is None
+
+
+@pytest.mark.unit
+def test_nonpositive_limit_means_unlimited():
+    for limit in (0, -1):
+        b = WorkBudget({EVAL: limit})
+        b.charge(EVAL, 10**9)
+        assert not b.exhausted(), limit
+
+
+@pytest.mark.unit
+def test_deadline_is_a_backstop_not_a_work_gate():
+    """A deadline that has already passed stops the loop (the user's
+    ``time_limit`` is honoured) and is attributed as such."""
+    b = WorkBudget({EVAL: 10**9}, deadline=time.perf_counter() - 1.0)
+    assert b.exhausted()
+    assert b.stopped_on == "deadline"
+    assert not b.deterministic
+
+
+@pytest.mark.unit
+def test_work_limit_wins_the_attribution_when_both_fire():
+    b = WorkBudget({EVAL: 1}, deadline=time.perf_counter() - 1.0)
+    b.charge(EVAL)
+    assert b.exhausted()
+    assert b.stopped_on == "work:eval"
+
+
+@pytest.mark.unit
+def test_stopped_on_is_latched_at_the_first_stop():
+    b = WorkBudget({EVAL: 1})
+    b.charge(EVAL)
+    assert b.exhausted() and b.stopped_on == "work:eval"
+    b.deadline = time.perf_counter() - 1.0
+    assert b.exhausted() and b.stopped_on == "work:eval"
+
+
+@pytest.mark.unit
+def test_unknown_kind_is_counted_but_never_gates():
+    b = WorkBudget({EVAL: 5})
+    b.charge("lp_iteration", 10**6)
+    assert not b.exhausted()
+    assert b.spent("lp_iteration") == 10**6
+
+
+# --------------------------------------------------------------------------
+# integer_local_search under a scaled clock
+# --------------------------------------------------------------------------
+
+
+class _ScaledClock:
+    """Run the process clock ``alpha`` times faster — i.e. pretend the machine is
+    ``alpha`` times slower. Patches the ``time`` module the heuristics read."""
+
+    def __init__(self, alpha: float):
+        self.alpha = alpha
+
+    def __enter__(self):
+        self._orig = time.perf_counter
+        t0 = self._orig()
+        alpha = self.alpha
+        orig = self._orig
+        time.perf_counter = lambda: t0 + alpha * (orig() - t0)
+        return self
+
+    def __exit__(self, *exc):
+        time.perf_counter = self._orig
+        return False
+
+
+def _ils_instance(name="nvs21"):
+    """A real corpus instance with integers, a nonlinear body and a continuous
+    block — i.e. one where ILS does sub-NLP repairs rather than no-opping."""
+    from discopt.modeling.core import from_nl
+
+    path = _NL_DIR / f"{name}.nl"
+    if not path.exists():  # pragma: no cover - corpus is vendored
+        pytest.skip(f"{path} missing")
+    return from_nl(str(path))
+
+
+def _run_ils(model, *, eval_budget, solve_budget, alpha, time_budget=5.0, deadline=None):
+    """Run ILS from the box midpoint under an ``alpha``-scaled clock, returning
+    the result and the budget object that gated it."""
+    from discopt._jax import primal_heuristics as ph
+    from discopt._jax.nlp_evaluator import cached_evaluator
+
+    ev = cached_evaluator(model)
+    lb, ub = ph._get_variable_bounds(model)
+    x0 = np.clip(0.5 * (np.clip(lb, -1e3, 1e3) + np.clip(ub, -1e3, 1e3)), lb, ub)
+
+    seen: list[WorkBudget] = []
+    orig_init = WorkBudget.__init__
+
+    def _init(self, limits=None, **kw):
+        orig_init(self, limits, **kw)
+        seen.append(self)
+
+    WorkBudget.__init__ = _init  # type: ignore[method-assign]
+    try:
+        with _ScaledClock(alpha):
+            out = ph.integer_local_search(
+                model,
+                x0,
+                evaluator=ev,
+                eval_budget=eval_budget,
+                solve_budget=solve_budget,
+                time_budget=time_budget,
+                deadline=deadline,
+            )
+    finally:
+        WorkBudget.__init__ = orig_init  # type: ignore[method-assign]
+    assert seen, "integer_local_search did not create a work budget"
+    return out, seen[0]
+
+
+@pytest.mark.slow
+def test_ils_is_invariant_to_machine_speed_with_a_work_budget():
+    """The regression this issue exists for: same model, same budget, clock
+    scaled 1x / 4x / 16x — identical work, identical point.
+
+    The budget is deliberately set *below* what an unbounded run consumes, so the
+    gate genuinely fires; with the pre-#912 wall gate that is exactly the regime
+    where the returned incumbent moved with machine speed.
+    """
+    model = _ils_instance()
+    ref_out, ref = _run_ils(model, eval_budget=2_000, solve_budget=8, alpha=1.0)
+    assert ref.stopped_on is not None and ref.stopped_on.startswith("work:"), (
+        "the budget must be the binding gate for this test to mean anything; "
+        f"got stopped_on={ref.stopped_on!r} after {ref.used!r}"
+    )
+    comparisons = 0
+    for alpha in (4.0, 16.0):
+        out, budget = _run_ils(model, eval_budget=2_000, solve_budget=8, alpha=alpha)
+        comparisons += 1
+        assert budget.used == ref.used, alpha
+        assert budget.stopped_on == ref.stopped_on, alpha
+        assert (out is None) == (ref_out is None), alpha
+        if out is not None:
+            np.testing.assert_allclose(out[0], ref_out[0], rtol=0, atol=0)
+            assert out[1] == ref_out[1], alpha
+    assert comparisons == 2  # rule 6: the probe must prove it compared something
+
+
+@pytest.mark.slow
+def test_legacy_wall_gate_is_the_mechanism_the_fix_removes():
+    """Fails-before evidence, kept executable: with both budgets disabled the
+    extent is decided by the clock, so a scaled (slower) machine stops the search
+    earlier — the property #912 measured on gear2."""
+    model = _ils_instance()
+    _, fast = _run_ils(model, eval_budget=0, solve_budget=0, alpha=1.0, time_budget=0.35)
+    _, slow = _run_ils(model, eval_budget=0, solve_budget=0, alpha=50.0, time_budget=0.35)
+    assert not fast.limits and not slow.limits, "legacy arm must be unlimited"
+    assert slow.stopped_on == "deadline", (
+        "the legacy arm is supposed to be cut by the clock; "
+        f"got {slow.stopped_on!r} after {slow.used!r}"
+    )
+    assert sum(slow.used.values()) < sum(fast.used.values()), (
+        "a 50x-slower machine must do strictly less work under the legacy wall "
+        f"gate (that is the bug): fast={fast.used!r} slow={slow.used!r}"
+    )
+
+
+@pytest.mark.slow
+def test_solve_deadline_still_stops_a_work_budgeted_search():
+    """The clock does not disappear: it remains the backstop that honours the
+    caller's ``time_limit``."""
+    model = _ils_instance()
+    t0 = time.perf_counter()
+    _, budget = _run_ils(
+        model,
+        eval_budget=10**9,
+        solve_budget=10**9,
+        alpha=1.0,
+        deadline=t0 + 0.2,
+    )
+    assert budget.stopped_on == "deadline"
+    assert time.perf_counter() - t0 < 30.0
+
+
+@pytest.mark.slow
+def test_default_budgets_are_resolved_from_tuning():
+    """``eval_budget=None`` must pick up ``SolverTuning``, so the shipped default
+    is what a plain ``Model.solve()`` actually runs with."""
+    from discopt import solver_tuning as st
+
+    model = _ils_instance()
+    _, budget = _run_ils(model, eval_budget=None, solve_budget=None, alpha=1.0)
+    tuning = st.current()
+    assert budget.limits == {EVAL: tuning.ils_eval_budget, NLP_SOLVE: tuning.ils_solve_budget}

--- a/python/tests/test_912_work_budget.py
+++ b/python/tests/test_912_work_budget.py
@@ -231,8 +231,11 @@ def test_legacy_wall_gate_is_the_mechanism_the_fix_removes():
     extent is decided by the clock, so a scaled (slower) machine stops the search
     earlier — the property #912 measured on gear2."""
     model = _ils_instance()
-    _, fast = _run_ils(model, eval_budget=0, solve_budget=0, alpha=1.0, time_budget=0.35)
-    _, slow = _run_ils(model, eval_budget=0, solve_budget=0, alpha=50.0, time_budget=0.35)
+    # The control's budget must comfortably cover this instance's search (measured
+    # ~0.4 s) even on a loaded machine, or both arms get cut and the comparison
+    # says nothing; the slow arm's scaling must cut it beyond any doubt.
+    _, fast = _run_ils(model, eval_budget=0, solve_budget=0, alpha=1.0, time_budget=5.0)
+    _, slow = _run_ils(model, eval_budget=0, solve_budget=0, alpha=500.0, time_budget=5.0)
     assert not fast.limits and not slow.limits, "legacy arm must be unlimited"
     assert slow.stopped_on == "deadline", (
         "the legacy arm is supposed to be cut by the clock; "

--- a/python/tests/test_gdpopt_heuristics_core_units.py
+++ b/python/tests/test_gdpopt_heuristics_core_units.py
@@ -987,8 +987,9 @@ class TestLocalBranchingBudget:
         assert calls["n"] >= 2
 
     def test_truncation_dispatches_bounded_submip(self, monkeypatch):
-        """When the enumeration cannot fit the budget but >= 2.5s remain, the
-        unexplored neighbourhood goes to the bounded sub-MIP."""
+        """When a radius round cannot fit the remaining sub-NLP budget, the
+        unexplored neighbourhood goes to the bounded sub-MIP (#912: the budget is
+        a deterministic solve count, not a predicted wall time)."""
         m = dm.Model("lb24")
         b = m.binary("b", shape=(24,))
         m.minimize(dm.sum(b))
@@ -1002,17 +1003,23 @@ class TestLocalBranchingBudget:
 
         monkeypatch.setattr(ph, "_local_branching_submip", fake_submip)
 
-        def slow_backend(evaluator, x0, options=None):
-            time.sleep(0.6)  # inflate the measured per-sub-NLP mean
+        def failing_backend(evaluator, x0, options=None):
+            # No point found. Truncation is triggered by the round's sub-NLP
+            # COUNT exceeding the remaining budget — since #912 it is no longer
+            # triggered by a measured per-sub-NLP wall mean, i.e. by how fast
+            # this machine happens to be.
             raise RuntimeError("no point")
 
         out = ph.local_branching(
             m,
             np.ones(24),
             k=2,
-            backend=slow_backend,
+            backend=failing_backend,
             submip_time_limit=8.0,
             max_binaries=30,  # force the enumeration branch (not the >12 dispatch)
+            # C(24,1)=24 fits the budget; C(24,2)=276 cannot, so radius 2 is
+            # handed to the bounded sub-MIP.
+            solve_budget=51,
         )
         assert submip_calls["n"] == 1
         assert out is not None


### PR DESCRIPTION
## Summary

The search tree was a function of *machine speed*. Four primal heuristics bounded their own extent with a wall clock, and their descents routinely never converge — so how far they got, the incumbent they handed the tree, and therefore `node_count` all depended on how fast the box was. #912 measured `gear2` at 3 nodes with a 5 s budget and 91 with 3 s, sitting exactly on that cliff. Not a flaky-CI detail: the repo's bound-neutral regime asserts `node_count` is *exactly* unchanged across a refactor, which only means something if the search is a function of its input.

New `discopt._work_budget.WorkBudget` counts **operations per kind** — evaluations and sub-NLP solves, each with its own cap — and four gates now use it instead of the clock:

| gate | extent now bounded by | legacy wall slice |
|---|---|---|
| `integer_local_search` | evals + sub-NLP solves | 5 s |
| `integer_box_search` | sub-NLP solves (one per cell) | 4 s |
| `local_branching` | sub-NLP solves per radius round | 2 s |
| `one_hot_swap_search` | objective evaluations | 1 s |

`local_branching` was the purest form of the bug in the repo: it predicted a round's cost as `C(n,r) × measured_mean_subnlp_seconds` against `deadline - now`, so the enumeration radius — and hence which neighbourhood got brute-forced versus handed to the sub-MIP — was a ratio of two machine measurements. Each gate takes the share of the budget matching its legacy slice (0.8 / 0.4 / 0.2), so the deterministic budgets preserve the relative effort the tuned wall budgets encoded.

The clock remains as a **backstop**: the solve deadline is passed down so `time_limit` is honoured while never deciding how much work a within-limit search does. `WorkBudget.stopped_on` records which one fired, so a panel can distinguish a reproducible run from one the machine cut short instead of assuming.

Contributes to #912, which is now closed **not planned** for the ~20 remaining wall gates — see the disposition below and §11 of the calibration doc.

## Correctness

- [x] Cannot produce a false certificate. All four are pure incumbent finders: every point is sub-NLP-verified and re-verified by `inject_incumbent`, so changing their extent can only change *which* feasible point is found, never the dual bound or the certificate. No bound, cut or relaxation is touched.
- [x] No validation, fallback, or safety guard was weakened. The wall clock was demoted from "how much work" to "when to stop", and the ILS now honours a solve deadline it previously could overrun by up to 5 s. Two behaviour contracts the conversion initially broke are restored and tested: an explicit `time_budget=0` still means "no budget at all", and the local-branching truncation test now exercises the count-based mechanism rather than a `time.sleep` inflating the deleted wall-mean estimator.

## Tests run (numbers, not adjectives)

- [x] `pytest -m smoke` → **900 passed, 16 skipped, 7913 deselected, 2 xpassed** (460 s)
- [x] `pytest -m slow python/tests/test_adversarial_recent_fixes.py` → **10 passed** (211 s)
- [x] `pytest python/tests/test_912_*.py` → **16 passed**; `test_gdpopt_heuristics_core_units.py` → 120 passed, 3 skipped, 2 xpassed
- [x] `cargo test -p discopt-core` → N/A, no Rust touched
- [x] `ruff check` / `ruff format --check` / `mypy python/discopt/` (320 files) clean

## Regression tests

`python/tests/test_912_work_budget.py` (12 tests):

- `test_ils_is_invariant_to_machine_speed_with_a_work_budget` — the regression this issue exists for. Same model, same budget, `time.perf_counter` scaled 1×/4×/16×: identical work counts, identical returned point. Fails before, passes after.
- `test_legacy_wall_gate_is_the_mechanism_the_fix_removes` — keeps the fails-before evidence executable: with the budgets disabled, a 500×-slower machine does strictly less work. If this stops holding, the first test has stopped testing anything.
- Plus `WorkBudget` semantics and a check that the shipped defaults are what a plain `Model.solve()` runs with.

`python/tests/test_912_wall_budget_inventory.py` (4 tests) — the ratchet. All 46 wall-budget constructions in `python/discopt/` are enumerated and categorised (contract / legacy / **20 residual**); a new unrecorded one fails, a stale entry fails, and the converted layer is asserted to stay converted.

## Bound-changing / performance change?

Not bound-changing — heuristic-policy regime (CLAUDE.md §5). Default-ON with an escape hatch.

- [x] Escape hatch, not a dead flag: `DISCOPT_ILS_EVAL_BUDGET=0 DISCOPT_ILS_SOLVE_BUDGET=0` restores the legacy wall gates, and the panel runs that arm.
- [x] Cert-clean: **88 field comparisons** (status, node_count, objective, bound) over 22 ILS-firing instances at `time_limit=60`, the only difference `nvs05`, which exhausts its limit on both arms and is out of scope by the panel's starvation rule. The 3 instances with a reference optimum checked on both arms: 6 bound/optimum pairs, 0 violations.
- [x] Determinism: clock scaled 1× vs 2× at `time_limit=60` → **18 in-scope comparisons, 0 mismatches**. The 4 out-of-scope rows are printed with their numbers and verdicts, not dropped.
- [x] Net effect on cost, interleaved 3 rounds/arm (the sequential panel's "+27 %" was arm-to-arm drift, not effect — rule 9): syn05hfsg 22.44 → 29.34 s, fac2 17.14 → 19.36 s, tspn05 and nvs21 neutral, node counts identical throughout. The residual is the ILS conversion on exactly the two instances the clock used to cut short; corpus-wide that trade measured +1.6 % total wall.

**Sizing is itself a measurement.** Handing all four gates the ILS budget was cert-clean but harmful (syn05hfsg 1.38×, fac2 1.18×, identical node counts) and did not ship at that sizing — the `DISCOPT_CUT_INHERIT` rule. Re-scaled to the legacy slices: 1.31× and 1.13×.

## Two designs built and falsified

Recorded in `docs/dev/work-budget-calibration-2026-08-01.md` rather than deleted, because they rule out the shortcut the issue text makes look available:

1. **One converted work currency.** A sub-NLP costs 2 933–77 964 evaluations depending on the instance. At the geomean, `nvs09` regressed 5 → 29 nodes while `syn05hfsg` got 3× its legacy wall. A size-scaled charge made the spread *worse* (67.8× vs 26.5×).
2. **A global deterministic clock** for the remaining ~20 gates, built twice. Charging the primitives at their proper boundaries — the NLP *backend* rather than one call site, which profiling `fac2` showed was seeing 5 of its 80 solves — lifted coverage only 0.13 → 0.19 of wall. fac2's solves cost ~86 ms each against a 15 ms nominal price drawn from a 1.9–104 ms distribution: **no fixed pricing tracks wall time when per-operation cost varies 55× across instances**, even with perfect coverage. Re-denominating those budgets in it would have silently stopped them firing (#875's 27 s pass back on, every test green). Both attempts reverted; no dead code ships.

## Why the remaining 20 are not planned

After the conversion the panel is 18/18 clean and **every extent gate ever caught cutting a search short was the root ILS** — no residual gate was observed moving a tree. Bounded honestly: those budgets bind mainly on large models and the corpus is 66 small ones, so that is a statement about what was tested. The reopen trigger is written into the doc and the ratchet test — a large-instance panel showing one of them move a tree inside its `time_limit`, or a need for bit-reproducibility as a guarantee.

`gear2` was never run: absent from the in-repo corpus and minlplib.org is unreachable from this environment, so the mechanism is reproduced on seven other instances of the same class and the 3-vs-91 cliff is quoted from the issue, not re-measured.