### PR TITLE
fix(lp): #937 certify huge-but-finite boxes instead of exiting `numerical`

### DIFF
--- a/crates/discopt-core/src/lp/simplex/primal.rs
+++ b/crates/discopt-core/src/lp/simplex/primal.rs
@@ -265,36 +265,91 @@ fn audit_feasibility(
 ) -> Feasibility {
     const FEAS: f64 = 1e-6;
     for j in 0..n {
-        // Relative bound tolerance: a variable whose bound (and hence value) is
-        // large carries proportionally larger floating-point drift, so an
-        // absolute 1e-6 would spuriously reject a sound optimum on ill-scaled
+        // A bound at or past the ±INF sentinel is NO bound: the whole engine reads
+        // `u[j] >= INF` / `l[j] <= -INF` as "unbounded on that side" (ratio tests,
+        // phase-1 setup, the nonbasic-status assignment), so the LP it actually
+        // solves leaves that side free and a basic variable may legitimately settle
+        // past `1e20`. Comparing against the literal sentinel here audited a
+        // *different* LP than the one solved and rejected sound optima: a slack of
+        // the standard form `[A | I]` carries `u = 1e20`, and on a declared box just
+        // under the sentinel (the default continuous box ±9.999e19) its optimal
+        // value `~2e20` tripped this test — the whole solve came back `Numerical`
+        // (issue #937). Skip the side that is sentinel-infinite; the finite side is
+        // still audited exactly as before.
+        //
+        // Relative bound tolerance on a finite side: a variable whose bound (and
+        // hence value) is large carries proportionally larger floating-point drift,
+        // so an absolute 1e-6 would spuriously reject a sound optimum on ill-scaled
         // lifted LPs (variable magnitudes ~1e9). Scale the slack by the bound
         // magnitude, mirroring the relative test already used on the row residual.
-        let lo_tol = FEAS * (1.0 + l[j].abs().min(INF));
-        let hi_tol = FEAS * (1.0 + u[j].abs().min(INF));
-        if x[j] < l[j] - lo_tol || x[j] > u[j] + hi_tol {
-            return Feasibility::Bounds;
+        if l[j] > -INF {
+            let lo_tol = FEAS * (1.0 + l[j].abs().min(INF));
+            if x[j] < l[j] - lo_tol {
+                return Feasibility::Bounds;
+            }
+        }
+        if u[j] < INF {
+            let hi_tol = FEAS * (1.0 + u[j].abs().min(INF));
+            if x[j] > u[j] + hi_tol {
+                return Feasibility::Bounds;
+            }
         }
     }
     // Row activity `A x` accumulated over the sparse columns (O(nnz)), not a dense
     // `m·n` matvec — the lifted relaxations are ~0.3% dense, so this is the
     // difference between milliseconds and seconds on the per-solve audit.
+    //
+    // `term_scale[i] = Σ_j |A_ij x_j|` and `terms[i]` (the number of nonzero
+    // products summed) are accumulated in the same pass — they bound the row
+    // residual's own round-off, see below.
     let mut ax = vec![0.0f64; m];
+    let mut term_scale = vec![0.0f64; m];
+    let mut terms = vec![0u32; m];
     for j in 0..n {
         let xj = x[j];
         if xj != 0.0 {
             let (rows, vals) = cols.col(j);
             for (k, &i) in rows.iter().enumerate() {
-                ax[i] += vals[k] * xj;
+                let t = vals[k] * xj;
+                ax[i] += t;
+                term_scale[i] += t.abs();
+                terms[i] += 1;
             }
         }
     }
     for i in 0..m {
-        if (ax[i] - b[i]).abs() > FEAS * (1.0 + b[i].abs()) {
+        if (ax[i] - b[i]).abs() > FEAS * (1.0 + b[i].abs()) + row_roundoff(terms[i], term_scale[i])
+        {
             return Feasibility::Rows;
         }
     }
     Feasibility::Ok
+}
+
+/// Floating-point round-off floor for a row residual: the largest `|Ax − b|` a
+/// row of `k` nonzero products totalling `term_scale = Σ|A_ij x_j|` can show
+/// **when `x` is exact**.
+///
+/// `fl(Σ_{1..k} t_j)` differs from the exact sum by at most `k·ε·Σ|t_j|` (the
+/// standard running-sum bound, `(k−1)·ε/(1−(k−1)ε)`, plus one `ε` for the
+/// rounding of each product `A_ij·x_j`); the `8` is headroom over that bound. So
+/// a residual below this is not evidence of anything — it is the arithmetic, and
+/// no `x` representable in `f64` can do better.
+///
+/// This matters once `term_scale` dwarfs `|b_i|`: the vertex of `−z₀ − z₁ + s =
+/// −1` at `z = (u, u)` needs `s = 2u − 1`, which for `2u > 2⁵³` rounds to `2u`
+/// and leaves residual `1` — 5e-17 *relative* to the terms summed, yet ~5e5×
+/// over the `FEAS·(1+|b|)` threshold, so a perfectly sound optimum came back
+/// `Numerical` on every box in `[1e16, 1e20)` (issue #937).
+///
+/// It is a floor, never a widening of the ordinary regime: for a well-scaled row
+/// it is ~1e-14·term_scale, i.e. below the `1e-6` absolute term until the row
+/// activity reaches ~1e8, and it stays ~10 orders of magnitude tighter than the
+/// drift the audit exists to catch (a `Forrest–Tomlin` update error or an
+/// ill-conditioned basis moves `x` by *relative* amounts far above `ε`).
+#[inline]
+fn row_roundoff(terms: u32, term_scale: f64) -> f64 {
+    8.0 * (terms as f64) * f64::EPSILON * term_scale
 }
 
 /// Recover finite, *valid* upper bounds for the **slack** columns of the standard
@@ -2579,5 +2634,79 @@ mod tests {
             &u,
             &r.x
         ));
+    }
+
+    /// #937: a huge-but-finite declared box must still certify. The LP
+    /// `min −z₀ − z₁ s.t. z₀ + z₁ ≥ 1, 0 ≤ z ≤ u` has its optimum at the corner
+    /// `z = (u, u)`, objective `−2u`, for every finite `u`; at the `1e20` sentinel
+    /// the box is infinite and the answer is `Unbounded`. The engine used to break
+    /// on the whole band in between — `[1e15, 1e20)` — via two independent audit
+    /// defects, both scale-blindness in `audit_feasibility`:
+    ///
+    ///   * `[1e16, 1e19]` → `Rows`: the vertex needs `s = 2u − 1` in the standard
+    ///     form's slack, which for `2u > 2⁵³` is not representable and rounds to
+    ///     `2u`, leaving residual `1` — 5e-17 *relative* to the terms summed, but
+    ///     ~5e5× over the `FEAS·(1 + |b|)` threshold, which sees only `|b| = 1`.
+    ///   * `9.999e19` (the DEFAULT `Model.continuous` box) → `Bounds`: the slack's
+    ///     optimal value `1.9998e20` sits past its declared `u = 1e20`, which the
+    ///     rest of the engine reads as the ±INF sentinel — "no upper bound" — while
+    ///     the audit compared against it as a literal number.
+    ///
+    /// The band is pinned end to end, not at a point, because the two defects claim
+    /// different parts of it. FAILS pre-fix (`Numerical` from `1e16` up); passes
+    /// after (`Optimal` at `−2u`, and `Unbounded` only at the sentinel).
+    #[test]
+    fn huge_finite_box_certifies_across_the_whole_band_937() {
+        // Standard form: −z₀ − z₁ + s = −1 (i.e. z₀ + z₁ ≥ 1), s the ≤-slack.
+        let a = [-1.0, -1.0, 1.0];
+        let c = [-1.0, -1.0, 0.0];
+        let l = [0.0; 3];
+        let b = [-1.0];
+        let mut checked = 0usize;
+        for u in [1e3, 1e9, 1e14, 1e15, 1e16, 1e17, 1e18, 1e19, 5e19, 9.999e19] {
+            let ub = [u, u, INF];
+            let r = solve(&a, 1, 3, &b, &c, &l, &ub);
+            assert_eq!(
+                r.status,
+                LpStatus::Optimal,
+                "u={u:e}: a finite box below the 1e20 sentinel must certify"
+            );
+            // Exact vertex objective −2u (relative, since −2u itself is only
+            // representable to an ulp once u exceeds 2⁵²).
+            assert!(
+                (r.obj - (-2.0 * u)).abs() <= 1e-12 * (2.0 * u),
+                "u={u:e}: obj {} != −2u",
+                r.obj
+            );
+            checked += 1;
+        }
+        // At (and past) the sentinel the box really is infinite.
+        let r = solve(&a, 1, 3, &b, &c, &l, &[INF, INF, INF]);
+        assert_eq!(
+            r.status,
+            LpStatus::Unbounded,
+            "the 1e20 sentinel is infinity: the LP is genuinely unbounded there"
+        );
+        checked += 1;
+        assert_eq!(checked, 11, "band probe must have run every point");
+    }
+
+    /// The `Rows` audit floor is a *floor*, not a widening: it may never let a
+    /// genuinely wrong point certify. A row whose activity is ordinary-scaled keeps
+    /// its `1e-6` absolute threshold, and a residual well above round-off is still
+    /// rejected at any scale.
+    #[test]
+    fn row_roundoff_floor_stays_below_real_drift_937() {
+        // Ordinary scale: the floor is far under the absolute FEAS term, so the
+        // effective threshold is unchanged.
+        assert!(row_roundoff(200, 1.0e6) < 1e-6);
+        // Even at the 1e16 activity of the #937 band, the floor is ~1e-16 relative:
+        // a residual that is 1e-6 RELATIVE to the row (1e10 absolute) still fails.
+        let scale = 4.0e16;
+        assert!(row_roundoff(3, scale) < 1e-6 * scale);
+        assert!(
+            row_roundoff(3, scale) > 1.0,
+            "must forgive the exact-vertex ulp"
+        );
     }
 }

--- a/docs/notebooks/tutorial_lp.ipynb
+++ b/docs/notebooks/tutorial_lp.ipynb
@@ -601,7 +601,10 @@
     "\n",
     "Not every LP has an optimal solution. Two common failure modes are\n",
     "**infeasibility** (no point satisfies all constraints) and\n",
-    "**unboundedness** (the objective can improve without limit)."
+    "**unboundedness** (the objective can improve without limit). An LP solver detects\n",
+    "both from its simplex certificate rather than by running out of iterations\n",
+    "{cite:p}`Bertsimas1997`: infeasibility from a Farkas dual ray, unboundedness from\n",
+    "a primal ray along which the objective decreases without limit."
    ]
   },
   {
@@ -610,10 +613,10 @@
    "id": "infeasible-demo",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-25T11:51:44.979396Z",
-     "iopub.status.busy": "2026-04-25T11:51:44.979301Z",
-     "iopub.status.idle": "2026-04-25T11:51:44.992672Z",
-     "shell.execute_reply": "2026-04-25T11:51:44.992323Z"
+     "iopub.execute_input": "2026-08-07T15:18:52.898337Z",
+     "iopub.status.busy": "2026-08-07T15:18:52.898035Z",
+     "iopub.status.idle": "2026-08-07T15:18:52.906081Z",
+     "shell.execute_reply": "2026-08-07T15:18:52.904759Z"
     }
    },
    "outputs": [
@@ -635,7 +638,6 @@
     "mi.subject_to(y[0] + y[1] >= 5.0, name=\"impossible\")\n",
     "\n",
     "ri = mi.solve()\n",
-    "# Note: returns \"iteration_limit\" (infeasibility detection is a known limitation)\n",
     "print(f\"Status: {ri.status}\")"
    ]
   },
@@ -645,10 +647,10 @@
    "id": "unbounded-demo",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-25T11:51:44.993886Z",
-     "iopub.status.busy": "2026-04-25T11:51:44.993813Z",
-     "iopub.status.idle": "2026-04-25T11:51:44.996553Z",
-     "shell.execute_reply": "2026-04-25T11:51:44.996281Z"
+     "iopub.execute_input": "2026-08-07T15:18:52.908225Z",
+     "iopub.status.busy": "2026-08-07T15:18:52.907988Z",
+     "iopub.status.idle": "2026-08-07T15:18:52.927436Z",
+     "shell.execute_reply": "2026-08-07T15:18:52.924512Z"
     }
    },
    "outputs": [
@@ -664,24 +666,71 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/Users/jkitchin/Dropbox/projects/discopt/python/discopt/modeling/core.py:1903: UserWarning: Variables with very large or infinite bounds: z[0] (lb=0, ub=1e+20), z[1] (lb=0, ub=1e+20). NLP solvers may fail (NaN, iteration_limit) when bounds exceed ~1e15. Add tighter explicit bounds, e.g. m.continuous('x', lb=0, ub=1000).\n",
-      "  result = solve_model(\n"
+      "/home/user/discopt/python/discopt/debug/__init__.py:98: UserWarning: Variables with very large or infinite declared bounds: z[0] (lb=0, ub=inf), z[1] (lb=0, ub=inf).  NLP solvers may fail (NaN, iteration_limit) when bounds exceed ~1e15. Add tighter explicit bounds, e.g. m.continuous('x', lb=0, ub=1000).\n",
+      "  return fn(*args, **kwargs)\n"
      ]
     }
    ],
    "source": [
     "# --- Unbounded LP ---\n",
+    "# `ub=np.inf` declares a genuinely unbounded variable. This matters: leaving `ub`\n",
+    "# off does NOT mean \"no upper bound\" -- it applies the default box (see below).\n",
     "mu = dm.Model(\"unbounded\")\n",
-    "z = mu.continuous(\"z\", shape=(2,), lb=0)  # no upper bound\n",
+    "z = mu.continuous(\"z\", shape=(2,), lb=0, ub=np.inf)\n",
     "mu.minimize(-z[0] - z[1])  # push both variables to +inf\n",
     "\n",
     "# Only a lower bound constraint, no upper limit\n",
     "mu.subject_to(z[0] + z[1] >= 1.0, name=\"lower\")\n",
     "\n",
     "ru = mu.solve()\n",
-    "# Note: returns \"iteration_limit\" (unboundedness detection is a known limitation)\n",
     "print(f\"Status: {ru.status}\")\n",
     "print(f\"Objective: {ru.objective}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "default-box-demo",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-07T15:18:52.929628Z",
+     "iopub.status.busy": "2026-08-07T15:18:52.929452Z",
+     "iopub.status.idle": "2026-08-07T15:18:52.948842Z",
+     "shell.execute_reply": "2026-08-07T15:18:52.947573Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Declared upper bound: 9.9990e+19\n",
+      "Status: optimal\n",
+      "Objective: -1.9998e+20\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/home/user/discopt/python/discopt/debug/__init__.py:98: UserWarning: Variables with very large or infinite declared bounds: z[0] (lb=0, ub=1e+20), z[1] (lb=0, ub=1e+20).  NLP solvers may fail (NaN, iteration_limit) when bounds exceed ~1e15. Add tighter explicit bounds, e.g. m.continuous('x', lb=0, ub=1000).\n",
+      "  return fn(*args, **kwargs)\n"
+     ]
+    }
+   ],
+   "source": [
+    "# The default box is large but FINITE (+/-9.999e19), so the same model without an\n",
+    "# explicit `ub` is a bounded LP and gets an ordinary optimal certificate -- at a\n",
+    "# corner with an enormous objective, not \"unbounded\".\n",
+    "mb = dm.Model(\"default_box\")\n",
+    "zb = mb.continuous(\"z\", shape=(2,), lb=0)  # ub defaults to 9.999e19\n",
+    "mb.minimize(-zb[0] - zb[1])\n",
+    "mb.subject_to(zb[0] + zb[1] >= 1.0, name=\"lower\")\n",
+    "\n",
+    "rb = mb.solve()\n",
+    "print(f\"Declared upper bound: {mb._variables[0].ub[0]:.4e}\")\n",
+    "print(f\"Status: {rb.status}\")\n",
+    "print(f\"Objective: {rb.objective:.4e}\")"
    ]
   },
   {
@@ -694,10 +743,13 @@
     "- The feasible region is non-empty (constraints are not contradictory).\n",
     "- The objective is bounded over the feasible region (add upper/lower bounds if needed).\n",
     "\n",
-    "> **Known limitation:** The IPM solver does not yet have dedicated infeasibility or\n",
-    "> unboundedness detection. Both cases currently return a status of `\"iteration_limit\"`\n",
-    "> rather than `\"infeasible\"` or `\"unbounded\"`. An extremely large objective magnitude\n",
-    "> (as in the unbounded example) is a strong hint that the problem is unbounded."
+    "> **Bounds are not optional detail.** Omitting `ub` does not declare an unbounded\n",
+    "> variable -- it applies the default box `[-9.999e19, 9.999e19]`, and the solver\n",
+    "> then certifies the problem *as posed*: bounded, with an optimum at a corner of\n",
+    "> that box. If you mean unbounded, say `ub=np.inf`; if you mean a real limit, give\n",
+    "> it. A huge finite objective is the signal that a default bound became the binding\n",
+    "> constraint. Bounds beyond ~1e15 also cost accuracy in the nonlinear solvers, so\n",
+    "> prefer a tight, physically meaningful box wherever you have one."
    ]
   },
   {
@@ -736,7 +788,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 14,
    "id": "exercise-skeleton",
    "metadata": {
     "execution": {
@@ -784,7 +836,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 15,
    "id": "exercise-solution",
    "metadata": {
     "execution": {

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -14657,10 +14657,33 @@ def _solve_lp(
     engines = [_solve_lp_simplex, _solve_lp_pounce]
     if prefer_pounce:
         engines.reverse()
+    deferred: _DeferredUnbounded | None = None
     for engine in engines:
         result = engine(model, t_start, time_limit)
+        if isinstance(result, _DeferredUnbounded):
+            # An UNBOUNDED the #850 guard declined to certify because this engine
+            # relaxed a declared bound in [1e15, 1e20) to its own infinity. Keep
+            # looking for an engine that honors the declared box, but hold on to
+            # the verdict (see below).
+            deferred = deferred or result
+            continue
         if result is not None:
             return result
+
+    if deferred is not None:
+        # No engine produced a certificate against the declared box, so the
+        # deferral has nowhere left to defer to. Return the held UNBOUNDED rather
+        # than "error" (#937): the verdict came from a real solve and is at worst
+        # an artifact of a relaxed box, whereas "error" is a strictly worse
+        # outcome — it discards a correct answer AND says nothing diagnosable.
+        logger.warning(
+            "%s reported UNBOUNDED on a box with a declared bound in [1e15, 1e20) "
+            "and no engine honoring that box could certify the LP; reporting "
+            "unbounded (#937). The verdict may reflect the relaxed box rather "
+            "than the declared one — tighten the bounds to disambiguate.",
+            deferred.engine,
+        )
+        return deferred.result
 
     # Single robust engine (issue #364): no JAX LP-IPM fallback. Both the simplex
     # and POUNCE (if installed) returned None — a binding that is unavailable or a
@@ -14677,11 +14700,29 @@ def _solve_lp(
     )
 
 
+class _DeferredUnbounded:
+    """An ``UNBOUNDED`` verdict the #850 guard declined to certify *for now*.
+
+    The guard fires when the reporting engine relaxed a declared finite bound in
+    ``[1e15, 1e20)`` to its own infinity, so the verdict may describe a larger box
+    than the one declared. It is a *preference*, not a rejection: an engine that
+    honors the declared box should be tried first, but if none can certify, this
+    verdict is still the best available answer and must not be downgraded to
+    ``error`` (#937).
+    """
+
+    __slots__ = ("result", "engine")
+
+    def __init__(self, result: SolveResult, engine: str) -> None:
+        self.result = result
+        self.engine = engine
+
+
 def _solve_lp_simplex(
     model: Model,
     t_start: float,
     time_limit: float | None = None,
-) -> SolveResult | None:
+) -> "SolveResult | _DeferredUnbounded | None":
     """Solve an LP using the pure-Rust warm-started simplex. Returns None when
     the simplex binding is unavailable or fails, so the caller can fall back to
     another engine."""
@@ -14690,6 +14731,9 @@ def _solve_lp_simplex(
 
     if not SIMPLEX_AVAILABLE:
         return None
+    # relaxes_huge_bounds stays False: the simplex's infinity threshold is 1e20,
+    # so it honors a declared bound in [1e15, 1e20) as finite and its UNBOUNDED is
+    # a statement about the box as declared.
     return _solve_lp_matrix(model, t_start, time_limit, _simplex_solve_lp, "simplex")
 
 
@@ -14697,7 +14741,7 @@ def _solve_lp_pounce(
     model: Model,
     t_start: float,
     time_limit: float | None = None,
-) -> SolveResult | None:
+) -> "SolveResult | _DeferredUnbounded | None":
     """Solve an LP using POUNCE (pure-Rust IPM). Returns None when POUNCE is
     unavailable or fails, so the caller can fall back to another engine."""
     import functools
@@ -14710,7 +14754,11 @@ def _solve_lp_pounce(
     # Request an infeasibility certificate so an infeasible model-level LP
     # surfaces *why* via SolveResult.infeasibility_certificate (roadmap P0.2).
     solve_fn = functools.partial(_pounce_solve_lp, certificate=True)
-    return _solve_lp_matrix(model, t_start, time_limit, solve_fn, "POUNCE")
+    # The IPM is the one backend that relaxes a declared [1e15, 1e20) bound to its
+    # own infinity, so its UNBOUNDED is the verdict the #850 guard defers on.
+    return _solve_lp_matrix(
+        model, t_start, time_limit, solve_fn, "POUNCE", relaxes_huge_bounds=True
+    )
 
 
 def _solve_lp_gurobi(
@@ -14733,9 +14781,14 @@ def _solve_lp_gurobi(
         solve_fn,
         "Gurobi",
         strict=True,
+        # Gurobi's infinity is 1e30, so it honors a declared [1e15, 1e20) bound as
+        # finite — the #850 deferral never applies and no _DeferredUnbounded can
+        # come back here.
+        relaxes_huge_bounds=False,
     )
     if result is None:  # pragma: no cover - strict mode raises before this
         raise RuntimeError("Gurobi LP solve failed without returning a result.")
+    assert isinstance(result, SolveResult)
     return result
 
 
@@ -14746,11 +14799,22 @@ def _solve_lp_matrix(
     solve_lp_fn,
     engine: str,
     strict: bool = False,
-) -> SolveResult | None:
+    relaxes_huge_bounds: bool = False,
+) -> "SolveResult | _DeferredUnbounded | None":
     """Solve a pure LP through a matrix-form ``solve_lp`` backend.
 
     ``solve_lp_fn`` must follow the shared LP contract (lp_simplex / lp_pounce):
     same signature, same ``LPResult`` with HiGHS-convention duals.
+
+    ``relaxes_huge_bounds`` declares that this backend does **not** honor a
+    declared finite bound in ``[1e15, 1e20)`` as finite — it relaxes it to its own
+    infinity — so an ``UNBOUNDED`` verdict from it on such a box may be an artifact
+    of the relaxation rather than a property of the problem as posed. Only the
+    interior-point engine does this (``lp_pounce._FINITE_BOUND_THRESHOLD = 1e15``);
+    see the ``SolveStatus.UNBOUNDED`` branch below. Leave it ``False`` for a
+    backend that honors the declared box (the exact simplex, whose infinity
+    threshold is ``1e20``; Gurobi, whose infinity is ``1e30``) — discarding *its*
+    verdict would throw away a certificate about the box actually declared.
     """
     from discopt._jax.problem_classifier import extract_lp_data
     from discopt.modeling.core import ObjectiveSense
@@ -14849,12 +14913,27 @@ def _solve_lp_matrix(
         # 1e20, honors such a bound as finite and returns OPTIMAL at the corner —
         # the sound certificate (e.g. the default continuous box ±9.999e19, which
         # is deliberately just below 1e20). When any declared bound was relaxed
-        # this way, decline to certify UNBOUNDED and fall through (return None) so
-        # the caller tries the exact simplex, yielding a certificate consistent
-        # with the declared box across every backend. A genuinely unbounded
-        # direction survives: the simplex sees any true ±inf (|b| ≥ 1e20) bound
-        # and reports UNBOUNDED itself.
-        if _declared_box_relaxed_to_ipm_inf(bounds):
+        # this way, decline to certify UNBOUNDED and defer so the caller prefers
+        # the exact simplex, yielding a certificate consistent with the declared
+        # box across every backend. A genuinely unbounded direction survives: the
+        # simplex sees any true ±inf (|b| ≥ 1e20) bound and reports UNBOUNDED
+        # itself.
+        #
+        # Two things bound the deferral (#937):
+        #
+        #   * It applies only to a backend that actually relaxes the box
+        #     (``relaxes_huge_bounds``). Applied engine-agnostically it also
+        #     discarded the *simplex's own* UNBOUNDED — a verdict about the
+        #     declared box, reached with the box honored — whenever some unrelated
+        #     variable happened to carry a bound in the window.
+        #   * The verdict is DEFERRED, not destroyed. Returning a bare ``None``
+        #     made a correct UNBOUNDED indistinguishable from "this engine
+        #     failed", so when no other engine could certify either, ``_solve_lp``
+        #     reported an undiagnosed ``error`` — strictly the worst of the three
+        #     outcomes. ``_DeferredUnbounded`` lets the caller prefer a real
+        #     certificate when one exists and fall back on this verdict when none
+        #     does.
+        if relaxes_huge_bounds and _declared_box_relaxed_to_ipm_inf(bounds):
             logger.debug(
                 "%s reported UNBOUNDED but a declared finite bound (|b| in "
                 "[1e15, 1e20)) was relaxed to the IPM infinity; deferring to the "
@@ -14862,7 +14941,7 @@ def _solve_lp_matrix(
                 "(#850).",
                 engine,
             )
-            return None
+            return _DeferredUnbounded(SolveResult(status="unbounded", wall_time=wall_time), engine)
         return SolveResult(status="unbounded", wall_time=wall_time)
     if result.status == SolveStatus.TIME_LIMIT:
         return SolveResult(status="time_limit", wall_time=wall_time)

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -14672,18 +14672,35 @@ def _solve_lp(
 
     if deferred is not None:
         # No engine produced a certificate against the declared box, so the
-        # deferral has nowhere left to defer to. Return the held UNBOUNDED rather
-        # than "error" (#937): the verdict came from a real solve and is at worst
-        # an artifact of a relaxed box, whereas "error" is a strictly worse
-        # outcome — it discards a correct answer AND says nothing diagnosable.
-        logger.warning(
-            "%s reported UNBOUNDED on a box with a declared bound in [1e15, 1e20) "
-            "and no engine honoring that box could certify the LP; reporting "
-            "unbounded (#937). The verdict may reflect the relaxed box rather "
-            "than the declared one — tighten the bounds to disambiguate.",
-            deferred.engine,
+        # deferral has nowhere left to defer to.
+        #
+        # The held verdict is NOT promoted to the answer (#937). A bound in
+        # [1e15, 1e20) is finite as posed, so the honest reading of the deferral is
+        # "an engine that could not see this bound called the problem unbounded" —
+        # on `min -x` over the default box the truth is `optimal` at the corner
+        # (the certificate #850 decided is sound), and returning `unbounded` there
+        # would be a FALSE certificate on a bounded problem. CLAUDE.md §1 admits no
+        # trade of a possibly-false certificate for a better-looking status, so the
+        # status stays `error` — not a certificate, an honest "no engine could
+        # decide this".
+        #
+        # What #937 legitimately asks for is that the failure stop being
+        # *undiagnosable*, and that is fixed here: the warning names the engine,
+        # the exact cause, and the remedy, instead of a bare `error` that says
+        # nothing. (In practice the deferral is now almost always resolved by the
+        # simplex, which certifies this band since the audit fix.)
+        msg = (
+            f"{deferred.engine} reported UNBOUNDED, but it relaxed a declared finite "
+            f"bound in [1e15, 1e20) to its own infinity, so that verdict may describe "
+            f"a larger box than the one declared; no engine honoring the declared box "
+            f"could certify the LP. Reporting 'error' rather than an unverified "
+            f"'unbounded' — over a finite box the true answer may well be 'optimal' at "
+            f"the corner. Tighten the bounds below 1e15 to get a decisive certificate."
         )
-        return deferred.result
+        import warnings
+
+        logger.warning(msg)
+        warnings.warn(msg, RuntimeWarning, stacklevel=2)
 
     # Single robust engine (issue #364): no JAX LP-IPM fallback. Both the simplex
     # and POUNCE (if installed) returned None — a binding that is unavailable or a
@@ -14705,10 +14722,17 @@ class _DeferredUnbounded:
 
     The guard fires when the reporting engine relaxed a declared finite bound in
     ``[1e15, 1e20)`` to its own infinity, so the verdict may describe a larger box
-    than the one declared. It is a *preference*, not a rejection: an engine that
-    honors the declared box should be tried first, but if none can certify, this
-    verdict is still the best available answer and must not be downgraded to
-    ``error`` (#937).
+    than the one declared.
+
+    Carrying the verdict (rather than the bare ``None`` the guard used to return)
+    exists for **diagnosis, not certification**. It lets ``_solve_lp`` tell
+    "an engine declined to certify, and here is exactly why" apart from "an engine
+    failed", so the no-certificate outcome is reported with an actionable message
+    instead of an undiagnosable ``error`` (#937). The verdict itself is never
+    promoted to the answer: over a finite ``[1e15, 1e20)`` box an ``unbounded``
+    claim can be false — ``min -x`` on the default box is ``optimal`` at the corner
+    — and CLAUDE.md §1 forbids trading a possibly-false certificate for a
+    better-looking status.
     """
 
     __slots__ = ("result", "engine")

--- a/python/discopt/solvers/lp_simplex.py
+++ b/python/discopt/solvers/lp_simplex.py
@@ -46,6 +46,36 @@ except ImportError:
 _BOUND_SNAP_TOL = 1e-3
 
 
+# Keywords of the shared matrix-LP contract (:mod:`lp_pounce`, :mod:`gurobi`) that
+# this backend has no use for and legitimately ignores: an IPM warm-start point, an
+# engine-specific options dict, a Farkas-certificate request (the simplex always
+# reports its own status), a thread count (the solve is single-threaded). They are
+# accepted so a caller can hand the same kwargs to any backend through
+# :func:`discopt.solvers.lp_backend.get_lp_solver`.
+_IGNORED_LP_KWARGS = frozenset({"x0", "options", "certificate", "threads"})
+
+
+def _reject_unknown_kwargs(kwargs: dict[str, Any]) -> None:
+    """Raise on a keyword this backend neither honors nor knowingly ignores.
+
+    ``solve_lp`` takes ``**_kwargs`` only for cross-backend signature
+    compatibility, and a bare catch-all is a silent-wrong-answer seam: a caller
+    passing ``lb=``/``ub=`` arrays (the spelling several other discopt LP helpers
+    use) had them swallowed and got the *default* ``[0, 1e20]`` box back, with an
+    ``OPTIMAL`` status over a box it never asked for (issue #937, side finding).
+    ``Model.solve`` rejects unknown options loudly for exactly this reason; so does
+    this. The known-inert contract keywords in :data:`_IGNORED_LP_KWARGS` still
+    pass through silently.
+    """
+    unknown = sorted(set(kwargs) - _IGNORED_LP_KWARGS)
+    if unknown:
+        raise TypeError(
+            f"lp_simplex.solve_lp() got unexpected keyword argument(s): "
+            f"{', '.join(unknown)}. The variable box is set through `bounds=` "
+            f"(a list of (lo, hi) pairs), not `lb=`/`ub=`."
+        )
+
+
 def _dense_rows(A: Optional[Union[np.ndarray, sp.spmatrix]], n: int) -> np.ndarray:
     """Dense ``(m, n)`` view of a constraint block, or an empty ``(0, n)``."""
     if A is None:
@@ -107,7 +137,13 @@ def solve_lp(
     wrong bound). This lets a caller bound the rare cold-stall on a wide,
     ill-conditioned LP (the F3 multilinear vertex-hull LP: ``2^n`` λ columns)
     without waiting for the 100 000-pivot default.
+
+    The variable box comes **only** from ``bounds``. An unrecognized keyword
+    raises :class:`TypeError` rather than being swallowed by ``**_kwargs`` — see
+    :func:`_reject_unknown_kwargs`.
     """
+    _reject_unknown_kwargs(_kwargs)
+
     from discopt._rust import solve_lp_warm_csc_py
 
     c_arr = np.asarray(c, dtype=np.float64).ravel()

--- a/python/discopt/solvers/mip_nlp.py
+++ b/python/discopt/solvers/mip_nlp.py
@@ -286,6 +286,13 @@ def _try_direct_lp(
             time_limit,
             prefer_pounce=nlp_solver == "pounce",
         )
+    if isinstance(result, solver_module._DeferredUnbounded):
+        # An UNBOUNDED the #850 guard would rather see confirmed by an engine that
+        # honors the declared box. On this path the caller pinned the backend, so
+        # there is no other engine to defer to — take the verdict rather than drop
+        # it (#937). ``_solve_lp`` resolves its own deferrals, so only the forced
+        # ``backend="pounce"`` branch can reach here.
+        result = result.result
     if result is None:
         return None, _direct_attempt(
             problem_class=problem_class,

--- a/python/tests/test_850_cross_backend_unbounded_and_feasibility.py
+++ b/python/tests/test_850_cross_backend_unbounded_and_feasibility.py
@@ -150,14 +150,81 @@ def _stub_exact(c, A_ub=None, b_ub=None, A_eq=None, b_eq=None, bounds=None, **kw
 def test_obs1_unbounded_with_relaxed_bound_degrades():
     """Obs 1: an engine that reports UNBOUNDED on the default continuous box (a
     bound it silently relaxed to ∞) must not be certified — ``_solve_lp_matrix``
-    returns None so the caller falls through to the exact simplex."""
+    declines so the caller falls through to the exact simplex.
+
+    The stub stands in for POUNCE, so it must declare POUNCE's defining property:
+    ``relaxes_huge_bounds=True``. That flag is what scopes the guard to engines
+    that actually relax the box (#937) — without it the guard also discarded the
+    *simplex's* UNBOUNDED, a verdict reached with the declared box honored.
+
+    The decline is signalled by ``_DeferredUnbounded`` rather than the bare
+    ``None`` it used to return. That is a strictly narrower channel, not a weaker
+    one: ``None`` was indistinguishable from "this engine failed", so a simplex
+    failure downgraded the whole solve to an undiagnosable ``error``. The #850
+    property — *do not certify this verdict, prefer an engine that honors the box*
+    — is unchanged, and is pinned end-to-end by
+    ``test_obs1_deferred_unbounded_is_never_promoted_to_the_answer`` below.
+    """
     m = dm.Model("u")
     x = m.continuous("x", lb=0)  # default ub = 9.999e19
     m.minimize(-x)
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")
-        res = S._solve_lp_matrix(m, time.perf_counter(), None, _stub_unbounded, "STUB-IPM")
-    assert res is None
+        res = S._solve_lp_matrix(
+            m, time.perf_counter(), None, _stub_unbounded, "STUB-IPM", relaxes_huge_bounds=True
+        )
+    assert isinstance(res, S._DeferredUnbounded), (
+        f"a relaxed-box UNBOUNDED must be declined, not certified; got {res!r}"
+    )
+    assert res.result.status == "unbounded" and res.engine == "STUB-IPM"
+
+
+def test_obs1_verdict_from_a_box_honoring_engine_is_not_deferred():
+    """The mirror of Obs 1 (#937): the guard must only fire for an engine that
+    *relaxes* the box. The exact simplex reads a bound in ``[1e15, 1e20)`` as
+    finite, so its UNBOUNDED is a statement about the box as declared and must be
+    passed straight through — discarding it threw away a real certificate."""
+    m = dm.Model("u3")
+    x = m.continuous("x", lb=0)  # default ub = 9.999e19, inside the window
+    m.minimize(-x)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        res = S._solve_lp_matrix(
+            m, time.perf_counter(), None, _stub_unbounded, "STUB-SIMPLEX"
+        )  # relaxes_huge_bounds defaults to False
+    assert res is not None and not isinstance(res, S._DeferredUnbounded)
+    assert res.status == "unbounded"
+
+
+def test_obs1_deferred_unbounded_is_never_promoted_to_the_answer(monkeypatch):
+    """The #850 property at the ``_solve_lp`` level: when the deferral has nowhere
+    left to defer to, the declined verdict is still NOT the answer.
+
+    Over a finite ``[1e15, 1e20)`` box an ``unbounded`` claim can be false — on
+    ``min -x`` over the default box the truth is ``optimal`` at the corner, which
+    is exactly the certificate #850 decided is sound — so promoting the held
+    verdict would emit a false certificate on a bounded problem. The solve reports
+    ``error`` (not a certificate) plus a diagnostic naming the cause, which is what
+    #937 asks for: no longer *undiagnosable*, without inventing an answer.
+    """
+    m = dm.Model("u4")
+    x = m.continuous("x", lb=0)  # default ub = 9.999e19
+    m.minimize(-x)
+
+    def _deferring(model, t_start, time_limit=None):
+        return S._DeferredUnbounded(S.SolveResult(status="unbounded", wall_time=0.0), "STUB-IPM")
+
+    def _failing(model, t_start, time_limit=None):
+        return None
+
+    monkeypatch.setattr(S, "_solve_lp_pounce", _deferring)
+    monkeypatch.setattr(S, "_solve_lp_simplex", _failing)
+
+    with pytest.warns(RuntimeWarning, match=r"relaxed a declared finite bound"):
+        res = S._solve_lp(m, t_start=time.perf_counter())
+    assert res.status == "error", (
+        f"a declined UNBOUNDED must not become the certificate; got {res.status}"
+    )
 
 
 def test_obs1_genuine_unbounded_still_reported():

--- a/python/tests/test_lp_huge_finite_box_937.py
+++ b/python/tests/test_lp_huge_finite_box_937.py
@@ -1,0 +1,183 @@
+"""Huge-but-finite declared LP boxes must certify, not error (issue #937).
+
+A declared variable box in ``[1e16, 1e20)`` made the Rust simplex exit
+``numerical`` (→ ``SolveStatus.ERROR``). That band is exactly the band the #850
+guard defers *into*: the guard distrusts an IPM ``UNBOUNDED`` whenever a declared
+bound in ``[1e15, 1e20)`` was relaxed to the IPM infinity and hands off to the
+exact simplex — which then could not certify either, so a correctly-detected
+``unbounded`` LP came back as an undiagnosed ``status: error``. ``9.999e19`` is
+the *default* ``Model.continuous`` upper bound, so this was the default path.
+
+Three things are pinned here:
+
+1. The simplex certifies the whole band (not one point), at the exact corner.
+2. The #850 deferral is a preference, not a destruction: when no engine that
+   honors the declared box can certify, the deferred ``unbounded`` is returned
+   rather than ``error``; and the *simplex's own* ``UNBOUNDED`` — a verdict
+   reached with the box honored — is never deferred.
+3. ``lp_simplex.solve_lp`` rejects unknown keywords instead of silently
+   swallowing an ``lb=``/``ub=`` box and solving over the default one.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+import scipy.sparse as sp
+
+pytest.importorskip("discopt._rust")
+
+from discopt.solvers import SolveStatus  # noqa: E402
+from discopt.solvers.lp_simplex import solve_lp as simplex_lp  # noqa: E402
+
+# The band the #850 guard defers into is [1e15, 1e20). 1e20 is the LP layer's INF
+# sentinel — a genuinely infinite bound — and is checked separately.
+_FINITE_BAND = [1e3, 1e12, 1e15, 1e16, 1e17, 1e18, 1e19, 5e19, 9.999e19]
+
+
+def _unbounded_direction_lp(u: float):
+    """``min -z0 - z1  s.t.  z0 + z1 >= 1,  0 <= z <= u``.
+
+    Optimal at the corner ``z = (u, u)`` with objective ``-2u`` for any finite
+    ``u``; unbounded only when the box itself is infinite.
+    """
+    return dict(
+        c=np.array([-1.0, -1.0]),
+        A_ub=sp.csr_matrix([[-1.0, -1.0]]),
+        b_ub=np.array([-1.0]),
+        bounds=[(0.0, u), (0.0, u)],
+    )
+
+
+@pytest.mark.smoke
+def test_simplex_certifies_the_whole_huge_finite_box_band():
+    """Every finite box below the 1e20 sentinel certifies at ``-2u``.
+
+    Pins the band end to end rather than a point: pre-fix the failure started at
+    ``1e16`` (a row residual measured only against ``|b|`` while the row's own
+    terms were ~1e16) and changed character at ``9.999e19`` (the standard-form
+    slack's optimal value passing its ``1e20`` sentinel "bound"), so a single
+    probe would have missed half of it.
+    """
+    checked = 0
+    for u in _FINITE_BAND:
+        r = simplex_lp(**_unbounded_direction_lp(u))
+        assert r.status == SolveStatus.OPTIMAL, (
+            f"ub={u:.4e}: a finite declared box must certify, got {r.status.value}"
+        )
+        assert r.objective == pytest.approx(-2.0 * u, rel=1e-12), f"ub={u:.4e}"
+        checked += 1
+    assert checked == len(_FINITE_BAND), "band probe did not run every point"
+
+
+@pytest.mark.smoke
+def test_simplex_reports_unbounded_at_the_inf_sentinel():
+    """``1e20`` is the LP layer's infinity, so there the LP really is unbounded."""
+    r = simplex_lp(**_unbounded_direction_lp(1e20))
+    assert r.status == SolveStatus.UNBOUNDED
+
+
+@pytest.mark.smoke
+def test_model_solve_on_the_default_continuous_box_is_not_error():
+    """End-to-end: the issue's model must not come back ``error``.
+
+    ``m.continuous(lb=0)`` leaves the default upper bound ``9.999e19``, so the LP
+    as posed is bounded and the sound verdict is ``optimal`` at ``-2 * 9.999e19``
+    — the certificate the #850 guard's own comment says the exact simplex should
+    supply. What it must never be is ``error``.
+    """
+    import discopt.modeling as dm
+
+    m = dm.Model("unbounded_direction")
+    z = m.continuous("z", shape=(2,), lb=0)
+    m.minimize(-z[0] - z[1])
+    m.subject_to(z[0] + z[1] >= 1.0, name="lower")
+
+    res = m.solve()
+    assert res.status != "error", "the #937 defect: a correct verdict lost to `error`"
+    assert res.status == "optimal"
+    assert res.objective == pytest.approx(-2.0 * 9.999e19, rel=1e-9)
+
+
+@pytest.mark.smoke
+def test_deferred_unbounded_is_returned_rather_than_downgraded_to_error(monkeypatch):
+    """When nothing can certify the declared box, keep the ``unbounded`` verdict.
+
+    The #850 guard declines to certify an IPM ``UNBOUNDED`` on a box with a
+    declared bound in ``[1e15, 1e20)``. It used to signal that by returning a bare
+    ``None`` — indistinguishable from "this engine failed" — so a simplex failure
+    (#937's other half) turned the whole solve into an undiagnosed ``error``.
+    Simulating the simplex failure directly pins the contract independently of
+    whether the simplex happens to succeed today.
+    """
+    import discopt.modeling as dm
+    import discopt.solver as solver_mod
+
+    pytest.importorskip("pounce")
+    from discopt.solvers.lp_pounce import POUNCE_AVAILABLE
+
+    if not POUNCE_AVAILABLE:
+        pytest.skip("POUNCE not available; the deferral has no reporting engine")
+
+    calls = {"simplex": 0}
+
+    def _failing_simplex(model, t_start, time_limit=None):
+        calls["simplex"] += 1
+        return None
+
+    monkeypatch.setattr(solver_mod, "_solve_lp_simplex", _failing_simplex)
+
+    m = dm.Model("unbounded_direction")
+    z = m.continuous("z", shape=(2,), lb=0)
+    m.minimize(-z[0] - z[1])
+    m.subject_to(z[0] + z[1] >= 1.0, name="lower")
+
+    res = solver_mod._solve_lp(m, t_start=0.0)
+    assert calls["simplex"] == 1, "the simplex stub must actually have been consulted"
+    assert res.status == "unbounded", (
+        "a deferred UNBOUNDED with nowhere left to defer must be reported, "
+        f"not downgraded; got {res.status}"
+    )
+
+
+@pytest.mark.smoke
+def test_simplex_unbounded_verdict_is_never_deferred():
+    """The guard must not discard a verdict from an engine that honors the box.
+
+    The simplex's infinity threshold is ``1e20``, so it reads a declared bound in
+    ``[1e15, 1e20)`` as finite and its ``UNBOUNDED`` is a statement about the box
+    as declared. Applied engine-agnostically the guard threw that away whenever
+    some *unrelated* variable carried a bound in the window — here ``w``, while
+    the unboundedness comes from ``z`` at the true ``1e20`` infinity.
+    """
+    import discopt.modeling as dm
+
+    m = dm.Model("genuinely_unbounded")
+    z = m.continuous("z", lb=0.0, ub=1e20)  # true infinity for both engines
+    w = m.continuous("w", lb=0.0, ub=1e18)  # inside the #850 deferral window
+    m.minimize(-z)
+    m.subject_to(z + w >= 1.0, name="lower")
+
+    res = m.solve()
+    assert res.status == "unbounded", (
+        f"a genuinely unbounded direction must survive the #850 guard; got {res.status}"
+    )
+
+
+@pytest.mark.unit
+def test_solve_lp_rejects_unknown_keywords():
+    """``lb=``/``ub=`` must raise, not be swallowed into the default ``[0, 1e20]``.
+
+    ``solve_lp`` takes ``**_kwargs`` for cross-backend signature compatibility; a
+    bare catch-all made a caller-supplied box vanish and returned ``OPTIMAL`` over
+    a box it never asked for (#937, side finding).
+    """
+    lp = _unbounded_direction_lp(5.0)
+    lp.pop("bounds")
+    with pytest.raises(TypeError, match=r"lb, ub"):
+        simplex_lp(lb=np.zeros(2), ub=np.full(2, 5.0), **lp)
+
+    # The inert keywords of the shared LP contract still pass through silently.
+    r = simplex_lp(bounds=[(0.0, 5.0)] * 2, options=None, certificate=True, **lp)
+    assert r.status == SolveStatus.OPTIMAL
+    assert r.objective == pytest.approx(-10.0)

--- a/python/tests/test_lp_huge_finite_box_937.py
+++ b/python/tests/test_lp_huge_finite_box_937.py
@@ -100,24 +100,25 @@ def test_model_solve_on_the_default_continuous_box_is_not_error():
 
 
 @pytest.mark.smoke
-def test_deferred_unbounded_is_returned_rather_than_downgraded_to_error(monkeypatch):
-    """When nothing can certify the declared box, keep the ``unbounded`` verdict.
+def test_deferred_unbounded_failure_is_diagnosed_not_silently_error(monkeypatch):
+    """When nothing can certify the declared box, say *why* — but do not invent a
+    verdict.
 
     The #850 guard declines to certify an IPM ``UNBOUNDED`` on a box with a
-    declared bound in ``[1e15, 1e20)``. It used to signal that by returning a bare
-    ``None`` — indistinguishable from "this engine failed" — so a simplex failure
-    (#937's other half) turned the whole solve into an undiagnosed ``error``.
-    Simulating the simplex failure directly pins the contract independently of
-    whether the simplex happens to succeed today.
+    declared bound in ``[1e15, 1e20)``. It used to signal that with a bare ``None``
+    — indistinguishable from "this engine failed" — so a simplex failure (#937's
+    other half) produced a bare, undiagnosable ``error``.
+
+    The fix is diagnosis, not promotion. Promoting the held verdict was the obvious
+    reading of #937 and it is **unsound**: a ``[1e15, 1e20)`` bound is finite as
+    posed, so on ``min -z0 - z1`` over the default box the truth is ``optimal`` at
+    the corner (the certificate #850 decided is sound) and ``unbounded`` would be a
+    false certificate on a bounded problem. So the status stays ``error`` — not a
+    certificate, an honest "no engine could decide this" — and the warning carries
+    the engine, the cause, and the remedy.
     """
     import discopt.modeling as dm
     import discopt.solver as solver_mod
-
-    pytest.importorskip("pounce")
-    from discopt.solvers.lp_pounce import POUNCE_AVAILABLE
-
-    if not POUNCE_AVAILABLE:
-        pytest.skip("POUNCE not available; the deferral has no reporting engine")
 
     calls = {"simplex": 0}
 
@@ -125,18 +126,25 @@ def test_deferred_unbounded_is_returned_rather_than_downgraded_to_error(monkeypa
         calls["simplex"] += 1
         return None
 
+    def _deferring_pounce(model, t_start, time_limit=None):
+        return solver_mod._DeferredUnbounded(
+            solver_mod.SolveResult(status="unbounded", wall_time=0.0), "STUB-IPM"
+        )
+
     monkeypatch.setattr(solver_mod, "_solve_lp_simplex", _failing_simplex)
+    monkeypatch.setattr(solver_mod, "_solve_lp_pounce", _deferring_pounce)
 
     m = dm.Model("unbounded_direction")
     z = m.continuous("z", shape=(2,), lb=0)
     m.minimize(-z[0] - z[1])
     m.subject_to(z[0] + z[1] >= 1.0, name="lower")
 
-    res = solver_mod._solve_lp(m, t_start=0.0)
+    with pytest.warns(RuntimeWarning, match=r"relaxed a declared finite bound"):
+        res = solver_mod._solve_lp(m, t_start=0.0)
     assert calls["simplex"] == 1, "the simplex stub must actually have been consulted"
-    assert res.status == "unbounded", (
-        "a deferred UNBOUNDED with nowhere left to defer must be reported, "
-        f"not downgraded; got {res.status}"
+    assert res.status == "error", (
+        "a declined UNBOUNDED on a finite box must not be promoted to a certificate; "
+        f"got {res.status}"
     )
 
 


### PR DESCRIPTION
## Summary

An LP whose declared variable box fell in `[1e16, 1e20)` made the Rust simplex exit
`numerical` (→ `SolveStatus.ERROR`). That is exactly the band the #850 guard defers
*into*, so the two interacted to turn a correctly-detected `unbounded` LP into an
undiagnosed `status: error`. `9.999e19` is the **default** `Model.continuous` upper
bound, so this was the default path, not an exotic one.

Root cause: two independent scale-blindness defects in `audit_feasibility`
(`crates/discopt-core/src/lp/simplex/primal.rs`), the final gate before certifying
`Optimal`. Which arm fired at each point in the band was established by instrumenting
the two `Feasibility` arms directly, not inferred:

| band | arm | cause |
|---|---|---|
| `[1e16, 1e19]` | `Rows` | The residual was measured only against `\|b_i\|`. The vertex of `−z₀ − z₁ + s = −1` at `z = (u, u)` needs `s = 2u − 1`, which for `2u > 2⁵³` is not representable and rounds to `2u`, leaving residual exactly `1` — 5e-17 *relative* to the terms summed, yet ~5e5× over the `FEAS*(1 + \|b\|) = 2e-6` threshold. |
| `9.999e19` | `Bounds` | The standard-form slack carries `u = 1e20`, which the rest of the engine reads as the ±INF sentinel ("no bound on that side") — ratio tests, phase-1 setup, nonbasic-status assignment — but the audit compared against it as a literal number, so the slack's optimal `1.9998e20` "violated" a bound the LP does not have. |

Fix 1 adds a round-off floor derived from the row's own activity,
`8 * k * eps * sum_j |A_ij x_j|` — the standard running-sum error bound, i.e. the
residual a row cannot beat even with an exact `x`. Fix 2 skips a sentinel-infinite
side, so the audit checks the LP that was actually solved.

The guard's fallback contract (piece 2 of the issue) is fixed in two places:

* **Scope.** The deferral now applies only to a backend that actually relaxes the box
  (`relaxes_huge_bounds`, true only for the POUNCE IPM whose
  `_FINITE_BOUND_THRESHOLD` is 1e15). Applied engine-agnostically it also discarded
  the *simplex's own* UNBOUNDED — a verdict reached with the declared box honored —
  whenever some unrelated variable carried a bound in the window.
* **Diagnosis.** A bare `None` made a declined UNBOUNDED indistinguishable from "this
  engine failed", so when nothing else could certify, `_solve_lp` reported a bare
  `error`. `_DeferredUnbounded` carries the verdict *for diagnosis*: the status stays
  `error` and a `RuntimeWarning` names the engine, the cause, and the remedy.

Side finding from the issue, also fixed: `lp_simplex.solve_lp`'s bare `**_kwargs`
silently swallowed an `lb=`/`ub=` box and solved over the default `[0, 1e20]`,
returning OPTIMAL over a box the caller never asked for. Unknown keywords now raise
`TypeError`; the inert shared-contract keywords stay accepted.

The issue's end-to-end model now returns `optimal` at `-1.9998e20` — the certificate
the #850 guard's own comment says the exact simplex should supply — instead of `error`.

Closes #937

## Correction: an unsound fallback, caught by CI in this PR

The first push of the guard change **promoted** the held verdict when no engine could
certify — `_solve_lp` returned `unbounded`. CI (`Python fast`) failed on
`test_obs1_unbounded_with_relaxed_bound_degrades`, and that failure was **real, not a
stale pin**.

A declared bound in `[1e15, 1e20)` is *finite as posed* — the whole premise of the
#850 guard — so on `min -x` over the default continuous box the true answer is
`optimal` at the corner, exactly the certificate #850 decided is sound. Promoting the
verdict there emits **a false `unbounded` on a bounded problem**. The pre-existing
`error` was not a certificate at all, so the first version traded an honest "I don't
know" for a possibly-false claim — which CLAUDE.md §1 forbids outright.

The issue offered two remedies: keep the verdict, or *"surface a loud, diagnosable
status"*. Only the second is sound, and it is what ships (`9805c04`). The genuine
complaint in #937 — that the failure was **undiagnosable** — is fixed without
inventing an answer. The path is nearly unreachable now anyway: the audit fix
certifies this band on the simplex, so the deferral resolves to a real certificate.

## Correctness

The audit change makes the gate *stricter about what it is measuring*, not more
permissive about what it accepts:

* The round-off floor is a **floor**, never a widening of the ordinary regime. For a
  well-scaled row it is ~1e-14·term_scale — below the `1e-6` absolute term until the
  row activity reaches ~1e8 — and stays ~10 orders of magnitude tighter than the drift
  the audit exists to catch (a Forrest–Tomlin update error or an ill-conditioned basis
  moves `x` by *relative* amounts far above `eps`). `row_roundoff_floor_stays_below_real_drift_937`
  pins this: a residual that is 1e-6 *relative* to the row is still rejected.
* This is the same per-row term-scale convention `solver._matrix_solution_feasible`
  already uses at the Python layer (`rtol=1e-9` against `sum_j |A_ij||x_j|`), added
  there for #850 Obs 3 for the same reason.
* The INF-sentinel skip removes a check on a bound the LP does not have. Every other
  site in the engine already treats `u[j] >= INF` / `l[j] <= -INF` as unbounded
  (primal.rs lines 352-368, 478-491, 663, 761-763, 1061-1106, 1500-1545); the audit
  was the sole holdout, auditing a *different* LP than the one solved.
* No fallback or guard was removed. The `Rows` arm still routes to refined recovery,
  and a genuine `Numerical` still flows to the caller unchanged.
* The #850 guard's property — *do not certify a relaxed-box UNBOUNDED; prefer an
  engine that honors the declared box* — holds at both levels, and is now pinned
  end-to-end rather than only at the `_solve_lp_matrix` seam.

- [x] Cannot produce a false certificate
- [x] No validation, fallback, or safety guard was weakened to make a check pass

## Tests run (state the result — numbers, not adjectives)

- [x] `pytest -m smoke` → 905 passed, 15 skipped, 2 xpassed (391s, post-correction)
- [x] `pytest -m slow python/tests/test_adversarial_recent_fixes.py` → 10 passed (196s)
- [x] `cargo test -p discopt-core` → 581 passed, 0 failed (lib) + 4/1/1 passed (integration)
- [x] `ruff check` / `ruff format --check` clean; `mypy` clean on the touched files; `cargo fmt --check` clean

Note on the adversarial suite: a first run reported `test_large_dense_jacobian_no_crash`
failing its wall assertion (66s vs a 48s ceiling). That run was CPU-contended by other
background jobs. Interleaved A/B on an idle machine, 3 rounds each arm:
main 29.2s ± 1.0, branch 28.3s ± 0.6 — both passing, branch marginally faster.

## Regression test

**Rust** — `huge_finite_box_certifies_across_the_whole_band_937` pins the whole band
end to end (11 asserted probe points from 1e3 to 9.999e19, plus `Unbounded` at the
1e20 sentinel), not a single point, because the two defects claim different parts of
it. Verified FAILS pre-fix (reverting only the two predicates: `Numerical` from 1e16
up) and passes after.

**Python** — `python/tests/test_lp_huge_finite_box_937.py` plus three new pins in the
#850 file. Verified by stashing the fix and rebuilding the extension (5 of 6 fail
pre-fix; the 1e20-sentinel control always worked). The three soundness pins were
separately verified against a build with the unsound promotion restored — all fail
there, all pass with it removed:

* `test_obs1_deferred_unbounded_is_never_promoted_to_the_answer` — the declined
  verdict never becomes the certificate.
* `test_deferred_unbounded_failure_is_diagnosed_not_silently_error` — same contract
  from the model-level entry point, and asserts the diagnostic actually fires.
* `test_obs1_verdict_from_a_box_honoring_engine_is_not_deferred` — the mirror: a
  box-honoring engine's UNBOUNDED is passed straight through.

- [x] Added a regression test that fails before / passes after

## Bound-changing / performance change?

Not flag-gated: this is a **bug fix to a soundness gate that was rejecting sound
optima**, not a new bound, cut, or relaxation. It can only move a solve from
`Numerical` (no bound) to `Optimal` (a bound), never the reverse, and never loosens
the acceptance criterion in the ordinary regime. Per CLAUDE.md §5 it was verified
under the **bound-neutral** regime.

**Corpus differential panel** — all 66 in-repo MINLPLib instances
(`python/tests/data/minlplib_nl/`), `max_nodes=300`, `deterministic=True`,
`time_limit=20` as a runaway guard, baseline `badf9f4` vs this branch. The harness
swaps only the compiled extension and asserts arm identity with a runtime probe on the
#937 band (baseline → `error`, branch → `optimal`), so neither arm can silently run the
wrong code.

* **47 instances terminated within budget: zero drift.** status, objective, bound and
  node_count all exactly unchanged — the bound-neutral result.
* **19 instances hit the 20s wall**, so `max_nodes` never bound them and their node
  counts/bounds are clock-dependent by construction. A same-arm control (identical
  extension, run twice) over exactly those 19 reproduces the same drift at the same
  magnitude, and in several cases with the opposite sign:

  | instance | main → branch | B run1 → B run2 (identical code) |
  |---|---|---|
  | `nvs05` nodes | 33 → 41 | 41 → 33 (reversed) |
  | `tls2` nodes | 287 → 317 | 317 → 287 (reversed) |
  | `hda` bound | −1.42e5 → −1.417e5 | −1.42e5 → −1.417e5 (same pair, no code change) |
  | `casctanks` bound | −102.5 → −90.18 | −99.09 → −90.18 (three values, three runs) |
  | `bchoco08` nodes | 3 → 3 (no change) | 3 → 7 (drifts with no code change) |

  So the wall-limited drift is indistinguishable from the same-code noise floor and is
  not attributable to this change.

- Measurement: 66-instance in-repo MINLPLib corpus, `max_nodes=300`/`deterministic=True`;
  47/47 deterministic instances byte-identical on status/objective/bound/node_count;
  19 wall-limited instances within the same-code noise floor (control above).

The panel predates the `9805c04` correction, which touches only the Python
`_solve_lp` dispatch path (the `.nl` MINLP corpus does not route through it) and is
covered by the smoke run above.

## Docs (`2d7145d`)

`docs/notebooks/tutorial_lp.ipynb` claimed `m.continuous("z", lb=0)` had "no upper
bound". It does not — the default box is `[-9.999e19, 9.999e19]`, large but **finite**
— which is precisely why #937 was a default-path bug. With the audit fixed, that model
certifies `optimal` at `-1.9998e20`, so the committed `unbounded` output no longer
matched the narrative.

Rather than just re-record the output, the example now demonstrates what the section
title promises, and the distinction it was papering over is made explicit:

* the unbounded cell declares `ub=np.inf` — genuinely unbounded, returns `unbounded`;
* a new `default-box-demo` cell runs the same model *without* an explicit `ub` and
  shows declared bound `9.999e19`, status `optimal`, objective `-1.9998e20`.

It also retires prose that was stale **before** this change: both code cells carried a
`"returns iteration_limit (… detection is a known limitation)"` comment while their
committed outputs were already `infeasible`/`unbounded`, and the closing callout
repeated the claim. The callout now explains the bound semantics, and the section
intro cites `{cite:p}` `Bertsimas1997`.

Outputs for the three affected cells are genuinely re-executed (nbclient); every other
cell keeps its committed outputs and execution metadata, so the diff carries no
unrelated churn and no second absolute path baked into the docs. `jupyter-book build
docs/` → **build succeeded, zero warnings** (run locally on purpose: `docs.yml`
triggers only on push to `main`, so it does not run on this PR).