### PR TITLE
fix(robustness): #925 iterative dag_compiler lowering and evaluation

### DIFF
--- a/python/discopt/_jax/dag_compiler.py
+++ b/python/discopt/_jax/dag_compiler.py
@@ -18,17 +18,26 @@ Two entry-point families are provided:
   evaluators (e.g., NMPC closed-loop solves).
 
 Common-subexpression handling: the Expression object graph is a DAG — a node may
-be shared by many parents. Lowering memoizes both *compilation* (each distinct
-node builds one closure, via ``memo`` keyed by ``id(expr)``) and *evaluation*
-(each distinct node computes one value per call, via a per-call ``cache`` keyed
-by ``id(expr)``). A node reachable by k references is therefore traced and run
-once, not k times. Without this a linear DAG lowered in time exponential in its
-sharing depth (issue #383).
+be shared by many parents. Lowering assigns each distinct node (keyed by
+``id(expr)``) exactly one *tape slot*, so it is both compiled once and evaluated
+once per call. A node reachable by k references is therefore traced and run once,
+not k times. Without this a linear DAG lowered in time exponential in its sharing
+depth (issue #383).
+
+Depth handling: the DAG walk and the evaluation are both **iterative** (issue
+#925). A plain Python ``sum``/``+=`` over a list of terms builds a *left-nested*
+``BinaryOp`` chain whose depth equals the term count, so a recursive lowering —
+or a lowering into nested child closures, which pushes the same depth onto the
+stack at *call* time — raised ``RecursionError`` on well-formed models of only a
+few hundred terms. Instead the DAG is flattened once into a post-order tape of
+``(kernel, child_slots)`` entries; both the flattening and the per-call
+evaluation are ordinary loops, so compile and eval depth are bounded by the heap
+rather than by the C stack.
 """
 
 from __future__ import annotations
 
-from typing import Callable, cast
+from typing import Callable
 
 import jax.numpy as jnp
 
@@ -60,55 +69,78 @@ def _compute_var_offset(var: Variable, model: Model) -> int:
     return model._flat_var_offset(var)
 
 
-_CACHE_MISS = object()
+def _build_tape(expr: Expression, model: Model, param_index: dict) -> list[tuple]:
+    """Flatten an Expression DAG into a post-order evaluation tape.
 
+    Returns a list of ``(kernel, child_slots)`` entries in dependency order: every
+    entry's children occupy strictly earlier slots, and the root is the final
+    entry. Each distinct node (keyed by ``id(expr)``) gets exactly one slot, so a
+    node shared by k parents is compiled and evaluated once (#383).
 
-def _compile_node(
-    expr: Expression, model: Model, param_index: dict, memo: dict | None = None
-) -> Callable:
-    """Compile an Expression node into ``f(x_flat, params, cache) -> value``.
-
-    The expression is a DAG: a node may be shared by many parents. ``memo`` (keyed
-    by ``id(expr)``) ensures each distinct node is *compiled* once; the per-call
-    ``cache`` (also keyed by ``id(expr)``) ensures it is *evaluated* once per call.
-    So a node reachable by k references is traced and run a single time — without
-    this a linear DAG lowered in time exponential in its sharing depth (#383).
-    ``cache`` is a fresh dict supplied per top-level evaluation by the ``compile_*``
-    wrappers.
+    The walk uses an explicit stack rather than recursion so a deep chain — a
+    left-nested ``sum`` over thousands of terms — costs heap, not C stack (#925).
     """
-    if memo is None:
-        memo = {}
-    key = id(expr)
-    existing = memo.get(key)
-    if existing is not None:
-        return cast(Callable, existing)
+    tape: list[tuple] = []
+    slot_of: dict[int, int] = {}  # id(expr) -> tape slot, set on emission
+    pending: dict[int, tuple] = {}  # id(expr) -> (children, kernel), set on first visit
+    stack: list[tuple[Expression, bool]] = [(expr, False)]
 
-    raw = _raw_node(expr, model, param_index, memo)
+    while stack:
+        node, expanded = stack.pop()
+        key = id(node)
+        if expanded:
+            # Reached at most once per node: the ``(node, True)`` marker is pushed
+            # only on the first visit, which ``pending`` below makes exclusive.
+            children, kernel = pending[key]
+            tape.append((kernel, tuple(slot_of[id(c)] for c in children)))
+            slot_of[key] = len(tape) - 1
+            continue
+        if key in slot_of:
+            continue  # already emitted through another parent
+        if key in pending:
+            # Visited but not yet emitted => this node is its own ancestor. The
+            # modeling layer never builds one, and silently skipping would leave
+            # a dangling child slot, so refuse loudly.
+            raise ValueError(
+                f"Cyclic expression graph at {type(node).__name__} node — "
+                "expression DAGs must be acyclic."
+            )
+        children, kernel = _node_kernel(node, model, param_index)
+        pending[key] = (children, kernel)
+        stack.append((node, True))
+        for child in reversed(children):
+            stack.append((child, False))
 
-    def node(x_flat, params, cache, _k=key, _raw=raw):
-        v = cache.get(_k, _CACHE_MISS)
-        if v is _CACHE_MISS:
-            v = _raw(x_flat, params, cache)
-            cache[_k] = v
-        return v
-
-    memo[key] = node
-    return node
+    return tape
 
 
-def _raw_node(expr: Expression, model: Model, param_index: dict, memo: dict) -> Callable:
-    """Build the uncached compute closure ``f(x_flat, params, cache)`` for one node.
+def _evaluate_tape(tape: list[tuple], x_flat, params):
+    """Run a tape built by :func:`_build_tape` and return the root value.
 
-    Children are compiled via :func:`_compile_node` (sharing ``memo``) and called
-    with the same ``cache`` so their values memoize across references.
+    ``values[i]`` holds slot ``i``'s value for this call only; the loop is flat, so
+    evaluation depth is independent of the expression's nesting depth (#925).
+    """
+    values: list = [None] * len(tape)
+    for i, (kernel, child_slots) in enumerate(tape):
+        values[i] = kernel(x_flat, params, [values[s] for s in child_slots])
+    return values[-1]
+
+
+def _node_kernel(expr: Expression, model: Model, param_index: dict) -> tuple[tuple, Callable]:
+    """Build one node's ``(children, kernel)`` pair.
+
+    ``children`` are the node's direct operand expressions, in evaluation order.
+    ``kernel(x_flat, params, a)`` computes the node's value from ``a``, the list of
+    already-computed child values aligned with ``children``. Kernels never call
+    each other, which is what keeps evaluation iterative.
     """
     if isinstance(expr, Constant):
         val = jnp.array(expr.value)
 
-        def fn(x_flat, params, cache):
+        def fn(x_flat, params, a):
             return val
 
-        return fn
+        return (), fn
 
     if isinstance(expr, Variable):
         offset = _compute_var_offset(expr, model)
@@ -116,70 +148,67 @@ def _raw_node(expr: Expression, model: Model, param_index: dict, memo: dict) -> 
         shape = expr.shape
         if shape == () or (len(shape) == 1 and shape[0] == 1 and shape == ()):
             # Scalar variable: single slot
-            def fn(x_flat, params, cache):
+            def fn(x_flat, params, a):
                 return x_flat[offset]
 
-            return fn
+            return (), fn
         else:
             # Array variable: slice and reshape
-            def fn(x_flat, params, cache, _offset=offset, _size=size, _shape=shape):
+            def fn(x_flat, params, a, _offset=offset, _size=size, _shape=shape):
                 return x_flat[_offset : _offset + _size].reshape(_shape)
 
-            return fn
+            return (), fn
 
     if isinstance(expr, Parameter):
         idx = param_index[id(expr)]
 
-        def fn(x_flat, params, cache, _i=idx):
+        def fn(x_flat, params, a, _i=idx):
             return params[_i]
 
-        return fn
+        return (), fn
 
     if isinstance(expr, BinaryOp):
-        left_fn = _compile_node(expr.left, model, param_index, memo)
-        right_fn = _compile_node(expr.right, model, param_index, memo)
         op = expr.op
         if op == "+":
 
-            def fn(x_flat, params, cache):
-                return left_fn(x_flat, params, cache) + right_fn(x_flat, params, cache)
+            def fn(x_flat, params, a):
+                return a[0] + a[1]
         elif op == "-":
 
-            def fn(x_flat, params, cache):
-                return left_fn(x_flat, params, cache) - right_fn(x_flat, params, cache)
+            def fn(x_flat, params, a):
+                return a[0] - a[1]
         elif op == "*":
 
-            def fn(x_flat, params, cache):
-                return left_fn(x_flat, params, cache) * right_fn(x_flat, params, cache)
+            def fn(x_flat, params, a):
+                return a[0] * a[1]
         elif op == "/":
 
-            def fn(x_flat, params, cache):
-                return left_fn(x_flat, params, cache) / right_fn(x_flat, params, cache)
+            def fn(x_flat, params, a):
+                return a[0] / a[1]
         elif op == "**":
 
-            def fn(x_flat, params, cache):
-                return left_fn(x_flat, params, cache) ** right_fn(x_flat, params, cache)
+            def fn(x_flat, params, a):
+                return a[0] ** a[1]
         else:
             raise ValueError(f"Unknown binary operator: {op!r}")
-        return fn
+        return (expr.left, expr.right), fn
 
     if isinstance(expr, UnaryOp):
-        operand_fn = _compile_node(expr.operand, model, param_index, memo)
         op = expr.op
         if op == "neg":
 
-            def fn(x_flat, params, cache):
-                return -operand_fn(x_flat, params, cache)
+            def fn(x_flat, params, a):
+                return -a[0]
         elif op == "abs":
 
-            def fn(x_flat, params, cache):
-                return jnp.abs(operand_fn(x_flat, params, cache))
+            def fn(x_flat, params, a):
+                return jnp.abs(a[0])
         else:
             raise ValueError(f"Unknown unary operator: {op!r}")
-        return fn
+        return (expr.operand,), fn
 
     if isinstance(expr, FunctionCall):
-        arg_fns = [_compile_node(a, model, param_index, memo) for a in expr.args]
+        args = tuple(expr.args)
         name = expr.func_name
 
         # Single-argument functions
@@ -212,69 +241,58 @@ def _raw_node(expr: Expression, model: Model, param_index: dict, memo: dict) -> 
 
         if name in _unary_funcs:
             jax_fn = _unary_funcs[name]
-            a_fn = arg_fns[0]
 
-            def fn(x_flat, params, cache, _jax_fn=jax_fn, _a_fn=a_fn):
-                return _jax_fn(_a_fn(x_flat, params, cache))
+            def fn(x_flat, params, a, _jax_fn=jax_fn):
+                return _jax_fn(a[0])
 
-            return fn
+            return args, fn
 
         if name == "min":
-            a_fn, b_fn = arg_fns[0], arg_fns[1]
 
-            def fn(x_flat, params, cache):
-                return jnp.minimum(a_fn(x_flat, params, cache), b_fn(x_flat, params, cache))
+            def fn(x_flat, params, a):
+                return jnp.minimum(a[0], a[1])
 
-            return fn
+            return args, fn
 
         if name == "atan2":
-            a_fn, b_fn = arg_fns[0], arg_fns[1]
 
-            def fn(x_flat, params, cache):
-                return jnp.arctan2(a_fn(x_flat, params, cache), b_fn(x_flat, params, cache))
+            def fn(x_flat, params, a):
+                return jnp.arctan2(a[0], a[1])
 
-            return fn
+            return args, fn
 
         if name == "signpower":
             # GAMS signpower(x, a) = sign(x) * |x|**a.
-            a_fn, b_fn = arg_fns[0], arg_fns[1]
+            def fn(x_flat, params, a):
+                xv = a[0]
+                return jnp.sign(xv) * jnp.abs(xv) ** a[1]
 
-            def fn(x_flat, params, cache):
-                xv = a_fn(x_flat, params, cache)
-                return jnp.sign(xv) * jnp.abs(xv) ** b_fn(x_flat, params, cache)
-
-            return fn
+            return args, fn
 
         if name == "centropy":
             # GAMS centropy(x, y) = x * log(x / y), with the x -> 0+ limit 0.
-            a_fn, b_fn = arg_fns[0], arg_fns[1]
-
-            def fn(x_flat, params, cache):
-                xv = a_fn(x_flat, params, cache)
-                yv = b_fn(x_flat, params, cache)
+            def fn(x_flat, params, a):
+                xv, yv = a[0], a[1]
                 return xv * jnp.log(jnp.maximum(xv, 1e-300) / yv)
 
-            return fn
+            return args, fn
 
         if name == "max":
-            a_fn, b_fn = arg_fns[0], arg_fns[1]
 
-            def fn(x_flat, params, cache):
-                return jnp.maximum(a_fn(x_flat, params, cache), b_fn(x_flat, params, cache))
+            def fn(x_flat, params, a):
+                return jnp.maximum(a[0], a[1])
 
-            return fn
+            return args, fn
 
         if name == "prod":
-            a_fn = arg_fns[0]
 
-            def fn(x_flat, params, cache):
-                return jnp.prod(a_fn(x_flat, params, cache))
+            def fn(x_flat, params, a):
+                return jnp.prod(a[0])
 
-            return fn
+            return args, fn
 
         if name.startswith("norm"):
             # norm{p}: p-norm of an array argument (norm1, norm2, ...).
-            a_fn = arg_fns[0]
             suffix = name[len("norm") :]
             try:
                 ord_p: float = (
@@ -285,10 +303,10 @@ def _raw_node(expr: Expression, model: Model, param_index: dict, memo: dict) -> 
             except ValueError as exc:
                 raise ValueError(f"Unsupported norm order: {name!r}") from exc
 
-            def fn(x_flat, params, cache, _ord=ord_p):
-                return jnp.linalg.norm(a_fn(x_flat, params, cache), ord=_ord)
+            def fn(x_flat, params, a, _ord=ord_p):
+                return jnp.linalg.norm(a[0], ord=_ord)
 
-            return fn
+            return args, fn
 
         raise ValueError(f"Unknown function: {name!r}")
 
@@ -297,51 +315,45 @@ def _raw_node(expr: Expression, model: Model, param_index: dict, memo: dict) -> 
         # value + autodiff gradients/Hessians come for free on the local NLP
         # path. No relaxation rule exists (see relaxation_compiler / solver
         # guards), so this branch is only reached on the continuous NLP path.
-        custom_arg_fns = tuple(_compile_node(a, model, param_index, memo) for a in expr.args)
         user_fn = expr.fn
 
-        def fn(x_flat, params, cache, _user_fn=user_fn, _arg_fns=custom_arg_fns):
-            return _user_fn(*[a(x_flat, params, cache) for a in _arg_fns])
+        def fn(x_flat, params, a, _user_fn=user_fn):
+            return _user_fn(*a)
 
-        return fn
+        return tuple(expr.args), fn
 
     if isinstance(expr, IndexExpression):
-        base_fn = _compile_node(expr.base, model, param_index, memo)
         idx = expr.index
 
-        def fn(x_flat, params, cache, _idx=idx):
-            return base_fn(x_flat, params, cache)[_idx]
+        def fn(x_flat, params, a, _idx=idx):
+            return a[0][_idx]
 
-        return fn
+        return (expr.base,), fn
 
     if isinstance(expr, MatMulExpression):
-        left_fn = _compile_node(expr.left, model, param_index, memo)
-        right_fn = _compile_node(expr.right, model, param_index, memo)
 
-        def fn(x_flat, params, cache):
-            return left_fn(x_flat, params, cache) @ right_fn(x_flat, params, cache)
+        def fn(x_flat, params, a):
+            return a[0] @ a[1]
 
-        return fn
+        return (expr.left, expr.right), fn
 
     if isinstance(expr, SumExpression):
-        operand_fn = _compile_node(expr.operand, model, param_index, memo)
         axis = expr.axis
 
-        def fn(x_flat, params, cache, _axis=axis):
-            return jnp.sum(operand_fn(x_flat, params, cache), axis=_axis)
+        def fn(x_flat, params, a, _axis=axis):
+            return jnp.sum(a[0], axis=_axis)
 
-        return fn
+        return (expr.operand,), fn
 
     if isinstance(expr, SumOverExpression):
-        term_fns = [_compile_node(t, model, param_index, memo) for t in expr.terms]
 
-        def fn(x_flat, params, cache):
-            result = term_fns[0](x_flat, params, cache)
-            for t_fn in term_fns[1:]:
-                result = result + t_fn(x_flat, params, cache)
+        def fn(x_flat, params, a):
+            result = a[0]
+            for v in a[1:]:
+                result = result + v
             return result
 
-        return fn
+        return tuple(expr.terms), fn
 
     raise TypeError(f"Unhandled expression type: {type(expr).__name__}")
 
@@ -372,11 +384,12 @@ def compile_expression_params(
     """
     if param_index is None:
         param_index = _build_param_index(model)
-    root = _compile_node(expr, model, param_index)
+    tape = _build_tape(expr, model, param_index)
 
     def fn(x_flat, params):
-        # Fresh per-call value cache so shared DAG nodes evaluate once (#383).
-        return root(x_flat, params, {})
+        # Each tape slot is computed once per call, so shared DAG nodes evaluate
+        # once (#383) and depth costs heap rather than C stack (#925).
+        return _evaluate_tape(tape, x_flat, params)
 
     return fn
 

--- a/python/tests/test_923_dense_lagrangian_hessian.py
+++ b/python/tests/test_923_dense_lagrangian_hessian.py
@@ -75,8 +75,11 @@ def _emfl_shaped_model(n_cone: int, n_new: int = 9, seed: int = 0) -> dm.Model:
         px, py = p[r % n_new]
         m.subject_to(u - px + float(rng.uniform(-10, 10)) == 0)
         m.subject_to(v - py + float(rng.uniform(-10, 10)) == 0)
-    # Balanced-tree sum: a left-nested chain of ~1000 additions trips the
-    # dag_compiler recursion limit noted at the end of #923 (a separate defect).
+    # Balanced-tree sum: a left-nested chain of ~1000 additions used to trip the
+    # dag_compiler recursion limit noted at the end of #923 (a separate defect,
+    # fixed under #925). Kept as-is so this test keeps measuring the Hessian,
+    # not the compiler; the depth itself is covered by
+    # test_925_dag_compiler_deep_chain.py.
     terms: list = list(d)
     while len(terms) > 1:
         terms = [

--- a/python/tests/test_925_dag_compiler_deep_chain.py
+++ b/python/tests/test_925_dag_compiler_deep_chain.py
@@ -1,0 +1,218 @@
+"""Regression tests for #925: the DAG compiler must not overflow the C stack.
+
+``dag_compiler`` used to lower an Expression by recursing once per node
+(``_compile_node`` -> ``_raw_node`` -> ``_compile_node`` per child) into *nested
+child closures*, so the same depth was pushed onto the stack again at every
+evaluation. A plain Python ``sum``/``+=`` over a list of terms builds a
+**left-nested** ``BinaryOp`` chain whose depth equals the term count, so both
+lowering and evaluating one raised ``RecursionError``.
+
+Measured on ``main`` @ 5800bfc (CPython 3.11, ``sys.getrecursionlimit() == 1000``)
+with the reproduction in #925: n=200 ok, n=300 ok, n=500 ``RecursionError``. The
+exact cliff moves with the interpreter and with how deep the caller already is,
+but it is far below any real model size — a #75 differential sweep skipped
+``edgecross10-030``/``-040``/``-090`` on it.
+
+The fix flattens the DAG once into a post-order tape and evaluates it with a
+flat loop, so compile *and* eval depth are bounded by the heap. These tests use
+left-nested chains an order of magnitude past the observed cliff, which is the
+shape that actually breaks — a balanced tree of the same term count never
+reproduced the defect (see the workaround in
+``test_923_dense_lagrangian_hessian.py``).
+"""
+
+from __future__ import annotations
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+from discopt._jax.dag_compiler import (
+    _build_param_index,
+    _build_tape,
+    compile_constraint,
+    compile_expression,
+    compile_expression_params,
+    compile_objective,
+)
+from discopt.modeling.core import BinaryOp, Model
+
+# Comfortably past the n=500 cliff measured on the pre-fix compiler, and past the
+# ~1000-frame default recursion limit that produced it.
+DEEP = 5000
+# Reverse mode is split across two depths on purpose. Tracing `jax.grad` is
+# linear and cheap (measured: 0.44 s at n=300, 0.99 s at n=600, 2.8 s at
+# n=2000) and is the step that would hit the recursion cliff, so the *depth*
+# probe traces at DEEP_AD. Actually running the gradient pays XLA compilation,
+# which is steeply superlinear in HLO op count (2.3 s at n=60, 8.5 s at n=200,
+# 340 s at n=5000) for reasons that have nothing to do with this compiler, so
+# the *numeric* probe stays at SHALLOW_AD.
+DEEP_AD = 2000
+SHALLOW_AD = 120
+
+
+def _left_nested_sum(terms):
+    """Build ``((t0 + t1) + t2) + ...`` — what ``sum(xs)``/``+=`` produces.
+
+    Depth equals ``len(terms)``, unlike a balanced tree's ``log2(len(terms))``.
+    """
+    acc = terms[0]
+    for t in terms[1:]:
+        acc = acc + t
+    return acc
+
+
+def _chain_model(n: int, name: str = "deep") -> tuple[Model, list]:
+    m = Model(name)
+    xs = [m.continuous(f"x{i}", lb=0.0, ub=1.0) for i in range(n)]
+    return m, xs
+
+
+def _assert_left_nested(expr, expected_depth: int) -> None:
+    """Fail loudly if the fixture degenerated into a shallow/balanced tree.
+
+    Without this the tests would still pass on the *pre-fix* compiler if the
+    modeling layer ever started folding chains, and would prove nothing.
+    """
+    depth = 0
+    node = expr
+    while isinstance(node, BinaryOp):
+        depth += 1
+        node = node.left
+    assert depth == expected_depth, f"chain depth {depth}, expected {expected_depth}"
+
+
+def test_left_nested_objective_compiles_and_evaluates():
+    """The #925 reproduction, an order of magnitude past the measured cliff."""
+    m, xs = _chain_model(DEEP)
+    obj = _left_nested_sum(xs)
+    _assert_left_nested(obj, DEEP - 1)
+    m.minimize(obj)
+
+    fn = compile_objective(m)
+    assert float(fn(jnp.ones(DEEP))) == pytest.approx(float(DEEP))
+
+    rng = np.random.default_rng(0)
+    pt = rng.uniform(0.0, 1.0, size=DEEP)
+    assert float(fn(jnp.asarray(pt))) == pytest.approx(float(pt.sum()), rel=1e-6)
+
+
+def test_left_nested_constraint_body_compiles_and_evaluates():
+    """The same shape reached through ``compile_constraint`` rather than the objective."""
+    m, xs = _chain_model(DEEP, "deep_con")
+    body = _left_nested_sum(xs)
+    _assert_left_nested(body, DEEP - 1)
+    m.subject_to(body <= float(DEEP))
+    m.minimize(xs[0])
+
+    con = m._constraints[0]
+    # ``subject_to`` normalizes to ``sum(x) - DEEP <= 0``, one level deeper.
+    _assert_left_nested(con.body, DEEP)
+
+    fn = compile_constraint(con, m)
+    assert float(fn(jnp.ones(DEEP))) == pytest.approx(0.0, abs=1e-6)
+
+    rng = np.random.default_rng(2)
+    pt = rng.uniform(0.0, 1.0, size=DEEP)
+    assert float(fn(jnp.asarray(pt))) == pytest.approx(float(pt.sum()) - DEEP, rel=1e-6)
+
+
+def test_left_nested_mixed_operators_match_numpy():
+    """Depth is not specific to ``+``: mix the binary ops and a unary/function layer."""
+    n = DEEP
+    m, xs = _chain_model(n, "deep_mixed")
+    rng = np.random.default_rng(1)
+    pt = rng.uniform(0.2, 0.9, size=n)
+
+    acc = xs[0]
+    expected = pt[0]
+    for i in range(1, n):
+        which = i % 3
+        if which == 0:
+            acc = acc + xs[i]
+            expected = expected + pt[i]
+        elif which == 1:
+            acc = acc - xs[i]
+            expected = expected - pt[i]
+        else:
+            # Keep the running value bounded so the comparison stays meaningful.
+            acc = acc * 1.0 + xs[i] * 0.5
+            expected = expected * 1.0 + pt[i] * 0.5
+    deep = abs(acc)
+    m.minimize(deep)
+
+    fn = compile_objective(m)
+    assert float(fn(jnp.asarray(pt))) == pytest.approx(float(abs(expected)), rel=1e-5)
+
+
+def test_deep_reverse_mode_trace_survives_depth():
+    """``jax.grad`` re-enters the tape to build its jaxpr — that trace is the
+    step that hit the cliff, so it must survive well past it."""
+    m, xs = _chain_model(DEEP_AD, "deep_ad")
+    m.minimize(_left_nested_sum(xs))
+    fn = compile_objective(m)
+
+    jaxpr = jax.make_jaxpr(jax.grad(fn))(jnp.ones(DEEP_AD))
+    # One primal add per link, plus the reverse sweep — the point is that the
+    # whole chain is present rather than truncated or folded away.
+    assert len(jaxpr.jaxpr.eqns) >= DEEP_AD
+
+
+def test_gradient_of_left_nested_sum_is_correct():
+    """AD through the tape must give the right numbers: d/dx_i of sum(x) is 1.
+
+    Shallow by design (see ``SHALLOW_AD``); this guards the rewritten kernels'
+    differentiability, not the depth property.
+    """
+    m, xs = _chain_model(SHALLOW_AD, "shallow_grad")
+    m.minimize(_left_nested_sum(xs))
+    fn = compile_objective(m)
+
+    g = np.asarray(jax.grad(fn)(jnp.ones(SHALLOW_AD)))
+    assert g.shape == (SHALLOW_AD,)
+    np.testing.assert_allclose(g, np.ones(SHALLOW_AD), rtol=0, atol=1e-9)
+
+
+def test_left_nested_params_path_compiles_and_evaluates():
+    """``compile_expression_params`` threads parameters and must handle the same depth."""
+    n = DEEP
+    m, xs = _chain_model(n, "deep_params")
+    scale = m.parameter("scale", value=2.0)
+    expr = _left_nested_sum([x * scale for x in xs])
+
+    fn = compile_expression_params(expr, m)
+    params = (jnp.asarray(3.0),)
+    assert float(fn(jnp.ones(n), params)) == pytest.approx(3.0 * n)
+    # Same trace, new parameter value — no recompile, no recursion.
+    assert float(fn(jnp.ones(n), (jnp.asarray(0.5),))) == pytest.approx(0.5 * n)
+
+
+def test_deep_shared_subexpression_still_evaluates_once():
+    """Depth-independence must not cost the #383 common-subexpression sharing.
+
+    The chain is referenced twice at the root; a tape that lost node sharing
+    would emit ~2x the slots (and, before #383, lower exponentially).
+    """
+    n = 400
+    m, xs = _chain_model(n, "deep_shared")
+    chain = _left_nested_sum(xs)
+    expr = chain + chain
+
+    tape = _build_tape(expr, m, _build_param_index(m))
+    # n leaves + (n-1) chain adds + 1 root add. One slot per *distinct* node.
+    assert len(tape) == n + (n - 1) + 1
+
+    fn = compile_expression(expr, m)
+    assert float(fn(jnp.ones(n))) == pytest.approx(2.0 * n)
+
+
+def test_cyclic_expression_graph_is_refused_loudly():
+    """A self-referential node has no valid post-order; refuse rather than emit
+    a tape with a dangling child slot."""
+    m, xs = _chain_model(3, "cyclic")
+    node = xs[0] + xs[1]
+    assert isinstance(node, BinaryOp)
+    node.left = node  # not reachable through the modeling API; defensive guard
+
+    with pytest.raises(ValueError, match="Cyclic expression graph"):
+        _build_tape(node, m, _build_param_index(m))


### PR DESCRIPTION
## Summary

`_jax/dag_compiler.py` lowered an Expression by recursing once per node
(`_compile_node` → `_raw_node` → `_compile_node` per child), **and** lowered each
node into a closure that called its children's closures — so the same depth was
pushed onto the C stack again at every *evaluation*. A plain Python `sum`/`+=`
over a list of terms builds a left-nested `BinaryOp` chain whose depth equals the
term count, so compiling one raised `RecursionError` on well-formed models of
only a few hundred terms.

Reproduced on `5800bfc` (CPython 3.11, `sys.getrecursionlimit() == 1000`) with
the script in the issue: `n=200 ok, n=300 ok, n=500 RecursionError`. Post-fix
`n=5000` compiles and evaluates to `5000.0`. The failure skipped
`edgecross10-030`/`-040`/`-090` in a #75 differential sweep.

The fix flattens the DAG once into a post-order tape:

* **`_build_tape`** walks the DAG with an explicit work stack, assigning each
  distinct node (keyed by `id(expr)`) exactly one tape slot — so #383's
  common-subexpression sharing is preserved unchanged. A node that is its own
  ancestor has no valid post-order and would leave a dangling child slot, so it
  is refused with a `ValueError` rather than silently skipped.
* **`_evaluate_tape`** runs the tape with a plain loop. This is what makes the
  *evaluation* depth flat too — an iterative compile alone would not have fixed
  this, since the nested child closures re-pushed the depth on every call.
* **`_node_kernel`** replaces `_raw_node`: each node returns `(children, kernel)`
  where `kernel(x_flat, params, a)` reads already-computed child values out of
  `a`. Kernels never call each other.

Raising `sys.setrecursionlimit` was rejected as the issue suggests: it moves the
cliff and trades a catchable exception for a hard interpreter crash.

Closes #925

## Correctness

No solver math changes — this is a lowering-mechanism refactor of the
expression → jaxpr path. Verified value-identical rather than argued:

Compiled the objective **and every constraint body** of all 66
`python/tests/data/minlplib_nl/*.nl` instances and evaluated each at a fixed
deterministic point, on this branch and on `5800bfc`, each arm behind a load gate
asserting `dag_compiler.__file__` *and* the presence/absence of the `_build_tape`
version marker (CLAUDE.md §8). **3,769 bodies compared, 0 differences** — exact
equality, not tolerance. The probe prints its comparison count and exits non-zero
if it is zero (§6).

Caveat stated plainly: the in-repo corpus's deepest expression is 89, well under
the cliff, so that panel proves *neutrality*, not that it unblocks the reported
instances. The `edgecross10-*` casualties live in the larger MINLPLib snapshot,
which is not present in this container; the depth property is covered by the
synthetic reproduction from the issue, which is the exact shape reported.

- [x] Cannot produce a false certificate (no solver-math change; value-identical
      over 3,769 corpus bodies)
- [x] No validation, fallback, or safety guard was weakened to make a check pass

## Tests run (state the result — numbers, not adjectives)

- [x] `pytest -m smoke` → **900 passed, 15 skipped, 7,936 deselected, 2 xpassed**
      in 7m01s
- [x] `pytest -m slow python/tests/test_adversarial_recent_fixes.py` →
      **10 passed** in 3m09s
- [x] PR-fast suite (`python/tests/`, CI's marker set, `-n 4`) → **7,385 passed,
      2 failed, 130 skipped, 5 xfailed, 2 xpassed** in 7m26s. Both failures are
      `ModuleNotFoundError: No module named 'cyipopt'` raised inside
      `nlp_ipopt.solve_nlp` — an optional dependency absent from this container
      (`test_neglog_interior_stall_not_false_optimal[ipopt]` and
      `test_ipopt_backend_active_constraint_gradient`; neither carries the
      `requires_cyipopt` marker). Unrelated to this change.
- [x] `cargo test -p discopt-core` → N/A, no Rust touched
- [x] `ruff check` / `ruff format --check` clean; `mypy` clean on the touched files
- [x] `pytest python/tests/test_dag_compiler.py python/tests/test_dag_cse.py` →
      59 passed, 3 deselected

One retraction, recorded per CLAUDE.md §11: a first adversarial run reported
`1 failed, 9 passed` on `test_large_dense_jacobian_no_crash`. That run overlapped
a concurrent smoke suite on the same box. The test asserts a wall-clock bound
(8s solve budget + 40s slack); re-run on an idle box it passes in **29.1s**, and
the full suite is 10/10 as above. The failure was self-inflicted load (§9), not a
regression.

## Regression test

`python/tests/test_925_dag_compiler_deep_chain.py` — 8 tests, 16s. Drives
5,000-term **left-nested** chains (the shape that actually breaks; a balanced
tree of the same term count never reproduced it) through the objective,
constraint and parameter entry points; checks mixed `+`/`-`/`*` plus a unary
layer against numpy; checks the reverse-mode trace at depth 2,000 and gradient
values; asserts the tape keeps one slot per distinct node so #383's sharing is
not lost; and covers the cycle refusal. `_assert_left_nested` fails loudly if the
fixture ever degenerates into a shallow tree, so the tests cannot silently stop
testing depth.

Fail-before/pass-after confirmed against `5800bfc` in a git worktree, behind the
load gate described above: the five depth tests fail with `RecursionError` at
`dag_compiler.py:81`. The shallow-AD test passes on both arms by design — it
guards the rewritten kernels' differentiability, not the depth property.

- [x] Added a regression test that fails before / passes after

## Bound-changing / performance change?

Not bound-changing. Performance measured anyway, since the evaluation path was
rewritten: interleaved A/B at n=300, 7 rounds per arm, 3 interleaves, load gate
on both arms, `uptime` checked before and after (CLAUDE.md §9). Steady-state
compile ≈2 ms on both arms; eval slightly faster on the tape (0.030–0.040 s vs
0.040–0.058 s); grad identical (0.482 s vs 0.497 s). First-round means are
warmup-dominated and excluded — that is what the large standard deviations in the
raw log reflect.

One measurement recorded so it is not mistaken for a regression here: `jax.grad`
over a flat chain of *n* scalar adds costs 2.3 s at n=60, 8.5 s at n=200 and
340 s at n=5000. That cost is XLA compilation, steeply superlinear in HLO op
count, and is **identical on both arms** — it is why the regression test splits
reverse mode into a cheap linear *trace* probe at depth 2,000 and a *numeric*
probe at depth 120.