### PR TITLE
fix(structure): #941 a negative index resolved to another variable's slot, certifying a false bound

### DIFF
--- a/python/discopt/_flat_index.py
+++ b/python/discopt/_flat_index.py
@@ -1,0 +1,124 @@
+"""Single source of truth for resolving a scalar variable reference to a flat slot.
+
+Every layer that reasons about *structure* rather than *values* — term
+classification, McCormick relaxation construction, OBBT, cutting planes,
+sparsity — needs to turn an expression like ``v[2]`` or ``w[1, 0]`` into the
+integer position that entry occupies in the stacked ``x`` vector the solver
+actually works with. Before issue #941 each of those layers open-coded that
+arithmetic, and most of them got negative indices wrong: they took ``-1``
+literally and returned ``base_offset - 1``, which is a perfectly valid slot
+belonging to a *different variable*. Nothing downstream errors on a wrong-but-
+in-range slot, so the relaxation was simply built for a bilinear pair that does
+not exist in the model — an invalid relaxation that cut off the true optimum and
+was then reported as ``optimal`` with ``gap_certified=True``.
+
+The layout this module inverts is fixed by ``_jax/dag_compiler.py``, which
+materializes a shaped variable as ``x_flat[off : off + size].reshape(shape)`` in
+C (row-major) order and then applies ``a[index]``. For a full-rank all-integer
+index that composition is exactly ``x_flat[off + ravel_multi_index(idx, shape)]``,
+which is what :func:`resolve_scalar_slot` computes.
+
+**Returning ``None`` is always sound; returning a wrong slot never is.** Callers
+treat ``None`` as "not a scalar variable reference" and fall back to a more
+general (more conservative) path. So every case this module cannot resolve
+exactly — a slice, a partial index, a symbolic index, an out-of-range index — is
+refused rather than guessed.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import numpy as np
+
+from discopt.modeling.core import IndexExpression, Variable
+
+if TYPE_CHECKING:
+    from discopt.modeling.core import Expression, Model
+
+
+def normalize_axis_index(i: Any, dim: int) -> int | None:
+    """Return ``i`` normalized into ``[0, dim)``, or ``None`` if it is not a valid index.
+
+    ``bool`` is rejected explicitly. It is a subclass of :class:`int` in Python,
+    so ``isinstance(True, int)`` is ``True``, but numpy reads ``x[True]`` as a
+    *mask* — it adds an axis — not as ``x[1]``. Accepting it would resolve a
+    mask to a scalar slot.
+
+    Out-of-range indices are refused rather than clamped. numpy raises where
+    ``jnp`` silently clamps, so the two evaluation paths do not agree on what
+    ``v[7]`` means for a shape-(4,) variable; inventing a slot here would bake in
+    one of those answers. Refusal leaves the caller on its general path.
+    """
+    if isinstance(i, bool) or not isinstance(i, (int, np.integer)):
+        return None
+    norm = int(i)
+    if norm < 0:
+        norm += dim
+    if not 0 <= norm < dim:
+        return None
+    return norm
+
+
+def flat_index_in_shape(index: Any, shape: tuple[int, ...]) -> int | None:
+    """C-order flat position of ``index`` within ``shape``, or ``None``.
+
+    ``index`` may be a bare integer (only for a 1-D ``shape``) or a tuple of
+    integers whose length matches ``shape``. A shorter tuple is a *partial*
+    index, which leaves an array rather than a scalar, and a longer one is
+    invalid; both return ``None``.
+    """
+    idx = index if isinstance(index, tuple) else (index,)
+    if len(idx) != len(shape):
+        return None
+
+    flat = 0
+    for i, dim in zip(idx, shape):
+        norm = normalize_axis_index(i, dim)
+        if norm is None:
+            return None
+        flat = flat * dim + norm
+    return flat
+
+
+def resolve_scalar_slot(expr: Expression, model: Model) -> int | None:
+    """Flat ``x`` slot named by ``expr``, or ``None`` if it does not name exactly one.
+
+    Resolves two forms:
+
+    * a scalar :class:`~discopt.modeling.core.Variable` (``size == 1``), and
+    * an :class:`~discopt.modeling.core.IndexExpression` whose base is a
+      ``Variable`` and whose index selects a single element.
+
+    Everything else — a multi-element ``Variable`` with no index, a slice, a
+    partial or out-of-range index, a non-``Variable`` base — returns ``None``.
+
+    Deliberately arithmetic rather than probe-based: indexing an
+    ``np.arange(size).reshape(shape)`` probe would match numpy semantics by
+    construction, but allocating one per index node is O(size) per leaf and
+    O(size·leaves) over a model build — the same quadratic root-setup cost issue
+    #654 removed from the per-variable offset scan.
+    """
+    if isinstance(expr, Variable):
+        # ``size == 1`` rather than ``not shape``: a shape-(1,) or (1, 1)
+        # variable occupies exactly one slot, and the callers this replaces
+        # already resolved it that way. Widening the refusal here would drop
+        # structure those layers currently detect — sound, but a capability
+        # regression, and #941 is about the *wrong* slot, not a missing one.
+        if expr.size == 1:
+            return model._flat_var_offset(expr)
+        return None
+
+    if not isinstance(expr, IndexExpression):
+        return None
+    base = expr.base
+    if not isinstance(base, Variable):
+        return None
+    shape = tuple(base.shape or ())
+    if not shape:
+        return None
+
+    flat = flat_index_in_shape(expr.index, shape)
+    if flat is None:
+        return None
+    return model._flat_var_offset(base) + flat

--- a/python/discopt/_jax/cutting_planes.py
+++ b/python/discopt/_jax/cutting_planes.py
@@ -19,6 +19,7 @@ from typing import NamedTuple, Optional
 
 import numpy as np
 
+from discopt._flat_index import resolve_scalar_slot
 from discopt._jax.nonlinear_bound_tightening import is_effectively_finite
 from discopt.constants import ALPHABB_EPS, ALPHABB_SAFETY
 from discopt.modeling.core import (
@@ -371,18 +372,9 @@ def _var_offset(var: Variable, model: Model) -> int:
 
 def _scalar_var_index(expr: Expression, model: Model) -> Optional[int]:
     """Return the flat index for a scalar variable expression."""
-    if isinstance(expr, Variable):
-        if expr.size == 1:
-            return _var_offset(expr, model)
-        return None
-    if isinstance(expr, IndexExpression) and isinstance(expr.base, Variable):
-        base_offset = _var_offset(expr.base, model)
-        idx = expr.index
-        if isinstance(idx, int):
-            return base_offset + idx
-        if isinstance(idx, tuple) and len(idx) == 1 and isinstance(idx[0], int):
-            return base_offset + idx[0]
-    return None
+    # #941: `base_offset + idx` took a negative index literally, so a cut could be
+    # generated against a different variable than the one the term names.
+    return resolve_scalar_slot(expr, model)
 
 
 def _cleanup_polynomial(poly: QuadraticPolynomial) -> QuadraticPolynomial:
@@ -755,7 +747,6 @@ def detect_bilinear_terms(model) -> list[BilinearTerm]:
     """
     from discopt.modeling.core import (
         BinaryOp,
-        IndexExpression,
         Variable,
     )
     from discopt.modeling.core import Constraint as ConstraintType
@@ -767,14 +758,10 @@ def detect_bilinear_terms(model) -> list[BilinearTerm]:
             if expr.shape == () or expr.shape == (1,):
                 return offset
             return None
-        if isinstance(expr, IndexExpression) and isinstance(expr.base, Variable):
-            var = expr.base
-            offset = model_._flat_var_offset(var)
-            idx = expr.index
-            if isinstance(idx, int):
-                return offset + idx
-            if isinstance(idx, tuple) and len(idx) == 1 and isinstance(idx[0], int):
-                return offset + idx[0]
+        if isinstance(expr, IndexExpression):
+            # #941: see the note on _scalar_var_index above. A wrong slot here
+            # registers a bilinear pair the model does not contain.
+            return resolve_scalar_slot(expr, model_)
         return None
 
     found: list[BilinearTerm] = []

--- a/python/discopt/_jax/nonlinear_bound_tightening.py
+++ b/python/discopt/_jax/nonlinear_bound_tightening.py
@@ -16,6 +16,7 @@ from typing import Callable, NoReturn, Optional, Sequence, TypeVar
 
 import numpy as np
 
+from discopt._flat_index import flat_index_in_shape
 from discopt._jax._numeric import is_effectively_finite as _is_effectively_finite
 from discopt.modeling.core import (
     BinaryOp,
@@ -82,8 +83,13 @@ class FlatVariableMetadata:
                     isinstance(i, (int, np.integer)) for i in idx
                 ):
                     return None
-                normalized = tuple(int(i) % s for i, s in zip(idx, base.shape))
-                flat_idx = int(np.ravel_multi_index(normalized, base.shape))
+                # #941: `% s` normalizes in-range negatives correctly but also
+                # *wraps* an out-of-range index onto a valid slot (7 % 4 == 3),
+                # and accepts `bool` as an index. Refusing is the sound answer.
+                normalized_flat = flat_index_in_shape(tuple(idx), tuple(base.shape))
+                if normalized_flat is None:
+                    return None
+                flat_idx = normalized_flat
             return base_offset + flat_idx
 
         return None

--- a/python/discopt/_jax/obbt.py
+++ b/python/discopt/_jax/obbt.py
@@ -17,6 +17,7 @@ from typing import Optional
 
 import numpy as np
 
+from discopt._flat_index import resolve_scalar_slot
 from discopt.modeling.core import Model
 from discopt.solvers import SolveStatus
 from discopt.solvers.lp_backend import (
@@ -490,13 +491,11 @@ def _extract_linear_constraints(
             return None
 
         if isinstance(expr, IndexExpression):
-            if isinstance(expr.base, Variable):
-                base_offset = _compute_var_offset(expr.base)
-                idx = expr.index
-                if isinstance(idx, int):
-                    return {base_offset + idx: 1.0}, 0.0
-                if isinstance(idx, tuple) and len(idx) == 1:
-                    return {base_offset + idx[0]: 1.0}, 0.0
+            # #941: `base_offset + idx` took a negative index literally, naming a
+            # slot that belongs to a different variable. Shared resolver.
+            slot = resolve_scalar_slot(expr, model)
+            if slot is not None:
+                return {slot: 1.0}, 0.0
             return None
 
         if isinstance(expr, SumExpression):
@@ -634,12 +633,10 @@ def _extract_linear_objective(
                 return None
             return {k: -v for k, v in inner[0].items()}, -inner[1]
         if isinstance(expr, IndexExpression) and isinstance(expr.base, Variable):
-            base_offset = _compute_var_offset(expr.base)
-            idx = expr.index
-            if isinstance(idx, int):
-                return {base_offset + idx: 1.0}, 0.0
-            if isinstance(idx, tuple) and len(idx) == 1:
-                return {base_offset + idx[0]: 1.0}, 0.0
+            # #941: see the note in the sibling extractor above.
+            slot = resolve_scalar_slot(expr, model)
+            if slot is not None:
+                return {slot: 1.0}, 0.0
             return None
         if isinstance(expr, SumExpression):
             return _extract(expr.operand)
@@ -1402,22 +1399,12 @@ def _scalar_flat_index(expr, model) -> Optional[int]:
     Returns the flat index (matching :func:`_get_var_bounds` ordering) for a
     scalar ``Variable`` or a scalar ``IndexExpression`` over a variable, else
     ``None``.
+
+    #941: this open-coded ``offset + idx``, which resolves ``v[-1]`` to the slot
+    before ``v``. OBBT tightens the bound of whatever slot it is handed, so a
+    wrong slot tightens the wrong variable's box.
     """
-    from discopt.modeling.core import IndexExpression, Variable
-
-    def _offset(var) -> int:
-        # Memoized O(1) prefix-sum lookup; see Model._flat_var_offset (#654, #863).
-        return int(model._flat_var_offset(var))
-
-    if isinstance(expr, Variable) and expr.size == 1:
-        return _offset(expr)
-    if isinstance(expr, IndexExpression) and isinstance(expr.base, Variable):
-        idx = expr.index
-        if isinstance(idx, int):
-            return _offset(expr.base) + idx
-        if isinstance(idx, tuple) and len(idx) == 1 and isinstance(idx[0], int):
-            return _offset(expr.base) + idx[0]
-    return None
+    return resolve_scalar_slot(expr, model)
 
 
 def _flat_indices(expr, model) -> set:

--- a/python/discopt/_jax/problem_classifier.py
+++ b/python/discopt/_jax/problem_classifier.py
@@ -27,6 +27,7 @@ if TYPE_CHECKING:
 # annotations``), so importing this module — done on every ``Model.solve`` to
 # route the problem class — does not pull in JAX. That keeps LP/MILP/MIQP solves
 # free of JAX/XLA cold-start.
+from discopt._flat_index import resolve_scalar_slot
 from discopt.modeling.core import (
     BinaryOp,
     Constant,
@@ -597,20 +598,11 @@ def _extract_quadratic_terms(expr, model: Model, n: int):
             if node.size != 1:
                 return None
             return _compute_var_offset(node, model)
-        if isinstance(node, IndexExpression) and isinstance(node.base, Variable):
-            offset = _compute_var_offset(node.base, model)
-            idx = node.index
-            if isinstance(idx, (int, np.integer)):
-                return offset + int(idx)
-            if isinstance(idx, tuple) and len(idx) == 1 and isinstance(idx[0], (int, np.integer)):
-                return offset + int(idx[0])
-            try:
-                flat_idx = np.ravel_multi_index(
-                    idx if isinstance(idx, tuple) else (idx,), node.base.shape
-                )
-            except (TypeError, ValueError):
-                return None  # sliced/partial subscript: not a scalar reference
-            return offset + int(flat_idx)
+        if isinstance(node, IndexExpression):
+            # #941: the bare-int fast path was `offset + int(idx)`, wrong for a
+            # negative index. (The `ravel_multi_index` fallback below it already
+            # refused negatives, by raising — so only the fast path was unsound.)
+            return resolve_scalar_slot(node, model)
         return None
 
     def _walk(node, scale=1.0, allow_array=False):

--- a/python/discopt/_jax/relaxation_compiler.py
+++ b/python/discopt/_jax/relaxation_compiler.py
@@ -18,6 +18,8 @@ import numpy as np
 if TYPE_CHECKING:
     from discopt._jax.learned_relaxations import LearnedRelaxationRegistry
 
+# Import expression types from the modeling API
+from discopt._flat_index import resolve_scalar_slot
 from discopt._jax.mccormick import (
     relax_abs,
     relax_acos,
@@ -54,8 +56,6 @@ from discopt._jax.piecewise_mccormick import (
     piecewise_relax_sin,
     piecewise_relax_sqrt,
 )
-
-# Import expression types from the modeling API
 from discopt.modeling.core import (
     BinaryOp,
     Constant,
@@ -101,17 +101,16 @@ def _resolve_scalar_var_offset(expr: Expression, model: Model) -> int | None:
     Returns the flat offset into the x vector if ``expr`` is a scalar
     ``Variable`` or an ``IndexExpression`` over a ``Variable`` that resolves
     to a single scalar component. Returns ``None`` otherwise.
+
+    #941: this used to open-code the index arithmetic as ``base_off + idx``,
+    which takes a negative index literally — ``v[-1]`` resolved to the slot
+    *before* ``v``, belonging to a different variable. The McCormick envelope was
+    then built over the wrong pair, producing an invalid relaxation that cut off
+    the true optimum and still reported ``gap_certified=True``. It also silently
+    dropped every multi-dimensional index and every ``np.integer``. One shared
+    resolver now handles all of it.
     """
-    if isinstance(expr, Variable) and expr.size == 1:
-        return _compute_var_offset(expr, model)
-    if isinstance(expr, IndexExpression) and isinstance(expr.base, Variable):
-        base_off = _compute_var_offset(expr.base, model)
-        idx = expr.index
-        if isinstance(idx, int):
-            return base_off + idx
-        if isinstance(idx, tuple) and len(idx) == 1 and isinstance(idx[0], int):
-            return base_off + idx[0]
-    return None
+    return resolve_scalar_slot(expr, model)
 
 
 def _try_extract_trilinear_chain(expr: Expression, model: Model) -> tuple[int, int, int] | None:

--- a/python/discopt/_jax/sparsity.py
+++ b/python/discopt/_jax/sparsity.py
@@ -19,6 +19,7 @@ from typing import Optional
 import numpy as np
 import scipy.sparse as sp
 
+from discopt._flat_index import resolve_scalar_slot
 from discopt.modeling.core import (
     BinaryOp,
     Constant,
@@ -101,8 +102,14 @@ def _collect_variable_indices(expr: Expression, model: Model) -> set[int]:
             base = expr.base
             offset = _var_offset(base, model)
             idx = expr.index
-            if isinstance(idx, (int, np.integer)):
-                return {offset + int(idx)}
+            # #941: this fast path was `offset + int(idx)`, which for a negative
+            # index names a slot belonging to a different variable — a sparsity
+            # pattern attributing a derivative to the wrong column. The shared
+            # resolver normalizes and range-checks; anything it refuses falls
+            # through to the probe below, which is numpy-exact.
+            slot = resolve_scalar_slot(expr, model)
+            if slot is not None:
+                return {slot}
             # Resolve a multi-dimensional / slice / fancy index (e.g. the 2-D
             # ``a0[i, j]`` of a collocation variable) to the exact flat element
             # set, rather than returning the whole variable. Over-reporting here

--- a/python/discopt/_jax/symbolic/cut_recognizer.py
+++ b/python/discopt/_jax/symbolic/cut_recognizer.py
@@ -92,6 +92,7 @@ def _ensure_sympy() -> None:
 
 
 def _var_key(node) -> Optional[str]:
+    from discopt._flat_index import flat_index_in_shape
     from discopt.modeling import core
 
     if isinstance(node, core.IndexExpression):
@@ -99,9 +100,26 @@ def _var_key(node) -> Optional[str]:
         # compound expression like (x+y)[0] has no Variable base -> skip.
         if not isinstance(node.base, core.Variable):
             return None
-        idx = node.index
-        i = idx if isinstance(idx, int) else (idx[0] if isinstance(idx, tuple) else idx)
-        return f"{node.base.name}[{i}]"
+        base = node.base
+        shape = tuple(base.shape or ())
+        # #941: this used to key on `idx[0]` — the FIRST AXIS only — so for a
+        # shape-(2, 3) variable both `w[0, 1]` and `w[0, 2]` keyed as "w[0]" and
+        # the recognizer treated two distinct variables as one symbol. It also
+        # keyed `v[-1]` and `v[3]` as different symbols for the same element.
+        #
+        # The canonical key is `name[flat]` — the format `_handle_map` builds, so
+        # a recognized cut can be mapped back to a model handle. `_handle_map`
+        # only builds honorable handles for 1-D variables (it uses `v[i]` with a
+        # bare int, which on an N-D variable selects a whole row, not an
+        # element), so N-D refs are refused here rather than given a key that
+        # cannot be resolved back. `None` is safe: `_to_sympy` substitutes a
+        # fresh Dummy and the recognizer simply matches no pattern involving it.
+        if len(shape) != 1:
+            return None
+        flat = flat_index_in_shape(node.index, shape)
+        if flat is None:
+            return None
+        return f"{base.name}[{flat}]"
     if isinstance(node, core.Variable):
         return node.name
     return None

--- a/python/discopt/_jax/term_classifier.py
+++ b/python/discopt/_jax/term_classifier.py
@@ -21,11 +21,10 @@ Theory references:
 
 from __future__ import annotations
 
-from collections.abc import Sequence
 from dataclasses import dataclass, field
-from operator import index as operator_index
 from typing import Any
 
+from discopt._flat_index import resolve_scalar_slot
 from discopt.modeling.core import (
     BinaryOp,
     Constant,
@@ -121,53 +120,19 @@ def _compute_var_offset(var: Variable, model: Model) -> int:
     return model._flat_var_offset(var)
 
 
-def _as_scalar_index(value: Any) -> int | None:
-    """Return a Python integer index, or None for slices and non-scalars."""
-    try:
-        return operator_index(value)
-    except TypeError:
-        return None
-
-
-def _tuple_to_flat_index(indices: Sequence[int], shape: Sequence[int]) -> int | None:
-    """Flatten a scalar multidimensional index in row-major order."""
-    if len(indices) != len(shape):
-        return None
-
-    flat = 0
-    stride = 1
-    for idx, dim in zip(reversed(indices), reversed(shape)):
-        flat += idx * stride
-        stride *= dim
-    return flat
-
-
 def _get_flat_index(expr: Expression, model: Model) -> int | None:
     """Return the flat variable index for a scalar Variable or IndexExpression.
 
     Returns None if the expression is not a scalar variable reference.
+
+    #941: this used to open-code the index arithmetic and took negatives
+    literally, so ``v[-1]`` resolved to ``base_offset - 1`` — a valid slot
+    belonging to a *different* variable. The bilinear catalog then registered a
+    pair that does not exist in the model, and the relaxation built from it cut
+    off the true optimum under a ``gap_certified=True`` label. It now shares one
+    resolver with every other structure layer.
     """
-    if isinstance(expr, Variable):
-        if expr.size == 1:
-            return _compute_var_offset(expr, model)
-        return None  # multi-element variable without index — can't reduce to scalar
-    if isinstance(expr, IndexExpression) and isinstance(expr.base, Variable):
-        base_off = _compute_var_offset(expr.base, model)
-        idx = expr.index
-        scalar_idx = _as_scalar_index(idx)
-        if scalar_idx is not None:
-            return base_off + scalar_idx
-        if isinstance(idx, tuple):
-            scalar_indices = []
-            for item in idx:
-                item_idx = _as_scalar_index(item)
-                if item_idx is None:
-                    return None
-                scalar_indices.append(item_idx)
-            flat = _tuple_to_flat_index(scalar_indices, expr.base.shape)
-            if flat is not None:
-                return base_off + flat
-    return None
+    return resolve_scalar_slot(expr, model)
 
 
 def _contains_expandable_square(model: Model) -> bool:

--- a/python/tests/test_941_flat_index.py
+++ b/python/tests/test_941_flat_index.py
@@ -1,0 +1,155 @@
+"""Issue #941: a scalar variable reference must resolve to the *correct* flat slot.
+
+A negative index (``v[-1]``) used to resolve to ``base_offset - 1`` — a valid slot
+belonging to a different variable. Nothing downstream errors on a wrong-but-
+in-range slot, so the McCormick relaxation was built for a bilinear pair that does
+not exist in the model, cutting off the true optimum and reporting it as
+``optimal`` with ``gap_certified=True``.
+
+The oracle here is numpy's own indexing, not a reimplementation of it: build
+``np.arange(size).reshape(shape)`` and read ``probe[idx]``. Whatever numpy says
+that element's flat position is, that is the truth — negatives, mixed spellings
+and all. (This allocation is fine in a test; it is exactly what the production
+resolver must *not* do per-leaf, for the O(size·leaves) reason issue #654 fixed.)
+"""
+
+from __future__ import annotations
+
+import itertools
+
+import discopt.modeling as dm
+import numpy as np
+import pytest
+from discopt._flat_index import flat_index_in_shape, normalize_axis_index, resolve_scalar_slot
+from discopt.modeling.core import IndexExpression
+
+
+@pytest.fixture
+def model_with_shapes():
+    """A model whose variables sit at known, non-zero flat offsets.
+
+    The leading scalar is what makes this test able to fail: with ``v`` at offset
+    0 a dropped base offset is invisible, and with ``s`` at slot 0 a negative
+    index that under-shoots lands on ``s`` — exactly the #941 aliasing.
+    """
+    m = dm.Model("t941")
+    s = m.continuous("s", lb=0.0, ub=1.0)  # slot 0
+    v = m.continuous("v", shape=(4,), lb=0.0, ub=1.0)  # slots 1-4
+    w = m.continuous("w", shape=(2, 3), lb=0.0, ub=1.0)  # slots 5-10
+    u = m.continuous("u", shape=(2, 3, 4), lb=0.0, ub=1.0)  # slots 11-34
+    return m, {"s": s, "v": v, "w": w, "u": u}
+
+
+def test_every_index_of_every_shaped_variable_matches_numpy(model_with_shapes):
+    """Exhaustive over all in-range indices, positive AND negative, for each shape."""
+    m, vs = model_with_shapes
+    offsets = {"v": 1, "w": 5, "u": 11}
+
+    checked = 0
+    for name in ("v", "w", "u"):
+        var = vs[name]
+        shape = tuple(var.shape)
+        off = offsets[name]
+        assert m._flat_var_offset(var) == off, f"{name} moved; the fixture's map is stale"
+        probe = np.arange(int(np.prod(shape))).reshape(shape)
+
+        # Each axis contributes both its positive and its negative spelling, so
+        # mixed forms like w[0, -1] and u[-2, 1, -3] are covered too.
+        per_axis = [list(range(d)) + list(range(-d, 0)) for d in shape]
+        for idx in itertools.product(*per_axis):
+            truth = off + int(probe[idx])
+            key = idx if len(idx) > 1 else idx[0]
+            got = resolve_scalar_slot(IndexExpression(var, key), m)
+            assert got == truth, f"{name}{list(idx)}: got slot {got}, numpy says {truth}"
+            checked += 1
+
+    # 8 (v) + 24 (w) + 192 (u) = 224. Anti-vacuity per CLAUDE.md §6.
+    assert checked == 224, f"expected 224 resolutions, made {checked}"
+
+
+def test_the_exact_aliasing_from_the_issue(model_with_shapes):
+    """`v[-1]` must not resolve to `s`'s slot. This is the reported failure."""
+    m, vs = model_with_shapes
+    assert resolve_scalar_slot(IndexExpression(vs["v"], -1), m) == 4  # not 0 (`s`)
+    assert resolve_scalar_slot(IndexExpression(vs["v"], -4), m) == 1  # not -3
+    assert resolve_scalar_slot(IndexExpression(vs["w"], (-1, -1)), m) == 10  # not 1
+    assert resolve_scalar_slot(IndexExpression(vs["w"], (0, -1)), m) == 7  # not 4
+
+
+@pytest.mark.parametrize(
+    "label,index",
+    [
+        ("slice", slice(0, 2)),
+        ("slice_all", slice(None)),
+        ("partial_2d", (0,)),
+        ("slice_in_tuple", (0, slice(None))),
+        ("ellipsis", Ellipsis),
+        ("float", 1.0),
+        ("string", "a"),
+        ("none", None),
+        ("too_many", (0, 0, 0)),
+    ],
+)
+def test_non_scalar_index_forms_return_none(model_with_shapes, label, index):
+    """Unresolvable is `None` — the sound answer, never a guessed slot."""
+    m, vs = model_with_shapes
+    base = (
+        vs["v"]
+        if label in ("slice", "slice_all", "ellipsis", "float", "string", "none")
+        else vs["w"]
+    )
+    assert resolve_scalar_slot(IndexExpression(base, index), m) is None
+
+
+@pytest.mark.parametrize("index", [4, 7, -5, -100])
+def test_out_of_range_is_refused_not_clamped(model_with_shapes, index):
+    """numpy raises where jnp clamps; resolving here would pick a side."""
+    m, vs = model_with_shapes
+    assert resolve_scalar_slot(IndexExpression(vs["v"], index), m) is None
+
+
+def test_bool_is_not_an_integer_index(model_with_shapes):
+    """`bool` subclasses `int`, but numpy reads `x[True]` as a mask, not `x[1]`."""
+    m, vs = model_with_shapes
+    assert resolve_scalar_slot(IndexExpression(vs["v"], True), m) is None
+    assert resolve_scalar_slot(IndexExpression(vs["v"], False), m) is None
+    assert resolve_scalar_slot(IndexExpression(vs["w"], (True, 0)), m) is None
+
+
+def test_numpy_integers_are_accepted(model_with_shapes):
+    """`isinstance(np.int64(2), int)` is False, so an `int`-only check drops these."""
+    m, vs = model_with_shapes
+    assert resolve_scalar_slot(IndexExpression(vs["v"], np.int64(2)), m) == 3
+    assert resolve_scalar_slot(IndexExpression(vs["v"], np.int32(-1)), m) == 4
+    assert resolve_scalar_slot(IndexExpression(vs["w"], (np.int64(-1), np.int8(2))), m) == 10
+
+
+def test_scalar_variable_and_non_variable_base(model_with_shapes):
+    m, vs = model_with_shapes
+    assert resolve_scalar_slot(vs["s"], m) == 0
+    assert resolve_scalar_slot(vs["v"], m) is None  # array, not one slot
+    # Base is an expression, not a Variable: no static slot exists.
+    assert resolve_scalar_slot(IndexExpression(vs["v"] + 1.0, 0), m) is None
+
+
+def test_flat_index_in_shape_is_c_order():
+    """Row-major, matching dag_compiler's `x_flat[off:off+size].reshape(shape)`."""
+    checked = 0
+    for shape in ((4,), (2, 3), (2, 3, 4)):
+        probe = np.arange(int(np.prod(shape))).reshape(shape)
+        for idx in itertools.product(*[range(-d, d) for d in shape]):
+            key = idx if len(idx) > 1 else idx[0]
+            assert flat_index_in_shape(key, shape) == int(probe[idx])
+            checked += 1
+    assert checked == 8 + 24 + 192
+
+
+def test_normalize_axis_index():
+    assert normalize_axis_index(0, 4) == 0
+    assert normalize_axis_index(3, 4) == 3
+    assert normalize_axis_index(-1, 4) == 3
+    assert normalize_axis_index(-4, 4) == 0
+    assert normalize_axis_index(4, 4) is None
+    assert normalize_axis_index(-5, 4) is None
+    assert normalize_axis_index(True, 4) is None
+    assert normalize_axis_index(1.0, 4) is None

--- a/python/tests/test_941_negative_index_solve_equivalence.py
+++ b/python/tests/test_941_negative_index_solve_equivalence.py
@@ -1,0 +1,118 @@
+"""Issue #941, end to end: index spelling must not change the answer.
+
+``v[-1]`` and ``v[3]`` name the same element of a shape-(4,) variable, so two
+models differing only in that spelling are the *same model*. Before the fix the
+structure layers resolved the negative form to the slot belonging to a different
+variable, the McCormick envelope was built over a bilinear pair the model does
+not contain, and the search returned ``status="optimal"`` with
+``gap_certified=True`` on a bound above a demonstrably feasible point.
+
+These are solve-level tests, so they are marked ``slow``. The unit-level
+guarantee they rest on lives in ``test_941_flat_index.py``.
+"""
+
+from __future__ import annotations
+
+import discopt.modeling as dm
+import numpy as np
+import pytest
+
+
+def _geom(last: int) -> dm.Model:
+    """The reported reproducer. ``last`` spells the final element -1 or 3."""
+    m = dm.Model("geom941")
+    s = m.continuous("s", lb=0.2, ub=3.0)
+    v = m.continuous("v", shape=(4,), lb=0.2, ub=3.0)
+    m.minimize(sum(dm.exp(v[i]) / (1.0 + v[(i + 1) % 4]) for i in range(4)) + dm.log(s))
+    m.subject_to(sum(v[i] ** 2 for i in range(4)) + s <= 9.0)
+    m.subject_to(v[0] * v[last] >= 0.5)
+    return m
+
+
+def _geom_truth(x: np.ndarray) -> tuple[float, float, float]:
+    """(objective, slack_1, slack_2) in plain numpy — independent of the solver."""
+    s, v = float(x[0]), np.asarray(x[1:], dtype=float)
+    obj = float(sum(np.exp(v[i]) / (1.0 + v[(i + 1) % 4]) for i in range(4)) + np.log(s))
+    return obj, 9.0 - (float(np.sum(v**2)) + s), float(v[0] * v[3]) - 0.5
+
+
+def _flat_solution(model: dm.Model, result) -> np.ndarray:
+    return np.concatenate(
+        [np.atleast_1d(np.asarray(result.x[v.name], dtype=float)).ravel() for v in model._variables]
+    )
+
+
+@pytest.mark.slow
+def test_negative_index_does_not_certify_a_false_bound():
+    """The reported failure: bound 3.4854 certified while 2.9619 is feasible.
+
+    Asserted as the *certificate invariant* rather than as a fixed number, so the
+    test keeps its meaning as the solver improves: a certified bound may never
+    exceed an objective the model actually attains.
+    """
+    model = _geom(-1)
+    res = model.solve(time_limit=60)
+
+    assert res.objective is not None, "no incumbent — the reproducer should be feasible"
+    x = _flat_solution(model, res)
+    obj, slack_1, slack_2 = _geom_truth(x)
+
+    # The returned point must really be feasible, re-checked outside the solver.
+    assert slack_1 >= -1e-6, f"returned point violates sum(v^2)+s <= 9 by {-slack_1}"
+    assert slack_2 >= -1e-6, f"returned point violates v0*v3 >= 0.5 by {-slack_2}"
+    assert obj == pytest.approx(res.objective, rel=1e-6), "reported objective is not the point's"
+
+    # The known-feasible point from the positive spelling. Any certified bound
+    # above this is false: a minimization cannot prove a floor above a value it
+    # can reach.
+    known_feasible = 2.9618839111
+    if res.gap_certified and res.bound is not None and np.isfinite(res.bound):
+        assert res.bound <= known_feasible + 1e-5, (
+            f"certified bound {res.bound} exceeds the feasible objective "
+            f"{known_feasible} — a false certificate"
+        )
+    assert obj <= known_feasible + 1e-4, (
+        f"negative-index spelling returned a worse incumbent ({obj}) than the "
+        f"positive spelling ({known_feasible}); the two are the same model"
+    )
+
+
+@pytest.mark.slow
+def test_both_spellings_agree():
+    """`v[0]*v[-1]` and `v[0]*v[3]` are one model and must give one answer.
+
+    Node counts are deliberately NOT compared: both arms are wall-clock limited
+    here, so their node totals reflect machine speed, not the search.
+    """
+    results = {}
+    for last in (-1, 3):
+        model = _geom(last)
+        res = model.solve(time_limit=60)
+        x = _flat_solution(model, res)
+        obj, slack_1, slack_2 = _geom_truth(x)
+        assert slack_1 >= -1e-6 and slack_2 >= -1e-6, f"v[{last}] arm returned an infeasible point"
+        results[last] = obj
+
+    assert results[-1] == pytest.approx(results[3], rel=1e-4), (
+        f"index spelling changed the optimum: v[-1] -> {results[-1]}, v[3] -> {results[3]}"
+    )
+
+
+@pytest.mark.slow
+def test_negative_index_bilinear_is_actually_seen_by_the_structure_layer():
+    """Anti-vacuity (CLAUDE.md §6): prove the bilinear term is catalogued.
+
+    Without this, the solve-level tests above could pass for the wrong reason —
+    a model whose nonconvexity is never detected has nothing to get wrong.
+    """
+    from discopt._jax.term_classifier import classify_nonlinear_terms
+
+    model = _geom(-1)
+    terms = classify_nonlinear_terms(model)
+
+    # `s` is slot 0 and `v` occupies slots 1-4, so v[0]*v[-1] is the pair (1, 4).
+    assert (1, 4) in terms.bilinear, (
+        f"v[0]*v[-1] should be catalogued as the bilinear pair (1, 4); "
+        f"got {terms.bilinear}. (0, 1) would be the #941 aliasing onto `s`."
+    )
+    assert (0, 1) not in terms.bilinear, "pair (0, 1) aliases `s` — the #941 defect"


### PR DESCRIPTION
# fix(structure): #941 a negative index resolved to another variable's slot, certifying a false bound

`v[-1]` and `v[3]` name the same element of a shape-`(4,)` variable. Before this
PR they did not name the same *slot*: eight independent layers open-coded
`base_offset + idx` and took the `-1` literally, landing on `base_offset - 1` —
a perfectly valid slot belonging to a **different variable**. Nothing downstream
errors on a wrong-but-in-range slot, so the McCormick envelope was simply built
for a bilinear pair the model does not contain. That relaxation is invalid, it
cut off the true optimum, and the search then reported it as certified:

```python
m = dm.Model()
s = m.continuous("s", lb=0.2, ub=3.0)
v = m.continuous("v", shape=(4,), lb=0.2, ub=3.0)
m.minimize(sum(dm.exp(v[i]) / (1.0 + v[(i + 1) % 4]) for i in range(4)) + dm.log(s))
m.subject_to(sum(v[i] ** 2 for i in range(4)) + s <= 9.0)
m.subject_to(v[0] * v[-1] >= 0.5)          # <- the only character that differs
```

| spelling | before | after |
|---|---|---|
| `v[-1]` | `nodes=3` `status=optimal` `obj=bound=3.4853698662` **`cert=True`** | `nodes=3671` `status=feasible` `obj=2.9619169848` `bound=2.9578997321` `cert=False` |
| `v[3]`  | `nodes=13073` `status=feasible` `obj=2.9618839111` `cert=False` | `nodes=9337` `status=feasible` `obj=2.9618839111` `bound=2.9571341220` `cert=False` |

`3.4854` was certified as a lower bound on a minimization while `2.9619` is
attainable. Both points were re-verified in plain numpy outside the solver
(slacks `6.77` / `-6.79e-08` and `7.56` / `-7.72e-09`, objectives matching to
~2e-14), so the incumbent is real and the certificate was false. This is a
violation of the CLAUDE.md §1 certificate invariant, hence P0.

The bug is pre-existing on `main`, not introduced by the JAX-removal work:
confirmed byte-identical on `main`, and the legacy arm of the #922 A/B reports
`STATIC_SLOT_CALLS=0` — the new static-index tape lowering never ran in the
failing configuration. `_jax/dag_compiler.py` (the *evaluator*) is immune,
because it hands the index to `jnp`, which handles negatives natively. That is
why the evaluated model was right while the relaxation built for it was wrong.

## The fix

New module `python/discopt/_flat_index.py` — one implementation of the layout
that `dag_compiler` fixes (`x_flat[off : off+size].reshape(shape)` in C order,
then `a[index]`), with a stated invariant:

> **Returning `None` is always sound; returning a wrong slot never is.**

Every case it cannot resolve exactly — a slice, a partial index, a symbolic
index, an out-of-range index, a `bool` (numpy reads it as a mask) — is refused,
and the caller falls back to its general, more conservative path.

It is arithmetic rather than probe-based on purpose: indexing an
`np.arange(size).reshape(shape)` probe would match numpy by construction but
costs O(size) per leaf and O(size·leaves) per model build — the same quadratic
root-setup cost issue #654 removed.

## Sites converted

| site | old arithmetic | failure |
|---|---|---|
| `term_classifier._get_flat_index` | `offset + idx` | negative → wrong slot |
| `relaxation_compiler._resolve_scalar_var_offset` | `offset + idx` | negative → wrong slot |
| `obbt._extract_linear_constraints._extract` | `offset + idx` | negative → wrong slot |
| `obbt._extract_linear_objective._extract` | `offset + idx` | negative → wrong slot |
| `obbt._scalar_flat_index` | `offset + idx` | negative → tightens the wrong variable's box |
| `cutting_planes._scalar_var_index` | `offset + idx` | negative → cut against the wrong variable |
| `cutting_planes.detect_bilinear_terms` | `offset + idx` | negative → wrong slot |
| `sparsity._collect_variable_indices` | `offset + int(idx)` fast path | negative → derivative attributed to the wrong column |
| `problem_classifier._extract_quadratic_terms` | `offset + int(idx)` fast path | negative → wrong slot |
| `nonlinear_bound_tightening.FlatVariableMetadata` | `int(i) % s` | out-of-range **wrapped** onto a valid slot |
| `symbolic/cut_recognizer._var_key` | `idx[0]` | **first axis only** — see below |

Two of these are distinct failure modes, not the reported one:

* `nonlinear_bound_tightening` normalized with `int(i) % s`. That is correct for
  an in-range negative, but silently wraps an out-of-range index (`7 % 4 == 3`)
  onto a valid slot, and accepts `bool`. Both now refuse.

* `cut_recognizer._var_key` built its key from `idx[0]`, the first axis. For a
  shape-`(2, 3)` variable, `w[0, 1]` and `w[0, 2]` **both keyed as `"w[0]"`** —
  two distinct variables collapsed onto one symbol. The key format also
  disagreed with `_handle_map`, which emits `name[flat]` and only builds
  honorable handles for 1-D variables (it uses `v[i]` with a bare int, which on
  an N-D variable selects a whole row, not an element). N-D references are
  therefore refused rather than given a key that cannot be resolved back;
  `None` is safe, because `_to_sympy` substitutes a fresh `Dummy` and the
  recognizer matches no pattern involving it. Closing the N-D gap in
  `_handle_map` is left open — refusing costs nothing today, since the format
  mismatch meant N-D keys were never resolvable anyway.

## Verification

**Resolver audit** across all six importable resolvers, on shapes `(4,)`,
`(2,3)`, `(2,3,4)`, every positive and negative spelling; oracle is numpy's own
indexing of an `np.arange(size).reshape(shape)` probe (not a reimplementation):

```
RESOLUTIONS_CHECKED=54  WRONG=0  SOUND_MISSES=0
```

Before the fix, the two resolvers on the reproducer's path scored 7 wrong out of
18. `cut_recognizer._var_key` is audited separately since it returns a string:
`v[3] -> "v[3]"`, `v[-1] -> "v[3]"`, `w[0,1] -> None`, `w[0,2] -> None`.

**Unit** — `python/tests/test_941_flat_index.py`, 20 tests, exhaustive over the
three shapes above with the resolution count asserted (`assert checked == 224`)
so the suite cannot pass vacuously (§6).

**Solve-level** — `python/tests/test_941_negative_index_solve_equivalence.py`,
3 `slow` tests, **3 passed in 180.65 s**. Asserts the certificate *invariant*
rather than a fixed number, so it keeps its meaning as the solver improves;
re-verifies feasibility in plain numpy outside the solver; and includes an
anti-vacuity check that the bilinear pair `(1, 4)` really is catalogued and
`(0, 1)` — the aliasing onto `s` — is not. Node counts are deliberately not
compared: both arms are wall-clock limited, so their totals reflect machine
speed rather than the search.

**Regression sweep** — `pytest python/tests/ -m "not slow" -k "obbt or cutting
or sparsity or classifier or relaxation or term or cut_recog or mccormick"`:
**1281 passed, 1 skipped in 234.75 s** (exit 0).

**Smoke + adversarial** — `pytest -m smoke` **913 passed, 1 skipped, 2 xpassed in 107.54 s** (exit 0);
`pytest -m slow python/tests/test_adversarial_recent_fixes.py` **10 passed in
145.20 s** (exit 0). No Rust was touched, so `cargo test` was not required.

`ruff check python/` and `ruff format --check python/` clean; `mypy` clean on
the seven touched files (a whole-package run fails in this environment on a
numpy stub, `numpy/__init__.pyi:737: Type statement is only supported in
Python 3.12 and greater` — pre-existing and unrelated).

Closes #941

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GZrQpYYd9tbLnFEH8gZokP
