### PR TITLE
fix(correctness): #923 dense Lagrangian Hessian silently wrong at scale

### DIFF
--- a/python/discopt/_jax/nlp_evaluator.py
+++ b/python/discopt/_jax/nlp_evaluator.py
@@ -44,6 +44,51 @@ logger = logging.getLogger(__name__)
 # option anyway, so sparse is strictly safer.
 _DENSE_JACOBIAN_COMPILE_LIMIT = 1_000_000
 
+# --- Dense Lagrangian-Hessian AD-mode gate (#923) --------------------------------
+# The dense Lagrangian Hessian is built by nesting two AD passes. The two nestings
+# have very different *memory* profiles, and the difference is what made #923 a
+# correctness bug rather than a performance one:
+#
+#   forward-over-forward  ``jacfwd(jacfwd(L))``  peak = 2 * n^2 * m * 8 bytes
+#   forward-over-reverse  ``jacfwd(grad(L))``    peak ~ 2 * n   * m * 8 bytes
+#
+# ``L`` is a scalar, so the inner forward pass has to carry one tangent per input
+# through *every* intermediate; the constraint vector (length ``m``) therefore
+# becomes an ``(n, n, m)`` array under the two nested vmaps. The closed form above
+# is measured, not estimated: on the emfl-shaped replica XLA's RESOURCE_EXHAUSTED
+# request matched ``2 * n^2 * m * 8`` to the byte at n=1068 (19,162,483,200) and
+# n=1368 (40,422,758,400).
+#
+# At MINLPLib emfl scale that is 66 GB for emfl050_3_3 (n=1611, m=1593) and 413 GB
+# for emfl100_3_3 (n=2961, m=2943) — which is exactly why the first is correct and
+# the second is not. Whether the over-large buffer surfaces as a clean
+# RESOURCE_EXHAUSTED (Linux, measured here) or as a silently under-populated
+# allocation that reads back as zeros (the #923 report) is platform allocator
+# behavior; either way the forward-over-forward nesting is not a viable way to
+# build this matrix once ``n^2 * m`` is large.
+#
+# Above this peak-byte budget the dense Hessian is therefore built forward-over-
+# reverse. Both nestings compute the same matrix — AD mode never changes a value —
+# so this is bound-neutral by construction and verified as such by
+# ``python/tests/test_923_dense_lagrangian_hessian.py``.
+#
+# The budget is a resource bound, not a tuned constant: 1 GiB is small enough that
+# no supported machine can be driven into swap by this buffer, and large enough
+# that every model on which the forward-over-forward compile advantage was measured
+# (du-opt n=21, fac2 n=66, tls2 n=37 — see the ``lagrangian`` comment below) keeps
+# it unchanged.
+_DENSE_HESSIAN_FWD_OVER_FWD_PEAK_BYTES = 1 << 30
+
+
+def _dense_hessian_fwd_over_fwd_peak_bytes(n_vars: int, n_constraints: int) -> int:
+    """Peak intermediate bytes of ``jacfwd(jacfwd(L))`` for the dense Hessian.
+
+    ``2 * n^2 * m * 8``, with ``m`` floored at 1 so an unconstrained model is
+    still charged for the ``(n, n)`` objective tangents. See the module comment
+    above for the measurement this closed form comes from.
+    """
+    return 2 * n_vars * n_vars * max(int(n_constraints), 1) * 8
+
 
 # --- First-time Lagrangian-Hessian XLA compile-cost model (F4) ------------------
 # The first evaluate_hessian_values call forces an uninterruptible first-time XLA
@@ -238,13 +283,50 @@ def cached_evaluator(model: Model) -> "NLPEvaluator":
     return ev
 
 
+def _lagrangian_gradient(evaluator, x: np.ndarray, obj_factor: float, lam: np.ndarray):
+    """``obj_factor * grad f(x) + J(x)^T lam``, from FIRST derivatives only.
+
+    Deliberately independent of both Hessian code paths: it uses the objective
+    gradient and the sparse Jacobian values, so finite-differencing it gives a
+    Hessian-vector product that can arbitrate between them (#923).
+    """
+    g = float(obj_factor) * np.asarray(evaluator.evaluate_gradient(x), dtype=np.float64)
+    if evaluator.n_constraints > 0:
+        rows, cols = evaluator.jacobian_structure()
+        vals = np.asarray(evaluator.evaluate_jacobian_values(x), dtype=np.float64)
+        np.add.at(g, np.asarray(cols), vals * np.asarray(lam, dtype=np.float64)[np.asarray(rows)])
+    return g
+
+
+def _coo_lower_matvec(rows, cols, vals, v, n: int) -> np.ndarray:
+    """``H @ v`` for a symmetric H stored as its lower triangle in COO."""
+    out = np.zeros(n, dtype=np.float64)
+    rows = np.asarray(rows)
+    cols = np.asarray(cols)
+    vals = np.asarray(vals, dtype=np.float64)
+    np.add.at(out, rows, vals * v[cols])
+    off = rows != cols
+    np.add.at(out, cols[off], vals[off] * v[rows[off]])
+    return out
+
+
 def validate_sparse_values(evaluator, x: np.ndarray, atol: float = 1e-8) -> bool:
-    """Check that sparse COO values agree with dense evaluation.
+    """Cross-check the sparse COO values against the dense evaluation.
 
-    Computes both dense and sparse Jacobian/Hessian at x and verifies that
-    the sparse values match the dense values at the declared positions.
+    Computes both dense and sparse Jacobian/Hessian at x and verifies that they
+    agree at the declared positions.
 
-    Returns True if validation passes, False otherwise.
+    Neither side is the oracle. This function used to *assume* the dense
+    Lagrangian Hessian was ground truth and report the sparse values as the
+    failing side; on emfl100_3_3 that was exactly backwards — the dense path
+    returned an all-zero matrix while the sparse values were correct (#923). So
+    on a Hessian disagreement an independent arbiter runs: a central finite
+    difference of the Lagrangian gradient (built from first derivatives only, via
+    :func:`_lagrangian_gradient`, so it shares no code with either Hessian path)
+    gives ``H @ v`` for a random direction ``v``, and the log records which side
+    it agrees with.
+
+    Returns True if the two representations agree, False otherwise.
     """
     import logging
 
@@ -263,16 +345,41 @@ def validate_sparse_values(evaluator, x: np.ndarray, atol: float = 1e-8) -> bool
             ok = False
 
     # Validate Hessian
+    n = evaluator.n_variables
     m = evaluator.n_constraints
+    obj_factor = 1.0
     lam = np.ones(m, dtype=np.float64)
-    hess_dense = evaluator.evaluate_lagrangian_hessian(x, 1.0, lam)
+    hess_dense = np.asarray(evaluator.evaluate_lagrangian_hessian(x, obj_factor, lam))
     rows, cols = evaluator.hessian_structure()
-    sparse_vals = evaluator.evaluate_hessian_values(x, 1.0, lam)
+    sparse_vals = np.asarray(evaluator.evaluate_hessian_values(x, obj_factor, lam))
     dense_at_pos = hess_dense[rows, cols]
     if not np.allclose(sparse_vals, dense_at_pos, atol=atol):
         max_err = float(np.max(np.abs(sparse_vals - dense_at_pos)))
-        logger.warning("Sparse Hessian validation failed (max err=%.2e)", max_err)
+        logger.warning(
+            "Dense/sparse Lagrangian Hessian disagree (max err=%.2e); arbitrating", max_err
+        )
         ok = False
+        # Neutral arbiter: finite-difference the Lagrangian gradient along v.
+        x64 = np.asarray(x, dtype=np.float64)
+        v = np.random.default_rng(0).standard_normal(n)
+        v /= np.linalg.norm(v) or 1.0
+        h = 1e-6
+        fd_hv = (
+            _lagrangian_gradient(evaluator, x64 + h * v, obj_factor, lam)
+            - _lagrangian_gradient(evaluator, x64 - h * v, obj_factor, lam)
+        ) / (2.0 * h)
+        scale = max(float(np.linalg.norm(fd_hv)), 1.0)
+        dense_err = float(np.linalg.norm(hess_dense @ v - fd_hv)) / scale
+        sparse_err = (
+            float(np.linalg.norm(_coo_lower_matvec(rows, cols, sparse_vals, v, n) - fd_hv)) / scale
+        )
+        logger.warning(
+            "Hessian arbitration (finite-difference of the Lagrangian gradient): "
+            "dense rel err=%.2e, sparse rel err=%.2e -> %s side disagrees with the arbiter",
+            dense_err,
+            sparse_err,
+            "dense" if dense_err > sparse_err else "sparse",
+        )
 
     return ok
 
@@ -450,6 +557,9 @@ class NLPEvaluator:
             def lagrangian_hess(x, obj_factor, lam, params):
                 return obj_factor * gn_obj_hess_fn(x, params) + constraint_hessian(x, lam, params)
 
+            # ``jax.hessian`` is forward-over-reverse, so the constraint term here
+            # never builds the ``(n, n, m)`` intermediate that #923 is about.
+            self._dense_hessian_mode = "gauss_newton"
             self._lagrangian_hess_fn_jit = jax.jit(lagrangian_hess)
             # The compressed-HVP Hessian path assumes the exact Lagrangian; it
             # is not wired for the Gauss-Newton approximation, so disable it.
@@ -462,21 +572,48 @@ class NLPEvaluator:
                     L = L + jnp.dot(lam, cons_fn_jit(x, params))
                 return L
 
-            # Dense Lagrangian Hessian via FORWARD-over-FORWARD AD. ``jax.hessian``
-            # is ``jacfwd(jacrev(...))``; its inner reverse pass hits the same
-            # super-linear XLA transpose codegen documented for the constraint
-            # Jacobian above — on a large lifted DAG (e.g. MINLPLib's du-opt, 21
-            # vars but a heavy constraint graph) that single compile runs ~12s,
-            # and because it is an uninterruptible C call it blows straight past
-            # the solver's per-node time budget. ``jacfwd(jacfwd(...))`` produces
-            # the identical matrix (AD mode never changes the value) and compiles
-            # it in ~half the time. This dense form is only taken when the sparse
-            # colored-HVP path declines (small ``n``, or a dense Hessian), so the
-            # O(n^2)-vs-O(n) forward-mode runtime constant is immaterial while the
-            # compile robustness is what matters.
-            self._lagrangian_hess_fn_jit = jax.jit(
-                jax.jacfwd(jax.jacfwd(lagrangian, argnums=0), argnums=0)
-            )
+            # Dense Lagrangian Hessian. Two AD nestings are available and they
+            # trade compile cost against memory:
+            #
+            # FORWARD-over-FORWARD ``jacfwd(jacfwd(L))`` — the default for models
+            # small enough to afford it. ``jax.hessian`` is ``jacfwd(jacrev(...))``;
+            # its inner reverse pass hits the same super-linear XLA transpose
+            # codegen documented for the constraint Jacobian above — on a large
+            # lifted DAG (e.g. MINLPLib's du-opt, 21 vars but a heavy constraint
+            # graph) that single compile runs ~12s, and because it is an
+            # uninterruptible C call it blows straight past the solver's per-node
+            # time budget. ``jacfwd(jacfwd(...))`` produces the identical matrix
+            # (AD mode never changes the value) and compiles it in ~half the time.
+            #
+            # FORWARD-over-REVERSE ``jacfwd(grad(L))`` — used once the
+            # forward-over-forward *intermediates* stop fitting in memory. Because
+            # ``L`` is a scalar, the inner forward pass carries one tangent per
+            # input through every intermediate, so the length-``m`` constraint
+            # vector becomes an ``(n, n, m)`` buffer: peak ``2 * n^2 * m * 8``
+            # bytes, i.e. 413 GB on emfl100_3_3. That over-large allocation is
+            # #923 — it read back as an all-zero Hessian with no error raised.
+            # The reverse inner pass produces the gradient in one sweep, so the
+            # same buffer is only ``(n, m)``: peak ``~2 * n * m * 8`` bytes.
+            #
+            # The gate is on the measured peak, not on ``n`` alone, and both
+            # branches return the same matrix. ``_lagrangian_grad`` below already
+            # builds (and the sparse colored-HVP path already compiles) the exact
+            # same reverse-mode Lagrangian gradient graph, so the large-model
+            # branch introduces no reverse-mode transposition that this evaluator
+            # was not already going to compile.
+            if (
+                _dense_hessian_fwd_over_fwd_peak_bytes(self._n_variables, self._n_constraints)
+                > _DENSE_HESSIAN_FWD_OVER_FWD_PEAK_BYTES
+            ):
+                self._dense_hessian_mode = "fwd_over_rev"
+                self._lagrangian_hess_fn_jit = jax.jit(
+                    jax.jacfwd(jax.grad(lagrangian, argnums=0), argnums=0)
+                )
+            else:
+                self._dense_hessian_mode = "fwd_over_fwd"
+                self._lagrangian_hess_fn_jit = jax.jit(
+                    jax.jacfwd(jax.jacfwd(lagrangian, argnums=0), argnums=0)
+                )
 
             # Matrix-free Lagrangian Hessian-vector product (forward-over-reverse).
             # Used by the compressed sparse-Hessian path to recover the block-

--- a/python/tests/test_923_dense_lagrangian_hessian.py
+++ b/python/tests/test_923_dense_lagrangian_hessian.py
@@ -1,0 +1,251 @@
+"""Regression tests for #923: the dense Lagrangian Hessian must not go wrong at scale.
+
+``NLPEvaluator.evaluate_lagrangian_hessian`` built the dense matrix with
+``jacfwd(jacfwd(L))``. ``L`` is a scalar, so the inner forward pass carries one
+tangent per input through every intermediate and the length-``m`` constraint
+vector becomes an ``(n, n, m)`` buffer. The peak allocation is exactly
+
+    2 * n^2 * m * 8 bytes
+
+— measured, not estimated: XLA's ``RESOURCE_EXHAUSTED`` request matched that
+closed form to the byte on the emfl-shaped replica below, at n=1068/m=1050
+(19,162,483,200) and n=1368/m=1350 (40,422,758,400).
+
+That is 66 GB on MINLPLib's ``emfl050_3_3`` (n=1611, m=1593) and 413 GB on
+``emfl100_3_3`` (n=2961, m=2943), which is precisely why #923 reported the first
+as correct and the second as wrong. On Linux the over-large buffer surfaces as a
+clean ``RESOURCE_EXHAUSTED``; in the #923 report it surfaced as an allocation
+that read back as zeros, so ``evaluate_lagrangian_hessian`` returned an all-zero
+matrix — right shape, no exception, no warning — while the sparse
+``evaluate_hessian_values`` path and finite differences both gave the true value.
+
+The fix routes the dense build to ``jacfwd(grad(L))`` (peak ``~2 * n * m * 8``)
+once the forward-over-forward peak exceeds a byte budget. Both nestings compute
+the same matrix, so the change is bound-neutral; that is asserted directly here.
+
+There was no cross-check between the dense Hessian, the sparse Hessian and
+finite differences anywhere in the suite, which is why the defect survived. The
+first test closes that gap.
+"""
+
+from __future__ import annotations
+
+import discopt._jax.nlp_evaluator as nev
+import discopt.modeling as dm
+import numpy as np
+import pytest
+from discopt._jax.nlp_evaluator import (
+    NLPEvaluator,
+    _dense_hessian_fwd_over_fwd_peak_bytes,
+)
+
+
+def _emfl_shaped_model(n_cone: int, n_new: int = 9, seed: int = 0) -> dm.Model:
+    """The structural shape of MINLPLib's ``emfl*_3_3`` family.
+
+    ``n_cone`` distance variables, ``n_cone`` coordinate-difference pairs and
+    ``n_new`` facility positions in 2-D, giving ``n = 3 * n_cone + 2 * n_new``
+    and ``m = 3 * n_cone``:
+
+        cone rows    -d_r^2 + u_r^2 + v_r^2 <= 0        (n_cone of them)
+        linear rows  u_r - px_j + ax_r == 0, likewise v (2 * n_cone of them)
+
+    At ``n_cone = 981`` that is exactly emfl100_3_3's n=2961 / m=2943, and row 0
+    is ``-x0**2 + x981**2 + x982**2 <= 0`` — the row #923 reports.
+    """
+    rng = np.random.default_rng(seed)
+    m = dm.Model(f"emfl_shape_{n_cone}")
+    d = [m.continuous(f"d{r}", lb=0.0, ub=100.0) for r in range(n_cone)]
+    uv = [
+        (
+            m.continuous(f"u{r}", lb=-100.0, ub=100.0),
+            m.continuous(f"v{r}", lb=-100.0, ub=100.0),
+        )
+        for r in range(n_cone)
+    ]
+    p = [
+        (m.continuous(f"px{j}", lb=-100.0, ub=100.0), m.continuous(f"py{j}", lb=-100.0, ub=100.0))
+        for j in range(n_new)
+    ]
+    for r in range(n_cone):
+        u, v = uv[r]
+        m.subject_to(-(d[r] ** 2) + u**2 + v**2 <= 0)
+    for r in range(n_cone):
+        u, v = uv[r]
+        px, py = p[r % n_new]
+        m.subject_to(u - px + float(rng.uniform(-10, 10)) == 0)
+        m.subject_to(v - py + float(rng.uniform(-10, 10)) == 0)
+    # Balanced-tree sum: a left-nested chain of ~1000 additions trips the
+    # dag_compiler recursion limit noted at the end of #923 (a separate defect).
+    terms: list = list(d)
+    while len(terms) > 1:
+        terms = [
+            terms[i] + terms[i + 1] if i + 1 < len(terms) else terms[i]
+            for i in range(0, len(terms), 2)
+        ]
+    m.minimize(terms[0])
+    return m
+
+
+def _sparse_at(ev: NLPEvaluator, x, obj_factor, lam, i, j) -> float:
+    rows, cols = ev.hessian_structure()
+    vals = np.asarray(ev.evaluate_hessian_values(x, obj_factor, lam))
+    rows = np.asarray(rows)
+    cols = np.asarray(cols)
+    mask = ((rows == i) & (cols == j)) | ((rows == j) & (cols == i))
+    return float(vals[mask].sum())
+
+
+def _fd_second_derivative(ev: NLPEvaluator, x, lam, i, h=1e-4) -> float:
+    """Central second difference of ``lam . g(x)`` in coordinate ``i``.
+
+    Uses only constraint *values* — no AD Hessian on either side — so it is a
+    neutral arbiter between the dense and sparse paths.
+    """
+
+    def L(xx):
+        return float(np.dot(lam, ev.evaluate_constraints(xx)))
+
+    xp = np.asarray(x, dtype=np.float64).copy()
+    xm = xp.copy()
+    xp[i] += h
+    xm[i] -= h
+    return (L(xp) - 2.0 * L(x) + L(xm)) / h**2
+
+
+@pytest.mark.unit
+def test_dense_sparse_and_finite_differences_agree_on_emfl_shape():
+    """The cross-check that did not exist: dense vs sparse vs finite differences.
+
+    Row 0 is ``-d_0^2 + u_0^2 + v_0^2``, so the exact curvature is
+    ``diag(-2, +2, +2)`` on ``(0, 0)``, ``(n_cone, n_cone)`` and
+    ``(n_cone + 1, n_cone + 1)`` with ``lam = e_0`` -- the ``u``/``v`` pair is
+    interleaved, exactly as emfl100_3_3's ``-x0**2 + x981**2 + x982**2``.
+    """
+    n_cone = 60
+    ev = NLPEvaluator(_emfl_shaped_model(n_cone))
+    x = np.full(ev.n_variables, 1.3)
+    lam = np.zeros(ev.n_constraints)
+    lam[0] = 1.0
+
+    H = np.asarray(ev.evaluate_lagrangian_hessian(x, 0.0, lam))
+    assert H.shape == (ev.n_variables, ev.n_variables)
+
+    checked = 0
+    for idx, expected in ((0, -2.0), (n_cone, 2.0), (n_cone + 1, 2.0)):
+        assert H[idx, idx] == pytest.approx(expected, abs=1e-9)
+        assert _sparse_at(ev, x, 0.0, lam, idx, idx) == pytest.approx(expected, abs=1e-9)
+        assert _fd_second_derivative(ev, x, lam, idx) == pytest.approx(expected, rel=1e-3)
+        checked += 1
+    assert checked == 3, "cross-check asserted nothing"
+
+    # An all-zero Hessian is the #923 signature; assert against it explicitly.
+    assert np.abs(H).max() > 0.0
+    assert np.count_nonzero(H) == 3
+
+    # Full-multiplier arm: the dense and sparse supports must coincide, not be
+    # disjoint (#923 reported 1571 dense nonzeros vs 2943 sparse, overlap 0).
+    lam_all = np.ones(ev.n_constraints)
+    H_all = np.asarray(ev.evaluate_lagrangian_hessian(x, 0.0, lam_all))
+    rows, cols = ev.hessian_structure()
+    vals = np.asarray(ev.evaluate_hessian_values(x, 0.0, lam_all))
+    assert np.allclose(vals, H_all[np.asarray(rows), np.asarray(cols)], atol=1e-12)
+    assert np.count_nonzero(H_all) == 3 * n_cone
+
+
+@pytest.mark.unit
+def test_peak_byte_model_and_gate_routing():
+    """The gate is on the measured ``2 * n^2 * m * 8`` peak, and it routes."""
+    assert _dense_hessian_fwd_over_fwd_peak_bytes(1068, 1050) == 19_162_483_200
+    assert _dense_hessian_fwd_over_fwd_peak_bytes(1368, 1350) == 40_422_758_400
+    # emfl050_3_3 (correct in #923) vs emfl100_3_3 (wrong in #923).
+    assert _dense_hessian_fwd_over_fwd_peak_bytes(1611, 1593) / 2**30 == pytest.approx(61.6, abs=1)
+    assert _dense_hessian_fwd_over_fwd_peak_bytes(2961, 2943) / 2**30 == pytest.approx(384.5, abs=1)
+    # m floored at 1 so an unconstrained model is still charged for (n, n).
+    assert _dense_hessian_fwd_over_fwd_peak_bytes(10, 0) == 2 * 100 * 8
+
+    small = NLPEvaluator(_emfl_shaped_model(20))
+    assert small._dense_hessian_mode == "fwd_over_fwd"
+    assert (
+        _dense_hessian_fwd_over_fwd_peak_bytes(small.n_variables, small.n_constraints)
+        <= nev._DENSE_HESSIAN_FWD_OVER_FWD_PEAK_BYTES
+    )
+
+    big = NLPEvaluator(_emfl_shaped_model(200))
+    assert (
+        _dense_hessian_fwd_over_fwd_peak_bytes(big.n_variables, big.n_constraints)
+        > nev._DENSE_HESSIAN_FWD_OVER_FWD_PEAK_BYTES
+    )
+    assert big._dense_hessian_mode == "fwd_over_rev"
+
+
+@pytest.mark.unit
+def test_both_ad_nestings_return_the_same_matrix(monkeypatch):
+    """Bound-neutrality: the routing changes memory, never a value.
+
+    AD mode never changes a derivative, but it does change the *summation order*
+    inside it, so the two builds are equal to floating-point rounding rather than
+    bit-identical. A differential panel over the in-repo ``.nl`` corpus (both
+    nestings forced, two multiplier settings each, 130 comparisons over 60
+    instances; ``hda.nl`` excluded because its forward-over-forward peak is
+    5.6 GiB) put the worst RELATIVE entrywise drift at 4.1e-15, on
+    ``syn05hfsg.nl``. The tolerance below is that scale.
+
+    Two instances (``4stufen``, ``beuster``) additionally differ in where the
+    matrix is non-finite when evaluated at an out-of-domain point, and the
+    asymmetry is one-directional in all four arms: 21009/21605/23393/24021
+    entries are non-finite under forward-over-forward and finite under
+    forward-over-reverse, and zero entries go the other way. The routed path is
+    never less defined than the one it replaces.
+    """
+    model = _emfl_shaped_model(20)
+    x = 1.3 + 0.05 * np.arange(3 * 20 + 18, dtype=np.float64)
+
+    out = {}
+    for mode, budget in (("fwd_over_fwd", 1 << 62), ("fwd_over_rev", 0)):
+        monkeypatch.setattr(nev, "_DENSE_HESSIAN_FWD_OVER_FWD_PEAK_BYTES", budget)
+        ev = NLPEvaluator(model)
+        assert ev._dense_hessian_mode == mode
+        lam = np.linspace(-1.0, 1.0, ev.n_constraints)
+        out[mode] = np.asarray(ev.evaluate_lagrangian_hessian(x, 1.0, lam))
+
+    a, b = out["fwd_over_fwd"], out["fwd_over_rev"]
+    assert a.shape == b.shape
+    scale = max(float(np.abs(a).max()), 1.0)
+    assert float(np.abs(a - b).max()) <= 1e-13 * scale
+    assert np.count_nonzero(a) == np.count_nonzero(b)
+    assert np.abs(a).max() > 0.0
+
+
+@pytest.mark.slow
+def test_dense_hessian_correct_past_the_forward_over_forward_memory_wall():
+    """The real #923 regression, at a shape no machine can afford unfixed.
+
+    ``n_cone = 400`` gives n=1218 / m=1200, whose forward-over-forward peak is
+    26.5 GiB (XLA requested exactly 28,483,660,800 bytes here before the fix).
+    The routed forward-over-reverse build needs ~22 MiB of intermediates and
+    returns the true curvature.
+    """
+    n_cone = 400
+    ev = NLPEvaluator(_emfl_shaped_model(n_cone))
+    assert ev.n_variables == 3 * n_cone + 18
+    assert ev.n_constraints == 3 * n_cone
+    assert ev.is_gauss_newton is False
+    assert ev._dense_hessian_mode == "fwd_over_rev"
+    assert (
+        _dense_hessian_fwd_over_fwd_peak_bytes(ev.n_variables, ev.n_constraints) == 28_483_660_800
+    )
+
+    x = np.full(ev.n_variables, 1.3)
+    lam = np.zeros(ev.n_constraints)
+    lam[0] = 1.0
+    H = np.asarray(ev.evaluate_lagrangian_hessian(x, 0.0, lam))
+
+    checked = 0
+    for idx, expected in ((0, -2.0), (n_cone, 2.0), (n_cone + 1, 2.0)):
+        assert H[idx, idx] == pytest.approx(expected, abs=1e-9)
+        assert _sparse_at(ev, x, 0.0, lam, idx, idx) == pytest.approx(expected, abs=1e-9)
+        assert _fd_second_derivative(ev, x, lam, idx) == pytest.approx(expected, rel=1e-3)
+        checked += 1
+    assert checked == 3, "regression asserted nothing"
+    assert np.count_nonzero(H) == 3


### PR DESCRIPTION
## Summary

`NLPEvaluator.evaluate_lagrangian_hessian` built the dense matrix with
`jacfwd(jacfwd(L))`. `L` is a scalar, so the inner forward pass carries one tangent per
input through every intermediate, and the length-`m` constraint vector becomes an
`(n, n, m)` buffer. The peak allocation is exactly

```
2 * n^2 * m * 8 bytes
```

Measured, not estimated: on an emfl-shaped replica XLA's `RESOURCE_EXHAUSTED` request
matched that closed form **to the byte** at n=1068/m=1050 (19,162,483,200) and
n=1368/m=1350 (40,422,758,400).

That is **66 GB** for `emfl050_3_3` (n=1611, m=1593) and **413 GB** for `emfl100_3_3`
(n=2961, m=2943) — which is exactly the emfl050-correct / emfl100-wrong discriminator
#923 asked to bisect for. Whether the over-large buffer surfaces as a clean
`RESOURCE_EXHAUSTED` (Linux, as measured here) or as an allocation that reads back as
zeros (the #923 report: right shape, no exception, `|H|.max() == 0`) is platform
allocator behavior; either way the nesting is not a viable way to build this matrix
once `n^2 * m` is large.

Above a 1 GiB peak-byte budget the dense build is routed to forward-over-reverse
`jacfwd(grad(L))`, whose same buffer is only `(n, m)`: peak `~2 * n * m * 8`. Models
below the budget keep forward-over-forward, so the measured compile advantage on
du-opt / fac2 / tls2 is unchanged. The reverse-mode Lagrangian gradient graph is
already built in this branch for the compressed-HVP path, so the routed branch
introduces no reverse-mode transposition this evaluator was not already compiling.

Also fixes the inverted oracle #923 calls out: `validate_sparse_values` used the dense
Hessian as ground truth for the sparse values, which on `emfl100_3_3` was backwards.
On a disagreement it now runs an independent arbiter — a central finite difference of
the Lagrangian gradient, assembled from **first** derivatives only (`grad f` + `J^T λ`),
sharing no code with either Hessian path — and logs which side the arbiter contradicts.

Closes #923

## Correctness

The dense Lagrangian Hessian feeds local NLP subsolves (`nlp_ipopt`, `oa`,
`gdpopt_loa`, `sipopt`, Benders feasibility, `_AugmentedEvaluator`) and the fallback
inside `evaluate_hessian_values` itself. A zero Hessian degrades a Newton step to a
gradient step — slow or failed local convergence, i.e. a lost/duplicated *primal*
point, not a bound — so this is not a false-certificate fix; it is a wrong derivative
being returned as a correct one. The change replaces one AD nesting with another that
computes the same matrix, and nothing is relaxed or skipped to make it pass.

- [x] Cannot produce a false certificate (no bound, cut, or relaxation math changed)
- [x] No validation, fallback, or safety guard was weakened to make a check pass —
      the one validator touched (`validate_sparse_values`) was *strengthened*: it no
      longer assumes either side is right.

Bound-neutrality of the routing was measured directly. Differential panel over the
in-repo `.nl` corpus, both nestings forced, two multiplier settings each: **130
comparisons over 60 instances, worst relative entrywise drift 4.1e-15** (`syn05hfsg`)
— floating-point summation order only. `hda.nl` excluded (its forward-over-forward
peak is 5.6 GiB). On `4stufen` and `beuster`, evaluated at an out-of-domain point,
21009 / 21605 / 23393 / 24021 entries are non-finite under forward-over-forward and
finite under forward-over-reverse, and **zero** entries go the other way — the routed
path is never less defined than the one it replaces.

## Tests run (state the result — numbers, not adjectives)

- [x] `pytest -m smoke` → **900 passed, 16 skipped, 2 xpassed, 7917 deselected** (406s)
- [x] `pytest -m slow python/tests/test_adversarial_recent_fixes.py` → **10 passed**
- [x] `cargo test -p discopt-core` → N/A, no Rust touched
- [x] `ruff check` / `ruff format --check` clean; `mypy` clean on the changed module

One earlier run of `test_large_dense_jacobian_no_crash` overran its wall assertion
(56s vs the 48s allowance). An interleaved A/B pinned to each routing arm did not
reproduce it: full file 4x — forward-over-forward 185.9s / 180.1s, routed 178.0s /
181.5s, **all 10 passing in every run** — and the single test 6x, 26.9 ± 0.4s
(forward-over-forward) vs 26.7 ± 1.4s (routed). No arm effect; a wall-clock artifact
on a 4-core sandbox.

## Regression test

`python/tests/test_923_dense_lagrangian_hessian.py` (4 tests). The structural replica
reproduces `emfl*_3_3` exactly — at `n_cone = 981` it is emfl100_3_3's n=2961 / m=2943
with row 0 `-x0**2 + x981**2 + x982**2 <= 0`.

- `test_dense_sparse_and_finite_differences_agree_on_emfl_shape` (unit) — the
  three-way cross-check that did not exist anywhere in the suite, which is why this
  survived: dense vs sparse vs central finite differences, plus an explicit assertion
  against the all-zero signature and against the disjoint-support signature (#923
  reported 1571 dense nonzeros vs 2943 sparse, overlap 0).
- `test_peak_byte_model_and_gate_routing` (unit) — pins the measured `2*n^2*m*8` model
  and the routing decision.
- `test_both_ad_nestings_return_the_same_matrix` (unit) — bound-neutrality.
- `test_dense_hessian_correct_past_the_forward_over_forward_memory_wall` (slow) —
  n=1218 / m=1200, whose forward-over-forward peak is 26.5 GiB (XLA requested exactly
  28,483,660,800 bytes there before the fix).

- [x] Added a regression test that fails before / passes after. **Fail-before
      confirmed by execution**: on this branch's parent, at n=1218/m=1200,
      `evaluate_lagrangian_hessian` raises
      `RESOURCE_EXHAUSTED: Out of memory allocating 28483660800 bytes`; at
      emfl100_3_3's own shape it demands 413 GB. After the fix that shape returns
      `H[0,0] = -2.0`, matching the sparse path and finite differences, with
      `max|dense - sparse| = 0.0` at `λ = 1`.

Verified directly at emfl100_3_3's shape (n=2961, m=2943): dense `H[0,0] = -2.0`,
sparse `-2.0`, finite differences `-2.0`; at `λ = 1` both paths give 2943 nonzeros
with max entrywise difference 0.0.

The MINLPLib corpus is not reachable from this sandbox (`minlplib.org` is blocked by
the network policy), so the real `.nl` was never loaded; every measurement above is on
the structural replica or the in-repo corpus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NjBehEv5MkrXFuMKJMX4rz

---
_Generated by [Claude Code](https://claude.ai/code/session_01NjBehEv5MkrXFuMKJMX4rz)_