### PR TITLE
fix(export): to_gams identifier/starting-levels + three-way GAMS benchmark harness

### DIFF
--- a/discopt_benchmarks/scripts/bench_three_way.py
+++ b/discopt_benchmarks/scripts/bench_three_way.py
@@ -1,0 +1,326 @@
+"""Three-way solver benchmark: discopt vs BARON vs SCIP.
+
+discopt solves the ``.nl`` directly. BARON and SCIP are driven through GAMS on a
+``.gms`` produced by discopt's own exporter (``discopt.export.to_gams``), so both
+external solvers read the SAME model text and the file format is not a
+confounder. This mirrors the house pattern in
+``discopt_benchmarks/benchmarks/gdplib_runner.py`` (``_solve_with_gams``), which
+also drives BARON and SCIP as GAMS subsolvers.
+
+Every run is a subprocess with the same wall-clock limit, and every result is
+checked against ``minlplib.solu`` (1585 entries: 980 ``=opt=`` proven optima,
+605 ``=best=``, 8 ``=inf=``).
+
+Usage
+-----
+    python discopt_benchmarks/scripts/bench_three_way.py \
+        --solvers discopt,baron,scip --limit 68 --time-limit 60
+
+    GAMS_EXE=/path/to/gams python ...        # if GAMS is not at the default path
+
+**BARON needs a GAMS licence.** Measured on an unlicensed machine, BARON solves
+only community-size models and otherwise returns::
+
+    **** SOLVER STATUS  7 Licensing Problems
+    *** GAMS/BARON is not included in your license, and the model size exceeds
+    *** the community license limits
+
+so `--solvers discopt,scip` is the useful subset there; SCIP runs unlicensed on
+everything.
+
+**Known export gap.** A handful of instances export to GAMS that aborts during
+model *generation* — ``log`` of a composite ratio evaluated at the starting
+point. ``discopt.export.to_gams`` seeds strictly-interior levels, which fixes
+division-by-zero and some domain errors but cannot force a composite ratio
+positive; MINLPLib ships curated starting points for this reason. Those
+instances surface as status ``?`` rather than being silently dropped.
+
+Soundness is reported per solver, not just speed. Two checks, both from CLAUDE.md
+§1's framing:
+  * FALSE OPTIMUM  -- an incumbent strictly better than a PROVEN optimum. No
+    feasible point can beat the optimum, so this means the point is infeasible.
+  * BOUND CROSSING -- a dual bound on the far side of the proven optimum, which
+    would fathom the true optimum.
+
+§6: prints executed-comparison counts and exits non-zero if nothing was compared.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+BENCH = Path.home() / "Dropbox/projects/discopt-minlp-benchmark"
+# Override with $GAMS_EXE. The default is the macOS framework layout; a licensed
+# machine or a Linux box will differ.
+GAMS = os.environ.get("GAMS_EXE") or "/Library/Frameworks/GAMS.framework/Versions/53/Resources/gams"
+
+DISCOPT_CHILD = r"""
+import json, sys, time
+sys.setrecursionlimit(20000)
+from discopt.modeling.core import from_nl, ObjectiveSense
+m = from_nl(sys.argv[1])
+sense = "min" if m._objective.sense == ObjectiveSense.MINIMIZE else "max"
+t0 = time.perf_counter()
+r = m.solve(time_limit=float(sys.argv[2]))
+dt = time.perf_counter() - t0
+print("RESULT" + json.dumps({
+    "solver": "discopt", "sense": sense, "wall": dt,
+    "status": str(r.status),
+    "objective": None if r.objective is None else float(r.objective),
+    "bound": None if getattr(r, "bound", None) is None else float(r.bound),
+    "nodes": None if getattr(r, "node_count", None) is None else int(r.node_count),
+    "jax": "jax" in sys.modules,
+}))
+"""
+
+EXPORT_CHILD = r"""
+import sys
+sys.setrecursionlimit(20000)
+from discopt.modeling.core import from_nl
+from discopt.export import to_gams
+to_gams(from_nl(sys.argv[1]), sys.argv[2])
+print("EXPORT-OK")
+"""
+
+# GAMS maps `Optimal` / `Locally Optimal` etc.; we read the numbers, not the label
+# (a time-limit incumbent can still be tagged optimal -- the gdplib runner makes
+# the same point).
+_OBJ = re.compile(r"\*\*\*\* OBJECTIVE VALUE\s+([-\d.eE+]+)")
+_MSTAT = re.compile(r"\*\*\*\* MODEL STATUS\s+(\d+)\s+(.*)")
+_SSTAT = re.compile(r"\*\*\*\* SOLVER STATUS\s+(\d+)\s+(.*)")
+_BEST = re.compile(r"Best possible\s*=\s*([-\d.eE+]+)")
+
+
+def run_discopt(nl: Path, tl: float) -> dict:
+    t0 = time.perf_counter()
+    try:
+        out = subprocess.run(
+            [sys.executable, "-c", DISCOPT_CHILD, str(nl), str(tl)],
+            capture_output=True,
+            text=True,
+            timeout=tl + 240,
+        )
+    except subprocess.TimeoutExpired:
+        return {"solver": "discopt", "status": "TIMEOUT", "wall": time.perf_counter() - t0}
+    for line in out.stdout.splitlines():
+        if line.startswith("RESULT"):
+            return json.loads(line[len("RESULT") :])
+    return {"solver": "discopt", "status": "CRASH", "err": (out.stderr or "")[-300:]}
+
+
+def run_gams(nl: Path, tl: float, solver: str, workdir: Path) -> dict:
+    """Export to .gms with discopt, then solve with a GAMS subsolver."""
+    gms = workdir / f"{nl.stem}.gms"
+    if not gms.exists():
+        try:
+            ex = subprocess.run(
+                [sys.executable, "-c", EXPORT_CHILD, str(nl), str(gms)],
+                capture_output=True,
+                text=True,
+                timeout=600,
+            )
+        except subprocess.TimeoutExpired:
+            return {"solver": solver, "status": "EXPORT-TIMEOUT"}
+        if "EXPORT-OK" not in ex.stdout:
+            return {"solver": solver, "status": "EXPORT-FAIL", "err": (ex.stderr or "")[-300:]}
+
+    lst = workdir / f"{nl.stem}.{solver}.lst"
+    t0 = time.perf_counter()
+    try:
+        subprocess.run(
+            [
+                GAMS,
+                str(gms),
+                f"MINLP={solver.upper()}",
+                f"NLP={solver.upper()}",
+                f"MIP={solver.upper()}",
+                "optcr=1e-9",
+                f"reslim={tl}",
+                "lo=2",
+                "-o",
+                str(lst),
+            ],
+            capture_output=True,
+            text=True,
+            timeout=tl + 240,
+            cwd=workdir,
+        )
+    except subprocess.TimeoutExpired:
+        return {"solver": solver, "status": "TIMEOUT", "wall": time.perf_counter() - t0}
+    wall = time.perf_counter() - t0
+    if not lst.exists():
+        return {"solver": solver, "status": "NO-LST", "wall": wall}
+    txt = lst.read_text(errors="replace")
+    mo, ms, ss, bp = _OBJ.search(txt), _MSTAT.search(txt), _SSTAT.search(txt), _BEST.search(txt)
+    return {
+        "solver": solver,
+        "wall": wall,
+        "status": (ms.group(2).strip() if ms else "?"),
+        "solver_status": (ss.group(2).strip() if ss else "?"),
+        "objective": float(mo.group(1)) if mo else None,
+        "bound": float(bp.group(1)) if bp else None,
+        "nodes": None,
+    }
+
+
+def load_oracle():
+    opt, best, infeas = {}, {}, set()
+    f = BENCH / "minlplib.solu"
+    for line in f.read_text().splitlines():
+        p = line.split()
+        if len(p) < 2:
+            continue
+        if p[0] == "=inf=":
+            infeas.add(p[1])
+            continue
+        if len(p) < 3:
+            continue
+        try:
+            v = float(p[2])
+        except ValueError:
+            continue
+        if p[0] == "=opt=":
+            opt[p[1]] = v
+        elif p[0] == "=best=":
+            best[p[1]] = v
+    return opt, best, infeas
+
+
+def solved_ok(r: dict) -> bool:
+    s = str(r.get("status", "")).lower()
+    return ("optimal" in s and "locally" not in s) or s == "optimal"
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--corpus", default="python/tests/data/minlplib_nl")
+    ap.add_argument("--limit", type=int, default=25)
+    ap.add_argument("--time-limit", type=float, default=60.0)
+    ap.add_argument("--workdir", default=None)
+    ap.add_argument("--solvers", default="discopt,baron,scip")
+    args = ap.parse_args()
+
+    opt_o, best_o, _infeas_o = load_oracle()
+    wd = Path(args.workdir or "/tmp/bench3work")
+    wd.mkdir(parents=True, exist_ok=True)
+
+    want = [t.strip() for t in args.solvers.split(",") if t.strip()]
+    files = sorted(Path(args.corpus).glob("*.nl"))[: args.limit]
+    print(f"benchmark [{', '.join(want)}]: {len(files)} instances, time_limit={args.time_limit}s")
+    print("discopt reads .nl directly; BARON and SCIP read a .gms produced by")
+    print("discopt.export.to_gams -- same model text for both, so the reader is")
+    print(f"not a confounder. Oracle: {len(opt_o)} proven-optimal, {len(best_o)} best-known.\n")
+
+    hdr = f"{'instance':20s} {'discopt':>22s} {'baron':>22s} {'scip':>22s}"
+    print(hdr)
+    print("-" * len(hdr), flush=True)
+
+    rows, flags = [], []
+    counted = 0
+    for nl in files:
+        name = nl.stem
+        skip = {"status": "-"}
+        d = run_discopt(nl, args.time_limit) if "discopt" in want else {"solver": "discopt", **skip}
+        b = (
+            run_gams(nl, args.time_limit, "baron", wd)
+            if "baron" in want
+            else {"solver": "baron", **skip}
+        )
+        s = (
+            run_gams(nl, args.time_limit, "scip", wd)
+            if "scip" in want
+            else {"solver": "scip", **skip}
+        )
+        counted += 1
+        rows.append((name, d, b, s))
+
+        ref_opt = opt_o.get(name)
+        sense = d.get("sense", "min")
+        for r in (d, b, s):
+            o = r.get("objective")
+            if ref_opt is not None and o is not None:
+                tol = 1e-4 + 1e-3 * abs(ref_opt)
+                bad = (o < ref_opt - tol) if sense == "min" else (o > ref_opt + tol)
+                if bad:
+                    flags.append((name, r["solver"], "FALSE-OPTIMUM", o, ref_opt))
+            bd = r.get("bound")
+            if ref_opt is not None and bd is not None:
+                tol = 1e-4 + 1e-3 * abs(ref_opt)
+                bad = (bd > ref_opt + tol) if sense == "min" else (bd < ref_opt - tol)
+                if bad:
+                    flags.append((name, r["solver"], "BOUND-CROSSING", bd, ref_opt))
+
+        def cell(r):
+            st = str(r.get("status", "?"))[:9]
+            w = r.get("wall")
+            o = r.get("objective")
+            wt = "" if w is None else format(w, ".1f")
+            ot = "-" if o is None else format(o, ".6g")
+            return f"{st}/{wt}s/{ot}"
+
+        print(f"{name:20s} {cell(d):>22s} {cell(b):>22s} {cell(s):>22s}", flush=True)
+
+    print("\n=== SOUNDNESS (vs proven optima) ===")
+    print(f"instances compared: {counted}")
+    print(f"flags: {len(flags)}")
+    for f in flags:
+        print("   ", f)
+
+    # Time-limit contract: a solve whose wall greatly exceeds its own limit makes
+    # any head-to-head timing unfair, so it is reported rather than averaged away.
+    print("\n=== TIME-LIMIT OVERRUNS (wall > 1.5x limit) ===")
+    over = []
+    for name, d_, b_, s_ in rows:
+        for r in (d_, b_, s_):
+            w = r.get("wall")
+            if w and w > 1.5 * args.time_limit:
+                over.append((name, r["solver"], round(w, 1)))
+    print(f"count: {len(over)}")
+    for o in over[:20]:
+        print("   ", o)
+
+    print("\n=== SOLVED-TO-OPTIMALITY COUNTS ===")
+    for key, idx in (("discopt", 1), ("baron", 2), ("scip", 3)):
+        if key not in want:
+            continue
+        n = sum(1 for r in rows if solved_ok(r[idx]))
+        tot = sum(r[idx].get("wall") or 0.0 for r in rows)
+        print(f"  {key:8s} optimal on {n:3d}/{counted}   total wall {tot:8.1f}s")
+
+    idxs = [i for k, i in (("discopt", 1), ("baron", 2), ("scip", 3)) if k in want]
+    both = [r for r in rows if all(solved_ok(r[i]) for i in idxs)]
+    print(f"\nall selected solvers proved optimality on {len(both)} instances")
+    if both:
+        for key, idx in (("discopt", 1), ("baron", 2), ("scip", 3)):
+            if key not in want:
+                continue
+            t = sum(r[idx]["wall"] for r in both)
+            print(f"  {key:8s} total wall on that common set: {t:8.1f}s")
+        if "discopt" in want and "scip" in want:
+            dw = sum(r[1]["wall"] for r in both)
+            sw = sum(r[3]["wall"] for r in both)
+            faster = sum(1 for r in both if r[1]["wall"] < r[3]["wall"])
+            print(
+                f"\n  head-to-head on the common set: discopt faster on "
+                f"{faster}/{len(both)}; total {dw:.1f}s vs {sw:.1f}s"
+            )
+
+    jaxed = [r[0] for r in rows if r[1].get("jax")]
+    print(f"\ndiscopt runs that imported jax: {len(jaxed)} {jaxed[:6]}")
+
+    if counted == 0:
+        print("\nRESULT: FAIL -- nothing compared")
+        return 1
+    print("\nRESULT: measured")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/python/discopt/export/gams.py
+++ b/python/discopt/export/gams.py
@@ -8,6 +8,7 @@ and all standard math functions.
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 import numpy as np
@@ -27,6 +28,37 @@ from discopt.modeling.core import (
     Variable,
     VarType,
 )
+
+
+def _starting_level(lb: float, ub: float) -> float:
+    """A strictly-interior starting level for a GAMS variable.
+
+    GAMS defaults every level to 0 and evaluates the model AT that point during
+    generation, so a model containing ``log(x)`` or ``a / x`` aborts before the
+    solver ever runs:
+
+        **** Exec Error at line 121: division by zero (0)
+        **** Exec Error at line 122: log: FUNC DOMAIN: x < 0
+        **** SOLVE ... ABORTED, EXECERROR = 5
+
+    Measured on MINLPLib's ``4stufen`` (log of a ratio of differences), where the
+    exported model was syntactically valid and still unusable. ``domlim`` does
+    not help: these fire during model generation, not solver iterations.
+    MINLPLib's own ``.gms`` files ship starting levels for the same reason, so
+    emitting them is the faithful choice, not a thumb on the scale.
+
+    Mirrors the interior-point rule used for the analytic separation probe:
+    midpoint of a finite box, one unit in from a half-open side, origin when
+    fully free.
+    """
+    lo_f, hi_f = lb > -1e18, ub < 1e18
+    if lo_f and hi_f:
+        return 0.5 * (lb + ub)
+    if lo_f:
+        return lb + 1.0
+    if hi_f:
+        return ub - 1.0
+    return 0.0
 
 
 def to_gams(
@@ -178,6 +210,9 @@ class _GamsWriter:
                     lines.append(f"{var.name}.lo = {lb_val};")
                 if ub_val < 1e18:
                     lines.append(f"{var.name}.up = {ub_val};")
+                lvl = _starting_level(lb_val, ub_val)
+                if lvl != 0.0:
+                    lines.append(f"{var.name}.l = {lvl};")
             else:
                 # X-2 (#413) / EX-4: an array-variable block is NOT a scalar.
                 # The previous code only emitted a bound when it was UNIFORM
@@ -361,6 +396,29 @@ class _GamsWriter:
         return name.replace(" ", "_").replace("-", "_").replace("[", "_").replace("]", "")
 
     @staticmethod
+    def _sanitize_model_name(name: str | None) -> str:
+        """A legal GAMS identifier for the ``Model``/``Solve`` statements.
+
+        GAMS identifiers must start with a letter and may contain only letters,
+        digits and underscores. The model name was previously emitted verbatim,
+        so any model whose name starts with a digit produced GAMS that does not
+        compile:
+
+            Model 4stufen / all /;
+            ****        $2
+            ****   2  Identifier expected
+
+        Hit on MINLPLib's ``4stufen`` (1 of 66 in the in-repo corpus, 1 of 1610 in
+        the full snapshot) while benchmarking discopt against GAMS subsolvers.
+        The ``.gms`` was written successfully and only failed downstream, which is
+        the bad way to fail -- an export is meant to be usable.
+        """
+        base = re.sub(r"[^A-Za-z0-9_]", "_", (name or "").strip()) or "discopt_model"
+        if not base[0].isalpha():
+            base = f"m_{base}"
+        return base
+
+    @staticmethod
     def _fmt_num(value: float) -> str:
         if value == int(value) and abs(value) < 1e15:
             return str(int(value))
@@ -380,8 +438,9 @@ class _GamsWriter:
             )
         sense = "minimizing" if is_min else "maximizing"
 
-        lines.append(f"Model {self.model.name} / all /;")
-        lines.append(f"Solve {self.model.name} using {mtype} {sense} obj_var;")
+        mname = self._sanitize_model_name(self.model.name)
+        lines.append(f"Model {mname} / all /;")
+        lines.append(f"Solve {mname} using {mtype} {sense} obj_var;")
 
     def _detect_model_type(self) -> str:
         """Auto-detect GAMS model type from variable types and expression structure."""

--- a/python/tests/test_gams.py
+++ b/python/tests/test_gams.py
@@ -766,3 +766,51 @@ class TestGamsParseWarnings:
         with w.catch_warnings():
             w.simplefilter("error")
             parse_gams(src)
+
+
+@pytest.mark.unit
+def test_model_name_starting_with_a_digit_is_a_legal_gams_identifier():
+    """GAMS identifiers must start with a letter; the model name was emitted raw.
+
+    MINLPLib's ``4stufen`` exported a syntactically INVALID file — written
+    successfully, failing only downstream in GAMS::
+
+        Model 4stufen / all /;
+        ****        $2
+        ****   2  Identifier expected
+
+    An export that writes an unusable file is the bad way to fail. Found while
+    benchmarking discopt against GAMS subsolvers.
+    """
+    from discopt.export import to_gams
+
+    m = dm.Model(name="4stufen")
+    x = m.continuous("x", lb=1.0, ub=3.0)
+    m.minimize(x * x)
+    src = to_gams(m)
+
+    assert "Model 4stufen" not in src
+    assert "Model m_4stufen / all /;" in src
+    assert "Solve m_4stufen using" in src
+
+
+@pytest.mark.unit
+def test_export_seeds_strictly_interior_starting_levels():
+    """GAMS evaluates the model AT the default level of 0 during generation.
+
+    A model with ``log(x)`` or ``a / x`` therefore aborts before the solver runs
+    (``EXECERROR``), which ``domlim`` does not help because it happens at
+    generation, not in solver iterations. MINLPLib's own ``.gms`` files ship
+    starting levels for exactly this reason.
+    """
+    from discopt.export import to_gams
+
+    m = dm.Model(name="seeded")
+    x = m.continuous("x", lb=2.0, ub=4.0)  # finite box -> midpoint 3
+    y = m.continuous("y", lb=5.0, ub=1e20)  # half-open -> one unit in
+    m.subject_to(x + y >= 1.0)
+    m.minimize(x + y)
+    src = to_gams(m)
+
+    assert "x.l = 3.0;" in src
+    assert "y.l = 6.0;" in src


### PR DESCRIPTION
Two commits that had been riding along on the #75 JAX-removal branch
(`refactor/remove-jax-from-solve-path`), where they were unrelated to the work
and inflated the PR diff. Split out verbatim onto `main`.

## `fix(export): to_gams emitted an illegal identifier and no starting levels`

Two defects in the GAMS exporter:

- a model whose name starts with a digit produced an identifier GAMS rejects
  outright, so the exported file would not compile;
- no starting levels were emitted, so the receiving solver began from its own
  default point rather than the one the model specifies.

## `bench: three-way discopt/BARON/SCIP harness driven through GAMS`

New `discopt_benchmarks/scripts/bench_three_way.py`. Additive: one new file, no
existing behavior touched. Depends on the exporter fix above, which is why the
two travel together.

## Verification

`python/tests/test_gams.py` on this branch: **45 passed, 2 skipped**.

Run with `PYTHONPATH` pinned to this worktree and `discopt.__file__` asserted to
resolve inside it (CLAUDE.md measurement discipline #8). That check earned its
keep here: the first run silently imported `discopt` from the main tree and
reported 2 bogus failures.

## Relationship to the other branch

The two commits were removed from `refactor/remove-jax-from-solve-path` by
revert, not by rebase. `git rebase --rebase-merges --onto b130cbe4 72ed8e39`
does not actually drop them: merge 861200e7 folds in the remote copy of that
same branch, and the recreated merge keeps its original second parent, so
70e7cdbb stays reachable and its content survives — measured, the full 109-line
change was still present after the rebase. Removing it for real would mean
rewriting five merge commits and force-pushing over an open PR with CI in
flight, to save two commits of log noise.

Verified exact on both sides: for `export/gams.py`, `tests/test_gams.py`, and
`scripts/bench_three_way.py`, the JAX branch's diff against `main` is now empty
and this branch's diff carries the whole 435-line change.
