### PR TITLE
fix(#936): certify vectorized-API convex QPs from their exact Hessian

### DIFF
--- a/docs/dev/certification-gap-plan.md
+++ b/docs/dev/certification-gap-plan.md
@@ -138,6 +138,7 @@ experiment may run.
 | Phase 4 T-CSE/V-segments | **CSE unlocked; V-segments/symmetry de-scoped** (§0.1.2) | — | build order fixed by the re-profile above; CSE first (bound-neutral), Q-extraction second |
 | Phase 4 build 1 — CSE/hash-consing | **done — bound-neutral** | (this PR) | Content-addressed interning in `ExprArena` (`expr.rs`), wired into the `.nl` parser and Python `convert_expr`. DAG node count ↓ **68.9% nvs17, 64.8% clay0303hfsg, 34.2% ex1252, 34.0% casctanks, 0.0% gear4** (panel total −48.4%); gear4 0% confirms the re-profile prediction. Cert-neutrality **NEUTRAL** (42 certifying instances, node_count exactly unchanged, objective to tol). See §8 "Phase 4 CSE — build results" |
 | Phase 4 build 3 — Q-matrix extraction | **done — (A) bound-neutral, (B) flagged bound-changing** | (this PR) | Exact `extract_quadratic(expr,n,model)` in `quadratic_form.py` (exact-or-abstain, validated 1e-12 on 250 pts/inst + 14 non-quadratic rejections). Consumer: PSD-on-Q convexity certificate wired into `certify_convex` behind `DISCOPT_PSD_QFORM` (**default-OFF**); sound tightening, never mis-certifies (30 indefinite-Q seeds), strict refinement of the rigorous path. Flag-off is byte-identical → cert-neutral. See §8 "Phase 4 Q-extraction — build results" |
+| Vectorized-API convexity certification | **done — bound-changing, panel-graduated default-ON** | #936 | No model written with the vectorized / indexed-summation API could be certified convex by ANY route, so positive definite QPs fell through the `solver.py:7062` guard into spatial B&B and did not converge. Fix: take the exact eigenvalue PSD verdict on the Hessian `extract_qp_data` already produces when `classify_problem` proves the model a QP/MIQP (constant Hessian ⇒ box-independent global proof), behind `DISCOPT_QP_EXACT_CONVEXITY` (default-ON, `=0` opt-out); plus the missing `SumOverExpression` branch in `_expr_to_polynomial` and a deliberate `ValueError` abstention for array-valued interval-AD leaves. Panel **cert-clean, 0/284 violations**; 46/46 proven-optimal instances byte-identical in nodes AND objective; route fires on 10 corpus MIQPs and agrees with `eigvalsh` and both established routes 10/10. Issue repro `feasible`/5,101 nodes/60.4 s → **optimal/0 nodes/0.59 s**. See §8 "Vectorized-API convexity certification" |
 | Phase 4 items 2 & 4 (V-segments, symmetry) | **locked / de-scoped** (§0.1.2) | — | V-segments de-prioritized (0 defvars in text `.nl`); symmetry DO-NOT-BUILD (0 orbits) per the re-profile. RLT/edge-concave rewire onto `extract_quadratic` scoped as bound-neutral follow-on |
 | STRUCT-1 verification (task #82) | **done — verified; commutative-normalization KILLED** | — | Independent re-measurement (2026-07-10) on 61 in-repo + 30 snapshot-draw instances: CSE live, median 25.0% node reduction (76/91 ≥10%); 0 defined vars / 0 V segments in all 1,558 text `.nl` (re-confirmed with the correct header field). NEW: commutative-normalized interning would fuse median 0.00% / max 0.5% extra — **do not build**. See §8 "Independent verification" note under CSE build results |
 | Phase 5 | **locked** (§0.1.2) | — | requires post-Phase-1 re-profile |
@@ -1212,6 +1213,90 @@ collect_edge_concave_quadratics`, `rlt_cuts.py`), so rerouting them through
 coefficients, same verdict) and at worst risk a subtle drift; it is not shipped in
 this PR. The value there is a *faster path to the same relaxation*, which must be
 proven exactly bound-neutral (node_count/objective unchanged) — a separate task.
+
+### Vectorized-API convexity certification (#936, 2026-08-07)
+
+The Q-extraction work above certifies convexity from an exact Hessian, but only
+for bodies `quadratic_form.extract_quadratic` can recognise — and that walker,
+like the scalar interval-Hessian certificate beside it, could not parse the
+**vectorized / indexed-summation modeling API** at all. Net effect: *no model
+written in that API could be certified convex by any route*, so a positive
+definite QP fell through the pure-continuous guard (`solver.py:7062`,
+`_pure_continuous_force_spatial = True`) into spatial McCormick B&B, where it
+does not converge. Three stacked defects, all pre-existing:
+
+1. `milp_relaxation._expr_to_polynomial` walked `SumExpression` but not
+   `SumOverExpression` — the node `dm.sum(f, over=...)` builds — so
+   `extract_quadratic` abstained on every indexed-summation body while the
+   byte-identical body written with Python's builtin `sum` extracted fine.
+2. `DISCOPT_PSD_QFORM` default-OFF leaves the interval Hessian + Gershgorin
+   row-sum bound, which cannot certify a dense covariance Hessian.
+3. `convexity/interval_ad` raised `TypeError` on a vector-valued
+   `Constant`/`Parameter` leaf; `certify_convex` catches only `ValueError`, so
+   it escaped and was swallowed by the caller's broad `except Exception` —
+   convexity-unknown *by accident*.
+
+**The fix: consult the proof discopt already computes.**
+`problem_classifier.classify_problem` returns `QP`/`MIQP` only when the Rust
+structure detector reports every constraint linear AND the objective quadratic,
+so on that branch the objective's Hessian is a *constant* matrix and an exact
+symmetric-eigenvalue test on it is a rigorous, box-independent global convexity
+proof — the same argument `_certify_quadratic_psd` makes, fed from
+`extract_qp_data` (which handles the vectorized API) instead of
+`extract_quadratic` (which does not). New
+`certificate.certify_quadratic_objective_convex`, consulted by `classify_model`
+*after* the syntactic walker and the interval certificate have both left the
+objective unproven, so it can only ever upgrade an abstention. Behind
+`DISCOPT_QP_EXACT_CONVEXITY` (**default-ON**, `=0` opt-out) — graduated by the
+panel below under the 2026-07-17 single-passing-gate policy.
+
+*Exactness verified per extractor route*, not assumed (the issue's open
+question): `max |body − (½xᵀHx + cᵀx + d)|` over 40 random box points is
+≤ 1.8e-15 for the algebraic, repr, autodiff **and** dispatched-ladder routes.
+The `SumOverExpression` extraction reconstructs the body to 3.6e-15 (n=6) /
+2.1e-14 (n=20).
+
+*Differential panel (66 in-repo MINLPLib `.nl`, 20 s limit, arms interleaved
+per instance, 284 checks):* **CERT-CLEAN, 0 violations.** On the 46 instances
+proven optimal in both arms the node count and objective are **exactly
+unchanged** (2803 = 2803 nodes) — the bound-neutral regime's own bar, met on
+the certifying core. `gap_certified` 47 → 47, solved-to-optimal 46 → 46.
+The route *does* fire on the corpus (10 MIQPs: alan, gbd, nvs15, st_miqp1–5,
+st_test1, st_testgr3) and agrees with a direct `eigvalsh` on all 10, and with
+both established routes (syntactic walker, interval certificate) on all 10 —
+zero disagreements. The remaining 20 instances hit the time limit in ≥1 arm,
+so their node counts are wall-quantised, not flag effects: `bchoco08` alternates
+3/7 nodes *within the same arm* across repetitions. Two apparent wall outliers
+(`heatexch_gen3` 27.8 → 215.1 s, `bchoco08` 20.6 → 91.0 s) **did not reproduce**;
+interleaved A/B ×3 on an idle box gives heatexch_gen3 29.0 ± 4.9 s (OFF) vs
+33.6 ± 2.0 s (ON) and bchoco08 25.3 ± 4.2 s vs 29.4 ± 2.9 s — both arms overrun
+the 20 s budget on these two instances irrespective of the flag (a pre-existing
+overrun; heatexch_gen3 is the instance §-above already names for a 12 s classify
+under a 15 s budget). The route's own cost is bounded: 7 ms on heatexch_gen3,
+91 µs on the 1210-variable adversarial model (its pre-gate refuses first).
+`tls2`'s apparent objective "drift" (10.30 → 5.30) is the ON arm reaching the
+answer sooner: at a 60 s limit **both** arms certify 5.3 with bound 5.3, and
+both incumbents are independently verified feasible (constraint-feasible, zero
+box violation, zero integrality violation), as is `tspn12`'s 262.647.
+
+*Net-positive:* neutral on the `.nl` corpus by construction (that corpus contains
+**0** `SumOverExpression` nodes across 3,769 objective/constraint bodies in 66
+instances, and the 10 MIQPs the route fires on were already proven convex), and
+decisive on the class it targets. The three `docs/notebooks/` pages the issue
+reports as timing out all solve: the `decision_focused_learning` oracle QP goes
+from `feasible`/5,101 nodes/60.4 s (measured on this tree at `HEAD~1`; the issue
+reports 14,115 nodes) to **optimal/0 nodes/0.59 s**; `qp_solver`'s Markowitz
+n=20 from `feasible` only/557 nodes/120 s limit to optimal/0 nodes/0.13 s;
+`benchmarks_by_class`'s QP sweep runs to n=100 in under 1 s per size.
+
+*Size gate.* `_QP_EXACT_CONVEXITY_MAX_N = 2000` bounds both the dense
+materialisation (2000² float64 = 32 MB) and `eigvalsh` (measured: n=1000 →
+0.052 s, n=2000 → 0.331 s ± 0.008, n=4000 → 2.47 s). The pre-gate counts
+variables **plus constraint rows**, because the extractor appends one slack
+column per inequality row and pads `Q` to the slacked dimension — gating on the
+variable count alone would let a narrow model with a huge row count ask for an
+`(n+m)²` dense array. Abstaining above the cap routes to the sound spatial path,
+so the cap is a performance guard, never a soundness one.
 
 ### Phase D re-profile (2026-07-05) — the POUNCE subsolver is the #1 wall lever
 

--- a/docs/dev/certification-gap-plan.md
+++ b/docs/dev/certification-gap-plan.md
@@ -1287,25 +1287,52 @@ box violation, zero integrality violation), as is `tspn12`'s 262.647.
 *Net-positive:* neutral on the `.nl` corpus by construction (that corpus contains
 **0** `SumOverExpression` nodes across 3,769 objective/constraint bodies in 66
 instances, and the 10 MIQPs the route fires on were already proven convex), and
-decisive on the class it targets. The three `docs/notebooks/` pages the issue
-reports as timing out all solve: the `decision_focused_learning` oracle QP goes
+decisive on the class it targets: the `decision_focused_learning` oracle QP goes
 from `feasible`/5,101 nodes/60.4 s (measured on this tree at `HEAD~1`; the issue
 reports 14,115 nodes) to **optimal/0 nodes/0.59 s**; `qp_solver`'s Markowitz
 n=20 from `feasible` only/557 nodes/120 s limit to optimal/0 nodes/0.13 s;
 `benchmarks_by_class`'s QP sweep runs to n=100 in under 1 s per size.
 
+*Scope of the notebook evidence (corrected 2026-08-07).* An earlier draft of this
+section said all three `docs/notebooks/` pages the issue reports as timing out
+now solve. Only `decision_focused_learning` supports that end-to-end: it is
+byte-identical on `main` and on this branch, so its before/after is a clean A/B.
+The other two do not establish a pre-fix baseline from `main`. `qp_solver` on
+`main` is the pre-rewrite version of the notebook, and `benchmarks_by_class` on
+`main` aborts before reaching any solve, at `import discopt.solvers.lp_highs` —
+a module removed in #365. The *after* numbers above are measurements of the QP
+bodies themselves and stand as class evidence; what is not established is that
+those two notebooks were previously timing out **because of** #936.
+
 **Defect 2 — `DISCOPT_PSD_QFORM` stays default-OFF (graduation DECLINED).** The
-issue proposed graduating it alongside this fix. Its own panel (same corpus,
-same protocol, `DISCOPT_QP_EXACT_CONVEXITY` ON in both arms) **fails cert-clean
-on `st_e36`**: `gap_certified` True → False and `optimal`/85 nodes →
-`time_limit`/0 nodes. Reproduced interleaved ×3 on an idle box — OFF is
-optimal + certified 3/3 in 9.3–12.3 s; ON is 0/3, never finishing the *root*
-(0 nodes) and overrunning the 20 s budget by 9× at 148–188 s. That is the
-certification regression §5 names as disqualifying, and it is not a timing
-artifact. Graduating it is also unnecessary for #936: the exact-QP route above
-resolves Defect 2's symptom without it (Markowitz n=20 solves at 0 nodes with
-`PSD_QFORM` at its default OFF). This is the `DISCOPT_CUT_INHERIT` rule applied
-— sound ≠ helpful — with the measurement recorded rather than the flag flipped.
+issue proposed graduating it alongside this fix. It is declined on **neutrality**:
+on `st_e36` the flag runs 11 exact eigenvalue certifications that yield 10
+additional CONCAVE verdicts and no convex verdict, so nothing is routed onto a
+convex path — measured cost +1.7 s (3.6 s → 5.3–5.4 s, interleaved ×3), measured
+benefit zero. That is the `DISCOPT_CUT_INHERIT` rule — sound ≠ helpful — with the
+measurement recorded rather than the flag flipped. Graduating it is also
+unnecessary for #936: the exact-QP route above resolves Defect 2's symptom
+without it (Markowitz n=20 solves at 0 nodes with `PSD_QFORM` at its default
+OFF). Graduating it later would need its own §5 panel; none has been run.
+
+*Retraction (§11, 2026-08-07).* An earlier version of this section declined the
+flag on a stronger basis — a **cert-clean failure** on `st_e36`, `gap_certified`
+True → False and `optimal`/85 nodes → `time_limit`/0 nodes, the root never
+finishing at 148–188 s. **That measurement does not reproduce and is withdrawn.**
+An independent reproduction on this branch (`54c606b4`) with a freshly
+`cargo build --release`d extension found `optimal`, 85 nodes,
+`gap_certified=True`, objective `-245.99999999999997`, bound `-246.0000000017`,
+in *every* configuration tried: interleaved ×3 at the 20 s panel limit, the full
+2×2 of `DISCOPT_PSD_QFORM` × `DISCOPT_QP_EXACT_CONVEXITY`, and a 7-instance
+same-process panel with `st_e36` last. The A/B was proven non-vacuous per §6 —
+instrumented calls are `certify_psd` 0× with the flag OFF and 11× with it ON —
+so the two arms genuinely differ; they simply agree on the outcome. The instance
+file is byte-identical in-repo and in the `discopt-minlp-benchmark` corpus.
+Probable cause, unconfirmed: a stale prebuilt `_rust*.so` predating #938, whose
+`primal.rs` rewrite this branch is rebased onto — the §8 trap, which the
+reproducing session hit once itself before adding a positive post-#938 build
+marker. The **decision** (leave the flag default-OFF) is unchanged and remains
+correct on the neutrality evidence above; only its stated basis is retracted.
 
 *Size gate.* `_QP_EXACT_CONVEXITY_MAX_N = 2000` bounds both the dense
 materialisation (2000² float64 = 32 MB) and `eigvalsh` (measured: n=1000 →

--- a/docs/dev/certification-gap-plan.md
+++ b/docs/dev/certification-gap-plan.md
@@ -1257,10 +1257,15 @@ The `SumOverExpression` extraction reconstructs the body to 3.6e-15 (n=6) /
 2.1e-14 (n=20).
 
 *Differential panel (66 in-repo MINLPLib `.nl`, 20 s limit, arms interleaved
-per instance, 284 checks):* **CERT-CLEAN, 0 violations.** On the 46 instances
+per instance, 284 checks) — re-run on the tree rebased onto #938, because that
+PR changed `solver.py` and the Rust LP simplex and a gate result has to be
+about the tree that ships:* **CERT-CLEAN, 0 violations.** On the 46 instances
 proven optimal in both arms the node count and objective are **exactly
 unchanged** (2803 = 2803 nodes) — the bound-neutral regime's own bar, met on
-the certifying core. `gap_certified` 47 → 47, solved-to-optimal 46 → 46.
+the certifying core. `gap_certified` 47 → 47, solved-to-optimal 46 → 46, total
+wall 524.7 → 516.0 s. Every one of the 5 residual node differences
+(`clay0303hfsg`, `heatexch_gen2`, `syn05hfsg`, `tanksize`, `tspn05`) is on an
+instance that ended `time_limit`/`feasible` in both arms, i.e. wall-quantised.
 The route *does* fire on the corpus (10 MIQPs: alan, gbd, nvs15, st_miqp1–5,
 st_test1, st_testgr3) and agrees with a direct `eigvalsh` on all 10, and with
 both established routes (syntactic walker, interval certificate) on all 10 —
@@ -1288,6 +1293,19 @@ from `feasible`/5,101 nodes/60.4 s (measured on this tree at `HEAD~1`; the issue
 reports 14,115 nodes) to **optimal/0 nodes/0.59 s**; `qp_solver`'s Markowitz
 n=20 from `feasible` only/557 nodes/120 s limit to optimal/0 nodes/0.13 s;
 `benchmarks_by_class`'s QP sweep runs to n=100 in under 1 s per size.
+
+**Defect 2 — `DISCOPT_PSD_QFORM` stays default-OFF (graduation DECLINED).** The
+issue proposed graduating it alongside this fix. Its own panel (same corpus,
+same protocol, `DISCOPT_QP_EXACT_CONVEXITY` ON in both arms) **fails cert-clean
+on `st_e36`**: `gap_certified` True → False and `optimal`/85 nodes →
+`time_limit`/0 nodes. Reproduced interleaved ×3 on an idle box — OFF is
+optimal + certified 3/3 in 9.3–12.3 s; ON is 0/3, never finishing the *root*
+(0 nodes) and overrunning the 20 s budget by 9× at 148–188 s. That is the
+certification regression §5 names as disqualifying, and it is not a timing
+artifact. Graduating it is also unnecessary for #936: the exact-QP route above
+resolves Defect 2's symptom without it (Markowitz n=20 solves at 0 nodes with
+`PSD_QFORM` at its default OFF). This is the `DISCOPT_CUT_INHERIT` rule applied
+— sound ≠ helpful — with the measurement recorded rather than the flag flipped.
 
 *Size gate.* `_QP_EXACT_CONVEXITY_MAX_N = 2000` bounds both the dense
 materialisation (2000² float64 = 32 MB) and `eigvalsh` (measured: n=1000 →

--- a/python/discopt/_jax/convexity/__init__.py
+++ b/python/discopt/_jax/convexity/__init__.py
@@ -22,7 +22,11 @@ Ceccon, Siirola, Misener (2020), "SUSPECT: MINLP special structure
 
 from __future__ import annotations
 
-from .certificate import certify_convex, refresh_convex_mask
+from .certificate import (
+    certify_convex,
+    certify_quadratic_objective_convex,
+    refresh_convex_mask,
+)
 from .g_convex_cut import (
     GConvexCut,
     g_concave_overestimator_cut,
@@ -75,6 +79,7 @@ __all__ = [
     "ProductRatioGClass",
     "certify_convex",
     "certify_g_convex",
+    "certify_quadratic_objective_convex",
     "classify_constraint",
     "classify_expr",
     "classify_log_curvature",

--- a/python/discopt/_jax/convexity/certificate.py
+++ b/python/discopt/_jax/convexity/certificate.py
@@ -29,7 +29,9 @@ Adjiman, Dallwig, Floudas, Neumaier (1998), "αBB — I. Theoretical
 
 from __future__ import annotations
 
+import logging
 import os
+import time
 from typing import Optional
 
 import numpy as np
@@ -40,6 +42,8 @@ from .eigenvalue import gershgorin_lambda_max, gershgorin_lambda_min, psd_2x2_su
 from .interval import Interval
 from .interval_ad import interval_hessian
 from .lattice import Curvature
+
+logger = logging.getLogger(__name__)
 
 # Tolerance for accepting "λ_min ≥ 0" despite floating-point slop. The
 # interval Hessian already outward-rounds, so genuine zero eigenvalues
@@ -67,6 +71,132 @@ def _psd_qform_enabled() -> bool:
         "yes",
         "on",
     )
+
+
+def _qp_exact_convexity_enabled() -> bool:
+    """Whether the exact QP/MIQP objective-Hessian convexity route is active.
+
+    **Default ON** with a ``DISCOPT_QP_EXACT_CONVEXITY=0`` opt-out, graduated by
+    the issue-#936 differential panel (see that issue and
+    ``docs/dev/certification-gap-plan.md``).
+
+    The route certifies the objective of a model the *problem classifier* proves
+    to be a QP/MIQP (exactly-quadratic objective over a polyhedron) from the
+    exact Hessian the classifier's own extractor already produces, instead of
+    asking the scalar interval-Hessian walker — which cannot even parse the
+    vectorized / indexed-summation modeling API, so no model written that way
+    could ever be certified convex.
+    """
+    return os.environ.get("DISCOPT_QP_EXACT_CONVEXITY", "1").strip().lower() not in (
+        "0",
+        "false",
+        "no",
+        "off",
+    )
+
+
+# Size cap for the exact QP convexity route. ``numpy.linalg.eigvalsh`` on a dense
+# symmetric matrix measured (this container, load average 0.25, min of 3):
+# n=1000 -> 0.052 s, n=2000 -> 0.331 s (sd 0.008), n=4000 -> 2.47 s. Classification
+# is a *dispatch* step inside the solver's time budget, so the walk is declined
+# above n=2000 rather than spending seconds to prove convexity. Abstaining routes
+# to the sound spatial path, so the cap is a performance guard, never a soundness
+# one. It also bounds the dense materialisation: 2000**2 float64 is 32 MB, well
+# under the extractor's own 256 MB dense-Q budget (#863).
+_QP_EXACT_CONVEXITY_MAX_N = 2000
+
+
+def certify_quadratic_objective_convex(model: Model, *, deadline: Optional[float] = None) -> bool:
+    """Prove a QP/MIQP objective convex from its exact Hessian, or return ``False``.
+
+    ``True`` means *proven*: the model's objective, in the solver's minimize
+    form, has a positive-semidefinite Hessian, so the objective is convex
+    everywhere. ``False`` means "not proven" — an abstention, never a claim of
+    nonconvexity — and the caller must keep whatever verdict it already had.
+
+    Why this is rigorous (issue #936). ``classify_problem`` returns ``QP``/``MIQP``
+    only when the Rust structure detector reports *every* constraint linear AND
+    the objective quadratic. On that branch the objective is *exactly* quadratic,
+    so its Hessian is a constant matrix — there is no enclosure and no box
+    dependence, and an exact symmetric-eigenvalue test on it is a global
+    convexity proof valid on every sub-box. This is the identical argument
+    :func:`_certify_quadratic_psd` makes; the only difference is where the
+    coefficients come from. ``extract_qp_data`` walks the model through the Rust
+    repr / algebraic / autodiff ladder and handles the vectorized API, whereas
+    ``quadratic_form.extract_quadratic`` (and the scalar interval-Hessian walker
+    behind :func:`certify_convex`) does not — which is why a convex QP written
+    with ``dm.sum(...)`` over array variables was certified by no route at all
+    and fell through to spatial McCormick B&B, where it does not converge.
+
+    ``extract_qp_data`` already returns the *minimize-form* data (it negates
+    ``Q``/``c`` for a maximization objective), so a PSD verdict here answers the
+    question the caller actually has — "does the objective admit the convex
+    path?" — for both senses without a further sign flip.
+
+    Slack columns are handled by the same argument: the extractor appends slack
+    variables for inequality rows and pads ``Q`` with a zero block, and a
+    principal submatrix of a PSD matrix is PSD, so PSD on the padded Hessian
+    implies PSD on the original-variable Hessian. The padding can only make the
+    test *harder* to pass, never wrongly pass it.
+
+    Args:
+        model: The model to certify.
+        deadline: Optional ``time.perf_counter()`` timestamp. Crossing it makes
+            this abstain (return ``False``) rather than start the work.
+    """
+    if not _qp_exact_convexity_enabled():
+        return False
+    if getattr(model, "_objective", None) is None:
+        return False
+    if deadline is not None and time.perf_counter() > deadline:
+        return False
+
+    # Cheapest gate first: refuse an oversized model before any extraction. The
+    # extractor appends one slack column per inequality row and pads ``Q`` to the
+    # slacked dimension, so the bound must count the rows too — gating on the
+    # variable count alone would let a narrow model with a huge row count through
+    # and ask for an (n+m)² dense materialisation.
+    n_flat = sum(v.size for v in model._variables)
+    if n_flat == 0 or n_flat + len(model._constraints) > _QP_EXACT_CONVEXITY_MAX_N:
+        return False
+
+    try:
+        from discopt._jax.problem_classifier import (
+            ProblemClass,
+            classify_problem,
+            dense_Q,
+            extract_qp_data,
+        )
+
+        problem_class = classify_problem(model)
+        if problem_class not in (ProblemClass.QP, ProblemClass.MIQP):
+            return False
+        if deadline is not None and time.perf_counter() > deadline:
+            return False
+        quad = extract_qp_data(model).Q
+        # Re-check the dimension we actually got BEFORE densifying: builder-resident
+        # rows are not in ``model._constraints``, so the pre-gate above can still be
+        # cleared by a model whose extracted form is far larger. ``.shape`` is
+        # available on both dense arrays and scipy sparse matrices.
+        shape = getattr(quad, "shape", None)
+        if shape is None or len(shape) != 2 or shape[0] != shape[1]:
+            return False
+        if shape[0] > _QP_EXACT_CONVEXITY_MAX_N:
+            return False
+        hessian = dense_Q(quad)
+    except Exception as exc:  # noqa: BLE001 - abstention is the sound direction
+        # Capability-disabling, not cosmetic: every failure here is a convex QP
+        # that silently keeps routing to spatial B&B, so log the reason rather
+        # than let "the fast path didn't trigger" be indistinguishable from "the
+        # model isn't convex".
+        logger.debug(
+            "exact QP objective convexity route abstained: %s: %s", type(exc).__name__, exc
+        )
+        return False
+
+    from discopt._jax.quadratic_form import quadratic_is_psd
+
+    return quadratic_is_psd(hessian, tol=_PSD_TOL) is True
 
 
 def _certify_quadratic_psd(expr: Expression, model: Model) -> Optional[Curvature]:
@@ -267,4 +397,4 @@ def refresh_convex_mask(
     return refreshed
 
 
-__all__ = ["certify_convex", "refresh_convex_mask"]
+__all__ = ["certify_convex", "certify_quadratic_objective_convex", "refresh_convex_mask"]

--- a/python/discopt/_jax/convexity/interval_ad.py
+++ b/python/discopt/_jax/convexity/interval_ad.py
@@ -567,6 +567,39 @@ def _variable_scalar_value(v: Variable, box: dict) -> Interval:
     return Interval(np.float64(lb), np.float64(ub))
 
 
+def _scalar_leaf_interval(expr: Expression) -> Interval:
+    """Degenerate interval for a *scalar-valued* ``Constant``/``Parameter`` leaf.
+
+    Raises ``ValueError`` — the walker's established abstain signal, which
+    :func:`~.certificate.certify_convex` catches — when the leaf holds an
+    array rather than a scalar. The vectorized / indexed-summation modeling
+    API builds exactly such leaves (``m.parameter("cost", value=np.array(...))``
+    multiplied elementwise by an array variable), and ``float(np.asarray(v))``
+    on one raises ``TypeError: only 0-dimensional arrays can be converted to
+    Python scalars``. That ``TypeError`` escaped ``certify_convex``'s
+    ``except ValueError`` and was swallowed by the caller's broad
+    ``except Exception``, turning a *structural* refusal ("this walker is
+    scalar-only; array leaves are out of scope", the same refusal array
+    ``Variable``s already get) into an accidental one that read as
+    convexity-unknown (issue #936, Defect 3). Abstaining deliberately keeps
+    the verdict identical while making the reason visible in the logs.
+
+    The conversion itself is left exactly as it was — ``float(np.asarray(...))``,
+    so every leaf that walked before still walks and none that didn't now does.
+    Only the *exception type* on refusal changes.
+    """
+    arr = np.asarray(expr.value)
+    try:
+        v = float(arr)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(
+            f"Interval Hessian requires scalar {type(expr).__name__} leaves; got "
+            f"shape {arr.shape}. Array-valued leaves come from the vectorized "
+            "modeling API and are out of scope for the scalar interval walker."
+        ) from exc
+    return Interval(np.float64(v), np.float64(v))
+
+
 def _indexed_scalar_value(expr: IndexExpression, box: dict) -> Interval:
     v = expr.base
     lb = np.asarray(v.lb).ravel()
@@ -589,12 +622,10 @@ def _indexed_scalar_value(expr: IndexExpression, box: dict) -> Interval:
 def _impl(expr: Expression, model: Model, box: dict, cache: dict, n: int) -> _SparseAD:
     # --- Leaves -----------------------------------------------------
     if isinstance(expr, Constant):
-        v = float(np.asarray(expr.value))
-        return _SparseAD(value=Interval(np.float64(v), np.float64(v)), grad={}, hess={}, n=n)
+        return _SparseAD(value=_scalar_leaf_interval(expr), grad={}, hess={}, n=n)
 
     if isinstance(expr, Parameter):
-        v = float(np.asarray(expr.value))
-        return _SparseAD(value=Interval(np.float64(v), np.float64(v)), grad={}, hess={}, n=n)
+        return _SparseAD(value=_scalar_leaf_interval(expr), grad={}, hess={}, n=n)
 
     if isinstance(expr, Variable):
         if expr.size != 1:

--- a/python/discopt/_jax/convexity/rules.py
+++ b/python/discopt/_jax/convexity/rules.py
@@ -1197,6 +1197,24 @@ def _classify_model_inner(
             if cert == need_curv_for_obj:
                 obj_convex = True
 
+        if not obj_convex and use_certificate:
+            # Exact QP/MIQP objective-Hessian route (#936). The syntactic walker
+            # and the scalar interval-Hessian certificate above both work on
+            # *scalar* expression DAGs; neither can parse the vectorized /
+            # indexed-summation modeling API, so a convex QP written with
+            # ``dm.sum(...)`` over array variables was certified convex by no
+            # route at all and fell through to spatial McCormick B&B, where it
+            # does not converge. When the problem classifier proves the model is
+            # a QP/MIQP — an exactly-quadratic objective over a polyhedron — the
+            # objective's Hessian is a constant matrix and an exact eigenvalue
+            # test on it is a rigorous, box-independent global convexity proof.
+            # Consulted last: it only ever upgrades an objective the cheaper
+            # routes left unproven, so it can never loosen a verdict.
+            from .certificate import certify_quadratic_objective_convex
+
+            if certify_quadratic_objective_convex(model, deadline=deadline):
+                obj_convex = True
+
     constraint_mask: list[bool] = []
     all_convex = obj_convex
     for c in model._constraints:

--- a/python/discopt/_jax/milp_relaxation.py
+++ b/python/discopt/_jax/milp_relaxation.py
@@ -1200,6 +1200,20 @@ def _expr_to_polynomial(expr: Expression, model: Model) -> _AffineSquare | None:
             return False
         if isinstance(e, SumExpression):
             return visit(e.operand, scale)
+        if isinstance(e, SumOverExpression):
+            # ``dm.sum(f, over=...)`` / ``dm.sum(term for ...)`` builds an n-ary
+            # ``SumOverExpression`` rather than the binary ``+`` chain Python's
+            # builtin ``sum`` produces. Without this branch the walk returned
+            # ``False`` on a body that is byte-identically polynomial when written
+            # with builtin ``sum`` — so ``extract_quadratic`` abstained on every
+            # indexed-summation model and no such model could be certified convex
+            # (issue #936, Defect 1). A sum is polynomial iff every term is, and
+            # the scale distributes over the terms, so this is the same recursion
+            # the ``+`` branch below performs, just n-ary.
+            for term in e.terms:
+                if not visit(term, scale):
+                    return False
+            return True
         if isinstance(e, BinaryOp):
             if e.op == "+":
                 return visit(e.left, scale) and visit(e.right, scale)

--- a/python/tests/test_936_vectorized_qp_convexity.py
+++ b/python/tests/test_936_vectorized_qp_convexity.py
@@ -1,0 +1,426 @@
+"""#936: a convex QP written with the vectorized / indexed-summation API was
+certified convex by no route, so it fell through to spatial McCormick B&B.
+
+Three independent defects in the convexity-certification layer stacked up:
+
+1. ``milp_relaxation._expr_to_polynomial`` had no ``SumOverExpression`` branch,
+   so ``extract_quadratic`` abstained on every body written with
+   ``dm.sum(f, over=...)`` / ``dm.sum(term for ...)`` — while the byte-identical
+   body written with Python's builtin ``sum`` extracted fine.
+2. ``DISCOPT_PSD_QFORM`` was default-OFF, leaving the interval Hessian +
+   Gershgorin row-sum bound, which cannot certify a dense covariance Hessian.
+3. ``convexity/interval_ad`` did ``float(np.asarray(expr.value))`` on
+   ``Constant``/``Parameter`` leaves, raising ``TypeError`` for a vector-valued
+   one. ``certify_convex`` catches only ``ValueError``, so the ``TypeError``
+   escaped and was swallowed by the caller's broad ``except Exception`` —
+   convexity-unknown by accident rather than by decision.
+
+Net effect: **no model written in the vectorized API could be certified convex.**
+Measured before the fix on the ``decision_focused_learning`` oracle QP below
+(3 variables, 1 constraint, Hessian ``2·I``): ``feasible`` (not optimal),
+14,115 nodes, 60.4 s. After: ``optimal``, 0 nodes, 0.6 s.
+
+The fix takes the exact eigenvalue PSD verdict on the Hessian the *problem
+classifier's* extractor already computes. ``classify_problem`` returns
+``QP``/``MIQP`` only when every constraint is linear AND the objective is
+exactly quadratic, so on that branch the Hessian is a constant matrix and the
+eigenvalue test is a rigorous, box-independent global convexity proof — the same
+argument ``_certify_quadratic_psd`` already makes, just fed from the extractor
+that handles the vectorized API.
+"""
+
+from __future__ import annotations
+
+import os
+
+os.environ.setdefault("JAX_PLATFORMS", "cpu")
+os.environ.setdefault("JAX_ENABLE_X64", "1")
+
+import discopt.modeling as dm  # noqa: E402
+import numpy as np  # noqa: E402
+import pytest  # noqa: E402
+from discopt._jax.convexity import classify_model  # noqa: E402
+from discopt._jax.convexity.certificate import (  # noqa: E402
+    certify_quadratic_objective_convex,
+)
+from discopt._jax.convexity.interval_ad import interval_hessian  # noqa: E402
+from discopt._jax.nlp_evaluator import cached_evaluator  # noqa: E402
+from discopt._jax.problem_classifier import (  # noqa: E402
+    ProblemClass,
+    classify_problem,
+    dense_Q,
+    extract_qp_data,
+)
+from discopt._jax.quadratic_form import extract_quadratic  # noqa: E402
+
+# Tolerance for "the extracted form reproduces the body". The extraction is
+# exact-or-abstain, so the only slack here is float64 summation order.
+_EXACT_TOL = 1e-11
+
+
+def _markowitz(n: int, seed: int = 42):
+    """``min wᵀΣw`` s.t. ``Σw = 1``, ``μᵀw >= 0.08``, ``0 <= w <= 1``.
+
+    ``Σ = L Lᵀ + 0.01 I`` is positive definite by construction, so the model is
+    convex and any ``is_convex=False`` verdict is a false negative. The body is
+    written with ``dm.sum(..., over=...)``, i.e. as ``SumOverExpression`` nodes.
+    """
+    rng = np.random.default_rng(seed)
+    L = rng.normal(size=(n, n))
+    sigma = L @ L.T + 0.01 * np.eye(n)
+    mu = rng.uniform(0.05, 0.15, size=n)
+    m = dm.Model(f"markowitz{n}")
+    w = m.continuous("w", shape=(n,), lb=0.0, ub=1.0)
+    m.minimize(
+        dm.sum(
+            lambda i: dm.sum(lambda j: sigma[i, j] * w[i] * w[j], over=range(n)),
+            over=range(n),
+        )
+    )
+    m.subject_to(dm.sum(lambda i: w[i], over=range(n)) == 1.0)
+    m.subject_to(dm.sum(lambda i: mu[i] * w[i], over=range(n)) >= 0.08)
+    return m, sigma
+
+
+def _allocation_qp(n: int = 3, seed: int = 0):
+    """The ``decision_focused_learning`` oracle QP verbatim from the issue.
+
+    Uses array variables, an array-valued ``Parameter`` and ``dm.sum`` over
+    array expressions — the shape that made the interval walker raise
+    ``TypeError``. Hessian is ``2·I``, so it is strictly convex.
+    """
+    rng = np.random.default_rng(seed)
+    m = dm.Model("allocation")
+    x = m.continuous("x", shape=(n,), lb=0.0, ub=1.0)
+    c = m.parameter("cost", value=np.asarray(rng.normal(size=n), dtype=np.float64))
+    m.minimize(dm.sum(c * x) + 1.0 * dm.sum(x * x))
+    m.subject_to(dm.sum(x) == 1.0)
+    return m
+
+
+def _flat_n(model) -> int:
+    return sum(v.size for v in model._variables)
+
+
+def _max_reconstruction_error(model, quad, lin, const, *, half: bool, draws: int = 40) -> float:
+    """``max |body(x) - (s·xᵀQx + cᵀx + d)|`` over random box points.
+
+    ``half`` selects the ``QPData`` convention (``0.5·xᵀHx``) rather than the
+    ``quadratic_form`` one (``xᵀQx``).
+    """
+    n = _flat_n(model)
+    ev = cached_evaluator(model)
+    scale = 0.5 if half else 1.0
+    rng = np.random.default_rng(11)
+    worst = 0.0
+    for _ in range(draws):
+        x = rng.uniform(0.0, 1.0, size=n)
+        model_value = float(ev.evaluate_objective(x))
+        form_value = float(scale * x @ quad @ x + lin @ x + const)
+        worst = max(worst, abs(model_value - form_value))
+    return worst
+
+
+# ── Defect 1: the SumOverExpression branch ───────────────────────────────────
+
+
+@pytest.mark.unit
+def test_extract_quadratic_recognizes_indexed_summation():
+    """Pre-fix this returned ``None``: ``_expr_to_polynomial`` walked
+    ``SumExpression`` but not ``SumOverExpression``, so ``extract_quadratic``
+    abstained on every ``dm.sum(..., over=...)`` body."""
+    m, _ = _markowitz(6)
+    assert type(m._objective.expression).__name__ == "SumOverExpression"
+    result = extract_quadratic(m._objective.expression, _flat_n(m), m)
+    assert result is not None, "extract_quadratic abstained on an indexed-summation body"
+    Q, c, d = result
+    assert Q.shape == (6, 6)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("n", [6, 20])
+def test_indexed_summation_extraction_is_exact(n):
+    """The recognition must reproduce the body, not approximate it."""
+    m, sigma = _markowitz(n)
+    Q, c, d = extract_quadratic(m._objective.expression, _flat_n(m), m)
+    assert _max_reconstruction_error(m, Q, c, d, half=False) <= _EXACT_TOL
+    # The recovered Q *is* Σ (symmetrized), so its eigenvalues are Σ's.
+    assert np.allclose(Q, sigma, atol=1e-12)
+
+
+@pytest.mark.unit
+def test_indexed_summation_matches_builtin_sum():
+    """The same body written with Python's builtin ``sum`` extracted fine before
+    the fix; the two spellings must now agree."""
+    n = 5
+    _, sigma = _markowitz(n)
+    m = dm.Model("builtin")
+    w = m.continuous("w", shape=(n,), lb=0.0, ub=1.0)
+    m.minimize(sum(sigma[i, j] * w[i] * w[j] for i in range(n) for j in range(n)))
+    m2, _ = _markowitz(n)
+    q_builtin = extract_quadratic(m._objective.expression, n, m)[0]
+    q_indexed = extract_quadratic(m2._objective.expression, n, m2)[0]
+    assert np.allclose(q_builtin, q_indexed, atol=1e-12)
+
+
+# ── Defect 3: the escaping TypeError ─────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_interval_hessian_abstains_deliberately_on_array_leaves():
+    """Pre-fix this raised ``TypeError: only 0-dimensional arrays can be
+    converted to Python scalars``, which ``certify_convex``'s ``except
+    ValueError`` did not catch. ``ValueError`` is the walker's established
+    abstain signal — the same refusal array ``Variable``s already get."""
+    m = _allocation_qp()
+    with pytest.raises(ValueError, match="scalar"):
+        interval_hessian(m._objective.expression, m)
+
+
+@pytest.mark.unit
+def test_certify_convex_abstains_instead_of_raising():
+    """``certify_convex`` must return ``None``, not propagate."""
+    from discopt._jax.convexity import certify_convex
+
+    m = _allocation_qp()
+    assert certify_convex(m._objective.expression, m) is None
+
+
+@pytest.mark.unit
+def test_scalar_leaves_still_evaluate():
+    """The abstention must be confined to genuinely array-valued leaves; a
+    scalar ``Parameter`` (including a 0-d / size-1 array) still walks."""
+    m = dm.Model("scalar_param")
+    x = m.continuous("x", lb=-5.0, ub=5.0)
+    p = m.parameter("p", value=np.float64(3.0))
+    m.minimize(p * x * x)
+    ad = interval_hessian(m._objective.expression, m)
+    assert float(np.asarray(ad.hess.lo).ravel()[0]) == pytest.approx(6.0)
+
+
+# ── The fix: exact QP/MIQP objective-Hessian convexity ───────────────────────
+
+
+@pytest.mark.unit
+def test_classifier_extractor_already_has_the_proof():
+    """The premise of the fix: ``extract_qp_data`` handles the vectorized model
+    that every convexity route failed on."""
+    m = _allocation_qp()
+    assert classify_problem(m) == ProblemClass.QP
+    hessian = dense_Q(extract_qp_data(m).Q)
+    assert np.allclose(hessian[:3, :3], 2.0 * np.eye(3), atol=1e-12)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("factory", [lambda: _allocation_qp(), lambda: _markowitz(6)[0]])
+def test_extracted_hessian_reproduces_the_body(factory):
+    """The eigenvalue verdict is only rigorous if the extracted Hessian really is
+    the body's Hessian — assert it numerically rather than assume it (the
+    extractor has three routes: Rust repr, algebraic, autodiff)."""
+    m = factory()
+    n = _flat_n(m)
+    data = extract_qp_data(m)
+    hessian = dense_Q(data.Q)[:n, :n]
+    lin = np.asarray(data.c)[:n]
+    err = _max_reconstruction_error(m, hessian, lin, float(data.obj_const), half=True)
+    assert err <= _EXACT_TOL
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("n", [5, 20])
+def test_vectorized_convex_qp_is_certified_convex(n):
+    """Pre-fix: ``classify_model`` returned ``is_convex=False`` on a positive
+    definite covariance QP — a false negative that routed it to spatial B&B."""
+    m, sigma = _markowitz(n)
+    assert np.linalg.eigvalsh(sigma)[0] > 0.0, "the fixture must be genuinely convex"
+    assert certify_quadratic_objective_convex(m) is True
+    is_convex, mask = classify_model(m, use_certificate=True)
+    assert is_convex is True
+    assert all(mask)
+
+
+@pytest.mark.unit
+def test_allocation_qp_is_certified_convex():
+    m = _allocation_qp()
+    assert certify_quadratic_objective_convex(m) is True
+    assert classify_model(m, use_certificate=True)[0] is True
+
+
+@pytest.mark.unit
+def test_route_is_opt_outable():
+    """``DISCOPT_QP_EXACT_CONVEXITY=0`` restores the pre-fix abstention, so the
+    legacy path stays reachable (CLAUDE.md §5)."""
+    m = _allocation_qp()
+    prior = os.environ.get("DISCOPT_QP_EXACT_CONVEXITY")
+    os.environ["DISCOPT_QP_EXACT_CONVEXITY"] = "0"
+    try:
+        assert certify_quadratic_objective_convex(m) is False
+    finally:
+        if prior is None:
+            os.environ.pop("DISCOPT_QP_EXACT_CONVEXITY", None)
+        else:
+            os.environ["DISCOPT_QP_EXACT_CONVEXITY"] = prior
+    assert certify_quadratic_objective_convex(m) is True
+
+
+# ── Soundness: the route must never certify a nonconvex model ───────────────
+
+
+def _indefinite_qp():
+    """``min x0² - x1²`` on ``[-3, 3]²`` s.t. ``x0 + x1 <= 4`` — true optimum -9."""
+    m = dm.Model("indefinite")
+    x = m.continuous("x", shape=(2,), lb=-3.0, ub=3.0)
+    m.minimize(dm.sum(lambda i: (1.0 if i == 0 else -1.0) * x[i] * x[i], over=range(2)))
+    m.subject_to(dm.sum(lambda i: x[i], over=range(2)) <= 4.0)
+    return m
+
+
+@pytest.mark.unit
+def test_indefinite_qp_is_not_certified_convex():
+    m = _indefinite_qp()
+    assert certify_quadratic_objective_convex(m) is False
+    assert classify_model(m, use_certificate=True)[0] is False
+
+
+@pytest.mark.unit
+def test_convex_maximize_is_not_certified_convex():
+    """``max xᵀx`` is a *concave-minimize* problem: the route must refuse it.
+    ``extract_qp_data`` returns minimize-form data (it negates for MAXIMIZE), so
+    the PSD test answers the right question without a further sign flip."""
+    m = dm.Model("convex_max")
+    x = m.continuous("x", shape=(2,), lb=0.0, ub=3.0)
+    m.maximize(dm.sum(lambda i: x[i] * x[i], over=range(2)))
+    m.subject_to(dm.sum(lambda i: x[i], over=range(2)) <= 6.0)
+    assert certify_quadratic_objective_convex(m) is False
+
+
+@pytest.mark.unit
+def test_concave_maximize_is_certified_convex():
+    """``max -(x-2)ᵀ(x-2)`` IS a convex problem and must be certified as one."""
+    m = dm.Model("concave_max")
+    x = m.continuous("x", shape=(2,), lb=0.0, ub=10.0)
+    m.maximize(dm.sum(lambda i: -1.0 * (x[i] - 2.0) * (x[i] - 2.0), over=range(2)))
+    m.subject_to(dm.sum(lambda i: x[i], over=range(2)) <= 10.0)
+    assert certify_quadratic_objective_convex(m) is True
+
+
+def _transcendental_objective():
+    m = dm.Model("transcendental")
+    x = m.continuous("x", lb=0.1, ub=5.0)
+    m.minimize(dm.log(x) * x)
+    m.subject_to(x <= 4.0)
+    return m
+
+
+def _convex_but_not_quadratic():
+    """``Σ exp(x_i)`` IS convex, but not *quadratic* — the route must still refuse
+    it, because its whole rigor rests on the Hessian being constant."""
+    m = dm.Model("exp_sum")
+    x = m.continuous("x", shape=(2,), lb=0.1, ub=5.0)
+    m.minimize(dm.sum(lambda i: dm.exp(x[i]), over=range(2)))
+    m.subject_to(dm.sum(lambda i: x[i], over=range(2)) <= 4.0)
+    return m
+
+
+def _quartic_objective():
+    m = dm.Model("quartic")
+    x = m.continuous("x", shape=(2,), lb=0.1, ub=5.0)
+    m.minimize(dm.sum(lambda i: x[i] ** 4, over=range(2)))
+    m.subject_to(dm.sum(lambda i: x[i], over=range(2)) <= 4.0)
+    return m
+
+
+def _convex_objective_nonconvex_constraint():
+    """The gate that matters most: a convex quadratic objective over a *nonconvex*
+    feasible set. ``classify_problem`` must not call this a QP, or the model would
+    route to a convex QP solver that assumes a polyhedron."""
+    m = dm.Model("qcqp")
+    x = m.continuous("x", shape=(2,), lb=-5.0, ub=5.0)
+    m.minimize(dm.sum(lambda i: x[i] * x[i], over=range(2)))
+    m.subject_to(x[0] * x[1] >= 1.0)
+    return m
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "factory",
+    [
+        _transcendental_objective,
+        _convex_but_not_quadratic,
+        _quartic_objective,
+        _convex_objective_nonconvex_constraint,
+    ],
+)
+def test_non_qp_models_are_refused(factory):
+    """The route's rigor rests entirely on ``classify_problem`` returning
+    ``QP``/``MIQP`` — exactly-quadratic objective over a polyhedron. Anything
+    else must be refused, convex or not."""
+    m = factory()
+    assert classify_problem(m) not in (ProblemClass.QP, ProblemClass.MIQP)
+    assert certify_quadratic_objective_convex(m) is False
+
+
+@pytest.mark.unit
+def test_oversized_model_abstains():
+    """The route declines above its size cap rather than spend seconds in
+    ``eigvalsh`` inside the solver's dispatch budget. Abstaining is sound."""
+    from discopt._jax.convexity import certificate as cert_mod
+
+    m = _allocation_qp()
+    prior = cert_mod._QP_EXACT_CONVEXITY_MAX_N
+    cert_mod._QP_EXACT_CONVEXITY_MAX_N = 1
+    try:
+        assert certify_quadratic_objective_convex(m) is False
+    finally:
+        cert_mod._QP_EXACT_CONVEXITY_MAX_N = prior
+
+
+@pytest.mark.unit
+def test_expired_deadline_abstains():
+    import time
+
+    m = _allocation_qp()
+    assert certify_quadratic_objective_convex(m, deadline=time.perf_counter() - 1.0) is False
+
+
+# ── End-to-end: the models that blocked three notebooks ─────────────────────
+
+
+@pytest.mark.smoke
+def test_allocation_qp_solves_to_optimal():
+    """The issue's repro. Pre-fix: ``feasible``, 14,115 nodes, 60.4 s (time
+    limit). The certificate makes it a root solve."""
+    m = _allocation_qp()
+    res = m.solve(time_limit=60)
+    assert res.status == "optimal", f"got {res.status} obj={res.objective!r}"
+    assert res.node_count == 0, f"expected a root solve, explored {res.node_count} nodes"
+
+
+@pytest.mark.smoke
+def test_markowitz_qp_solves_to_optimal():
+    """``qp_solver.ipynb``'s model. Pre-fix at n=20: ``feasible`` only, 557
+    nodes, 120 s limit hit."""
+    m, _ = _markowitz(20)
+    res = m.solve(time_limit=60)
+    assert res.status == "optimal", f"got {res.status} obj={res.objective!r}"
+    assert res.node_count == 0, f"expected a root solve, explored {res.node_count} nodes"
+
+
+@pytest.mark.smoke
+def test_indefinite_qp_still_finds_the_global_optimum():
+    """The soundness half: a genuinely nonconvex vectorized QP must keep routing
+    to spatial B&B and return the true optimum, not a stationary point."""
+    res = _indefinite_qp().solve(time_limit=60)
+    assert res.status == "optimal", f"got {res.status}"
+    assert float(res.objective) == pytest.approx(-9.0, abs=1e-4)
+
+
+@pytest.mark.smoke
+def test_convex_maximize_still_finds_the_global_optimum():
+    m = dm.Model("convex_max")
+    x = m.continuous("x", shape=(2,), lb=0.0, ub=3.0)
+    m.maximize(dm.sum(lambda i: x[i] * x[i], over=range(2)))
+    m.subject_to(dm.sum(lambda i: x[i], over=range(2)) <= 6.0)
+    res = m.solve(time_limit=60)
+    assert res.status == "optimal", f"got {res.status}"
+    assert float(res.objective) == pytest.approx(18.0, abs=1e-4)


### PR DESCRIPTION
## Summary

A convex QP written with discopt's **vectorized / indexed-summation modeling API** was certified convex by *no* route, so it fell through the pure-continuous guard at `solver.py:7062` (`_pure_continuous_force_spatial = True`) into spatial McCormick B&B, where it does not converge. Three independent, pre-existing defects stacked up; all three are fixed here.

1. **`_expr_to_polynomial` had no `SumOverExpression` branch** — the node `dm.sum(f, over=...)` builds — so `extract_quadratic` abstained on every indexed-summation body, while the byte-identical body written with Python's builtin `sum` extracted fine.
2. **`interval_ad` raised `TypeError`** on a vector-valued `Constant`/`Parameter` leaf. `certify_convex` catches only `ValueError`, so it escaped and was swallowed by the caller's broad `except Exception` — convexity-unknown *by accident* rather than by decision. Now raises `ValueError`, the walker's established abstain signal (the same refusal array `Variable`s already get). The conversion itself is unchanged, so no leaf that walked before stops walking and none that didn't now does.
3. **The proof was already computed and discarded.** `classify_problem` returns `QP`/`MIQP` only when the Rust structure detector reports *every* constraint linear **and** the objective quadratic — so on that branch the objective's Hessian is a *constant* matrix, and an exact symmetric-eigenvalue test on it is a rigorous, box-independent global convexity proof. New `certificate.certify_quadratic_objective_convex` takes that verdict from `extract_qp_data` (which handles the vectorized API) instead of asking the scalar interval walker (which cannot parse it).

`docs/dev/certification-gap-plan.md` gets the §8 build-results section and status-table row.

Closes #936

## Correctness

The new route is consulted by `classify_model` **only after** the syntactic walker and the interval-Hessian certificate have both left the objective unproven, so it can only ever upgrade an abstention — it can never loosen a verdict. It returns `False` (abstain) on every failure path.

Rigour rests on `classify_problem`'s QP/MIQP branch: exactly-quadratic objective over a polyhedron ⟹ constant Hessian ⟹ no enclosure, no box dependence, proof valid on every sub-box. This is the identical argument `_certify_quadratic_psd` already makes; only the coefficient source differs. `extract_qp_data` returns *minimize-form* data (it negates for `MAXIMIZE`), so the PSD test answers the caller's actual question in both senses without a further sign flip. Slack padding is a zero block, and a principal submatrix of a PSD matrix is PSD — padding can only make the test harder to pass, never wrongly pass it.

Exactness was **verified, not assumed**, per extractor route (the open question in the issue's second comment): `max |body − (½xᵀHx + cᵀx + d)|` over 40 random box points ≤ **1.8e-15** for the algebraic, repr, autodiff *and* dispatched-ladder routes. The `SumOverExpression` extraction reconstructs the body to 3.6e-15 (n=6) / 2.1e-14 (n=20).

Independent cross-validation on the corpus: the route fires on **10 MIQPs** (`alan`, `gbd`, `nvs15`, `st_miqp1`–`5`, `st_test1`, `st_testgr3`) and agrees with a direct `eigvalsh` on all 10, and with both established routes (syntactic walker, interval certificate) on all 10 — zero disagreements.

Refusals are pinned by tests in both directions: an indefinite vectorized QP is refused and still returns the true global −9; `max xᵀx` (convex-maximize = concave-minimize) is refused and returns 18; `Σ exp(x_i)` is convex but not quadratic and is refused; a convex quadratic objective over a **bilinear** constraint classifies QCQP and is refused.

- [x] Cannot produce a false certificate
- [x] No validation, fallback, or safety guard was weakened to make a check pass

## Tests run (state the result — numbers, not adjectives)

- [x] `pytest -m smoke` → **904 passed, 16 skipped, 2 xpassed, 7962 deselected** (406 s)
- [x] `pytest -m slow python/tests/test_adversarial_recent_fixes.py` → **10 passed** (174 s)
- [x] `cargo test -p discopt-core` → **N/A — no Rust touched** (`git diff origin/main...HEAD -- crates/` is empty)
- [x] `ruff check` clean; `ruff format --check` clean **on every file this branch touches** (the two files it reports — `test_log_square_relaxation.py`, `test_mo_augmecon2.py` — are unformatted on `main` already and are not in this diff)

`test_adversarial_recent_fixes.py::test_large_dense_jacobian_no_crash` failed once on its first run, immediately after the 406 s smoke suite in the same container; its only non-soundness assertion is a wall-deadline one. It passed in isolation and on two subsequent full-file runs, and on the pre-fix tree. The route's cost on that model is **91 µs** (its pre-gate refuses before any extraction), so it cannot be implicated. I did not capture that run's assertion message.

## Regression test

`python/tests/test_936_vectorized_qp_convexity.py` — **27 passed**. Fail-before confirmed by checking out `HEAD~1`'s `python/discopt/_jax/`: collection fails on the missing symbol, and the underlying defects reproduce directly — `extract_quadratic` → `None`, `interval_hessian` → `TypeError: only 0-dimensional arrays…`, `classify_model` → `(False, …)`, and the issue's repro solves to `feasible`, 5,101 nodes, 60.4 s.

- [x] Added a regression test that fails before / passes after

## Bound-changing / performance change?

- [x] Flag: **`DISCOPT_QP_EXACT_CONVEXITY`**, **default-ON with a `=0` opt-out**, graduated by the panel below under the 2026-07-17 single-passing-gate policy. The legacy path is intact and reachable via the opt-out (pinned by a test).
- [x] Differential panel, flag ON vs OFF, arms interleaved per instance
- [x] Graduation panel evidence: **cert-clean AND net-positive** (below)

**Measurement** — 66 in-repo MINLPLib `.nl`, 20 s limit, arms interleaved per instance, **re-run on the tree rebased onto #938** (that PR changed `solver.py` and the Rust LP simplex, so the pre-rebase gate result could not be carried forward):

```
284 soundness/regression checks executed.
CERT-CLEAN: PASS (0 violations)

solved to optimal : OFF 46   ON 46
gap_certified     : OFF 47   ON 47
total wall (s)    : OFF 524.7   ON 516.0
```

On the **46 instances proven optimal in both arms, node count and objective are exactly unchanged** (2803 = 2803 nodes) — the bound-neutral regime's own bar, met on the certifying core. All 5 residual node differences (`clay0303hfsg`, `heatexch_gen2`, `syn05hfsg`, `tanksize`, `tspn05`) are on instances that ended `time_limit`/`feasible` in **both** arms, i.e. wall-quantised rather than flag effects — `bchoco08` alternates 3/7 nodes *within the same arm* across repetitions.

Net-positive is neutral-on-corpus by construction (that corpus contains **0** `SumOverExpression` nodes across 3,769 bodies in 66 instances, and the 10 MIQPs the route fires on were already proven convex) and decisive on the class it targets:

| model | before | after |
|---|---|---|
| `decision_focused_learning` oracle QP | `feasible`, 5,101 nodes, 60.4 s | **optimal, 0 nodes, 0.59 s** |
| `qp_solver` Markowitz n=20 | `feasible` only, 557 nodes, 120 s limit | optimal, 0 nodes, 0.13 s |
| `benchmarks_by_class` QP sweep | 600 s cell timeout | runs to n=100 in <1 s per size |

All 13 models lifted from the three blocked notebooks now solve to `optimal`.

**Scope of the notebook evidence (corrected).** Only `decision_focused_learning` is a clean before/after: it is byte-identical on `main` and on this branch. The other two rows measure the QP bodies, but do not establish a pre-fix baseline *from `main`* — `qp_solver` on `main` is the pre-rewrite version of the notebook, and `benchmarks_by_class` on `main` aborts before reaching any solve, at `import discopt.solvers.lp_highs` (a module removed in #365). The *after* numbers stand as class evidence; what is not established is that those two notebooks were previously timing out **because of** #936. Raised in #issuecomment-5220858494.

**Two readings I published during this work and then retracted on re-measurement** (CLAUDE.md §11):

- An apparent wall regression (`heatexch_gen3` 27.8 → 215.1 s, `bchoco08` 20.6 → 91.0 s) **does not reproduce.** Interleaved A/B ×3 on an idle box: 29.0 ± 4.9 s vs 33.6 ± 2.0 s, and 25.3 ± 4.2 s vs 29.4 ± 2.9 s — both arms overrun the 20 s budget on those two instances irrespective of the flag. My first root-cause hypothesis (that `classify_problem` was expensive there) was falsified by direct timing — **7 ms** on `heatexch_gen3` — before I acted on it.
- `tls2`'s apparent objective drift (10.30 → 5.30) was the ON arm reaching the answer *sooner*, not a soundness event: at a 60 s limit **both** arms certify 5.3 with bound 5.3, and both incumbents are independently verified feasible (constraint-feasible, zero box violation, zero integrality violation), as is `tspn12`'s 262.647. The panel's drift check was wrong and is corrected to apply only where both arms prove optimality.

**Size gate.** `_QP_EXACT_CONVEXITY_MAX_N = 2000` bounds the dense materialisation (2000² float64 = 32 MB) and `eigvalsh` (measured: n=1000 → 0.052 s, n=2000 → 0.331 s ± 0.008, n=4000 → 2.47 s). The pre-gate counts variables **plus constraint rows**, because the extractor appends one slack column per inequality row and pads `Q` to the slacked dimension — gating on the variable count alone would let a narrow model with a huge row count ask for an `(n+m)²` dense array. Abstaining above the cap routes to the sound spatial path, so it is a performance guard, never a soundness one.

### `DISCOPT_PSD_QFORM` graduation — declined on neutrality

The issue's Defect 2 proposed graduating this flag alongside the fix. **It stays default-OFF**, because it is measurably useless on the class it would affect, not because it is unsound.

On `st_e36` the flag runs 11 exact eigenvalue certifications that produce 10 additional **CONCAVE** verdicts and no convex verdict, so nothing is routed onto a convex path. Measured cost +1.7 s (3.6 s → 5.3–5.4 s, interleaved ×3); measured benefit zero. That is the `DISCOPT_CUT_INHERIT` rule — sound ≠ helpful — with the measurement recorded rather than the flag flipped. Graduating it is also unnecessary here: the exact-QP route resolves Defect 2's *symptom* without it (Markowitz n=20 solves at 0 nodes with `PSD_QFORM` at its default OFF). A later graduation would need its own §5 panel; none has been run.

<details>
<summary><b>Retraction (§11):</b> this section previously declined the flag on a cert-clean failure that does not reproduce</summary>

The earlier text read:

> Its own panel fails cert-clean on `st_e36`: `gap_certified` True → False, `optimal`/85 nodes → `time_limit`/0 nodes.
> ```
> PSD_QFORM=0: optimal 3/3, gap_certified 3/3   (9.3 / 11.0 / 12.3 s)
> PSD_QFORM=1: optimal 0/3, gap_certified 0/3   (148 / 171 / 188 s, 0 nodes — the ROOT never finishes)
> ```
> That is the certification regression §5 names as disqualifying, and it is not a timing artifact.

**That measurement does not reproduce and is withdrawn.** An independent reproduction on `54c606b4` with a freshly `cargo build --release`d extension returns `optimal`, 85 nodes, `gap_certified=True`, objective `-245.99999999999997`, bound `-246.0000000017` in *every* configuration tried: interleaved ×3 at the 20 s panel limit, the full 2×2 of `DISCOPT_PSD_QFORM` × `DISCOPT_QP_EXACT_CONVEXITY`, and a 7-instance same-process panel with `st_e36` last. The A/B is non-vacuous per §6 — instrumented `certify_psd` calls are 0× with the flag OFF and 11× with it ON — so the arms genuinely differ and simply agree on the outcome. The instance file is byte-identical in-repo and in the `discopt-minlp-benchmark` corpus.

Probable cause, unconfirmed: a stale prebuilt `_rust*.so` predating #938, whose `primal.rs` rewrite this branch is rebased onto — the CLAUDE.md §8 trap, which the reproducing session hit once itself before adding a positive post-#938 build marker.

No issue is filed, since there is no defect to file. Full detail: #issuecomment-5220999652.
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0128NkHBGMq5KFXJDTDCvgAy


---
_Generated by [Claude Code](https://claude.ai/code/session_0128NkHBGMq5KFXJDTDCvgAy)_
