### PR TITLE
fix(solver): honor time_limit as a contract, not a hint

### DIFF
--- a/python/discopt/_jax/milp_relaxation.py
+++ b/python/discopt/_jax/milp_relaxation.py
@@ -255,6 +255,11 @@ class MilpRelaxationResult:
 def _lp_warm_deadline_enabled() -> bool:
     """Honour the caller's ``time_limit`` on the warm pure-LP node path.
 
+    Tracking issue: **#928**. (This helper's panel script and companion test are
+    named ``issue917_*`` / ``test_917_*`` for historical reasons only — #917 is a
+    different, closed issue about the #844 LP-spatial reserve. Do not follow that
+    number.)
+
     **The defect it fixes.** ``MilpRelaxationModel.solve`` takes a ``time_limit``,
     but its default ``backend="simplex"`` pure-LP fast path dropped it on the floor:
     ``_solve_lp_warm`` / ``_solve_lp_warm_equilibrated`` / ``solve_lp_warm_std`` took
@@ -292,10 +297,54 @@ def _lp_warm_deadline_enabled() -> bool:
       82.1 / 79.2 / 175.6 s. Cells over budget went 15 -> 18.
 
     So it stays OFF: cert-clean is necessary, not sufficient (CLAUDE.md §5 bar 2, the
-    ``DISCOPT_CUT_INHERIT`` rule). What would settle it is a load-gated, multi-rep
-    panel over the instances where the deadline actually binds — on the corpus average
-    the effect is diluted by the ~50 instances that finish far inside 15 s and are
-    bit-identical either way.
+    ``DISCOPT_CUT_INHERIT`` rule).
+
+    **The settling experiment has now been run, and it does not graduate the flag.**
+    The paragraph here used to say what would settle it: *a load-gated, multi-rep panel
+    over the instances where the deadline actually binds* — the corpus average being
+    diluted by the ~50 instances that finish far inside the budget and are bit-identical
+    either way. That panel is ``issue917_lp_warm_deadline_panel.py --instances`` over the
+    17 non-closing in-repo instances, 3 reps at a 20 s budget, load-gated per CLAUDE.md §9
+    (``scratchpad/issue917_bind.log``):
+
+    ====  ============  ===========  ==========  =========
+    rep   overrun OFF   overrun ON   cells OFF   cells ON
+    ====  ============  ===========  ==========  =========
+    1     30.9 s        27.7 s       7           5
+    2     21.3 s        27.9 s       5           6
+    3     29.6 s        35.3 s       7           5
+    ====  ============  ===========  ==========  =========
+
+    All three reps ``CERT_CLEAN=True`` (0 unsound / 0 lost_bound / 0 cert_regressions /
+    0 lost_incumbents), so bar 1 holds on the binding subset too. Bar 2 does not: the
+    paired ON-OFF deltas are -3.2 / +6.6 / +5.7 s — they *flip sign*, mean +3.0 s with
+    sd 5.3 s, and the OFF arm alone spans 21.3-30.9 s. Concentrating the panel on the
+    subset where the deadline binds did not resolve the effect out of the noise; if
+    anything it leans the wrong way. **The flag stays OFF, and this is now a measured
+    negative rather than an open question.**
+
+    Two by-products of that run are worth keeping. First, ``nvs05`` and
+    ``clay0303hfsg`` reported ``tighter_bound``/``looser_bound`` in *opposite
+    directions between reps at identical flag state* — their bounds are
+    timing-nondeterministic, so a single-rep bound delta on either is not evidence of
+    anything. Second, on ``hda`` at ``time_limit=10`` (5 reps per arm,
+    ``scratchpad/hda10.py``) the flag buys wall consistency at the price of the bound:
+
+    ==============  ==================  ================================
+    WARM_DEADLINE   wall                dual bound
+    ==============  ==================  ================================
+    0 (default)     12.03 s ± 1.23      -64473 in 3/5 reps, -141697 in 2
+    1               11.14 s ± 0.04      -141697 in 5/5 reps
+    ==============  ==================  ================================
+
+    The OFF arm is bimodal because the #138 fallback's separated-relaxation phase is
+    what overruns: when its grant is already spent by the time a first bound is in
+    hand, ``_fb_stop`` returns the weak bound at ~10.7 s; when the grant still has room
+    the phase starts and then ignores the budget passed to it — *this* drop — for a
+    full ~4 s, reaching the full bound at ~12.9 s. Turning the flag on clamps that
+    phase, which is why the wall tightens to ±0.04 s and why the bound is the weak one
+    every time. Trading a rigorous bound for punctuality is the wrong trade under
+    CLAUDE.md §1, which is the second, independent reason the flag is not the fix here.
 
     **What it took to become cert-clean** — the first two cuts were NOT, and both
     failures are worth keeping (CLAUDE.md §11):

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -4123,11 +4123,18 @@ def _root_relaxation_lower_bound(
     # (fewer cuts), never falsifies one, so ``incorrect_count`` is unaffected.
     # Corpus-measured bound-neutral: no in-repo instance both spends the whole
     # grant before a checkpoint and has a candidate in hand, so no bound changes.
-    _fb_t0 = time.perf_counter()
+    # The fallback's own grant as an ABSOLUTE deadline, and the single source of
+    # truth for it: rule 2 (``_fb_stop``), the separated-relaxation clamp
+    # (``_fb_left``) and the relaxation build deadlines below all read this one
+    # value, which the three of them used to recompute independently. Kept in the
+    # ``<clock>() + <budget>`` form on purpose — that is one of the two
+    # constructions ``test_912_wall_budget_inventory.py`` scans for, so this gate
+    # stays visible to that ratchet instead of hiding inside a helper.
+    _fb_deadline = time.perf_counter() + max(0.0, float(time_limit))
 
     def _fb_left() -> float:
         """Seconds remaining of the fallback's OWN grant (rule 2's anchor)."""
-        return max(0.0, float(time_limit) - (time.perf_counter() - _fb_t0))
+        return max(0.0, _fb_deadline - time.perf_counter())
 
     def _fb_stop(have: "list[float]") -> bool:
         """True when this phase should decline to *start* another optional
@@ -4173,10 +4180,10 @@ def _root_relaxation_lower_bound(
     _base_deadline_on = getattr(_tuning(), "root_build_deadline", False)
     _build_deadline: Optional[float] = None
     if getattr(_tuning(), "anytime_root_build", False) or _base_deadline_on:
-        _build_deadline = _fb_t0 + max(0.0, float(time_limit))
+        _build_deadline = _fb_deadline
     _base_build_deadline: Optional[float] = None
     if _base_deadline_on:
-        _base_build_deadline = _fb_t0 + max(0.0, float(time_limit))
+        _base_build_deadline = _fb_deadline
 
     try:
         terms = classify_nonlinear_terms(model)

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -1472,15 +1472,29 @@ _CONVEX_OBJ_PSD_TOL = 1e-6
 _LAZY_RESEP_STALL_WINDOW = 24
 _LAZY_RESEP_PROBE_BUDGET = 8
 _LAZY_RESEP_GLB_EPS = 1e-9
-# Floor on the time budget handed to the end-of-solve root-relaxation fallback
-# bound (issue #138). On a hard nonconvex minimize the B&B loop can consume the
-# entire `time_limit` and exit uncertified, leaving no time for the rigorous
-# root MILP-relaxation bound — so a sound dual bound is dropped to None. This
-# floor lets the fallback still run a small, bounded solve so an uncertified exit
-# reports a finite *sound* bound instead of None. It is paid only when the search
-# produced no usable bound at all (never on a clean/certified solve), and the
-# fallback's own internal budget (~10% of this) keeps the overrun small.
-_ROOT_FALLBACK_FLOOR_S = 3.0
+# Wall-clock slice WITHHELD FROM the search and spent, inside ``time_limit``, on
+# the rigorous root MILP-relaxation fallback bound (issue #138) whenever the tree
+# holds no finite global bound of its own.
+#
+# This used to be the opposite: a post-deadline *grant*. On a hard nonconvex
+# minimize the search consumed the whole limit and exited with no bound, and the
+# fallback was then handed 3.0 s of fresh budget past an already-spent deadline —
+# so ``solve(time_limit=T)`` returned at ``T + 3`` or worse. Measured on ``hda``:
+# the fallback was entered 1.95 s past a 5 s deadline and ran a further 4.25 s
+# (wall 11.75 s), and at a 60 s limit it was entered at 60.16 s and ran 4.04 s
+# against its 3.0 s grant. The claim the old comment made — "the fallback's own
+# internal budget keeps the overrun small" — was false by 32-35% at the grant it
+# was describing, and the whole grant sat outside the contract regardless.
+#
+# Withholding the same slice up front costs the search nothing it was using: the
+# reserve is only held while the tree's global lower bound is non-finite, which
+# is exactly the state in which the fallback is the sole bound producer, and it
+# is released the moment the tree has a bound of its own (an instance that
+# produces a bound sees a byte-identical deadline). The fallback is anytime with
+# respect to its grant — measured on ``hda``: 0.25 s -> -141697 (valid, weak),
+# 2 s -> -64473 (the full bound) — so a smaller pre-deadline slice buys a weaker
+# but still rigorous bound rather than no bound at all.
+_ROOT_FALLBACK_RESERVE_S = 3.0
 # Multistart runs 3 starts per nonconvex node (warm/midpoint/random) and keeps
 # the best — better incumbents on nonconvex models, but ~3x the node-solve cost.
 # Off by default; flip to opt in (or pass multistart=True to _solve_batch_pounce).
@@ -4111,11 +4125,15 @@ def _root_relaxation_lower_bound(
     # grant before a checkpoint and has a candidate in hand, so no bound changes.
     _fb_t0 = time.perf_counter()
 
+    def _fb_left() -> float:
+        """Seconds remaining of the fallback's OWN grant (rule 2's anchor)."""
+        return max(0.0, float(time_limit) - (time.perf_counter() - _fb_t0))
+
     def _fb_stop(have: "list[float]") -> bool:
         """True when this phase should decline to *start* another optional
         tightening: the fallback's own grant is spent AND a valid bound is
         already in hand (rules 1 and 2 above)."""
-        return bool(have) and (time.perf_counter() - _fb_t0) >= max(0.0, float(time_limit))
+        return bool(have) and _fb_left() <= 0.0
 
     # Issue #694 anytime build (opt-in, ``DISCOPT_ANYTIME_ROOT_BUILD``, default off).
     # When on, the SEPARATED relaxation build (``sep`` below) stops adding constraint
@@ -4336,8 +4354,20 @@ def _root_relaxation_lower_bound(
             try:
                 from discopt._jax.mccormick_lp import MccormickLPRelaxer
 
+                # Rule 1 vs rule 2, applied to the SOLVE budget and not just to
+                # whether the phase starts. With no candidate in hand this is the
+                # sole bound producer and keeps the full slice. Once ``plain`` (or a
+                # strengthened candidate) has landed it is optional tightening, and
+                # it must fit in what is genuinely LEFT of the grant — a phase that
+                # merely starts before the checkpoint could otherwise run arbitrarily
+                # past it (measured on hda at a 2.0s grant: this solve started at
+                # 1.62s and ran 2.19s, so the fallback took 4.05s, 2.0x its grant).
+                # A solve stopped on its own deadline still reports the sound
+                # Neumaier-Shcherbina floor via ``_time_limit_result``, so the clamp
+                # weakens the candidate at worst — it never invalidates one.
+                _sep_budget = min(budget, _fb_left()) if _have else budget
                 node_res = MccormickLPRelaxer(model).solve_at_node(
-                    root_lb, root_ub, time_limit=budget, build_deadline=_build_deadline
+                    root_lb, root_ub, time_limit=_sep_budget, build_deadline=_build_deadline
                 )
                 if node_res.lower_bound is not None and np.isfinite(node_res.lower_bound):
                     sep_bound = float(node_res.lower_bound)
@@ -5014,6 +5044,16 @@ def solve_model(
         box or fewer cuts — never makes it unsound.
         """
         return _remaining_budget() <= floor
+
+    # Slice held back from the search for the root-relaxation fallback so that
+    # bound recovery happens INSIDE ``time_limit`` (see ``_ROOT_FALLBACK_RESERVE_S``).
+    # Capped at a fraction of the limit so a short budget is not dominated by the
+    # reserve, and zero for a non-finite limit (nothing to honor).
+    _rr_reserve_s = (
+        min(_ROOT_FALLBACK_RESERVE_S, 0.30 * float(time_limit))
+        if math.isfinite(float(time_limit))
+        else 0.0
+    )
 
     # Reset the per-solve convexity-classification memo (a previous solve, or an
     # IIS feasibility probe, may have cached a verdict for a different constraint
@@ -7385,31 +7425,43 @@ def solve_model(
     # completion (never truncated mid-flight, so casctanks-class keeps its dual
     # bound), the reported status is ``time_limit`` (never a certified/optimal
     # claim), and skipping the search only ever *weakens* a still-valid bound —
-    # never falsifies it. When budget remains, ``_deadline_exhausted()`` is False and
-    # this is byte-identical to the pre-fix path (the search runs as before).
-    if _deadline_exhausted():
+    # never falsifies it. When budget remains, this is byte-identical to the pre-fix
+    # path (the search runs as before).
+    #
+    # The trigger is the fallback RESERVE, not a bare floor: once the remaining
+    # budget is down to the slice the fallback needs, starting a search that cannot
+    # finish would spend the reserve and leave the fallback to run past the deadline
+    # (the old post-deadline grant). Handing the remainder to the fallback here keeps
+    # the whole solve inside ``time_limit``. Measured on ``hda`` at a 5 s limit: the
+    # mandatory root work (2.0 s Rust presolve + 1.3 s convexity classification +
+    # ~3.4 s root McCormick LP) alone exceeds the budget, so this is the arm that
+    # runs, and it returns a valid (weaker) bound on time instead of the full bound
+    # 6.75 s late.
+    if _deadline_exhausted(_rr_reserve_s):
         from discopt.modeling.core import ObjectiveSense as _ObjSenseSC
 
         _rr_bound: Optional[float] = None
         if model._objective is not None:
             _is_maximize = model._objective.sense == _ObjSenseSC.MAXIMIZE
-            # Same bounded budget the post-search fallback grants once the limit is
-            # spent: the ``_ROOT_FALLBACK_FLOOR_S`` floor recovers a bound instead of
-            # None while keeping the overrun to a single bounded op.
-            _rr_budget = max(_remaining_budget(), _ROOT_FALLBACK_FLOOR_S)
-            try:
-                _rr_val = _root_relaxation_lower_bound(
-                    model,
-                    _root_lb_snapshot,
-                    _root_ub_snapshot,
-                    _rr_budget,
-                    psd_cuts=psd_cuts,
-                )
-            except Exception as _rr_exc:  # pragma: no cover - defensive
-                logger.debug(
-                    "root-relaxation fallback (deadline short-circuit) failed: %s", _rr_exc
-                )
-                _rr_val = None
+            # Whatever is genuinely left, and no more. A zero/negative remainder
+            # means the budget is gone; the fallback then returns nothing rather
+            # than manufacturing time it was not given.
+            _rr_budget = _remaining_budget()
+            _rr_val = None
+            if _rr_budget > 0.0:
+                try:
+                    _rr_val = _root_relaxation_lower_bound(
+                        model,
+                        _root_lb_snapshot,
+                        _root_ub_snapshot,
+                        _rr_budget,
+                        psd_cuts=psd_cuts,
+                    )
+                except Exception as _rr_exc:  # pragma: no cover - defensive
+                    logger.debug(
+                        "root-relaxation fallback (deadline short-circuit) failed: %s", _rr_exc
+                    )
+                    _rr_val = None
             if _rr_val is not None and np.isfinite(_rr_val):
                 # A lower bound on the internally minimized objective: for a MINIMIZE
                 # it is the dual lower bound directly; for a MAXIMIZE the builder
@@ -8915,8 +8967,46 @@ def solve_model(
     # incumbent. 0.0 (the default) reproduces the pre-#917 deadline exactly.
     _incumbent_extension_s = max(0.0, float(incumbent_time_extension))
     _incumbent_extension_taken = 0.0
+    # ``_ROOT_FALLBACK_RESERVE_S``: once released, the search owns the whole limit
+    # and the deadline below is exactly the pre-reserve one. The release is a latch
+    # (a finite tree bound never becomes non-finite) and it is only evaluated in the
+    # last ``_rr_reserve_s`` seconds of the budget, so a solve that finishes earlier
+    # -- or one with no finite limit -- never reads ``tree.stats()`` for it at all.
+    _rr_reserve_released = _rr_reserve_s <= 0.0
+    # Set when the loop is cut short to hand the reserve to the fallback. The
+    # search is then INTERRUPTED, not exhausted, and the status decision must say
+    # so — a break with ``wall_time < time_limit`` and an unfinished tree otherwise
+    # falls through to the certified ``"infeasible"`` branch, i.e. a feasible model
+    # declared infeasible (measured: hda at a 10 s limit and casctanks at 5 s both
+    # reported ``infeasible`` on the first cut of this change).
+    _rr_reserve_yield = False
     while True:
         elapsed = time.perf_counter() - t_start
+        if not _rr_reserve_released and elapsed >= time_limit - _rr_reserve_s:
+            try:
+                _rr_glb = float(tree.stats()["global_lower_bound"])
+            except Exception:  # pragma: no cover - defensive
+                _rr_glb = -np.inf
+            if np.isfinite(_rr_glb) or tree.is_finished():
+                # Either the tree has a dual bound of its own (the fallback will not
+                # run) or it is exhausted and the natural ``n_batch == 0`` exit below
+                # owns the termination — including a legitimately certified
+                # ``infeasible``, which yielding here would downgrade. The reserve is
+                # the search's in both cases.
+                _rr_reserve_released = True
+            else:
+                # Bound-less at the reserve boundary with an open frontier: the
+                # root-relaxation fallback is the only remaining bound producer and
+                # it must run INSIDE ``time_limit``. Stop the search and leave it the
+                # slice. Stopping early only ever weakens a still-valid bound (fewer
+                # nodes proved), never falsifies one.
+                logger.debug(
+                    "search yielding %.2fs to the root-relaxation fallback "
+                    "(tree bound still non-finite at the reserve boundary)",
+                    _rr_reserve_s,
+                )
+                _rr_reserve_yield = True
+                break
         if elapsed >= time_limit:
             if _incumbent_extension_taken == 0.0:
                 _extended = _extend_budget_for_incumbent(
@@ -11662,8 +11752,8 @@ def solve_model(
                     _gap_certified = True
                     _taint_rig_bound_internal = _rig_int
 
-        search_closed = _gap_converged(tree, gap_tolerance) or (
-            tree.is_finished() and not _bound_unresolved
+        search_closed = not _rr_reserve_yield and (
+            _gap_converged(tree, gap_tolerance) or (tree.is_finished() and not _bound_unresolved)
         )
         if search_closed and _gap_certified:
             status = "optimal"
@@ -11679,7 +11769,12 @@ def solve_model(
             # describes an unexplored search, not a proven optimum — a certified
             # exit here would claim optimality with no solution at all.
             _gap_certified = False
-        elif wall_time >= time_limit:
+        elif wall_time >= time_limit or _rr_reserve_yield:
+            # ``_rr_reserve_yield``: the search was cut short *by the time budget*
+            # (the tail of it was reassigned to the root-relaxation fallback), so
+            # the tree is NOT exhausted and neither infeasibility nor optimality was
+            # proven. "time_limit" is the honest reason; falling through to the
+            # ``infeasible`` branch below would be a false certificate.
             status = "time_limit"
             _gap_certified = False
         elif _nonrigorous_fathom:
@@ -11857,19 +11952,15 @@ def solve_model(
     # the taint floor (tanksize: floor 0.847 vs root relaxation 0.868). Run it in
     # that case too and keep the tighter of the two rigorous bounds.
     _rr_needed = bound_val is None or not np.isfinite(bound_val) or _bound_from_taint_recovery
+    # Whatever is genuinely left of ``time_limit``, and no more. The search loop
+    # above withholds ``_ROOT_FALLBACK_RESERVE_S`` precisely when it is bound-less,
+    # so in the case this fallback exists to serve the remainder is positive and the
+    # bound is recovered INSIDE the contract. When it is not — the mandatory root
+    # work alone outran the limit — the honest answer is the weaker bound the search
+    # already has (possibly none), not a fresh grant of time the caller did not give.
     _rr_remaining = time_limit - (time.perf_counter() - t_start)
-    if _rr_needed and _rr_remaining <= 0.0:
-        # B&B consumed the whole limit and surfaced no bound. Spend a small bounded
-        # slice on the rigorous root-relaxation fallback anyway so an uncertified
-        # exit reports a sound dual bound instead of None (issue #138). Only ever
-        # reached when the search produced nothing usable; the floor's own ~10%
-        # internal budget keeps the wall-time overrun small.
-        _rr_remaining = _ROOT_FALLBACK_FLOOR_S
     if _rr_needed and _rr_remaining > 0.0:
         _is_maximize = model._objective.sense == ObjectiveSense.MAXIMIZE
-        # Budget the fallback to the time actually left: it runs *after* the B&B
-        # loop already consumed the limit, so passing the full ``time_limit`` here
-        # would let it overrun by a second whole budget.
         _rr = _root_relaxation_lower_bound(
             model, _root_lb_snapshot, _root_ub_snapshot, _rr_remaining, psd_cuts=psd_cuts
         )

--- a/python/tests/test_912_wall_budget_inventory.py
+++ b/python/tests/test_912_wall_budget_inventory.py
@@ -113,10 +113,21 @@ KNOWN: tuple[tuple[str, str, str], ...] = (
         "deadline = (time.perf_counter() + budget) if budget else None",
         "residual",
     ),
+    # The #138 root-relaxation fallback's rule-2 stop. This was ``residual`` and is
+    # now ``contract``, because the thing it spends changed: the fallback used to
+    # receive a fresh ``_ROOT_FALLBACK_FLOOR_S`` grant handed out *past* an already
+    # spent deadline, so the gate genuinely decided how much EXTRA work ran beyond
+    # the caller's budget. It is now ``_ROOT_FALLBACK_RESERVE_S``, withheld from the
+    # search up front and spent inside ``time_limit``, so the gate answers "have I
+    # used up my slice of the caller's budget?" — the ``contract`` role by the
+    # definition above. The arithmetic moved into the ``_fb_left()`` helper, which is
+    # why the recorded line text changed with it: the grant is now materialised once
+    # as an absolute deadline, which ``_fb_left()``/``_fb_stop`` and the two
+    # relaxation build deadlines all read instead of each recomputing it.
     (
         "solver.py",
-        "return bool(have) and (time.perf_counter() - _fb_t0) >= max(0.0, float(time_limit))",
-        "residual",
+        "_fb_deadline = time.perf_counter() + max(0.0, float(time_limit))",
+        "contract",
     ),
     (
         "solver.py",
@@ -372,8 +383,12 @@ def test_residual_count_is_visible():
     """Publish the residual count so shrinking it is a visible, reviewable act
     rather than a silent one."""
     residual = sorted(k for k, c in _CATEGORY.items() if c == "residual")
-    assert len(residual) == 20, (
-        f"the #912 residual inventory changed ({len(residual)} entries, expected 20). "
+    # 20 -> 19: the #138 fallback's rule-2 stop was reclassified ``residual`` ->
+    # ``contract`` when its grant became a pre-deadline reserve rather than a
+    # post-deadline hand-out. Not a conversion to a deterministic budget — a change
+    # in what the gate spends. See the comment on its KNOWN entry.
+    assert len(residual) == 19, (
+        f"the #912 residual inventory changed ({len(residual)} entries, expected 19). "
         "If you converted one, drop it from KNOWN and lower this number; if you added "
         "one, convert it instead. This count is a deliberate resting point, not a "
         "backlog — see the module docstring for the evidence and the condition that "

--- a/python/tests/test_time_limit_contract.py
+++ b/python/tests/test_time_limit_contract.py
@@ -1,0 +1,104 @@
+"""``Model.solve(time_limit=T)`` must return within T.
+
+Measured on ``hda`` before this test existed, discopt overran a *constant*
+~6-8 s regardless of ``T`` — +7.22 s against a 2 s limit (361%), +6.19 s
+against 40 s (15%) — so no limit below ~10 s was honorable at all:
+
+    limit=  2s  wall=  9.22s   limit= 10s  wall= 18.20s
+    limit=  5s  wall= 12.20s   limit= 20s  wall= 25.76s
+    limit= 40s  wall= 46.19s
+
+The dominant term was a root-relaxation fallback granted ``_ROOT_FALLBACK_FLOOR_S``
+(3.0 s) *against an already-spent budget*, which then overran even that grant by
+32-35%: on ``hda`` at a 5 s limit it was entered 1.95 s late and ran a further
+4.25 s. It is now a pre-deadline reserve (``_ROOT_FALLBACK_RESERVE_S``) withheld
+from the search only while the tree is bound-less, so the same bound recovery
+happens inside the contract.
+
+SCIP 10.0.2 on the same instances lands within 0.03-0.09 s of the limit at
+every limit tested (2 s / 5 s / 10 s, 9/9 runs) while still reporting a finite,
+monotonically improving dual bound — the limit is a contract, not a hint.
+
+The overrun is not merely untidy: it silently handicaps every benchmark
+comparison (in the in-repo global50 run BARON was held to 60.3 s on
+``casctanks`` while discopt took 66.3 s), so any shifted-geometric-mean or
+wall-ratio computed against another solver is flattering by that margin.
+"""
+
+import math
+import time
+from pathlib import Path
+
+import pytest
+from discopt.modeling.core import from_nl
+
+_NL_DIR = Path(__file__).parent / "data" / "minlplib_nl"
+
+# Absolute slack for interpreter/result-marshaling teardown. SCIP's measured
+# overshoot is 0.03-0.09 s; 1.5 s is generous for a Python solver and still far
+# below the 6-8 s regression this test exists to catch.
+_SLACK_S = 1.5
+# Proportional slack, applied on top: a solver polling a deadline at node
+# granularity may finish the node it is in.
+_SLACK_FRAC = 0.10
+
+# (instance, time_limit) pairs. Short limits are the discriminating cases —
+# a constant-overhead overrun is invisible at 60 s and catastrophic at 2 s.
+_CASES = [
+    ("hda", 5.0),
+    ("hda", 10.0),
+    ("casctanks", 5.0),
+]
+
+
+@pytest.mark.slow
+@pytest.mark.parametrize("name,limit", _CASES)
+def test_solve_returns_within_time_limit(name, limit):
+    """``solve(time_limit=T)`` returns within T plus a small fixed slack."""
+    model = from_nl(str(_NL_DIR / f"{name}.nl"))
+
+    t0 = time.perf_counter()
+    result = model.solve(time_limit=limit)
+    wall = time.perf_counter() - t0
+
+    budget = limit * (1.0 + _SLACK_FRAC) + _SLACK_S
+    assert wall <= budget, (
+        f"{name}: solve(time_limit={limit}) took {wall:.2f}s, "
+        f"overran by {wall - limit:+.2f}s ({100 * (wall - limit) / limit:.0f}%); "
+        f"allowed {budget:.2f}s. status={result.status} bound={result.bound}"
+    )
+
+
+@pytest.mark.slow
+def test_dual_bound_is_anytime():
+    """A longer budget must buy a bound, and never a *worse* one.
+
+    Before the reserve fix the dual bound came from a post-deadline patch rather
+    than from anything inside the budget, so ``hda`` reported the identical
+    -64473.4 at 5 s, 10 s, 20 s and 40 s: eight times the budget bought zero
+    improvement. Monotonicity is asserted (never worse), not strict improvement —
+    a search whose root bound has genuinely converged may legitimately plateau.
+
+    ``bound is None`` is read as -inf, which is what it means: no dual bound was
+    proved. That is the honest report when the *mandatory* root work (Rust
+    presolve + convexity classification + the root McCormick LP, ~7 s on ``hda``)
+    outruns the whole limit, and it is exactly the case the deleted
+    post-deadline grant used to paper over by spending time it had not been
+    given. At the larger budget there is time, so a finite bound is required.
+    """
+    model_bounds = []
+    for limit in (5.0, 15.0):
+        model = from_nl(str(_NL_DIR / "hda.nl"))
+        result = model.solve(time_limit=limit)
+        model_bounds.append(-math.inf if result.bound is None else float(result.bound))
+
+    assert len(model_bounds) == 2, "PROBE NEVER FIRED: fewer than 2 solves recorded"
+    assert math.isfinite(model_bounds[1]), (
+        f"no dual bound at time_limit=15.0 (got {model_bounds[1]}); "
+        "15 s is well past the mandatory root work, so a bound must be proved"
+    )
+    # hda is a minimization: a larger lower bound is tighter.
+    assert model_bounds[1] >= model_bounds[0] - 1e-6, (
+        f"dual bound regressed with a larger budget: "
+        f"{model_bounds[0]:.6g} at 5s -> {model_bounds[1]:.6g} at 15s"
+    )

--- a/python/tests/test_time_limit_contract.py
+++ b/python/tests/test_time_limit_contract.py
@@ -42,11 +42,46 @@ _SLACK_S = 1.5
 # granularity may finish the node it is in.
 _SLACK_FRAC = 0.10
 
+# The residual overrun the reserve does NOT fix, and why it is not fixed here.
+#
+# ``hda`` at a 10 s limit is bimodal (5 reps, load-gated, ``scratchpad/hda10.py``):
+# 10.60 / 10.78 / 12.79 / 13.03 / 12.94 s — mean 12.03 s, sd 1.23, against 12.50 s
+# allowed. The two fast reps report the weak dual bound -141697, the three slow
+# ones the full -64473, and that is the whole story: the #138 fallback's optional
+# separated-relaxation phase is what overruns. When the fallback's grant is already
+# spent by the time a first bound is in hand, ``_fb_stop`` returns the weak bound
+# and the solve lands at ~10.7 s; when the grant still has room the phase starts,
+# and ``solve_at_node`` then *ignores the budget it was handed* for a further ~4 s.
+#
+# That drop is issue #928 (``_lp_warm_deadline_enabled`` in
+# ``_jax/milp_relaxation.py``): the warm pure-LP fast path discards the caller's
+# ``time_limit``. It predates this test and is not the reserve's to fix. The
+# ``_fb_left()`` clamp on that call site is already in place and correct; it is
+# inert only because the callee drops it. (The flag's panel script and companion
+# test are named ``issue917_*``/``test_917_*`` for historical reasons; #917 is a
+# different, closed issue.)
+#
+# Turning ``DISCOPT_LP_WARM_DEADLINE=1`` makes all cases here pass (11.14 s ± 0.04
+# on this one), but it is not the fix, for two independently sufficient reasons:
+# it fails CLAUDE.md §5 bar 2 — a 3-rep load-gated panel over the 17 instances
+# where the deadline actually binds gives ON-OFF deltas of -3.2 / +6.6 / +5.7 s,
+# flipping sign inside the metric's own noise — and it buys the punctuality by
+# losing the bound (-64473 -> -141697 in 5/5 reps), which is the wrong trade under
+# §1. So this case is marked xfail non-strict rather than silenced or given a
+# wider slack: it keeps running, it keeps reporting, and it will xpass the moment
+# #917 is properly resolved.
+_XFAIL_LP_DEADLINE_DROP = pytest.mark.xfail(
+    reason="#928: warm pure-LP path drops the caller's time_limit, so the #138 "
+    "fallback's separated-relaxation phase overruns its grant by ~4s. Bimodal: "
+    "10.6-13.0s against 12.5s allowed. Not strict — it passes ~2/5 runs.",
+    strict=False,
+)
+
 # (instance, time_limit) pairs. Short limits are the discriminating cases —
 # a constant-overhead overrun is invisible at 60 s and catastrophic at 2 s.
 _CASES = [
     ("hda", 5.0),
-    ("hda", 10.0),
+    pytest.param("hda", 10.0, marks=_XFAIL_LP_DEADLINE_DROP),
     ("casctanks", 5.0),
 ]
 


### PR DESCRIPTION
## The defect

`solve(time_limit=T)` overran by a near-constant 6-8 s regardless of `T`, so no
limit below ~10 s was honorable at all:

| limit | wall (hda, before) | overrun |
|------:|-------------------:|--------:|
|   2 s |              9.22 s| +361%   |
|   5 s |             12.20 s| +144%   |
|  10 s |             18.20 s|  +82%   |
|  20 s |             25.76 s|  +29%   |
|  40 s |             46.19 s|  +15%   |

SCIP 10.0.2 on the same instances lands within **0.03-0.09 s** of the limit at
every limit tested (2 s / 5 s / 10 s, 9/9 runs) while still reporting a finite,
monotonically improving dual bound. The limit is a contract, not a hint.

This is not merely untidy: it silently handicaps every benchmark comparison. In
the in-repo global50 run BARON was held to 60.3 s on `casctanks` while discopt
took 66.3 s, so any shifted-geometric-mean or wall-ratio computed against
another solver was flattering by that margin.

### Root cause (measured, not hypothesised)

The dominant term is the issue-#138 root-relaxation fallback. It was granted
`_ROOT_FALLBACK_FLOOR_S` (3.0 s) of **fresh** budget *against an already-spent
deadline* — the whole grant sat outside the contract by construction — and it
then overran even that grant by 32-35%:

* `hda` at `T=5`: fallback entered 1.95 s **past** the deadline, ran a further
  4.25 s → wall 11.75 s.
* `hda` at `T=60`: entered at 60.16 s, ran 4.04 s against its 3.0 s grant.

So the old comment's claim — *"the fallback's own internal budget keeps the
overrun small"* — was false at the grant it was describing.

A `LOOPPROBE` also showed the B&B loop breaks on its **first** iteration on
`hda` (`elapsed=6.95 iters=1` against a 5.0 s limit): the entire pre-deadline
cost is mandatory root work (2.0 s uninterruptible Rust presolve + 1.3 s
convexity classification + ~3.4 s root McCormick LP), so a reserve placed only
inside the node loop would have been irrelevant for this class.

## The change

Invert the post-deadline **grant** into a pre-deadline **reserve**.
`_ROOT_FALLBACK_RESERVE_S` is withheld from the search up front and spent inside
`time_limit`:

* The spatial loop **releases** the reserve the moment the tree holds a finite
  global lower bound (or is exhausted), so an instance that produces a bound of
  its own sees a byte-identical deadline. The release is a latch and is only
  evaluated in the last `_rr_reserve_s` seconds, so a solve that finishes
  earlier never reads `tree.stats()` for it at all.
* While the tree is bound-less at the reserve boundary — exactly the state in
  which the fallback is the sole bound producer — the loop stops and hands the
  slice over. The fallback is *anytime with respect to its grant* (measured on
  `hda`: 0.25 s → -141697, valid but weak; 2 s → -64473, the full bound), so a
  smaller pre-deadline slice buys a weaker rigorous bound rather than none.
* The post-search fallback takes `max(0, remaining)` with **no floor**, and the
  #654 short-circuit triggers on the reserve rather than on a bare exhausted
  deadline.
* The fallback's own optional separated-relaxation solve is clamped to what is
  genuinely LEFT of its grant (`_fb_left()`) — the same rule-1 / rule-2 split
  `_fb_stop` already applies to whether that phase *starts*.

### A false `infeasible` this change introduced, and how it was caught

The first cut broke an invariant: the no-incumbent status branch reads
`elif wall_time >= time_limit: "time_limit"` … `else: "infeasible"`, so an early
break left `wall_time < time_limit` with an unfinished tree and fell through to
a **certified `infeasible` on a feasible model** — the worst class of error
(measured: `hda` at `T=10` and `casctanks` at `T=5`). `_rr_reserve_yield` now
marks the interruption and forces `status="time_limit"`,
`_gap_certified=False`; the yield is additionally suppressed when
`tree.is_finished()` so a legitimately certified `infeasible` is never
downgraded.

## Verification

### CLAUDE.md §5 differential panel

`origin/main` worktree vs this tree, **interleaved per instance** (alternating
which arm runs first) in isolated subprocesses, each arm asserting both
`discopt.solver.__file__` *and* the presence/absence of the
`_ROOT_FALLBACK_RESERVE_S` marker (§8). 66 in-repo instances, `T=20 s`.

**Bar 1 — cert-clean: PASS**

| check | comparisons executed | violations |
|---|---:|---:|
| dual bound vs `minlplib.solu` oracle | 116 | **0** |
| `gap_certified` regression | 66 | **0** |
| lost incumbent | 66 | **0** |
| false `infeasible` | 66 | **0** |
| certified objective drift | 49 | **0** |
| bound crosses incumbent | 4 | **0** |
| finite bound → `None` | 17 | **0** |

**Bound-neutral where it applies**: node counts are **exactly** unchanged on all
49 instances that close (14470 == 14470, 0/49 changed).

**Bar 2 — net-positive: PASS**

|                | base (origin/main) | new (reserve) |
|----------------|-------------------:|--------------:|
| total overrun  |            44.97 s |   **24.68 s** |
| max overrun    |            11.07 s |    **7.85 s** |
| `hda` wall     |            31.07 s |   **20.74 s** |

**Bound quality** on the 17 non-closing instances — the only class where the
fallback is live and the reserve can change anything: 1 looser
(`clay0303hfsg` 20947.6 → 19513.3, still far below its 26669.1 incumbent),
1 tighter (`4stufen` 20712.2 → 21372.2), 0 lost.

### Test suites

* `pytest -m smoke` — **904 passed, 1 skipped, 2 xpassed**
* `pytest -m slow python/tests/test_adversarial_recent_fixes.py` — **10 passed**
* New: `python/tests/test_time_limit_contract.py` pins the contract (`hda` at
  5 s / 10 s, `casctanks` at 5 s) and the anytime property of the dual bound.

Rust untouched (`git diff origin/main -- crates/` is empty), so `cargo test` is
not implicated; the panel's baseline arm reuses the same built extension, which
is why the arms differ only in `solver.py`.

## What this does NOT fix, and why it is not hidden

One case stays over the line: `hda` at `time_limit=10` is bimodal — 10.60 /
10.78 / 12.79 / 13.03 / 12.94 s over 5 load-gated reps (mean 12.03, sd 1.23)
against 12.50 s allowed. It is marked `xfail(strict=False)` against **#928**,
filed by this PR, with the measurement in the source.

The two modes are attributed, not guessed: they are "did the #138 fallback's
optional separated-relaxation phase start". The fast reps report the weak dual
bound -141697 (grant already spent, `_fb_stop` returns the banked bound); the
slow ones the full -64473 (the phase started and then ran ~4 s past its budget).
The `_fb_left()` clamp this PR puts on that call site is correct and in place —
it is inert because `solve_at_node`'s warm pure-LP path *discards the
`time_limit` it is handed*. That is a pre-existing defect one layer down, and
it had no open tracker: the flag's panel script and companion test are named
`issue917_*` / `test_917_*`, but #917 is a different, closed issue, and #814
(the ancestor overrun issue) is closed too. Hence #928.

`DISCOPT_LP_WARM_DEADLINE=1` makes all four cases pass (11.14 s ± 0.04 on this
one) and is **still not the fix**, for two independently sufficient reasons —
both now recorded in the flag's docstring per §4/§11:

* **It fails §5 bar 2 on the subset built to favour it.** That docstring named
  the settling experiment: a load-gated, multi-rep panel over the instances
  where the deadline actually binds, since a corpus average is diluted by the
  ~50 instances that are bit-identical either way. Run over the 17 non-closing
  instances, 3 reps at a 20 s budget, the ON−OFF deltas are −3.2 / +6.6 / +5.7 s
  — they **flip sign**, mean +3.0 s with sd 5.3 s, and the OFF arm alone spans
  21.3–30.9 s. All 3 reps `CERT_CLEAN=True`; cert-clean is necessary, not
  sufficient (the `DISCOPT_CUT_INHERIT` rule).
* **It buys punctuality by losing the bound**: -64473 → -141697 in 5/5 `hda`
  reps, and an earlier panel saw the severe form (bchoco08 `1.0 → None`). Wrong
  trade under §1.

Weakening `_SLACK_S`/`_SLACK_FRAC` to turn that case green is exactly what §1
forbids, so it is xfailed and tracked instead — it keeps running, keeps
reporting, and will xpass when #928 lands.

**A §4/§11 by-product worth carrying forward:** in that 3-rep run `nvs05` and
`clay0303hfsg` reported bound deltas in *opposite directions between reps at
identical flag state*. Their bounds are timing-nondeterministic, which also
re-reads this PR's own bound-quality table above — `clay0303hfsg`'s single
"looser" cell is one of those two instances and should not be read as an effect
of the reserve.

Contributes to #654. Files #928.
