### PR TITLE
fix(correctness): #940 stop POUNCE returning points outside the declared box (bound_relax_factor)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -100,3 +100,4 @@ scratchpad/*_out*.txt
 scratchpad/*.log
 scratchpad/**/*_out*.txt
 scratchpad/**/*.log
+scratchpad/**/*.out

--- a/.gitignore
+++ b/.gitignore
@@ -98,3 +98,5 @@ docs/notebooks/*.xlsx
 # scratchpad run logs (keep the harnesses, drop the outputs)
 scratchpad/*_out*.txt
 scratchpad/*.log
+scratchpad/**/*_out*.txt
+scratchpad/**/*.log

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -44,7 +44,7 @@ from discopt.modeling.core import (
 from discopt.solver_tuning import current as _tuning
 from discopt.solver_tuning import reset_current as _reset_tuning
 from discopt.solver_tuning import set_current as _set_tuning
-from discopt.solvers import SolveStatus
+from discopt.solvers import POUNCE_BOUND_RELAX_FACTOR, SolveStatus
 
 # R3a measurement sink (temporary, behavior-neutral). When set to a mutable
 # dict by an experiment harness, the nonconvex B&B path stores the Rust tree's
@@ -15041,7 +15041,16 @@ def _solve_lp_pounce(
         return None
     # Request an infeasibility certificate so an infeasible model-level LP
     # surfaces *why* via SolveResult.infeasibility_certificate (roadmap P0.2).
-    solve_fn = functools.partial(_pounce_solve_lp, certificate=True)
+    # bound_relax_factor=0 is requested HERE, not as a backend default: it is this
+    # call site's point that _matrix_solution_feasible checks, and Ipopt's default
+    # 1e-8 relaxation is what puts that point outside the declared box (#940).
+    # Applied backend-wide it also reaches the Benders dual LP, where it costs
+    # convergence (2 correctness-lane tests, 1.6s -> 79s) — see #945.
+    solve_fn = functools.partial(
+        _pounce_solve_lp,
+        certificate=True,
+        options={"bound_relax_factor": POUNCE_BOUND_RELAX_FACTOR},
+    )
     # The IPM is the one backend that relaxes a declared [1e15, 1e20) bound to its
     # own infinity, so its UNBOUNDED is the verdict the #850 guard defers on.
     return _solve_lp_matrix(
@@ -15315,7 +15324,12 @@ def _solve_qp_pounce(
         return None
     if any(v.var_type in (VarType.BINARY, VarType.INTEGER) for v in model._variables):
         return None
-    solve_fn = functools.partial(_pounce_solve_qp, certificate=True)
+    # Same reasoning as _solve_lp_pounce: the guard checks THIS call site's point.
+    solve_fn = functools.partial(
+        _pounce_solve_qp,
+        certificate=True,
+        options={"bound_relax_factor": POUNCE_BOUND_RELAX_FACTOR},
+    )
     return _solve_qp_matrix(model, t_start, time_limit, solve_fn, "POUNCE")
 
 

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -14306,11 +14306,9 @@ def _solve_batch_pounce(
 
     # Batch-level options. Whitelist keys POUNCE understands and enforce the
     # per-node wall-time guard (issue #5) used by the serial pounce path.
-    # Seeded from the shared POUNCE baseline so this batch path keeps iterates
-    # inside their declared node box like every other entry point (#940).
-    from discopt.solvers import pounce_option_defaults
-
-    batch_opts: dict = pounce_option_defaults()
+    # Deliberately NOT seeded from solvers.pounce_option_defaults: this is the NLP
+    # batch path, and bound_relax_factor=0 there breaks OA/GDPopt gap closure (#945).
+    batch_opts: dict = {"print_level": 0}
     for k in ("max_iter", "tol", "acceptable_tol"):
         if options.get(k) is not None:
             batch_opts[k] = options[k]

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -15516,7 +15516,7 @@ def _matrix_solution_feasible(x, A_ub, b_ub, A_eq, b_eq, bounds, tol=1e-6, rtol=
     across ALL rows — which on a large-RHS row inflated the tolerance far past
     discopt's own constraint tolerance: for ``x <= 1e4`` the threshold became
     ``1e-6 * 1e4 = 1e-2``, so an interior-point primal sitting ``1e-4`` on the
-    infeasible side of the row (POUNCE's fixed Ipopt ``constr_viol_tol`` floor)
+    infeasible side of the row (POUNCE's default Ipopt ``constr_viol_tol``)
     was accepted as "optimal" — a super-optimal, constraint-infeasible incumbent
     (issue #850 Obs 3). With the per-row term scale that same point is rejected
     (threshold ``1e-6 + 1e-9*1e4 ≈ 1.1e-5``) and the caller degrades to the exact
@@ -15524,6 +15524,15 @@ def _matrix_solution_feasible(x, A_ub, b_ub, A_eq, b_eq, bounds, tol=1e-6, rtol=
     is kept extremely tight (1e-9) so only cancellation noise proportional to the
     row terms is forgiven; a gross mislabel (the ~7.5 HiGHS case) is still caught.
     A bound row ``lo <= x_i <= hi`` has term scale ``|x_i|`` (unit coefficient).
+
+    #940 correction: that ``1e-4`` was described here as POUNCE's *fixed* floor.
+    Measurement falsifies "fixed" — ``constr_viol_tol`` is settable and honored,
+    and the POUNCE LP/QP backends now request ``1e-9``
+    (:data:`discopt.solvers.lp_pounce._CONSTR_VIOL_TOL`) so their own convergence
+    criterion implies this test. Before that, the guard rejected 50% of POUNCE LP
+    solves — every correct one of them — because the two tolerances were three
+    orders apart. Nothing about THIS check changed: it is the arbiter, and a
+    point that fails it is still rejected however it was produced.
     """
     x = np.asarray(x, dtype=np.float64)
     if not np.all(np.isfinite(x)):

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -14306,7 +14306,11 @@ def _solve_batch_pounce(
 
     # Batch-level options. Whitelist keys POUNCE understands and enforce the
     # per-node wall-time guard (issue #5) used by the serial pounce path.
-    batch_opts: dict = {"print_level": 0}
+    # Seeded from the shared POUNCE baseline so this batch path keeps iterates
+    # inside their declared node box like every other entry point (#940).
+    from discopt.solvers import pounce_option_defaults
+
+    batch_opts: dict = pounce_option_defaults()
     for k in ("max_iter", "tol", "acceptable_tol"):
         if options.get(k) is not None:
             batch_opts[k] = options[k]

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -15525,14 +15525,26 @@ def _matrix_solution_feasible(x, A_ub, b_ub, A_eq, b_eq, bounds, tol=1e-6, rtol=
     row terms is forgiven; a gross mislabel (the ~7.5 HiGHS case) is still caught.
     A bound row ``lo <= x_i <= hi`` has term scale ``|x_i|`` (unit coefficient).
 
-    #940 correction: that ``1e-4`` was described here as POUNCE's *fixed* floor.
-    Measurement falsifies "fixed" — ``constr_viol_tol`` is settable and honored,
-    and the POUNCE LP/QP backends now request ``1e-9``
-    (:data:`discopt.solvers.lp_pounce._CONSTR_VIOL_TOL`) so their own convergence
-    criterion implies this test. Before that, the guard rejected 50% of POUNCE LP
-    solves — every correct one of them — because the two tolerances were three
-    orders apart. Nothing about THIS check changed: it is the arbiter, and a
-    point that fails it is still rejected however it was produced.
+    #940 correction: that ``1e-4`` was described here as POUNCE's *fixed*
+    ``constr_viol_tol`` floor. Measurement falsifies "fixed" — it is settable, and
+    on the published wheel it is honored, so the POUNCE backends request
+    ``1e-8`` (:data:`discopt.solvers.lp_pounce._CONSTR_VIOL_TOL`), two orders
+    under this test's ``1e-6``.
+
+    But that tolerance was never the whole story, and on current POUNCE it is not
+    even the operative half. The setting that actually put returned points on the
+    infeasible side of a row is Ipopt's ``bound_relax_factor`` (default 1e-8),
+    which relaxes bounds — including the slack bounds standing in for inequality
+    rows — by ``1e-8*(1 + |bound|)``. The engine then converges honestly, but to a
+    RELAXED box, so the violation grows with the data (~4.4e-6 at ``|b| ~ 440``,
+    ~4.4e-4 at ``|b| ~ 44000``) and no convergence tolerance can remove it.
+    :data:`discopt.solvers.lp_pounce._BOUND_RELAX_FACTOR` pins it to 0; that is the
+    line that makes this guard stop firing on correct solves. See
+    ``lp_pounce._CONSTR_VIOL_TOL`` for the per-build measurements — which of the
+    two mechanisms dominates depends on the POUNCE build, so both are set.
+
+    Nothing about THIS check changed: it is the arbiter, and a point that fails it
+    is still rejected however it was produced.
     """
     x = np.asarray(x, dtype=np.float64)
     if not np.all(np.isfinite(x)):

--- a/python/discopt/solvers/__init__.py
+++ b/python/discopt/solvers/__init__.py
@@ -140,3 +140,79 @@ class NLPResult:
     bound_multipliers_upper: Optional[np.ndarray] = None
     iterations: int = 0
     wall_time: float = 0.0
+
+
+# ---------------------------------------------------------------------------
+# Shared POUNCE/Ipopt option defaults (issue #940)
+# ---------------------------------------------------------------------------
+
+# Per-build measurement behind these two values (issue #940). A 49-LP battery
+# (n=5..40, data scale 1e0..1e7, plus the tutorial diet LP), counting rejections
+# by discopt's own feasibility guard / non-convergence, with EVERY arm pinning
+# BOTH options explicitly:
+#
+#                                  pounce @ main        PyPI 0.9.0
+#   POUNCE's own defaults          38 trips, 3 nonopt   23 trips, 3 nonopt
+#   constr_viol_tol=1e-8 alone     39 trips, 2 nonopt    0 trips, 3 nonopt
+#   bound_relax_factor=0 alone      0 trips, 2 nonopt    (not measured alone)
+#   BOTH (what ships)               0 trips, 2 nonopt    0 trips, 2 nonopt
+#
+# Which mechanism dominates depends on the build, so both are set:
+# constr_viol_tol carries the published wheel and is a no-op on main;
+# bound_relax_factor carries main. `pyproject.toml` admits `pounce-solver>=0.9`
+# while CI tracks `main`, so neither may be dropped on the grounds that the
+# other covers it. Naming only one in an experiment arm leaves the other at the
+# shipped value and silently mislabels the arm — that cost one round of this fix.
+#
+# The residual 2 non-convergences are pre-existing stalls at data scale ~1e7,
+# present under POUNCE's own defaults too. `constr_viol_tol=1e-12` was measured
+# and REJECTED: it reaches the tolerance but destroys convergence on main (18 of
+# 49 instances fail to reach OPTIMAL, against 2 at the default).
+#
+# None of this relaxes any discopt guard: the guards remain the arbiter
+# (CLAUDE.md §1), and a point that still fails one is still rejected.
+# Requested absolute cap on the max-norm of the UNSCALED constraint violation at
+# termination. POUNCE inherits Ipopt's default of 1e-4, two orders LOOSER than
+# discopt's own 1e-6 constraint tolerance
+# (``solver._matrix_solution_feasible``, ``_jax.primal_heuristics.
+# _check_constraint_feasibility``), so a converged point can sit 1e-4 on the
+# infeasible side of a row and still be reported OPTIMAL. Dominant on the
+# published pounce-solver wheel; a no-op on current ``main``.
+POUNCE_CONSTR_VIOL_TOL = 1e-8
+
+# Ipopt's ``bound_relax_factor`` (default 1e-8) deliberately relaxes every
+# bound — including the slack bounds standing in for inequality rows — by
+# ``1e-8*(1 + |bound|)``. The solve then converges honestly, but to a RELAXED
+# box, so the returned point sits OUTSIDE the box the caller declared and the
+# error grows with the data. That is what discopt's feasibility guards were
+# rejecting POUNCE points for, and no convergence tolerance can remove it: the
+# solver has already converged; the box it converged to is the wrong one.
+#
+# Pinning it to 0 keeps iterates inside the declared box. This matters well
+# beyond the LP/QP fast path — an NLP iterate stepping below a bound of 0 is
+# exactly how ``log``/``sqrt``/``1/x`` produce the NaN failures discopt warns
+# about — which is why it lives here rather than in one backend (CLAUDE.md §2:
+# fix the class, not the instance).
+POUNCE_BOUND_RELAX_FACTOR = 0.0
+
+
+def pounce_option_defaults() -> dict:
+    """discopt's baseline POUNCE options: quiet, and inside the declared box.
+
+    THE single source of truth, seeded at every site that hands options to
+    POUNCE. Seed it *before* merging a caller's options so an explicit request
+    still wins::
+
+        opts = pounce_option_defaults()
+        opts.update(caller_options or {})
+
+    Do not re-spell these values at a call site — a second copy is how one entry
+    point silently keeps Ipopt's defaults while the rest move (issue #940, where
+    patching the LP/QP entry points alone left the NLP path returning points
+    ~7.5e-9 below their declared lower bounds).
+    """
+    return {
+        "print_level": 0,
+        "constr_viol_tol": POUNCE_CONSTR_VIOL_TOL,
+        "bound_relax_factor": POUNCE_BOUND_RELAX_FACTOR,
+    }

--- a/python/discopt/solvers/__init__.py
+++ b/python/discopt/solvers/__init__.py
@@ -199,17 +199,25 @@ POUNCE_BOUND_RELAX_FACTOR = 0.0
 def pounce_option_defaults() -> dict:
     """discopt's baseline POUNCE options: quiet, and inside the declared box.
 
-    THE single source of truth, seeded at every site that hands options to
-    POUNCE. Seed it *before* merging a caller's options so an explicit request
-    still wins::
+    THE single source of truth for the **matrix-form** backends (``lp_pounce``,
+    ``qp_pounce``). Seed it *before* merging a caller's options so an explicit
+    request still wins::
 
         opts = pounce_option_defaults()
         opts.update(caller_options or {})
 
     Do not re-spell these values at a call site — a second copy is how one entry
-    point silently keeps Ipopt's defaults while the rest move (issue #940, where
-    patching the LP/QP entry points alone left the NLP path returning points
-    ~7.5e-9 below their declared lower bounds).
+    point silently keeps Ipopt's defaults while the rest move.
+
+    The NLP path (``nlp_pounce.solve_nlp``, and ``solver.py``'s batch path) does
+    NOT use this yet, and so still returns points up to ~7.5e-9 outside their
+    declared bounds. That is not an oversight: pinning ``bound_relax_factor`` to 0
+    there makes incumbents genuinely feasible, which turns ``incumbent - bound``
+    from ``<= 0`` into a small positive number and breaks 12 ``gap == 0 @ 1e-9``
+    assertions across OA / GDPopt / MindtPy parity — those expectations are
+    currently calibrated against a solver that returns slightly-infeasible
+    incumbents. Extending this seed to the NLP path is tracked in #945, together
+    with the gap-closure question it forces.
     """
     return {
         "print_level": 0,

--- a/python/discopt/solvers/__init__.py
+++ b/python/discopt/solvers/__init__.py
@@ -222,5 +222,4 @@ def pounce_option_defaults() -> dict:
     return {
         "print_level": 0,
         "constr_viol_tol": POUNCE_CONSTR_VIOL_TOL,
-        "bound_relax_factor": POUNCE_BOUND_RELAX_FACTOR,
     }

--- a/python/discopt/solvers/lp_pounce.py
+++ b/python/discopt/solvers/lp_pounce.py
@@ -22,7 +22,12 @@ from typing import Any, List, Optional, Tuple, Union, cast
 import numpy as np
 import scipy.sparse as sp
 
-from discopt.solvers import InfeasibilityCertificate, LPResult, SolveStatus
+from discopt.solvers import (
+    InfeasibilityCertificate,
+    LPResult,
+    SolveStatus,
+    pounce_option_defaults,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -48,68 +53,10 @@ _FEAS_TOL = 1e-6
 # them. Inversions beyond this tolerance are left intact so they surface as
 # genuine infeasibility rather than being masked.
 _BOUND_SNAP_TOL = 1e-7
-# Two option requests, targeting two DIFFERENT mechanisms by which POUNCE returns
-# a point that discopt then rejects. Which one dominates depends on the POUNCE
-# build, so both are set (issue #940).
-#
-# discopt checks every returned matrix-form point against its OWN per-row
-# constraint tolerance — ``solver._matrix_solution_feasible``, the #850 Obs 3
-# guard: ``|viol_i| <= 1e-6 + 1e-9 * sum_j |A_ij||x_j|``. When a returned point
-# misses that, the guard rejects a *correct* solve, logs a WARNING at the
-# ``_solve_lp_matrix`` call site and re-solves with the exact simplex.
-#
-# (1) ``bound_relax_factor = 0`` — THE ROOT CAUSE, and the one that matters on
-#     current POUNCE. Ipopt's default 1e-8 deliberately relaxes bounds — including
-#     the slack bounds standing in for inequality rows — by
-#     ``1e-8*(1 + |bound|)``. The iterate is then genuinely feasible for the
-#     RELAXED problem while sitting outside the declared one, and the violation
-#     grows in proportion to the data: with ``|b| ~ 440`` the relaxation is
-#     ~4.4e-6, with ``|b| ~ 44000`` it is ~4.4e-4. Measured on pounce @ main
-#     exactly that way — worst violation 8.1e-6 / 8.1e-5 / 8.1e-4 at data scale
-#     1e2 / 1e3 / 1e4, i.e. a constant ~8.1e-8 RELATIVE error. No convergence
-#     tolerance can fix this, because the solver has already converged; the box it
-#     converged to is the wrong one.
-#
-# (2) ``constr_viol_tol = 1e-8`` — the absolute cap on the max-norm of the
-#     unscaled constraint violation at termination. POUNCE inherits Ipopt's
-#     default of 1e-4, 100x LOOSER than the guard's 1e-6 floor. On PyPI 0.9.0
-#     this is the dominant term (violations pinned at a flat 1e-4) and this
-#     request alone fixes it; on pounce @ main it is a no-op, because there
-#     mechanism (1) dominates.
-#
-# Measured over a 49-LP battery (n=5..40, data scale 1e0..1e7, plus the tutorial
-# diet LP), on BOTH builds, counting guard trips / non-convergence / status
-# disagreement with the exact-simplex oracle:
-#
-#                                  pounce @ main        PyPI 0.9.0
-#   POUNCE's own defaults          38 trips, 3 nonopt   23 trips, 3 nonopt
-#   constr_viol_tol=1e-8 alone     39 trips, 2 nonopt    0 trips, 3 nonopt
-#   bound_relax_factor=0 alone      0 trips, 2 nonopt    (not measured alone)
-#   BOTH (what ships here)          0 trips, 2 nonopt    0 trips, 2 nonopt
-#
-# Every arm above pins BOTH options explicitly. Naming only one leaves the other
-# at this module's value, which silently turns a "POUNCE defaults" arm into
-# "defaults plus whatever we ship" — a mislabel that cost one round of this fix.
-#
-# The residual 2 non-convergences are the pre-existing scale-1e7 stalls present
-# under POUNCE's own defaults too (see _certify_unbounded_ray), not a cost of
-# these settings. ``constr_viol_tol=1e-12`` was measured and REJECTED: it reaches
-# the tolerance but destroys convergence on main (18 of 49 instances fail to reach
-# OPTIMAL, against 2 at the default).
-#
-# Do not drop either request on the grounds that the other covers it — they bind
-# on different builds, and ``pyproject.toml`` admits ``pounce-solver>=0.9`` while
-# CI tracks ``main``. The regression suite pins the *behaviour* (returned point
-# within discopt's tolerance), not these option names, so a future POUNCE that
-# changes which mechanism dominates fails loudly instead of silently regressing —
-# which is exactly how the ``constr_viol_tol``-only version of this fix was caught.
-#
-# Neither request relaxes the guard, which remains the arbiter (CLAUDE.md §1): a
-# point that still fails it is still rejected and the exact simplex still answers.
-# A caller's explicit options still win.
-_CONSTR_VIOL_TOL = 1e-8
-# Keep iterates inside the declared box; see (1) above.
-_BOUND_RELAX_FACTOR = 0.0
+# The POUNCE option baseline (constr_viol_tol, bound_relax_factor) lives in
+# :func:`discopt.solvers.pounce_option_defaults` — one source of truth shared
+# by every entry point that hands options to POUNCE. See the measurements and
+# the per-build analysis there (issue #940).
 
 
 # A recession direction must lower the objective by at least this much, relative
@@ -457,13 +404,9 @@ def solve_lp(
         x0 = _interior_start(lb, ub)
     x0 = np.asarray(x0, dtype=np.float64).ravel()
 
-    # Both requests go in before the caller's options so an explicit one still
-    # wins; see _CONSTR_VIOL_TOL for why these are not Ipopt's defaults (#940).
-    opts: dict[str, Any] = {
-        "print_level": 0,
-        "constr_viol_tol": _CONSTR_VIOL_TOL,
-        "bound_relax_factor": _BOUND_RELAX_FACTOR,
-    }
+    # Shared baseline first, so an explicit caller option still wins; see
+    # solvers.pounce_option_defaults for why these are not Ipopt's (#940).
+    opts: dict[str, Any] = pounce_option_defaults()
     if options:
         opts.update(options)
     if time_limit is not None:
@@ -550,7 +493,7 @@ def solve_lp_kkt(
     cu = b_arr.copy()
     x0 = _interior_start(lb, ub)
 
-    opts: dict[str, Any] = {"print_level": 0}
+    opts: dict[str, Any] = pounce_option_defaults()
     if options:
         opts.update(options)
 

--- a/python/discopt/solvers/lp_pounce.py
+++ b/python/discopt/solvers/lp_pounce.py
@@ -15,6 +15,7 @@ below expose exactly that to POUNCE.
 
 from __future__ import annotations
 
+import logging
 import time
 from typing import Any, List, Optional, Tuple, Union, cast
 
@@ -22,6 +23,8 @@ import numpy as np
 import scipy.sparse as sp
 
 from discopt.solvers import InfeasibilityCertificate, LPResult, SolveStatus
+
+logger = logging.getLogger(__name__)
 
 try:
     import pounce as _pounce  # noqa: F401
@@ -45,6 +48,99 @@ _FEAS_TOL = 1e-6
 # them. Inversions beyond this tolerance are left intact so they surface as
 # genuine infeasibility rather than being masked.
 _BOUND_SNAP_TOL = 1e-7
+# Requested absolute bound on the max-norm of the UNSCALED constraint violation
+# at termination (Ipopt's ``constr_viol_tol``, which POUNCE is shape-compatible
+# with).
+#
+# discopt checks every returned matrix-form point against its OWN per-row
+# constraint tolerance — ``solver._matrix_solution_feasible``, the #850 Obs 3
+# guard: ``|viol_i| <= 1e-6 + 1e-9 * sum_j |A_ij||x_j|``. POUNCE inherits Ipopt's
+# default ``constr_viol_tol`` of 1e-4, which is 100x LOOSER than that 1e-6 floor,
+# so a legitimately converged IPM point can sit up to 1e-4 on the infeasible side
+# of a row and still be reported OPTIMAL. On any LP whose rows carry term
+# magnitudes above a few hundred the guard then rejects a *correct* solve, logs a
+# WARNING at the ``_solve_lp_matrix`` call site and re-solves with the exact
+# simplex (issue #940). Measured over a 148-solve LP population: 50% of POUNCE LP
+# solves tripped the guard, and 100% of those with row term scale in [1e2, 1e5) —
+# the everyday range of a textbook diet/transport/blending LP, not an exotic
+# corner.
+#
+# Requesting 1e-8 makes POUNCE's own convergence criterion IMPLY discopt's: it
+# bounds exactly the quantity the guard measures, two orders of magnitude under
+# the guard's floor. Measured over 26 LPs spanning n=5..40 and data scale
+# 1e2..1e4: guard trips 24 -> 0, worst absolute violation 1.0e-4 -> 9.8e-9, with
+# the iteration count unchanged within noise (21.1 -> 21.3 mean iterations, so the
+# extra accuracy is not bought with extra work). The same request also pulls a
+# variable binding at a large bound back INSIDE its box (Ipopt's
+# ``bound_relax_factor`` slack stops showing up in the returned point), so no
+# separate bound-side option is needed.
+#
+# The value is a floor set by ATTAINABILITY, not by taste. A request must stay
+# above double-precision noise on the problem's own data, or POUNCE stops short of
+# it and exits with Ipopt code 3/4 — which ``_LP_STATUS_MAP`` reads as UNBOUNDED,
+# i.e. a FALSE certificate on a bounded LP. Sweeping the request against the exact
+# simplex oracle over data scales 1e0..1e8: every request down to 1e-10 is
+# reachable up to scale 1e4; 1e-9 already produces a false UNBOUNDED at scale 1e6
+# (n=40) where 1e-4 does not; 1e-8 reproduces the oracle everywhere the 1e-4
+# default does. Above scale ~1e7 POUNCE is erratic at EVERY request including its
+# own 1e-4 default — pre-existing, not caused by this setting, and now covered by
+# :func:`_reject_impossible_unbounded`, which refuses to dress that failure up as
+# a certificate. Do not tighten this past 1e-8 without re-running that sweep; the
+# margin under the guard is already 100x.
+#
+# This does NOT relax the guard, which remains the arbiter (CLAUDE.md §1): a
+# point that still fails it is still rejected and the exact simplex still
+# answers. A caller's explicit ``options["constr_viol_tol"]`` still wins.
+_CONSTR_VIOL_TOL = 1e-8
+
+
+def _box_is_compact(lb: np.ndarray, ub: np.ndarray) -> bool:
+    """Whether every variable is boxed between two finite bounds *as POUNCE sees
+    them* (i.e. after the ``[1e15, 1e20)`` relaxation to the ``_INF`` sentinel).
+
+    A linear (or convex quadratic) objective over a nonempty subset of a compact
+    box attains its minimum, so on such a box ``UNBOUNDED`` is not merely
+    unlikely — it is impossible. See :func:`solve_lp` for why that matters.
+    """
+    return bool(np.all(lb > -_INF) and np.all(ub < _INF))
+
+
+def _reject_impossible_unbounded(result: LPResult, lb: np.ndarray, ub: np.ndarray) -> LPResult:
+    """Refuse to report ``UNBOUNDED`` for a problem posed on a compact box.
+
+    POUNCE reaches ``UNBOUNDED`` through :data:`_LP_STATUS_MAP` from Ipopt codes
+    3 and 4 (``Search_Direction_Becomes_Too_Small`` / ``Diverging_Iterates``),
+    which are *ambiguous*: they say the interior-point iteration stalled or blew
+    up, not that the problem has a ray. ``solve_lp`` already disambiguates the
+    infeasible reading with an elastic Phase-1; this closes the remaining one.
+    When every declared bound is finite the feasible set lies inside a compact
+    box, so an unbounded ray cannot exist and the verdict is provably false —
+    it is a numerical failure wearing a certificate's clothes.
+
+    Measured (issue #940): on random LPs with data scale ~1e7 and an ordinary
+    ``[0, 1e8]`` box, POUNCE returns ``UNBOUNDED`` on ~4 of 10 instances whose
+    true status is ``optimal``, and because those bounds are far below the
+    ``[1e15, 1e20)`` window that triggers the #850 Obs 1 deferral,
+    ``solver._solve_lp_matrix`` certified it: ``model.solve()`` returned
+    ``status='unbounded'`` for an LP whose exact-simplex optimum is 6.5e7. This
+    predates the #940 tolerance change and occurs at POUNCE's own default
+    tolerance too — the change only shifts which instances land on it.
+
+    Reporting ``ERROR`` instead is the honest outcome: the engine could not
+    decide, the caller degrades to the exact simplex, and no false certificate
+    is ever produced (CLAUDE.md §1). A genuinely unbounded LP is untouched — it
+    has at least one infinite bound, so the box is not compact.
+    """
+    if result.status != SolveStatus.UNBOUNDED or not _box_is_compact(lb, ub):
+        return result
+    logger.debug(
+        "POUNCE reported UNBOUNDED on a compact box (every bound finite), which "
+        "is impossible; reporting ERROR so the caller degrades to the exact "
+        "simplex rather than certifying a false 'unbounded' (#940)."
+    )
+    return LPResult(
+        status=SolveStatus.ERROR, iterations=result.iterations, wall_time=result.wall_time
+    )
 
 
 def _snap_inverted_bounds(lb: np.ndarray, ub: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
@@ -253,7 +349,9 @@ def solve_lp(
         x0 = _interior_start(lb, ub)
     x0 = np.asarray(x0, dtype=np.float64).ravel()
 
-    opts: dict[str, Any] = {"print_level": 0}
+    # constr_viol_tol goes in before the caller's options so an explicit request
+    # still wins; see _CONSTR_VIOL_TOL for why the default is not Ipopt's (#940).
+    opts: dict[str, Any] = {"print_level": 0, "constr_viol_tol": _CONSTR_VIOL_TOL}
     if options:
         opts.update(options)
     if time_limit is not None:
@@ -291,7 +389,11 @@ def solve_lp(
         if slacks is not None and _is_infeasible_violation(slacks, cl, cu):
             result.infeasibility_certificate = _build_certificate(slacks, n_ineq)
 
-    return result
+    # Phase-1 above settles the "was it really infeasible?" reading of an
+    # ambiguous code-3/4 exit. This settles the other one: on a compact box an
+    # UNBOUNDED verdict is impossible, so it is a numerical failure, not a
+    # certificate (#940).
+    return _reject_impossible_unbounded(result, lb, ub)
 
 
 def solve_lp_kkt(

--- a/python/discopt/solvers/lp_pounce.py
+++ b/python/discopt/solvers/lp_pounce.py
@@ -48,50 +48,68 @@ _FEAS_TOL = 1e-6
 # them. Inversions beyond this tolerance are left intact so they surface as
 # genuine infeasibility rather than being masked.
 _BOUND_SNAP_TOL = 1e-7
-# Requested absolute bound on the max-norm of the UNSCALED constraint violation
-# at termination (Ipopt's ``constr_viol_tol``, which POUNCE is shape-compatible
-# with).
+# Two option requests, targeting two DIFFERENT mechanisms by which POUNCE returns
+# a point that discopt then rejects. Which one dominates depends on the POUNCE
+# build, so both are set (issue #940).
 #
 # discopt checks every returned matrix-form point against its OWN per-row
 # constraint tolerance — ``solver._matrix_solution_feasible``, the #850 Obs 3
-# guard: ``|viol_i| <= 1e-6 + 1e-9 * sum_j |A_ij||x_j|``. POUNCE inherits Ipopt's
-# default ``constr_viol_tol`` of 1e-4, which is 100x LOOSER than that 1e-6 floor,
-# so a legitimately converged IPM point can sit up to 1e-4 on the infeasible side
-# of a row and still be reported OPTIMAL. On any LP whose rows carry term
-# magnitudes above a few hundred the guard then rejects a *correct* solve, logs a
-# WARNING at the ``_solve_lp_matrix`` call site and re-solves with the exact
-# simplex (issue #940). Measured over a 148-solve LP population: 50% of POUNCE LP
-# solves tripped the guard, and 100% of those with row term scale in [1e2, 1e5) —
-# the everyday range of a textbook diet/transport/blending LP, not an exotic
-# corner.
+# guard: ``|viol_i| <= 1e-6 + 1e-9 * sum_j |A_ij||x_j|``. When a returned point
+# misses that, the guard rejects a *correct* solve, logs a WARNING at the
+# ``_solve_lp_matrix`` call site and re-solves with the exact simplex.
 #
-# Requesting 1e-8 makes POUNCE's own convergence criterion IMPLY discopt's: it
-# bounds exactly the quantity the guard measures, two orders of magnitude under
-# the guard's floor. Measured over 26 LPs spanning n=5..40 and data scale
-# 1e2..1e4: guard trips 24 -> 0, worst absolute violation 1.0e-4 -> 9.8e-9, with
-# the iteration count unchanged within noise (21.1 -> 21.3 mean iterations, so the
-# extra accuracy is not bought with extra work). The same request also pulls a
-# variable binding at a large bound back INSIDE its box (Ipopt's
-# ``bound_relax_factor`` slack stops showing up in the returned point), so no
-# separate bound-side option is needed.
+# (1) ``bound_relax_factor = 0`` — THE ROOT CAUSE, and the one that matters on
+#     current POUNCE. Ipopt's default 1e-8 deliberately relaxes bounds — including
+#     the slack bounds standing in for inequality rows — by
+#     ``1e-8*(1 + |bound|)``. The iterate is then genuinely feasible for the
+#     RELAXED problem while sitting outside the declared one, and the violation
+#     grows in proportion to the data: with ``|b| ~ 440`` the relaxation is
+#     ~4.4e-6, with ``|b| ~ 44000`` it is ~4.4e-4. Measured on pounce @ main
+#     exactly that way — worst violation 8.1e-6 / 8.1e-5 / 8.1e-4 at data scale
+#     1e2 / 1e3 / 1e4, i.e. a constant ~8.1e-8 RELATIVE error. No convergence
+#     tolerance can fix this, because the solver has already converged; the box it
+#     converged to is the wrong one.
 #
-# The value is a floor set by ATTAINABILITY, not by taste. A request must stay
-# above double-precision noise on the problem's own data, or POUNCE stops short of
-# it and exits with Ipopt code 3/4 — which ``_LP_STATUS_MAP`` reads as UNBOUNDED,
-# i.e. a FALSE certificate on a bounded LP. Sweeping the request against the exact
-# simplex oracle over data scales 1e0..1e8: every request down to 1e-10 is
-# reachable up to scale 1e4; 1e-9 already produces a false UNBOUNDED at scale 1e6
-# (n=40) where 1e-4 does not; 1e-8 reproduces the oracle everywhere the 1e-4
-# default does. Above scale ~1e7 POUNCE is erratic at EVERY request including its
-# own 1e-4 default — pre-existing, not caused by this setting, and now covered by
-# :func:`_reject_impossible_unbounded`, which refuses to dress that failure up as
-# a certificate. Do not tighten this past 1e-8 without re-running that sweep; the
-# margin under the guard is already 100x.
+# (2) ``constr_viol_tol = 1e-8`` — the absolute cap on the max-norm of the
+#     unscaled constraint violation at termination. POUNCE inherits Ipopt's
+#     default of 1e-4, 100x LOOSER than the guard's 1e-6 floor. On PyPI 0.9.0
+#     this is the dominant term (violations pinned at a flat 1e-4) and this
+#     request alone fixes it; on pounce @ main it is a no-op, because there
+#     mechanism (1) dominates.
 #
-# This does NOT relax the guard, which remains the arbiter (CLAUDE.md §1): a
-# point that still fails it is still rejected and the exact simplex still
-# answers. A caller's explicit ``options["constr_viol_tol"]`` still wins.
+# Measured over a 49-LP battery (n=5..40, data scale 1e0..1e7, plus the tutorial
+# diet LP), on BOTH builds, counting guard trips / non-convergence / status
+# disagreement with the exact-simplex oracle:
+#
+#                                  pounce @ main        PyPI 0.9.0
+#   POUNCE's own defaults          38 trips, 3 nonopt   23 trips, 3 nonopt
+#   constr_viol_tol=1e-8 alone     39 trips, 2 nonopt    0 trips, 3 nonopt
+#   bound_relax_factor=0 alone      0 trips, 2 nonopt    (not measured alone)
+#   BOTH (what ships here)          0 trips, 2 nonopt    0 trips, 2 nonopt
+#
+# Every arm above pins BOTH options explicitly. Naming only one leaves the other
+# at this module's value, which silently turns a "POUNCE defaults" arm into
+# "defaults plus whatever we ship" — a mislabel that cost one round of this fix.
+#
+# The residual 2 non-convergences are the pre-existing scale-1e7 stalls present
+# under POUNCE's own defaults too (see _certify_unbounded_ray), not a cost of
+# these settings. ``constr_viol_tol=1e-12`` was measured and REJECTED: it reaches
+# the tolerance but destroys convergence on main (18 of 49 instances fail to reach
+# OPTIMAL, against 2 at the default).
+#
+# Do not drop either request on the grounds that the other covers it — they bind
+# on different builds, and ``pyproject.toml`` admits ``pounce-solver>=0.9`` while
+# CI tracks ``main``. The regression suite pins the *behaviour* (returned point
+# within discopt's tolerance), not these option names, so a future POUNCE that
+# changes which mechanism dominates fails loudly instead of silently regressing —
+# which is exactly how the ``constr_viol_tol``-only version of this fix was caught.
+#
+# Neither request relaxes the guard, which remains the arbiter (CLAUDE.md §1): a
+# point that still fails it is still rejected and the exact simplex still answers.
+# A caller's explicit options still win.
 _CONSTR_VIOL_TOL = 1e-8
+# Keep iterates inside the declared box; see (1) above.
+_BOUND_RELAX_FACTOR = 0.0
 
 
 # A recession direction must lower the objective by at least this much, relative
@@ -429,9 +447,13 @@ def solve_lp(
         x0 = _interior_start(lb, ub)
     x0 = np.asarray(x0, dtype=np.float64).ravel()
 
-    # constr_viol_tol goes in before the caller's options so an explicit request
-    # still wins; see _CONSTR_VIOL_TOL for why the default is not Ipopt's (#940).
-    opts: dict[str, Any] = {"print_level": 0, "constr_viol_tol": _CONSTR_VIOL_TOL}
+    # Both requests go in before the caller's options so an explicit one still
+    # wins; see _CONSTR_VIOL_TOL for why these are not Ipopt's defaults (#940).
+    opts: dict[str, Any] = {
+        "print_level": 0,
+        "constr_viol_tol": _CONSTR_VIOL_TOL,
+        "bound_relax_factor": _BOUND_RELAX_FACTOR,
+    }
     if options:
         opts.update(options)
     if time_limit is not None:

--- a/python/discopt/solvers/lp_pounce.py
+++ b/python/discopt/solvers/lp_pounce.py
@@ -94,49 +94,129 @@ _BOUND_SNAP_TOL = 1e-7
 _CONSTR_VIOL_TOL = 1e-8
 
 
-def _box_is_compact(lb: np.ndarray, ub: np.ndarray) -> bool:
-    """Whether every variable is boxed between two finite bounds *as POUNCE sees
-    them* (i.e. after the ``[1e15, 1e20)`` relaxation to the ``_INF`` sentinel).
-
-    A linear (or convex quadratic) objective over a nonempty subset of a compact
-    box attains its minimum, so on such a box ``UNBOUNDED`` is not merely
-    unlikely — it is impossible. See :func:`solve_lp` for why that matters.
-    """
-    return bool(np.all(lb > -_INF) and np.all(ub < _INF))
+# A recession direction must lower the objective by at least this much, relative
+# to the cost vector's magnitude, before ``UNBOUNDED`` is certified. The ray LP's
+# directions are normalized to the unit box, so a genuine ray registers as an
+# O(|c|) drop while interior-point noise registers near zero. Erring toward NOT
+# certifying is the safe direction: the caller then degrades to the exact simplex.
+_RAY_COST_TOL = 1e-7
 
 
-def _reject_impossible_unbounded(result: LPResult, lb: np.ndarray, ub: np.ndarray) -> LPResult:
-    """Refuse to report ``UNBOUNDED`` for a problem posed on a compact box.
+def _certify_unbounded_ray(
+    c: np.ndarray,
+    A: np.ndarray,
+    cl: np.ndarray,
+    cu: np.ndarray,
+    lb: np.ndarray,
+    ub: np.ndarray,
+    opts: dict,
+    Q: Optional[np.ndarray] = None,
+) -> bool:
+    """Whether a genuine improving recession direction exists — an *earned*
+    ``UNBOUNDED``, rather than one inferred from a numerical-failure code.
 
     POUNCE reaches ``UNBOUNDED`` through :data:`_LP_STATUS_MAP` from Ipopt codes
-    3 and 4 (``Search_Direction_Becomes_Too_Small`` / ``Diverging_Iterates``),
-    which are *ambiguous*: they say the interior-point iteration stalled or blew
-    up, not that the problem has a ray. ``solve_lp`` already disambiguates the
-    infeasible reading with an elastic Phase-1; this closes the remaining one.
-    When every declared bound is finite the feasible set lies inside a compact
-    box, so an unbounded ray cannot exist and the verdict is provably false —
-    it is a numerical failure wearing a certificate's clothes.
+    3 and 4 (``Search_Direction_Becomes_Too_Small`` / ``Diverging_Iterates``).
+    Those codes are *ambiguous*: they report that the interior-point iteration
+    stalled or blew up, not that the problem has a ray. POUNCE never claims
+    unboundedness — that inference was discopt's, and it is unsound. Measured
+    (issue #940): on random LPs of data magnitude ~1e7 over an ordinary
+    ``[0, 1e8]`` box, ~4 in 10 instances whose true status is ``optimal`` exit
+    this way, and 42 of 90 do so on a box carrying one infinite bound, where the
+    objective is ``min c'x`` with ``c >= 0, x >= 0`` and therefore cannot decrease
+    along any ray by construction. Those bounds sit far below the
+    ``[1e15, 1e20)`` window of the #850 Obs 1 deferral, so
+    ``solver._solve_lp_matrix`` certified the verdict: ``model.solve()`` returned
+    ``status='unbounded'`` for an LP whose exact optimum is 5.1e7.
 
-    Measured (issue #940): on random LPs with data scale ~1e7 and an ordinary
-    ``[0, 1e8]`` box, POUNCE returns ``UNBOUNDED`` on ~4 of 10 instances whose
-    true status is ``optimal``, and because those bounds are far below the
-    ``[1e15, 1e20)`` window that triggers the #850 Obs 1 deferral,
-    ``solver._solve_lp_matrix`` certified it: ``model.solve()`` returned
-    ``status='unbounded'`` for an LP whose exact-simplex optimum is 6.5e7. This
-    predates the #940 tolerance change and occurs at POUNCE's own default
-    tolerance too — the change only shifts which instances land on it.
+    Rather than drop the verdict (which would cost the Benders dual seam its
+    feasibility-cut signal, where an unbounded dual is the normal case), settle it
+    exactly. ``solve_lp``'s elastic Phase-1 has already established feasibility on
+    this path, and a feasible LP is unbounded **iff** its recession cone contains
+    a direction of strictly negative cost. That cone is described by the same data:
 
-    Reporting ``ERROR`` instead is the honest outcome: the engine could not
-    decide, the caller degrades to the exact simplex, and no false certificate
-    is ever produced (CLAUDE.md §1). A genuinely unbounded LP is untouched — it
-    has at least one infinite bound, so the box is not compact.
+        min  c'd   s.t.   (A d)_i <= 0 where cu_i is finite,
+                          (A d)_i >= 0 where cl_i is finite,
+                          d_j >= 0 where lb_j is finite,
+                          d_j <= 0 where ub_j is finite,
+                          -1 <= d <= 1                        (normalization)
+
+    which is itself always feasible (``d = 0``) and bounded, so it is a far easier
+    solve than the one that just failed. A strictly negative optimum exhibits the
+    ray and ``x + t·d`` stays feasible for every ``t >= 0``, certifying
+    unboundedness; anything else means the exit was numerical and the caller
+    should degrade to the exact simplex.
+
+    ``Q`` extends this to a convex QP: along ``d`` the objective is
+    ``½t²·d'Qd + t·(c'd + x'Qd)``, so it can only fall without bound when
+    ``d'Qd = 0``, which for positive-semidefinite ``Q`` is equivalent to
+    ``Qd = 0`` — added here as equality rows.
+
+    Returns ``False`` whenever the ray LP does not itself reach a clean optimum,
+    so an undecidable case never becomes a certificate (CLAUDE.md §1).
     """
-    if result.status != SolveStatus.UNBOUNDED or not _box_is_compact(lb, ub):
+    n = len(c)
+    finite_lo = lb > -_INF
+    finite_hi = ub < _INF
+    # Directions live in the unit box, tightened to a half-line (or to {0}) by
+    # whichever variable bounds are finite.
+    d_lo = np.where(finite_lo, 0.0, -1.0)
+    d_hi = np.where(finite_hi, 0.0, 1.0)
+    if not np.any(d_lo < 0.0) and not np.any(d_hi > 0.0):
+        return False  # compact box: the only recession direction is d = 0
+
+    rows = [A]
+    row_lo = [np.where(cl > -_INF, 0.0, -_INF)]
+    row_hi = [np.where(cu < _INF, 0.0, _INF)]
+    if Q is not None:
+        rows.append(np.asarray(Q, dtype=np.float64).reshape(n, n))
+        row_lo.append(np.zeros(n))
+        row_hi.append(np.zeros(n))
+    A_ray = np.vstack(rows) if rows[0].shape[0] or len(rows) > 1 else np.empty((0, n))
+    cl_ray = np.concatenate(row_lo)
+    cu_ray = np.concatenate(row_hi)
+
+    res = _solve_core(
+        np.asarray(c, dtype=np.float64),
+        A_ray,
+        cl_ray,
+        cu_ray,
+        d_lo,
+        d_hi,
+        np.zeros(n),
+        opts,
+    )
+    if res.status != SolveStatus.OPTIMAL or res.objective is None:
+        return False
+    threshold = -_RAY_COST_TOL * max(1.0, float(np.max(np.abs(c))) if n else 1.0)
+    return bool(res.objective < threshold)
+
+
+def _settle_ambiguous_unbounded(
+    result: LPResult,
+    c: np.ndarray,
+    A: np.ndarray,
+    cl: np.ndarray,
+    cu: np.ndarray,
+    lb: np.ndarray,
+    ub: np.ndarray,
+    opts: dict,
+) -> LPResult:
+    """Keep ``UNBOUNDED`` only when :func:`_certify_unbounded_ray` exhibits a ray.
+
+    Reporting ``ERROR`` otherwise is the honest outcome: the engine could not
+    decide, the caller degrades to the exact simplex, and no false certificate is
+    produced (#940).
+    """
+    if result.status != SolveStatus.UNBOUNDED:
+        return result
+    if _certify_unbounded_ray(c, A, cl, cu, lb, ub, opts):
         return result
     logger.debug(
-        "POUNCE reported UNBOUNDED on a compact box (every bound finite), which "
-        "is impossible; reporting ERROR so the caller degrades to the exact "
-        "simplex rather than certifying a false 'unbounded' (#940)."
+        "POUNCE exited with an ambiguous Ipopt code 3/4 and no improving recession "
+        "direction exists, so the problem is not unbounded; reporting ERROR so the "
+        "caller degrades to the exact simplex rather than certifying a false "
+        "'unbounded' (#940)."
     )
     return LPResult(
         status=SolveStatus.ERROR, iterations=result.iterations, wall_time=result.wall_time
@@ -389,11 +469,11 @@ def solve_lp(
         if slacks is not None and _is_infeasible_violation(slacks, cl, cu):
             result.infeasibility_certificate = _build_certificate(slacks, n_ineq)
 
-    # Phase-1 above settles the "was it really infeasible?" reading of an
-    # ambiguous code-3/4 exit. This settles the other one: on a compact box an
-    # UNBOUNDED verdict is impossible, so it is a numerical failure, not a
-    # certificate (#940).
-    return _reject_impossible_unbounded(result, lb, ub)
+    # Phase-1 above settles the "was it really infeasible?" reading of an ambiguous
+    # code-3/4 exit. This settles the other one: UNBOUNDED survives only if a ray
+    # is actually exhibited, so the certificate is earned rather than inferred from
+    # a numerical-failure code (#940).
+    return _settle_ambiguous_unbounded(result, c_arr, A, cl, cu, lb, ub, opts)
 
 
 def solve_lp_kkt(

--- a/python/discopt/solvers/lp_pounce.py
+++ b/python/discopt/solvers/lp_pounce.py
@@ -149,9 +149,9 @@ def _certify_unbounded_ray(
 
     Rather than drop the verdict (which would cost the Benders dual seam its
     feasibility-cut signal, where an unbounded dual is the normal case), settle it
-    exactly. ``solve_lp``'s elastic Phase-1 has already established feasibility on
-    this path, and a feasible LP is unbounded **iff** its recession cone contains
-    a direction of strictly negative cost. That cone is described by the same data:
+    with the recession cone: a **feasible** LP is unbounded **iff** its recession
+    cone contains a direction of strictly negative cost. That cone is described by
+    the same data:
 
         min  c'd   s.t.   (A d)_i <= 0 where cu_i is finite,
                           (A d)_i >= 0 where cl_i is finite,
@@ -164,6 +164,16 @@ def _certify_unbounded_ray(
     ray and ``x + t·d`` stays feasible for every ``t >= 0``, certifying
     unboundedness; anything else means the exit was numerical and the caller
     should degrade to the exact simplex.
+
+    On the feasibility hypothesis of that "iff": ``solve_lp``'s elastic Phase-1
+    establishes it on the paths where Phase-1 actually runs — ``m > 0`` and the
+    Phase-1 solve itself returning slacks. It is *not* established when there are
+    no constraint rows at all, or when that solve fails and returns ``None``
+    (``qp_pounce.solve_qp`` has the identical structure). That gap costs nothing,
+    because this test is one-directional: it can only ever WITHDRAW an ``UNBOUNDED``
+    verdict, never add one. An infeasible LP that happens to own a recession ray
+    keeps whatever verdict it already had, so an unestablished premise costs a
+    certificate, never soundness.
 
     ``Q`` extends this to a convex QP: along ``d`` the objective is
     ``½t²·d'Qd + t·(c'd + x'Qd)``, so it can only fall without bound when

--- a/python/discopt/solvers/nlp_pounce.py
+++ b/python/discopt/solvers/nlp_pounce.py
@@ -71,15 +71,17 @@ def solve_nlp(
 
     import pounce
 
-    # discopt's shared POUNCE baseline, seeded BEFORE the caller's options so an
-    # explicit request still wins. Chiefly this pins bound_relax_factor=0 so a
-    # returned NLP point stays inside its declared box — patching only the LP/QP
-    # entry points left this path handing back points ~7.5e-9 below their lower
-    # bounds (issue #940). See solvers.pounce_option_defaults.
-    from discopt.solvers import pounce_option_defaults
-
-    opts = pounce_option_defaults()
-    opts.update(dict(options) if options else {})
+    opts = dict(options) if options else {}
+    opts.setdefault("print_level", 0)
+    # NOT seeded from solvers.pounce_option_defaults yet. This path returns points
+    # up to ~7.5e-9 OUTSIDE their declared bounds (Ipopt's bound_relax_factor),
+    # measured in #940 — but pinning that to 0 here makes incumbents genuinely
+    # feasible, which turns `incumbent - bound` from <=0 into a small positive
+    # number and breaks 12 `gap == 0 @ 1e-9` assertions across OA / GDPopt /
+    # MindtPy parity. Those expectations are currently calibrated against a solver
+    # that returns slightly-infeasible incumbents; correcting that is a
+    # certification-semantics change needing its own differential panel. Tracked
+    # in #945 with the full attribution.
 
     n = evaluator.n_variables
     m = evaluator.n_constraints

--- a/python/discopt/solvers/nlp_pounce.py
+++ b/python/discopt/solvers/nlp_pounce.py
@@ -71,8 +71,15 @@ def solve_nlp(
 
     import pounce
 
-    opts = dict(options) if options else {}
-    opts.setdefault("print_level", 0)
+    # discopt's shared POUNCE baseline, seeded BEFORE the caller's options so an
+    # explicit request still wins. Chiefly this pins bound_relax_factor=0 so a
+    # returned NLP point stays inside its declared box — patching only the LP/QP
+    # entry points left this path handing back points ~7.5e-9 below their lower
+    # bounds (issue #940). See solvers.pounce_option_defaults.
+    from discopt.solvers import pounce_option_defaults
+
+    opts = pounce_option_defaults()
+    opts.update(dict(options) if options else {})
 
     n = evaluator.n_variables
     m = evaluator.n_constraints

--- a/python/discopt/solvers/qp_pounce.py
+++ b/python/discopt/solvers/qp_pounce.py
@@ -35,6 +35,7 @@ import scipy.sparse as sp
 
 from discopt.solvers import QPResult, SolveStatus
 from discopt.solvers.lp_pounce import (
+    _BOUND_RELAX_FACTOR,
     _CONSTR_VIOL_TOL,
     _FINITE_BOUND_THRESHOLD,
     _INF,
@@ -152,14 +153,16 @@ def solve_qp(
         x0 = _interior_start(lb, ub)
     x0 = np.asarray(x0, dtype=np.float64).ravel()
 
-    # Same constraint-tolerance mismatch as the LP path, and the same fix: the QP
-    # point is checked by the SAME #850 guard (``_matrix_solution_feasible``, via
-    # ``solver._solve_qp_matrix``), so POUNCE's default 1e-4 constr_viol_tol lets
-    # a converged QP point be rejected on any row with a term scale above a few
-    # hundred. Measured on 18 convex QPs (n=5..20, data scale 1e2..1e4): guard
-    # trips 4 -> 0, worst absolute violation 1.0e-4 -> 9.9e-9 (issue #940).
-    # See lp_pounce._CONSTR_VIOL_TOL. A caller's explicit option still wins.
-    opts: dict[str, Any] = {"print_level": 0, "constr_viol_tol": _CONSTR_VIOL_TOL}
+    # The QP point is checked by the SAME #850 guard (``_matrix_solution_feasible``,
+    # via ``solver._solve_qp_matrix``), so it needs the same two requests as the LP
+    # path and for the same two reasons — see lp_pounce._CONSTR_VIOL_TOL. Measured
+    # on 18 convex QPs (n=5..20, data scale 1e2..1e4): guard trips 4 -> 0 (#940).
+    # A caller's explicit options still win.
+    opts: dict[str, Any] = {
+        "print_level": 0,
+        "constr_viol_tol": _CONSTR_VIOL_TOL,
+        "bound_relax_factor": _BOUND_RELAX_FACTOR,
+    }
     if options:
         opts.update(options)
     if time_limit is not None:

--- a/python/discopt/solvers/qp_pounce.py
+++ b/python/discopt/solvers/qp_pounce.py
@@ -41,8 +41,8 @@ from discopt.solvers.lp_pounce import (
     _LP_STATUS_MAP,
     POUNCE_AVAILABLE,
     PounceKKTError,
-    _box_is_compact,
     _build_certificate,
+    _certify_unbounded_ray,
     _interior_start,
     _is_infeasible_violation,
     _phase1_min_violation,
@@ -190,12 +190,17 @@ def solve_qp(
         if slacks is not None and _is_infeasible_violation(slacks, cl, cu):
             result.infeasibility_certificate = _build_certificate(slacks, n_ineq)
 
-    # Same reasoning as the LP path (see lp_pounce._reject_impossible_unbounded):
-    # a continuous objective over a nonempty subset of a compact box attains its
-    # minimum, so UNBOUNDED on a fully bounded box is a numerical failure wearing
-    # a certificate's clothes, not a certificate. Spelled out here rather than
-    # reusing the LP helper because the result type differs (#940).
-    if result.status == SolveStatus.UNBOUNDED and _box_is_compact(lb, ub):
+    # Same reasoning as the LP path (see lp_pounce._certify_unbounded_ray): Ipopt
+    # codes 3/4 report a stalled or diverging iteration, not a ray, so UNBOUNDED
+    # survives only when a genuine improving recession direction is exhibited.
+    # Passing ``Q`` adds the ``Qd = 0`` rows that make the test exact for a convex
+    # QP — along ``d`` the objective is ``½t²·d'Qd + t·(c'd + x'Qd)``, so it can
+    # only fall without bound when ``d'Qd = 0``, equivalently ``Qd = 0`` for PSD
+    # ``Q``. Spelled out here rather than reusing the LP wrapper because the result
+    # type differs and the quadratic term has to be threaded through (#940).
+    if result.status == SolveStatus.UNBOUNDED and not _certify_unbounded_ray(
+        c_arr, A, cl, cu, lb, ub, opts, Q=Q_arr
+    ):
         return QPResult(
             status=SolveStatus.ERROR, iterations=result.iterations, wall_time=result.wall_time
         )

--- a/python/discopt/solvers/qp_pounce.py
+++ b/python/discopt/solvers/qp_pounce.py
@@ -35,11 +35,13 @@ import scipy.sparse as sp
 
 from discopt.solvers import QPResult, SolveStatus
 from discopt.solvers.lp_pounce import (
+    _CONSTR_VIOL_TOL,
     _FINITE_BOUND_THRESHOLD,
     _INF,
     _LP_STATUS_MAP,
     POUNCE_AVAILABLE,
     PounceKKTError,
+    _box_is_compact,
     _build_certificate,
     _interior_start,
     _is_infeasible_violation,
@@ -150,7 +152,14 @@ def solve_qp(
         x0 = _interior_start(lb, ub)
     x0 = np.asarray(x0, dtype=np.float64).ravel()
 
-    opts: dict[str, Any] = {"print_level": 0}
+    # Same constraint-tolerance mismatch as the LP path, and the same fix: the QP
+    # point is checked by the SAME #850 guard (``_matrix_solution_feasible``, via
+    # ``solver._solve_qp_matrix``), so POUNCE's default 1e-4 constr_viol_tol lets
+    # a converged QP point be rejected on any row with a term scale above a few
+    # hundred. Measured on 18 convex QPs (n=5..20, data scale 1e2..1e4): guard
+    # trips 4 -> 0, worst absolute violation 1.0e-4 -> 9.9e-9 (issue #940).
+    # See lp_pounce._CONSTR_VIOL_TOL. A caller's explicit option still wins.
+    opts: dict[str, Any] = {"print_level": 0, "constr_viol_tol": _CONSTR_VIOL_TOL}
     if options:
         opts.update(options)
     if time_limit is not None:
@@ -180,6 +189,16 @@ def solve_qp(
         slacks = _phase1_min_violation(A, cl, cu, lb, ub, opts)
         if slacks is not None and _is_infeasible_violation(slacks, cl, cu):
             result.infeasibility_certificate = _build_certificate(slacks, n_ineq)
+
+    # Same reasoning as the LP path (see lp_pounce._reject_impossible_unbounded):
+    # a continuous objective over a nonempty subset of a compact box attains its
+    # minimum, so UNBOUNDED on a fully bounded box is a numerical failure wearing
+    # a certificate's clothes, not a certificate. Spelled out here rather than
+    # reusing the LP helper because the result type differs (#940).
+    if result.status == SolveStatus.UNBOUNDED and _box_is_compact(lb, ub):
+        return QPResult(
+            status=SolveStatus.ERROR, iterations=result.iterations, wall_time=result.wall_time
+        )
 
     return result
 

--- a/python/discopt/solvers/qp_pounce.py
+++ b/python/discopt/solvers/qp_pounce.py
@@ -33,10 +33,8 @@ from typing import Any, List, Optional, Tuple, Union
 import numpy as np
 import scipy.sparse as sp
 
-from discopt.solvers import QPResult, SolveStatus
+from discopt.solvers import QPResult, SolveStatus, pounce_option_defaults
 from discopt.solvers.lp_pounce import (
-    _BOUND_RELAX_FACTOR,
-    _CONSTR_VIOL_TOL,
     _FINITE_BOUND_THRESHOLD,
     _INF,
     _LP_STATUS_MAP,
@@ -154,15 +152,11 @@ def solve_qp(
     x0 = np.asarray(x0, dtype=np.float64).ravel()
 
     # The QP point is checked by the SAME #850 guard (``_matrix_solution_feasible``,
-    # via ``solver._solve_qp_matrix``), so it needs the same two requests as the LP
-    # path and for the same two reasons — see lp_pounce._CONSTR_VIOL_TOL. Measured
-    # on 18 convex QPs (n=5..20, data scale 1e2..1e4): guard trips 4 -> 0 (#940).
+    # via ``solver._solve_qp_matrix``), so it takes the shared POUNCE baseline like
+    # every other entry point — see solvers.pounce_option_defaults. Measured on 18
+    # convex QPs (n=5..20, data scale 1e2..1e4): guard trips 4 -> 0 (#940).
     # A caller's explicit options still win.
-    opts: dict[str, Any] = {
-        "print_level": 0,
-        "constr_viol_tol": _CONSTR_VIOL_TOL,
-        "bound_relax_factor": _BOUND_RELAX_FACTOR,
-    }
+    opts: dict[str, Any] = pounce_option_defaults()
     if options:
         opts.update(options)
     if time_limit is not None:
@@ -254,7 +248,7 @@ def solve_qp_kkt(
     cu = b_arr.copy()
     x0 = _interior_start(lb, ub)
 
-    opts: dict[str, Any] = {"print_level": 0}
+    opts: dict[str, Any] = pounce_option_defaults()
     if options:
         opts.update(options)
 

--- a/python/tests/test_940_pounce_lp_constraint_tolerance.py
+++ b/python/tests/test_940_pounce_lp_constraint_tolerance.py
@@ -41,7 +41,7 @@ import discopt.modeling as dm  # noqa: E402
 import numpy as np  # noqa: E402
 import pytest  # noqa: E402
 from discopt.solver import _matrix_solution_feasible  # noqa: E402
-from discopt.solvers import SolveStatus  # noqa: E402
+from discopt.solvers import POUNCE_BOUND_RELAX_FACTOR, SolveStatus  # noqa: E402
 from discopt.solvers.lp_pounce import POUNCE_AVAILABLE  # noqa: E402
 
 pytestmark = pytest.mark.skipif(not POUNCE_AVAILABLE, reason="pounce not installed")
@@ -69,6 +69,32 @@ def _diet_matrices():
     return c, -A, -req, [(0.0, 10.0)] * 5
 
 
+def _model_from_matrices(c, A_ub, b_ub, bounds, name="m940"):
+    """Build a `dm.Model` equivalent to ``min cᵀx s.t. A_ub x ≤ b_ub, bounds``.
+
+    The tests below go through ``model.solve()`` deliberately. ``bound_relax_factor``
+    is requested by the model-level POUNCE call sites (``solver._solve_lp_pounce`` /
+    ``_solve_qp_pounce``) rather than as a backend-wide default, because those are
+    the call sites whose points ``_matrix_solution_feasible`` checks — and applying
+    it backend-wide reaches the Benders dual LP, where it costs convergence (#945).
+    So calling the backend directly would test a different contract than the one
+    #940 is about.
+    """
+    n = len(c)
+    m = dm.Model(name)
+    lo = float(bounds[0][0])
+    hi = float(bounds[0][1])
+    x = m.continuous("x", shape=(n,), lb=lo, ub=hi)
+    m.minimize(dm.sum(lambda j: float(c[j]) * x[j], over=range(n)))
+    for i in range(A_ub.shape[0]):
+        row = A_ub[i]
+        m.subject_to(
+            dm.sum(lambda j: float(row[j]) * x[j], over=range(n)) <= float(b_ub[i]),
+            name=f"r{i}",
+        )
+    return m, x
+
+
 def _worst_violation(x, A_ub, b_ub, bounds):
     """Max absolute amount by which ``x`` breaks a row or a bound."""
     x = np.asarray(x, dtype=np.float64)
@@ -79,17 +105,17 @@ def _worst_violation(x, A_ub, b_ub, bounds):
 
 
 def test_pounce_lp_point_meets_discopt_constraint_tolerance():
-    """POUNCE's own LP convergence must imply discopt's constraint tolerance."""
-    from discopt.solvers.lp_pounce import solve_lp
-
+    """The model-level LP fast path must return a point discopt's guard accepts."""
     c, A_ub, b_ub, bounds = _diet_matrices()
-    res = solve_lp(c=c, A_ub=A_ub, b_ub=b_ub, bounds=bounds)
+    model, x = _model_from_matrices(c, A_ub, b_ub, bounds, name="diet940")
+    res = model.solve(nlp_solver="pounce")
 
-    assert res.status == SolveStatus.OPTIMAL
-    worst = _worst_violation(res.x, A_ub, b_ub, bounds)
+    assert res.status == "optimal"
+    sol = np.asarray(res.value(x), dtype=np.float64).ravel()
+    worst = _worst_violation(sol, A_ub, b_ub, bounds)
     # Pre-fix this is ~5.8e-6 (and up to Ipopt's 1e-4 default on other data).
     assert worst <= DISCOPT_CONSTR_TOL, f"worst violation {worst:.3e} exceeds 1e-6"
-    assert _matrix_solution_feasible(res.x, A_ub, b_ub, None, None, bounds)
+    assert _matrix_solution_feasible(sol, A_ub, b_ub, None, None, bounds)
 
 
 @pytest.mark.parametrize("scale", [1e2, 1e3, 1e4])
@@ -99,8 +125,6 @@ def test_pounce_lp_guard_holds_across_data_scales(scale):
     Pre-fix, 100% of solves with row term scale in ``[1e2, 1e5)`` tripped it;
     this is the general statement, not the tutorial instance.
     """
-    from discopt.solvers.lp_pounce import solve_lp
-
     rng = np.random.default_rng(940)
     n, m = 20, 10
     A_ub = -np.abs(rng.uniform(0.5, 5.0, size=(m, n)))
@@ -108,11 +132,13 @@ def test_pounce_lp_guard_holds_across_data_scales(scale):
     c = np.abs(rng.uniform(1.0, 10.0, size=n))
     bounds = [(0.0, 10.0 * scale)] * n
 
-    res = solve_lp(c=c, A_ub=A_ub, b_ub=b_ub, bounds=bounds)
-    assert res.status == SolveStatus.OPTIMAL
-    assert _matrix_solution_feasible(res.x, A_ub, b_ub, None, None, bounds), (
-        f"guard rejected a converged POUNCE LP point at data scale {scale:g}; "
-        f"worst violation {_worst_violation(res.x, A_ub, b_ub, bounds):.3e}"
+    model, x = _model_from_matrices(c, A_ub, b_ub, bounds, name=f"sw{scale:g}")
+    res = model.solve(nlp_solver="pounce")
+    assert res.status == "optimal"
+    sol = np.asarray(res.value(x), dtype=np.float64).ravel()
+    assert _matrix_solution_feasible(sol, A_ub, b_ub, None, None, bounds), (
+        f"guard rejected the model-level POUNCE LP point at data scale {scale:g}; "
+        f"worst violation {_worst_violation(sol, A_ub, b_ub, bounds):.3e}"
     )
 
 
@@ -153,7 +179,16 @@ def test_pounce_qp_point_meets_discopt_constraint_tolerance():
     b_ub = -scale * np.abs(rng.uniform(0.5, 2.0, size=m)) * n * 0.25
     bounds = [(0.0, 10.0 * scale)] * n
 
-    res = solve_qp(Q=Q, c=c, A_ub=A_ub, b_ub=b_ub, bounds=bounds)
+    # Mirrors exactly what solver._solve_qp_pounce requests at the guard-checked
+    # call site; the wiring itself is pinned by the test below.
+    res = solve_qp(
+        Q=Q,
+        c=c,
+        A_ub=A_ub,
+        b_ub=b_ub,
+        bounds=bounds,
+        options={"bound_relax_factor": POUNCE_BOUND_RELAX_FACTOR},
+    )
     assert res.status == SolveStatus.OPTIMAL
     assert _matrix_solution_feasible(res.x, A_ub, b_ub, None, None, bounds), (
         "guard rejected a converged POUNCE QP point; worst violation "
@@ -210,20 +245,41 @@ def test_returned_point_stays_inside_its_declared_box(flat):
     assert res.objective >= 3.0 - 1e-12
 
 
-def test_shared_pounce_defaults_are_the_single_source_of_truth():
-    """The option baseline must not be re-spelled per backend.
+def test_option_requests_are_wired_where_the_guard_checks():
+    """Pin WHERE each request lives, because the two have different blast radii.
 
-    A second copy is how one entry point silently keeps Ipopt's defaults while
-    the rest move — the #940 failure mode exactly.
+    ``constr_viol_tol`` is a backend-wide default: it is harmless everywhere and
+    carries the fix on the published pounce wheel.
+
+    ``bound_relax_factor = 0`` is NOT backend-wide. It is requested by the
+    model-level POUNCE call sites, whose points ``_matrix_solution_feasible``
+    checks. Applied backend-wide it also reaches the Benders dual LP, where it
+    costs convergence — two correctness-lane tests go 1.6s -> 79s and end at
+    iteration/time limit (#945). Keeping the request at the consumer that needs
+    the guarantee is the difference between fixing #940 and breaking Benders.
     """
-    from discopt.solvers import pounce_option_defaults
+    import inspect
+
+    from discopt import solver as S
+    from discopt.solvers import POUNCE_BOUND_RELAX_FACTOR, pounce_option_defaults
 
     defaults = pounce_option_defaults()
-    assert defaults["bound_relax_factor"] == 0.0
     assert defaults["constr_viol_tol"] <= DISCOPT_CONSTR_TOL
+    assert "bound_relax_factor" not in defaults, (
+        "bound_relax_factor must NOT be a backend-wide default — it breaks the "
+        "Benders dual LP (#945)"
+    )
     # A fresh dict each call: a caller mutating it must not poison the next solve.
-    defaults["bound_relax_factor"] = 999.0
-    assert pounce_option_defaults()["bound_relax_factor"] == 0.0
+    defaults["constr_viol_tol"] = 999.0
+    assert pounce_option_defaults()["constr_viol_tol"] <= DISCOPT_CONSTR_TOL
+
+    assert POUNCE_BOUND_RELAX_FACTOR == 0.0
+    for fn in (S._solve_lp_pounce, S._solve_qp_pounce):
+        src = inspect.getsource(fn)
+        assert "bound_relax_factor" in src, (
+            f"{fn.__name__} must request bound_relax_factor — it is the call site "
+            "whose point the #850 guard checks"
+        )
 
 
 def test_caller_supplied_constr_viol_tol_still_wins():

--- a/python/tests/test_940_pounce_lp_constraint_tolerance.py
+++ b/python/tests/test_940_pounce_lp_constraint_tolerance.py
@@ -210,7 +210,8 @@ def test_unbounded_is_never_certified_on_a_compact_box():
     whose true status is ``optimal``, and since those bounds are far below the
     ``[1e15, 1e20)`` window of the #850 Obs 1 deferral, ``_solve_lp_matrix``
     certified a **false ``unbounded``** end to end. Predates #940 and reproduced
-    at POUNCE's own 1e-4 default; closed by ``_reject_impossible_unbounded``.
+    at POUNCE's own 1e-4 default; closed by ``_certify_unbounded_ray``, which
+    finds no improving recession direction here (the only one is ``d = 0``).
     """
     from discopt.solvers.lp_pounce import solve_lp
     from discopt.solvers.lp_simplex import solve_lp as simplex_solve_lp
@@ -248,11 +249,58 @@ def test_unbounded_is_never_certified_on_a_compact_box():
     assert out.objective == pytest.approx(ref.objective, rel=1e-9)
 
 
+def test_unbounded_is_never_certified_on_a_non_compact_box():
+    """An infinite bound does not make a ray exist — the ray must be exhibited.
+
+    The stronger half of the fix. With ``min c'x`` under ``c >= 0, x >= 0`` no ray
+    can lower the objective *by construction*, yet POUNCE's ambiguous exit
+    certified ``unbounded`` on 42 of 90 such instances at data scale 1e7-1e8, and
+    an infinite upper bound puts them outside any compact-box argument. Only a
+    genuine recession direction may keep the verdict.
+    """
+    from discopt.solvers.lp_pounce import solve_lp
+    from discopt.solvers.lp_simplex import solve_lp as simplex_solve_lp
+
+    rng = np.random.default_rng(0)
+    n, m, scale = 20, 10, 1e7
+    A_ub = -np.abs(rng.uniform(0.5, 5.0, size=(m, n)))
+    b_ub = -scale * np.abs(rng.uniform(0.5, 2.0, size=m)) * n * 0.25
+    c = np.abs(rng.uniform(1.0, 10.0, size=n))  # c >= 0 with x >= 0: no improving ray
+    bounds = [(0.0, np.inf)] + [(0.0, 10.0 * scale)] * (n - 1)
+
+    ref = simplex_solve_lp(c=c, A_ub=A_ub, b_ub=b_ub, bounds=bounds)
+    assert ref.status == SolveStatus.OPTIMAL, "oracle says this LP is bounded"
+
+    res = solve_lp(c=c, A_ub=A_ub, b_ub=b_ub, bounds=bounds)
+    assert res.status != SolveStatus.UNBOUNDED, (
+        "POUNCE certified UNBOUNDED for an LP with c >= 0 and x >= 0, where no "
+        "recession direction can lower the objective"
+    )
+
+    mdl = dm.Model("noncompact")
+    x = mdl.continuous("x", shape=(n,), lb=0.0, ub=np.inf)
+    mdl.minimize(dm.sum(lambda j: float(c[j]) * x[j], over=range(n)))
+    for i in range(m):
+        row = A_ub[i]
+        mdl.subject_to(
+            dm.sum(lambda j: float(row[j]) * x[j], over=range(n)) <= float(b_ub[i]), name=f"r{i}"
+        )
+    out = mdl.solve(nlp_solver="pounce")
+    assert out.status == "optimal"
+    assert out.objective == pytest.approx(ref.objective, rel=1e-6)
+
+
 def test_genuinely_unbounded_lp_is_still_reported_unbounded():
-    """The compact-box refusal must not swallow a real unbounded ray."""
+    """The refusal must not swallow a real unbounded ray.
+
+    This is what a bare "codes 3/4 never certify anything" rule would have cost:
+    the Benders dual seam relies on an unbounded dual LP as its feasibility-cut
+    signal, so the verdict has to survive when a ray genuinely exists.
+    """
     from discopt.solvers.lp_pounce import solve_lp
 
-    # min -x0 - x1 with x free above: the box is NOT compact, so UNBOUNDED stands.
+    # min -x0 - x1 with x free above: d = (1, 1) is a recession direction of
+    # strictly negative cost, so UNBOUNDED is earned and must stand.
     res = solve_lp(
         c=np.array([-1.0, -1.0]),
         A_ub=np.array([[-1.0, -1.0]]),
@@ -260,6 +308,44 @@ def test_genuinely_unbounded_lp_is_still_reported_unbounded():
         bounds=[(0.0, np.inf)] * 2,
     )
     assert res.status == SolveStatus.UNBOUNDED
+
+
+def test_genuinely_unbounded_qp_is_still_reported_unbounded():
+    """A convex QP that is flat along its improving ray stays UNBOUNDED.
+
+    ``Q = diag(1, 0)`` and ``c = (0, -1)``: the objective is ``½x0² - x1``, which
+    falls without bound along ``d = (0, 1)`` — and ``Qd = 0`` there, so the
+    quadratic extension of the ray test admits it.
+    """
+    from discopt.solvers.qp_pounce import solve_qp
+
+    res = solve_qp(
+        Q=np.diag([1.0, 0.0]),
+        c=np.array([0.0, -1.0]),
+        A_ub=np.array([[1.0, 0.0]]),
+        b_ub=np.array([10.0]),
+        bounds=[(0.0, np.inf)] * 2,
+    )
+    assert res.status == SolveStatus.UNBOUNDED
+
+
+def test_qp_unbounded_refused_when_the_ray_is_curved():
+    """A ray the quadratic term curves upward is not an unbounded direction.
+
+    ``Q = I``, ``c = (0, -1)``: the objective ``½‖x‖² - x1`` grows along every
+    direction, so ``Qd = 0`` has no nonzero solution and no verdict may be
+    certified even though the box is unbounded above.
+    """
+    from discopt.solvers.qp_pounce import solve_qp
+
+    res = solve_qp(
+        Q=np.eye(2),
+        c=np.array([0.0, -1.0]),
+        A_ub=np.array([[1.0, 0.0]]),
+        b_ub=np.array([10.0]),
+        bounds=[(0.0, np.inf)] * 2,
+    )
+    assert res.status != SolveStatus.UNBOUNDED
 
 
 def test_infeasible_and_unbounded_lps_still_certified():

--- a/python/tests/test_940_pounce_lp_constraint_tolerance.py
+++ b/python/tests/test_940_pounce_lp_constraint_tolerance.py
@@ -1,23 +1,31 @@
-"""Regression tests for #940: POUNCE's LP/QP points must meet discopt's own
-constraint tolerance, so the #850 guard stops rejecting correct solves.
+"""Regression tests for #940: POUNCE's LP/QP points must stay inside the box and
+meet discopt's own constraint tolerance, so the #850 guard stops rejecting correct
+solves.
 
-POUNCE inherits Ipopt's default ``constr_viol_tol`` of ``1e-4``. discopt checks
-every matrix-form point against ``solver._matrix_solution_feasible`` — the #850
-Obs 3 guard, ``|viol_i| ≤ 1e-6 + 1e-9·Σ_j|A_ij||x_j|``. The two are three orders
-of magnitude apart, so on any LP whose rows carry term magnitudes above a few
-hundred POUNCE returned a point on the infeasible side of a row, labeled it
-``optimal``, and the guard — correctly — threw it away, logged a WARNING and
-re-solved with the exact simplex. Measured before the fix: **50%** of POUNCE LP
-solves over a 148-solve population tripped the guard, including all four
-``docs/notebooks/tutorial_lp.ipynb`` models and 100% of a random sweep with row
-term scale in ``[1e2, 1e5)``.
+Two independent mechanisms put a returned point where discopt rejects it, and
+which one dominates depends on the POUNCE build — so both are pinned, in
+``discopt.solvers.pounce_option_defaults``:
 
-The fix is at the source, not at the guard: ``lp_pounce._CONSTR_VIOL_TOL = 1e-9``
-is requested for the LP and QP backends, which makes POUNCE's own convergence
-criterion imply discopt's. The guard is untouched and remains the arbiter.
+* ``bound_relax_factor = 0``. Ipopt's default 1e-8 deliberately relaxes bounds,
+  including the slack bounds standing in for inequality rows, by
+  ``1e-8*(1 + |bound|)``. The solve converges honestly but to a RELAXED box, so
+  the point sits outside the declared one and the error grows with the data
+  (8.1e-6 / 8.1e-5 / 8.1e-4 at data scale 1e2 / 1e3 / 1e4). No convergence
+  tolerance can fix this. Dominant on pounce @ main.
+* ``constr_viol_tol = 1e-8``. POUNCE inherits Ipopt's 1e-4, two orders looser
+  than the guard's 1e-6 floor. Dominant on the published wheel; a no-op on main.
 
-These tests fail on the pre-fix tree (worst violation ``1e-4``, guard trips,
-warning emitted) and pass after.
+Measured before the fix: **50%** of POUNCE LP solves over a 148-solve population
+tripped the guard, including all four ``docs/notebooks/tutorial_lp.ipynb`` models
+and 100% of a random sweep with row term scale in ``[1e2, 1e5)``.
+
+The fix is at the source, not at the guard — the guard is untouched and remains
+the arbiter. These tests pin BEHAVIOUR (the returned point), never the option
+names, which is why they caught a ``constr_viol_tol``-only version of this fix
+being a complete no-op on the build CI actually installs.
+
+8 of these cases fail on the pre-fix tree. The ``nlp_path`` xfail is a live
+marker for #945, not a skip.
 """
 
 from __future__ import annotations
@@ -153,7 +161,23 @@ def test_pounce_qp_point_meets_discopt_constraint_tolerance():
     )
 
 
-@pytest.mark.parametrize("flat", [True, False], ids=["lp_path", "nlp_path"])
+@pytest.mark.parametrize(
+    "flat",
+    [
+        True,
+        pytest.param(
+            False,
+            marks=pytest.mark.xfail(
+                strict=True,
+                reason="#945: the NLP path is not seeded from pounce_option_defaults yet — "
+                "bound_relax_factor=0 there makes incumbents feasible, which breaks 12 "
+                "gap==0@1e-9 assertions across OA/GDPopt/MindtPy. Kept as a live xfail so "
+                "the defect stays visible and flips to a pass the moment #945 lands.",
+            ),
+        ),
+    ],
+    ids=["lp_path", "nlp_path"],
+)
 def test_returned_point_stays_inside_its_declared_box(flat):
     """Every POUNCE entry point must return a point inside the declared bounds.
 

--- a/python/tests/test_940_pounce_lp_constraint_tolerance.py
+++ b/python/tests/test_940_pounce_lp_constraint_tolerance.py
@@ -158,11 +158,21 @@ def test_caller_supplied_constr_viol_tol_still_wins():
     from discopt.solvers.lp_pounce import solve_lp
 
     c, A_ub, b_ub, bounds = _diet_matrices()
-    res = solve_lp(c=c, A_ub=A_ub, b_ub=b_ub, bounds=bounds, options={"constr_viol_tol": 1e-4})
+    # Hand back BOTH of POUNCE's own defaults. Overriding only one is not enough:
+    # the two requests target different mechanisms and either alone keeps the
+    # point tight, which is the whole point of setting both (#940).
+    res = solve_lp(
+        c=c,
+        A_ub=A_ub,
+        b_ub=b_ub,
+        bounds=bounds,
+        options={"constr_viol_tol": 1e-4, "bound_relax_factor": 1e-8},
+    )
     assert res.status == SolveStatus.OPTIMAL
-    # With the loose tolerance restored the point is allowed back out to ~1e-4,
-    # which is the pre-fix behavior — proof the option is honored end to end and
-    # that the tests above are measuring the option, not a coincidence.
+    # With POUNCE's own defaults restored the point is allowed back out past
+    # discopt's tolerance — the pre-fix behavior. This is proof the requests are
+    # honored end to end, so the tests above are measuring them and not a
+    # coincidence of this POUNCE build.
     assert _worst_violation(res.x, A_ub, b_ub, bounds) > DISCOPT_CONSTR_TOL
 
 

--- a/python/tests/test_940_pounce_lp_constraint_tolerance.py
+++ b/python/tests/test_940_pounce_lp_constraint_tolerance.py
@@ -153,6 +153,55 @@ def test_pounce_qp_point_meets_discopt_constraint_tolerance():
     )
 
 
+@pytest.mark.parametrize("flat", [True, False], ids=["lp_path", "nlp_path"])
+def test_returned_point_stays_inside_its_declared_box(flat):
+    """Every POUNCE entry point must return a point inside the declared bounds.
+
+    Pins the *property* directly rather than through an objective comparison.
+    Ipopt's ``bound_relax_factor`` (default 1e-8) relaxes every bound by
+    ``1e-8*(1 + |bound|)``, so a converged point legitimately sits outside the box
+    the caller declared — which is what discopt's feasibility guards were
+    rejecting POUNCE points for.
+
+    Both entry points are exercised because they are genuinely different code
+    paths: ``dm.sum(y.flat)`` classifies linear and routes to ``lp_pounce``,
+    while ``dm.sum(y)`` on the bare indexed container routes to the general NLP
+    path. Seeding the option in the LP/QP backends alone left this second path
+    returning points ~7.5e-9 below ``lb``; the fix lives in
+    ``solvers.pounce_option_defaults`` so every entry point inherits it (#940).
+    """
+    m = dm.Model()
+    s = m.set("S", [10, 20, 30])
+    y = m.continuous("y", lb=1.0, ub=5.0, over=s)
+    m.minimize(dm.sum(y.flat) if flat else dm.sum(y))
+    res = m.solve()
+
+    assert res.status == "optimal"
+    x = np.asarray(res.value(y), dtype=np.float64).ravel()
+    assert x.size == 3
+    below = float(np.max(1.0 - x))
+    assert below <= 1e-12, f"returned point sits {below:.3e} below its declared lb=1"
+    # The optimum is exactly 3.0; a point outside the box buys a super-optimal
+    # objective, so pin that it is not below the true value either.
+    assert res.objective >= 3.0 - 1e-12
+
+
+def test_shared_pounce_defaults_are_the_single_source_of_truth():
+    """The option baseline must not be re-spelled per backend.
+
+    A second copy is how one entry point silently keeps Ipopt's defaults while
+    the rest move — the #940 failure mode exactly.
+    """
+    from discopt.solvers import pounce_option_defaults
+
+    defaults = pounce_option_defaults()
+    assert defaults["bound_relax_factor"] == 0.0
+    assert defaults["constr_viol_tol"] <= DISCOPT_CONSTR_TOL
+    # A fresh dict each call: a caller mutating it must not poison the next solve.
+    defaults["bound_relax_factor"] = 999.0
+    assert pounce_option_defaults()["bound_relax_factor"] == 0.0
+
+
 def test_caller_supplied_constr_viol_tol_still_wins():
     """The tightened value is a default, not an override of the caller."""
     from discopt.solvers.lp_pounce import solve_lp

--- a/python/tests/test_940_pounce_lp_constraint_tolerance.py
+++ b/python/tests/test_940_pounce_lp_constraint_tolerance.py
@@ -1,0 +1,293 @@
+"""Regression tests for #940: POUNCE's LP/QP points must meet discopt's own
+constraint tolerance, so the #850 guard stops rejecting correct solves.
+
+POUNCE inherits Ipopt's default ``constr_viol_tol`` of ``1e-4``. discopt checks
+every matrix-form point against ``solver._matrix_solution_feasible`` — the #850
+Obs 3 guard, ``|viol_i| ≤ 1e-6 + 1e-9·Σ_j|A_ij||x_j|``. The two are three orders
+of magnitude apart, so on any LP whose rows carry term magnitudes above a few
+hundred POUNCE returned a point on the infeasible side of a row, labeled it
+``optimal``, and the guard — correctly — threw it away, logged a WARNING and
+re-solved with the exact simplex. Measured before the fix: **50%** of POUNCE LP
+solves over a 148-solve population tripped the guard, including all four
+``docs/notebooks/tutorial_lp.ipynb`` models and 100% of a random sweep with row
+term scale in ``[1e2, 1e5)``.
+
+The fix is at the source, not at the guard: ``lp_pounce._CONSTR_VIOL_TOL = 1e-9``
+is requested for the LP and QP backends, which makes POUNCE's own convergence
+criterion imply discopt's. The guard is untouched and remains the arbiter.
+
+These tests fail on the pre-fix tree (worst violation ``1e-4``, guard trips,
+warning emitted) and pass after.
+"""
+
+from __future__ import annotations
+
+import os
+
+os.environ.setdefault("JAX_PLATFORMS", "cpu")
+os.environ.setdefault("JAX_ENABLE_X64", "1")
+
+import logging  # noqa: E402
+
+import discopt.modeling as dm  # noqa: E402
+import numpy as np  # noqa: E402
+import pytest  # noqa: E402
+from discopt.solver import _matrix_solution_feasible  # noqa: E402
+from discopt.solvers import SolveStatus  # noqa: E402
+from discopt.solvers.lp_pounce import POUNCE_AVAILABLE  # noqa: E402
+
+pytestmark = pytest.mark.skipif(not POUNCE_AVAILABLE, reason="pounce not installed")
+
+# discopt's absolute constraint tolerance (conftest ``abs``; the guard's ``tol``).
+DISCOPT_CONSTR_TOL = 1e-6
+
+
+def _diet_matrices():
+    """The tutorial_lp.ipynb diet LP in ``min cᵀx  s.t.  A_ub x ≤ b_ub`` form.
+
+    Worst row term scale ≈ 800, which is exactly the regime the guard rejected.
+    """
+    c = np.array([2.0, 3.5, 8.0, 11.0, 25.0])
+    A = np.array(
+        [
+            [3.0, 8.0, 15.0, 22.0, 31.0],
+            [25.0, 120.0, 200.0, 10.0, 15.0],
+            [1.0, 0.1, 0.5, 3.0, 5.5],
+            [250.0, 150.0, 400.0, 200.0, 450.0],
+        ]
+    )
+    req = np.array([55.0, 800.0, 12.0, 2000.0])
+    # ``A x ≥ req``  ⇒  ``-A x ≤ -req``
+    return c, -A, -req, [(0.0, 10.0)] * 5
+
+
+def _worst_violation(x, A_ub, b_ub, bounds):
+    """Max absolute amount by which ``x`` breaks a row or a bound."""
+    x = np.asarray(x, dtype=np.float64)
+    viol = float(np.max(np.asarray(A_ub, dtype=np.float64) @ x - np.asarray(b_ub, float)))
+    for xi, (lo, hi) in zip(x, bounds):
+        viol = max(viol, lo - xi, xi - hi)
+    return viol
+
+
+def test_pounce_lp_point_meets_discopt_constraint_tolerance():
+    """POUNCE's own LP convergence must imply discopt's constraint tolerance."""
+    from discopt.solvers.lp_pounce import solve_lp
+
+    c, A_ub, b_ub, bounds = _diet_matrices()
+    res = solve_lp(c=c, A_ub=A_ub, b_ub=b_ub, bounds=bounds)
+
+    assert res.status == SolveStatus.OPTIMAL
+    worst = _worst_violation(res.x, A_ub, b_ub, bounds)
+    # Pre-fix this is ~5.8e-6 (and up to Ipopt's 1e-4 default on other data).
+    assert worst <= DISCOPT_CONSTR_TOL, f"worst violation {worst:.3e} exceeds 1e-6"
+    assert _matrix_solution_feasible(res.x, A_ub, b_ub, None, None, bounds)
+
+
+@pytest.mark.parametrize("scale", [1e2, 1e3, 1e4])
+def test_pounce_lp_guard_holds_across_data_scales(scale):
+    """The guard trips as a function of row term scale, so pin the whole band.
+
+    Pre-fix, 100% of solves with row term scale in ``[1e2, 1e5)`` tripped it;
+    this is the general statement, not the tutorial instance.
+    """
+    from discopt.solvers.lp_pounce import solve_lp
+
+    rng = np.random.default_rng(940)
+    n, m = 20, 10
+    A_ub = -np.abs(rng.uniform(0.5, 5.0, size=(m, n)))
+    b_ub = -scale * np.abs(rng.uniform(0.5, 2.0, size=m)) * n * 0.25
+    c = np.abs(rng.uniform(1.0, 10.0, size=n))
+    bounds = [(0.0, 10.0 * scale)] * n
+
+    res = solve_lp(c=c, A_ub=A_ub, b_ub=b_ub, bounds=bounds)
+    assert res.status == SolveStatus.OPTIMAL
+    assert _matrix_solution_feasible(res.x, A_ub, b_ub, None, None, bounds), (
+        f"guard rejected a converged POUNCE LP point at data scale {scale:g}; "
+        f"worst violation {_worst_violation(res.x, A_ub, b_ub, bounds):.3e}"
+    )
+
+
+def test_pounce_lp_respects_binding_bound_at_large_magnitude():
+    """A variable pinned at a large upper bound must not overshoot it.
+
+    Ipopt's ``bound_relax_factor`` lets iterates sit outside a bound by
+    ``1e-8·(1+|bound|)``; pre-fix the returned point sat 1e-4 above ``ub=1e4``,
+    which the guard (threshold ``1e-6 + 1e-9·1e4 ≈ 1.1e-5``) rejected.
+    """
+    from discopt.solvers.lp_pounce import solve_lp
+
+    n, B = 4, 1e4
+    res = solve_lp(
+        c=-np.ones(n),
+        A_ub=np.ones((1, n)),
+        b_ub=np.array([10.0 * n * B]),  # slack row; the BOUND is what binds
+        bounds=[(0.0, B)] * n,
+    )
+    assert res.status == SolveStatus.OPTIMAL
+    over = float(np.max(np.asarray(res.x) - B))
+    assert over <= DISCOPT_CONSTR_TOL, f"x overshot its upper bound by {over:.3e}"
+
+
+def test_pounce_qp_point_meets_discopt_constraint_tolerance():
+    """The QP backend goes through the same guard and needs the same tolerance."""
+    from discopt.solvers.qp_pounce import solve_qp
+
+    # Seed 20 is one that demonstrably trips the guard with POUNCE's old 1e-4
+    # tolerance (found by sweeping seeds with ``options={"constr_viol_tol": 1e-4}``),
+    # so this test genuinely fails on the pre-fix tree rather than passing by luck.
+    rng = np.random.default_rng(20)
+    n, m, scale = 10, 6, 1e3
+    B = rng.normal(size=(n, n))
+    Q = B @ B.T + n * np.eye(n)
+    c = -np.abs(rng.uniform(1.0, 10.0, size=n)) * scale
+    A_ub = -np.abs(rng.uniform(0.5, 5.0, size=(m, n)))
+    b_ub = -scale * np.abs(rng.uniform(0.5, 2.0, size=m)) * n * 0.25
+    bounds = [(0.0, 10.0 * scale)] * n
+
+    res = solve_qp(Q=Q, c=c, A_ub=A_ub, b_ub=b_ub, bounds=bounds)
+    assert res.status == SolveStatus.OPTIMAL
+    assert _matrix_solution_feasible(res.x, A_ub, b_ub, None, None, bounds), (
+        "guard rejected a converged POUNCE QP point; worst violation "
+        f"{_worst_violation(res.x, A_ub, b_ub, bounds):.3e}"
+    )
+
+
+def test_caller_supplied_constr_viol_tol_still_wins():
+    """The tightened value is a default, not an override of the caller."""
+    from discopt.solvers.lp_pounce import solve_lp
+
+    c, A_ub, b_ub, bounds = _diet_matrices()
+    res = solve_lp(c=c, A_ub=A_ub, b_ub=b_ub, bounds=bounds, options={"constr_viol_tol": 1e-4})
+    assert res.status == SolveStatus.OPTIMAL
+    # With the loose tolerance restored the point is allowed back out to ~1e-4,
+    # which is the pre-fix behavior — proof the option is honored end to end and
+    # that the tests above are measuring the option, not a coincidence.
+    assert _worst_violation(res.x, A_ub, b_ub, bounds) > DISCOPT_CONSTR_TOL
+
+
+def test_tutorial_lp_solves_without_the_fallback_warning(caplog):
+    """End to end: a tutorial LP solves on the first engine, warning-free.
+
+    This is the user-visible symptom from #940 — all four ``tutorial_lp.ipynb``
+    LP cells printed "POUNCE LP returned an infeasible point labeled optimal"
+    above otherwise-correct output.
+    """
+    cost = np.array([2.0, 3.5, 8.0, 11.0, 25.0])
+    A = np.array(
+        [
+            [3.0, 8.0, 15.0, 22.0, 31.0],
+            [25.0, 120.0, 200.0, 10.0, 15.0],
+            [1.0, 0.1, 0.5, 3.0, 5.5],
+            [250.0, 150.0, 400.0, 200.0, 450.0],
+        ]
+    )
+    req = np.array([55.0, 800.0, 12.0, 2000.0])
+
+    m = dm.Model("diet")
+    x = m.continuous("x", shape=(5,), lb=0, ub=10)
+    m.minimize(dm.sum(lambda j: cost[j] * x[j], over=range(5)))
+    for i in range(4):
+        m.subject_to(dm.sum(lambda j: A[i, j] * x[j], over=range(5)) >= req[i], name=f"n{i}")
+
+    with caplog.at_level(logging.WARNING, logger="discopt.solver"):
+        res = m.solve()
+
+    assert res.status == "optimal"
+    assert res.objective == pytest.approx(41.559888579, rel=1e-6)
+    offending = [
+        r.message for r in caplog.records if "infeasible point labeled optimal" in str(r.msg)
+    ]
+    assert not offending, f"the #850 fallback warning still fires: {offending}"
+
+
+def test_unbounded_is_never_certified_on_a_compact_box():
+    """A finite box makes ``UNBOUNDED`` impossible, so POUNCE must not report it.
+
+    POUNCE reaches ``UNBOUNDED`` from Ipopt codes 3/4 (stalled search direction /
+    diverging iterates), which are ambiguous numerical-failure signals. On data
+    of magnitude ~1e7 over an ordinary ``[0, 1e8]`` box it hit that exit on LPs
+    whose true status is ``optimal``, and since those bounds are far below the
+    ``[1e15, 1e20)`` window of the #850 Obs 1 deferral, ``_solve_lp_matrix``
+    certified a **false ``unbounded``** end to end. Predates #940 and reproduced
+    at POUNCE's own 1e-4 default; closed by ``_reject_impossible_unbounded``.
+    """
+    from discopt.solvers.lp_pounce import solve_lp
+    from discopt.solvers.lp_simplex import solve_lp as simplex_solve_lp
+
+    # Seed 0 at this shape/scale reaches the ambiguous code-3/4 exit at BOTH
+    # POUNCE's own 1e-4 default and the #940 value, so this test fails on the
+    # pre-fix tree (it certified ``unbounded``) independently of the tolerance.
+    rng = np.random.default_rng(0)
+    n, m, scale = 20, 10, 1e7
+    A_ub = -np.abs(rng.uniform(0.5, 5.0, size=(m, n)))
+    b_ub = -scale * np.abs(rng.uniform(0.5, 2.0, size=m)) * n * 0.25
+    c = np.abs(rng.uniform(1.0, 10.0, size=n))
+    bounds = [(0.0, 10.0 * scale)] * n
+
+    ref = simplex_solve_lp(c=c, A_ub=A_ub, b_ub=b_ub, bounds=bounds)
+    assert ref.status == SolveStatus.OPTIMAL, "oracle says this LP is bounded"
+
+    res = solve_lp(c=c, A_ub=A_ub, b_ub=b_ub, bounds=bounds)
+    assert res.status != SolveStatus.UNBOUNDED, (
+        "POUNCE certified UNBOUNDED for an LP whose every bound is finite; "
+        "on a compact box that verdict is impossible"
+    )
+
+    # End to end: the model-level certificate must be the oracle's.
+    mdl = dm.Model("scale1e7")
+    x = mdl.continuous("x", shape=(n,), lb=0.0, ub=10.0 * scale)
+    mdl.minimize(dm.sum(lambda j: float(c[j]) * x[j], over=range(n)))
+    for i in range(m):
+        row = A_ub[i]
+        mdl.subject_to(
+            dm.sum(lambda j: float(row[j]) * x[j], over=range(n)) <= float(b_ub[i]), name=f"r{i}"
+        )
+    out = mdl.solve(nlp_solver="pounce")
+    assert out.status == "optimal"
+    assert out.objective == pytest.approx(ref.objective, rel=1e-9)
+
+
+def test_genuinely_unbounded_lp_is_still_reported_unbounded():
+    """The compact-box refusal must not swallow a real unbounded ray."""
+    from discopt.solvers.lp_pounce import solve_lp
+
+    # min -x0 - x1 with x free above: the box is NOT compact, so UNBOUNDED stands.
+    res = solve_lp(
+        c=np.array([-1.0, -1.0]),
+        A_ub=np.array([[-1.0, -1.0]]),
+        b_ub=np.array([-1.0]),
+        bounds=[(0.0, np.inf)] * 2,
+    )
+    assert res.status == SolveStatus.UNBOUNDED
+
+
+def test_infeasible_and_unbounded_lps_still_certified():
+    """The tighter tolerance must not cost POUNCE its infeasible/unbounded verdicts.
+
+    ``solve_lp``'s Phase-1 elastic disambiguation inherits the same option dict,
+    so pin that it still converges and still certifies.
+    """
+    from discopt.solvers.lp_pounce import solve_lp
+
+    # Infeasible: x0 + x1 ≥ 5 with both in [0, 1].
+    res = solve_lp(
+        c=np.array([1.0, 1.0]),
+        A_ub=np.array([[-1.0, -1.0]]),
+        b_ub=np.array([-5.0]),
+        bounds=[(0.0, 1.0)] * 2,
+        certificate=True,
+    )
+    assert res.status == SolveStatus.INFEASIBLE
+    assert res.infeasibility_certificate is not None
+    assert res.infeasibility_certificate.total_violation > 0.0
+
+    # Feasible and bounded on a large-but-finite box: still an ordinary optimum.
+    res2 = solve_lp(
+        c=np.array([-1.0, -1.0]),
+        A_ub=np.array([[-1.0, -1.0]]),
+        b_ub=np.array([-1.0]),
+        bounds=[(0.0, 1e6)] * 2,
+    )
+    assert res2.status == SolveStatus.OPTIMAL
+    assert res2.objective == pytest.approx(-2e6, rel=1e-6)

--- a/python/tests/test_sets_adversarial.py
+++ b/python/tests/test_sets_adversarial.py
@@ -27,6 +27,21 @@ class TestSumProdOverIndexedContainer:
         assert r.objective == pytest.approx(3.0, abs=1e-5)
 
     def test_sum_indexed_var_equals_sum_flat(self):
+        # Both formulations must reach the same optimum: three variables at
+        # lb=1, so the true value is exactly 3.0. Checked against that ground
+        # truth rather than only against each other — a cross-model comparison
+        # alone passes just as happily when BOTH are wrong in the same way.
+        #
+        # Tolerance is discopt's absolute constraint/objective tolerance (1e-6),
+        # not a tighter number: these are interior-point solves, so the last
+        # digits are convergence noise and the two models need not tread
+        # identical floating-point paths. The bug this class guards is summing
+        # the index KEYS (10+20+30 = 60) instead of the variables (3.0) — a
+        # factor of 20, which any tolerance here catches. The previous 1e-9
+        # cross-model bound was 1000x tighter than the solver's own contract and
+        # broke on #940, where POUNCE stopped relaxing bounds and the flat model
+        # became STRICTLY MORE accurate than before (-2.25e-8 super-optimal ->
+        # +7.5e-9 on the feasible side) while the indexed model was unchanged.
         m = dm.Model()
         s = m.set("S", [10, 20, 30])
         y = m.continuous("y", lb=1, ub=5, over=s)
@@ -36,7 +51,10 @@ class TestSumProdOverIndexedContainer:
         s2 = m2.set("S", [10, 20, 30])
         y2 = m2.continuous("y", lb=1, ub=5, over=s2)
         m2.minimize(dm.sum(y2.flat))
-        assert r0.objective == pytest.approx(m2.solve().objective, abs=1e-9)
+        r2 = m2.solve()
+        assert r0.objective == pytest.approx(3.0, abs=1e-6)
+        assert r2.objective == pytest.approx(3.0, abs=1e-6)
+        assert r0.objective == pytest.approx(r2.objective, abs=1e-6)
 
     def test_prod_indexed_var(self):
         m = dm.Model()

--- a/python/tests/test_sets_adversarial.py
+++ b/python/tests/test_sets_adversarial.py
@@ -27,21 +27,17 @@ class TestSumProdOverIndexedContainer:
         assert r.objective == pytest.approx(3.0, abs=1e-5)
 
     def test_sum_indexed_var_equals_sum_flat(self):
-        # Both formulations must reach the same optimum: three variables at
-        # lb=1, so the true value is exactly 3.0. Checked against that ground
-        # truth rather than only against each other — a cross-model comparison
-        # alone passes just as happily when BOTH are wrong in the same way.
+        # The two arms take DIFFERENT engine paths — `dm.sum(y.flat)` classifies
+        # linear and goes to lp_pounce, `dm.sum(y)` on the bare container goes to
+        # the general NLP path — so this is a real cross-path invariant and the
+        # tight 1e-9 bound is worth keeping.
         #
-        # Tolerance is discopt's absolute constraint/objective tolerance (1e-6),
-        # not a tighter number: these are interior-point solves, so the last
-        # digits are convergence noise and the two models need not tread
-        # identical floating-point paths. The bug this class guards is summing
-        # the index KEYS (10+20+30 = 60) instead of the variables (3.0) — a
-        # factor of 20, which any tolerance here catches. The previous 1e-9
-        # cross-model bound was 1000x tighter than the solver's own contract and
-        # broke on #940, where POUNCE stopped relaxing bounds and the flat model
-        # became STRICTLY MORE accurate than before (-2.25e-8 super-optimal ->
-        # +7.5e-9 on the feasible side) while the indexed model was unchanged.
+        # It briefly passed for the wrong reason: before #940 both paths returned
+        # points ~7.5e-9 BELOW lb=1 (Ipopt's bound_relax_factor), so both
+        # objectives were 2.25e-8 super-optimal and agreed to 1.4e-11 — two
+        # matched errors cancelling. The ground-truth assertions below are what
+        # make that visible, since a cross-model comparison alone passes just as
+        # happily when both models are wrong in the same way.
         m = dm.Model()
         s = m.set("S", [10, 20, 30])
         y = m.continuous("y", lb=1, ub=5, over=s)
@@ -54,7 +50,7 @@ class TestSumProdOverIndexedContainer:
         r2 = m2.solve()
         assert r0.objective == pytest.approx(3.0, abs=1e-6)
         assert r2.objective == pytest.approx(3.0, abs=1e-6)
-        assert r0.objective == pytest.approx(r2.objective, abs=1e-6)
+        assert r0.objective == pytest.approx(r2.objective, abs=1e-9)
 
     def test_prod_indexed_var(self):
         m = dm.Model()

--- a/python/tests/test_sets_adversarial.py
+++ b/python/tests/test_sets_adversarial.py
@@ -26,18 +26,27 @@ class TestSumProdOverIndexedContainer:
         # vars at lb=1 -> 3.0, NOT 60.0 (= the keys 10+20+30)
         assert r.objective == pytest.approx(3.0, abs=1e-5)
 
+    @pytest.mark.xfail(
+        strict=True,
+        reason="#945: the two arms take different engine paths and only the LP one is "
+        "seeded from pounce_option_defaults, so they no longer agree to 1e-9. Kept "
+        "STRICT at 1e-9 rather than loosened — it flips to a pass when #945 seeds the "
+        "NLP path, and loosening would re-hide the defect (#940 review).",
+    )
     def test_sum_indexed_var_equals_sum_flat(self):
         # The two arms take DIFFERENT engine paths — `dm.sum(y.flat)` classifies
         # linear and goes to lp_pounce, `dm.sum(y)` on the bare container goes to
         # the general NLP path — so this is a real cross-path invariant and the
         # tight 1e-9 bound is worth keeping.
         #
-        # It briefly passed for the wrong reason: before #940 both paths returned
-        # points ~7.5e-9 BELOW lb=1 (Ipopt's bound_relax_factor), so both
-        # objectives were 2.25e-8 super-optimal and agreed to 1.4e-11 — two
-        # matched errors cancelling. The ground-truth assertions below are what
-        # make that visible, since a cross-model comparison alone passes just as
-        # happily when both models are wrong in the same way.
+        # It previously passed for the WRONG reason: both paths returned points
+        # ~7.5e-9 BELOW lb=1 (Ipopt's bound_relax_factor), so both objectives were
+        # 2.25e-8 super-optimal and agreed to 1.4e-11 — two matched errors
+        # cancelling. #940 fixed the LP arm only, so the arms now disagree by
+        # ~3.0e-8 and this fails honestly instead of passing dishonestly. The
+        # ground-truth assertions below are what make the difference visible: a
+        # cross-model comparison alone passes just as happily when both models are
+        # wrong in the same way.
         m = dm.Model()
         s = m.set("S", [10, 20, 30])
         y = m.continuous("y", lb=1, ub=5, over=s)

--- a/scratchpad/issue940/arm_plugin.py
+++ b/scratchpad/issue940/arm_plugin.py
@@ -1,0 +1,31 @@
+"""pytest plugin: select the POUNCE option arm via DISCOPT_940_ARM.
+
+Lets the SAME test files run under POUNCE's own defaults vs the shipped
+baseline, in-process, so a CI failure can be attributed rather than guessed at.
+"""
+import os
+
+ARMS = {
+    "pounce_defaults": {"print_level": 0, "constr_viol_tol": 1e-4, "bound_relax_factor": 1e-8},
+    "cvt_only":        {"print_level": 0, "constr_viol_tol": 1e-8, "bound_relax_factor": 1e-8},
+    "brf_only":        {"print_level": 0, "constr_viol_tol": 1e-4, "bound_relax_factor": 0.0},
+    "shipped":         None,   # leave the real defaults in place
+}
+
+
+def pytest_configure(config):
+    arm = os.environ.get("DISCOPT_940_ARM", "shipped")
+    if arm not in ARMS:
+        raise SystemExit(f"unknown DISCOPT_940_ARM={arm!r}; expected {sorted(ARMS)}")
+    override = ARMS[arm]
+    print(f"\n[#940 arm] {arm} -> {override if override else 'module defaults'}")
+    if override is None:
+        return
+    import discopt.solvers as S
+    import discopt.solvers.lp_pounce as LPP
+    import discopt.solvers.qp_pounce as QPP
+
+    fn = lambda: dict(override)  # noqa: E731
+    S.pounce_option_defaults = fn
+    LPP.pounce_option_defaults = fn
+    QPP.pounce_option_defaults = fn

--- a/scratchpad/issue940/arm_plugin.py
+++ b/scratchpad/issue940/arm_plugin.py
@@ -1,15 +1,28 @@
-"""pytest plugin: select the POUNCE option arm via DISCOPT_940_ARM.
+"""pytest plugin: select the #940 change dimensions via DISCOPT_940_ARM.
 
-Lets the SAME test files run under POUNCE's own defaults vs the shipped
-baseline, in-process, so a CI failure can be attributed rather than guessed at.
+Three independent dimensions shipped in #943, so an attribution must be able to
+switch each off separately:
+  * constr_viol_tol / bound_relax_factor  (pounce_option_defaults)
+  * ray certification of UNBOUNDED        (_settle_ambiguous_unbounded / _certify_unbounded_ray)
 """
 import os
 
+POUNCE_DEFAULTS = {"print_level": 0, "constr_viol_tol": 1e-4, "bound_relax_factor": 1e-8}
+
 ARMS = {
-    "pounce_defaults": {"print_level": 0, "constr_viol_tol": 1e-4, "bound_relax_factor": 1e-8},
-    "cvt_only":        {"print_level": 0, "constr_viol_tol": 1e-8, "bound_relax_factor": 1e-8},
-    "brf_only":        {"print_level": 0, "constr_viol_tol": 1e-4, "bound_relax_factor": 0.0},
-    "shipped":         None,   # leave the real defaults in place
+    # everything off -> pre-#943 behaviour
+    "baseline":      {"opts": POUNCE_DEFAULTS, "ray": False},
+    # option dimensions only
+    "opts_only":     {"opts": None,            "ray": False},
+    # ray certification only
+    "ray_only":      {"opts": POUNCE_DEFAULTS, "ray": True},
+    # what ships
+    "shipped":       {"opts": None,            "ray": True},
+    # option dimensions split, ray left ON (measured innocent)
+    "cvt_only":      {"opts": {"print_level": 0, "constr_viol_tol": 1e-8,
+                               "bound_relax_factor": 1e-8}, "ray": True},
+    "brf_only":      {"opts": {"print_level": 0, "constr_viol_tol": 1e-4,
+                               "bound_relax_factor": 0.0}, "ray": True},
 }
 
 
@@ -17,15 +30,21 @@ def pytest_configure(config):
     arm = os.environ.get("DISCOPT_940_ARM", "shipped")
     if arm not in ARMS:
         raise SystemExit(f"unknown DISCOPT_940_ARM={arm!r}; expected {sorted(ARMS)}")
-    override = ARMS[arm]
-    print(f"\n[#940 arm] {arm} -> {override if override else 'module defaults'}")
-    if override is None:
-        return
+    spec = ARMS[arm]
+    print(f"\n[#940 arm] {arm} -> opts={'module' if spec['opts'] is None else 'pounce'} "
+          f"ray_certification={spec['ray']}")
+
     import discopt.solvers as S
     import discopt.solvers.lp_pounce as LPP
     import discopt.solvers.qp_pounce as QPP
 
-    fn = lambda: dict(override)  # noqa: E731
-    S.pounce_option_defaults = fn
-    LPP.pounce_option_defaults = fn
-    QPP.pounce_option_defaults = fn
+    if spec["opts"] is not None:
+        fn = lambda: dict(spec["opts"])  # noqa: E731
+        S.pounce_option_defaults = fn
+        LPP.pounce_option_defaults = fn
+        QPP.pounce_option_defaults = fn
+
+    if not spec["ray"]:
+        # restore the pre-#943 inference: keep whatever UNBOUNDED the status map gave
+        LPP._settle_ambiguous_unbounded = lambda result, c, A, cl, cu, lb, ub, opts: result
+        QPP._certify_unbounded_ray = lambda *a, **k: True

--- a/scratchpad/issue940/find_qp_seed.py
+++ b/scratchpad/issue940/find_qp_seed.py
@@ -1,0 +1,24 @@
+import os, sys
+os.environ.setdefault("JAX_PLATFORMS","cpu"); os.environ.setdefault("JAX_ENABLE_X64","1")
+import numpy as np
+from discopt.solvers.qp_pounce import solve_qp
+from discopt.solver import _matrix_solution_feasible
+from discopt.solvers import SolveStatus
+CHECKS = 0
+for seed in range(40):
+    for scale in (1e2, 1e3, 1e4):
+        rng = np.random.default_rng(seed)
+        n, m = 10, 6
+        B = rng.normal(size=(n,n)); Q = B @ B.T + n*np.eye(n)
+        c = -np.abs(rng.uniform(1.,10.,size=n))*scale
+        A_ub = -np.abs(rng.uniform(0.5,5.,size=(m,n)))
+        b_ub = -scale*np.abs(rng.uniform(0.5,2.,size=m))*n*0.25
+        bounds=[(0., 10.*scale)]*n
+        # force the PRE-FIX behaviour explicitly via the caller option
+        res = solve_qp(Q=Q,c=c,A_ub=A_ub,b_ub=b_ub,bounds=bounds,options={"constr_viol_tol":1e-4})
+        CHECKS += 1
+        if res.status != SolveStatus.OPTIMAL: continue
+        if not _matrix_solution_feasible(res.x,A_ub,b_ub,None,None,bounds):
+            print(f"TRIPS pre-fix: seed={seed} scale={scale:g}")
+print(f"CHECKS_EXECUTED={CHECKS}")
+sys.exit(0 if CHECKS else 1)

--- a/scratchpad/issue940/find_unbounded_seed.py
+++ b/scratchpad/issue940/find_unbounded_seed.py
@@ -1,0 +1,25 @@
+import os, sys
+os.environ.setdefault("JAX_PLATFORMS","cpu"); os.environ.setdefault("JAX_ENABLE_X64","1")
+import numpy as np
+import discopt.solvers.lp_pounce as LPP
+from discopt.solvers.lp_simplex import solve_lp as simplex
+from discopt.solvers import SolveStatus
+CHECKS=0
+hits=[]
+for seed in range(60):
+    for n, m, scale in ((20,10,1e7),(40,20,1e7),(20,10,1e8)):
+        rng = np.random.default_rng(seed)
+        A = -np.abs(rng.uniform(0.5,5.,size=(m,n)))
+        b = -scale*np.abs(rng.uniform(0.5,2.,size=m))*n*0.25
+        c = np.abs(rng.uniform(1.,10.,size=n))
+        bounds=[(0.,10.*scale)]*n
+        ref = simplex(c=c,A_ub=A,b_ub=b,bounds=bounds)
+        old = LPP.solve_lp(c=c,A_ub=A,b_ub=b,bounds=bounds,options={"constr_viol_tol":1e-4})
+        new = LPP.solve_lp(c=c,A_ub=A,b_ub=b,bounds=bounds)
+        CHECKS+=1
+        if ref.status==SolveStatus.OPTIMAL and old.status==SolveStatus.ERROR and new.status==SolveStatus.ERROR:
+            hits.append((seed,n,m,scale))
+print("both arms hit the impossible-UNBOUNDED path (pre-fix would certify it):")
+for h in hits[:10]: print("  ", h)
+print(f"CHECKS_EXECUTED={CHECKS}  hits={len(hits)}")
+sys.exit(0 if CHECKS else 1)

--- a/scratchpad/issue940/panel.json
+++ b/scratchpad/issue940/panel.json
@@ -1,0 +1,1193 @@
+{
+ "rows": {
+  "4stufen": {
+   "pre": {
+    "status": "time_limit",
+    "objective": null,
+    "bound": 19713.036064206917,
+    "node_count": 7,
+    "wall": 21.508910659999856
+   },
+   "post": {
+    "status": "time_limit",
+    "objective": null,
+    "bound": 19713.036064206917,
+    "node_count": 7,
+    "wall": 20.887375094999697
+   }
+  },
+  "alan": {
+   "post": {
+    "status": "optimal",
+    "objective": 2.9249999983013426,
+    "bound": 2.9249999983013426,
+    "node_count": 21,
+    "wall": 0.11002031300040471
+   },
+   "pre": {
+    "status": "optimal",
+    "objective": 2.9249999983013426,
+    "bound": 2.9249999983013426,
+    "node_count": 21,
+    "wall": 0.11820259100022668
+   }
+  },
+  "bchoco06": {
+   "pre": {
+    "status": "time_limit",
+    "objective": null,
+    "bound": 0.9999887833666715,
+    "node_count": 7,
+    "wall": 22.467671041999893
+   },
+   "post": {
+    "status": "time_limit",
+    "objective": null,
+    "bound": 0.9999887833703148,
+    "node_count": 7,
+    "wall": 21.18098447200009
+   }
+  },
+  "bchoco07": {
+   "post": {
+    "status": "time_limit",
+    "objective": null,
+    "bound": 1.000000000000286,
+    "node_count": 7,
+    "wall": 29.30848712399984
+   },
+   "pre": {
+    "status": "time_limit",
+    "objective": null,
+    "bound": 1.000000000000286,
+    "node_count": 7,
+    "wall": 22.659606178000104
+   }
+  },
+  "bchoco08": {
+   "pre": {
+    "status": "time_limit",
+    "objective": null,
+    "bound": 1.000000000002788,
+    "node_count": 3,
+    "wall": 21.245285416000115
+   },
+   "post": {
+    "status": "time_limit",
+    "objective": null,
+    "bound": 1.000000000002788,
+    "node_count": 3,
+    "wall": 21.40287190500021
+   }
+  },
+  "beuster": {
+   "post": {
+    "status": "time_limit",
+    "objective": null,
+    "bound": 6352.99834504317,
+    "node_count": 7,
+    "wall": 22.180832595000084
+   },
+   "pre": {
+    "status": "time_limit",
+    "objective": null,
+    "bound": 6352.99834504317,
+    "node_count": 7,
+    "wall": 21.46282591299996
+   }
+  },
+  "casctanks": {
+   "pre": {
+    "status": "time_limit",
+    "objective": null,
+    "bound": -90.17862329759835,
+    "node_count": 1,
+    "wall": 24.244932596000126
+   },
+   "post": {
+    "status": "time_limit",
+    "objective": null,
+    "bound": -90.17862329759835,
+    "node_count": 1,
+    "wall": 21.77157353299981
+   }
+  },
+  "chance": {
+   "post": {
+    "status": "optimal",
+    "objective": 29.894378154271102,
+    "bound": 29.894378154271102,
+    "node_count": 0,
+    "wall": 0.42270455300013055
+   },
+   "pre": {
+    "status": "optimal",
+    "objective": 29.894378154271102,
+    "bound": 29.894378154271102,
+    "node_count": 0,
+    "wall": 0.19776669599968955
+   }
+  },
+  "clay0303hfsg": {
+   "pre": {
+    "status": "time_limit",
+    "objective": null,
+    "bound": null,
+    "node_count": 3,
+    "wall": 24.398320659999627
+   },
+   "post": {
+    "status": "time_limit",
+    "objective": null,
+    "bound": null,
+    "node_count": 63,
+    "wall": 20.582645404999766
+   }
+  },
+  "contvar": {
+   "post": {
+    "status": "time_limit",
+    "objective": null,
+    "bound": 180782.8593284799,
+    "node_count": 3,
+    "wall": 26.119079677999707
+   },
+   "pre": {
+    "status": "time_limit",
+    "objective": null,
+    "bound": 183430.50053431175,
+    "node_count": 3,
+    "wall": 22.135885255000176
+   }
+  },
+  "cvxnonsep_nsig30": {
+   "pre": {
+    "status": "optimal",
+    "objective": 130.62871116925294,
+    "bound": 130.61841392487688,
+    "node_count": 171,
+    "wall": 8.01772743299989
+   },
+   "post": {
+    "status": "optimal",
+    "objective": 130.62871116925294,
+    "bound": 130.61841392487688,
+    "node_count": 171,
+    "wall": 5.626963754999906
+   }
+  },
+  "cvxnonsep_psig30": {
+   "post": {
+    "status": "optimal",
+    "objective": 78.99885435294289,
+    "bound": 78.99701703820377,
+    "node_count": 89,
+    "wall": 5.301478297000358
+   },
+   "pre": {
+    "status": "optimal",
+    "objective": 78.99885435294289,
+    "bound": 78.99701703820377,
+    "node_count": 89,
+    "wall": 2.4127081909996377
+   }
+  },
+  "cvxnonsep_psig40r": {
+   "pre": {
+    "status": "optimal",
+    "objective": 86.54527995164959,
+    "bound": 86.53873600363832,
+    "node_count": 103,
+    "wall": 10.417140275000293
+   },
+   "post": {
+    "status": "optimal",
+    "objective": 86.54527995164959,
+    "bound": 86.53873600363832,
+    "node_count": 103,
+    "wall": 8.604540518000249
+   }
+  },
+  "dispatch": {
+   "post": {
+    "status": "optimal",
+    "objective": 3155.2879266857854,
+    "bound": 3155.2878615366776,
+    "node_count": 23,
+    "wall": 0.7293691979998584
+   },
+   "pre": {
+    "status": "optimal",
+    "objective": 3155.2879266857854,
+    "bound": 3155.2878615366776,
+    "node_count": 23,
+    "wall": 0.6962513250000484
+   }
+  },
+  "ex1221": {
+   "pre": {
+    "status": "optimal",
+    "objective": 7.667180068813135,
+    "bound": 7.667180068813077,
+    "node_count": 5,
+    "wall": 1.249194176000401
+   },
+   "post": {
+    "status": "optimal",
+    "objective": 7.667180068813135,
+    "bound": 7.667180068813077,
+    "node_count": 5,
+    "wall": 0.9177672659998279
+   }
+  },
+  "ex1222": {
+   "post": {
+    "status": "optimal",
+    "objective": 1.0765430833322625,
+    "bound": 1.0765430463031964,
+    "node_count": 1,
+    "wall": 0.5601772030004213
+   },
+   "pre": {
+    "status": "optimal",
+    "objective": 1.0765430833322625,
+    "bound": 1.0765430463031964,
+    "node_count": 1,
+    "wall": 0.35711891700020715
+   }
+  },
+  "ex1224": {
+   "pre": {
+    "status": "optimal",
+    "objective": -0.9434704942820806,
+    "bound": -0.9434705000000166,
+    "node_count": 5,
+    "wall": 4.3252883699997255
+   },
+   "post": {
+    "status": "optimal",
+    "objective": -0.9434704942820806,
+    "bound": -0.9434705000000166,
+    "node_count": 5,
+    "wall": 3.636300170999675
+   }
+  },
+  "ex1225": {
+   "post": {
+    "status": "optimal",
+    "objective": 30.999999913557566,
+    "bound": 30.999999913557566,
+    "node_count": 5,
+    "wall": 3.681566657000076
+   },
+   "pre": {
+    "status": "optimal",
+    "objective": 30.999999913557566,
+    "bound": 30.999999913557566,
+    "node_count": 5,
+    "wall": 3.4148386019996906
+   }
+  },
+  "ex1226": {
+   "pre": {
+    "status": "optimal",
+    "objective": -17.000000003887443,
+    "bound": -17.000000003887443,
+    "node_count": 3,
+    "wall": 1.310781259000123
+   },
+   "post": {
+    "status": "optimal",
+    "objective": -17.000000003887443,
+    "bound": -17.000000003887443,
+    "node_count": 3,
+    "wall": 1.4155730269999367
+   }
+  },
+  "ex14_1_9": {
+   "post": {
+    "status": "optimal",
+    "objective": -1.9775220540513224e-16,
+    "bound": -1.9775220540513224e-16,
+    "node_count": 3,
+    "wall": 0.4155350740002177
+   },
+   "pre": {
+    "status": "optimal",
+    "objective": -1.9775220540513224e-16,
+    "bound": -1.9775220540513224e-16,
+    "node_count": 3,
+    "wall": 0.39447935499993037
+   }
+  },
+  "fac2": {
+   "pre": {
+    "status": "optimal",
+    "objective": 331837497.8394821,
+    "bound": 331837497.54563797,
+    "node_count": 41,
+    "wall": 13.340976797999701
+   },
+   "post": {
+    "status": "optimal",
+    "objective": 331837497.8394821,
+    "bound": 331837497.54563797,
+    "node_count": 41,
+    "wall": 12.449896032999732
+   }
+  },
+  "flay02m": {
+   "post": {
+    "status": "optimal",
+    "objective": 37.94733186383461,
+    "bound": 37.947331804569515,
+    "node_count": 7,
+    "wall": 0.8972219729998869
+   },
+   "pre": {
+    "status": "optimal",
+    "objective": 37.94733186383461,
+    "bound": 37.947331804569515,
+    "node_count": 7,
+    "wall": 0.624575878000087
+   }
+  },
+  "flay03m": {
+   "pre": {
+    "status": "optimal",
+    "objective": 48.98979479383567,
+    "bound": 48.98979470823052,
+    "node_count": 111,
+    "wall": 10.442630846999691
+   },
+   "post": {
+    "status": "optimal",
+    "objective": 48.98979479383567,
+    "bound": 48.98979470823052,
+    "node_count": 111,
+    "wall": 9.464744239000083
+   }
+  },
+  "gbd": {
+   "post": {
+    "status": "optimal",
+    "objective": 2.1999999825308127,
+    "bound": 2.1999999825308127,
+    "node_count": 3,
+    "wall": 0.03595365299997866
+   },
+   "pre": {
+    "status": "optimal",
+    "objective": 2.199999982504936,
+    "bound": 2.199999982504936,
+    "node_count": 3,
+    "wall": 0.03328848499995729
+   }
+  },
+  "gkocis": {
+   "pre": {
+    "status": "optimal",
+    "objective": -1.9230987798770212,
+    "bound": -1.9230988280923489,
+    "node_count": 5,
+    "wall": 1.8277999140000247
+   },
+   "post": {
+    "status": "optimal",
+    "objective": -1.9230987798770212,
+    "bound": -1.9230988280923489,
+    "node_count": 5,
+    "wall": 1.6135536520000642
+   }
+  },
+  "hda": {
+   "post": {
+    "status": "time_limit",
+    "objective": null,
+    "bound": -64473.44240243703,
+    "node_count": 1,
+    "wall": 26.00178211599996
+   },
+   "pre": {
+    "status": "time_limit",
+    "objective": null,
+    "bound": -64473.44240243703,
+    "node_count": 1,
+    "wall": 25.005090283999834
+   }
+  },
+  "heatexch_gen1": {
+   "pre": {
+    "status": "time_limit",
+    "objective": null,
+    "bound": 38183.5317460179,
+    "node_count": 3,
+    "wall": 22.89515350000056
+   },
+   "post": {
+    "status": "time_limit",
+    "objective": null,
+    "bound": 38183.5317460179,
+    "node_count": 3,
+    "wall": 23.951368686999558
+   }
+  },
+  "heatexch_gen2": {
+   "post": {
+    "status": "time_limit",
+    "objective": null,
+    "bound": 555767.7902857271,
+    "node_count": 7,
+    "wall": 22.608721485999922
+   },
+   "pre": {
+    "status": "time_limit",
+    "objective": null,
+    "bound": 555767.7902857271,
+    "node_count": 7,
+    "wall": 21.981647496000733
+   }
+  },
+  "heatexch_gen3": {
+   "pre": {
+    "status": "time_limit",
+    "objective": null,
+    "bound": null,
+    "node_count": 3,
+    "wall": 32.95270681200054
+   },
+   "post": {
+    "status": "time_limit",
+    "objective": null,
+    "bound": null,
+    "node_count": 3,
+    "wall": 248.09698854099952
+   }
+  },
+  "m3": {
+   "post": {
+    "status": "optimal",
+    "objective": 37.79999966997884,
+    "bound": 37.79999951039201,
+    "node_count": 47,
+    "wall": 6.490866232000371
+   },
+   "pre": {
+    "status": "optimal",
+    "objective": 37.79999966997884,
+    "bound": 37.79999951039201,
+    "node_count": 47,
+    "wall": 5.6113365699993665
+   }
+  },
+  "nvs01": {
+   "pre": {
+    "status": "optimal",
+    "objective": 12.46966882156821,
+    "bound": 12.46966882156821,
+    "node_count": 3,
+    "wall": 2.222138625000298
+   },
+   "post": {
+    "status": "optimal",
+    "objective": 12.46966882156821,
+    "bound": 12.46966882156821,
+    "node_count": 3,
+    "wall": 1.9361843890001182
+   }
+  },
+  "nvs02": {
+   "post": {
+    "status": "optimal",
+    "objective": 5.96418452307,
+    "bound": 5.96418452307,
+    "node_count": 345,
+    "wall": 0.6423666600003344
+   },
+   "pre": {
+    "status": "optimal",
+    "objective": 5.96418452307,
+    "bound": 5.96418452307,
+    "node_count": 345,
+    "wall": 0.4747323880001204
+   }
+  },
+  "nvs03": {
+   "pre": {
+    "status": "optimal",
+    "objective": 16.0,
+    "bound": 15.99999972676511,
+    "node_count": 5,
+    "wall": 0.41465291300028184
+   },
+   "post": {
+    "status": "optimal",
+    "objective": 16.0,
+    "bound": 15.99999972676511,
+    "node_count": 5,
+    "wall": 0.24724682700070844
+   }
+  },
+  "nvs04": {
+   "post": {
+    "status": "optimal",
+    "objective": 0.720000000000006,
+    "bound": 0.7199999999999773,
+    "node_count": 5,
+    "wall": 0.677775856000153
+   },
+   "pre": {
+    "status": "optimal",
+    "objective": 0.720000000000006,
+    "bound": 0.7199999999999773,
+    "node_count": 5,
+    "wall": 0.4733197619998464
+   }
+  },
+  "nvs05": {
+   "pre": {
+    "status": "feasible",
+    "objective": 8.731956986640078,
+    "bound": 3.5139117087764977,
+    "node_count": 25,
+    "wall": 20.348141084000417
+   },
+   "post": {
+    "status": "feasible",
+    "objective": 8.731956986640078,
+    "bound": 3.5139117087764977,
+    "node_count": 33,
+    "wall": 20.13810035699953
+   }
+  },
+  "nvs06": {
+   "post": {
+    "status": "optimal",
+    "objective": 1.7703125,
+    "bound": 1.7703124999999627,
+    "node_count": 5,
+    "wall": 2.2296432680004727
+   },
+   "pre": {
+    "status": "optimal",
+    "objective": 1.7703125,
+    "bound": 1.7703124999999627,
+    "node_count": 5,
+    "wall": 1.6296473370002786
+   }
+  },
+  "nvs07": {
+   "pre": {
+    "status": "optimal",
+    "objective": 4.0,
+    "bound": 4.0,
+    "node_count": 5,
+    "wall": 0.1523981129994354
+   },
+   "post": {
+    "status": "optimal",
+    "objective": 4.0,
+    "bound": 4.0,
+    "node_count": 5,
+    "wall": 0.09493232699969667
+   }
+  },
+  "nvs08": {
+   "post": {
+    "status": "optimal",
+    "objective": 23.449727347139827,
+    "bound": 23.44972734516655,
+    "node_count": 3,
+    "wall": 2.048825206999936
+   },
+   "pre": {
+    "status": "optimal",
+    "objective": 23.449727347139827,
+    "bound": 23.44972734516655,
+    "node_count": 3,
+    "wall": 1.7602878499992585
+   }
+  },
+  "nvs09": {
+   "pre": {
+    "status": "optimal",
+    "objective": -43.134336918035295,
+    "bound": -43.13433691803662,
+    "node_count": 5,
+    "wall": 8.207970409000154
+   },
+   "post": {
+    "status": "optimal",
+    "objective": -43.134336918035295,
+    "bound": -43.13433691803662,
+    "node_count": 5,
+    "wall": 5.702279522000026
+   }
+  },
+  "nvs10": {
+   "post": {
+    "status": "optimal",
+    "objective": -310.7999999999999,
+    "bound": -310.7999999999999,
+    "node_count": 5,
+    "wall": 0.2771273719999954
+   },
+   "pre": {
+    "status": "optimal",
+    "objective": -310.7999999999999,
+    "bound": -310.7999999999999,
+    "node_count": 5,
+    "wall": 0.23883065599966358
+   }
+  },
+  "nvs11": {
+   "pre": {
+    "status": "optimal",
+    "objective": -431.0000000000085,
+    "bound": -431.0000000000085,
+    "node_count": 55,
+    "wall": 1.0633460030003334
+   },
+   "post": {
+    "status": "optimal",
+    "objective": -431.0000000000085,
+    "bound": -431.0000000000085,
+    "node_count": 55,
+    "wall": 0.7546429849999186
+   }
+  },
+  "nvs12": {
+   "post": {
+    "status": "optimal",
+    "objective": -481.20000000001,
+    "bound": -481.20000000001,
+    "node_count": 231,
+    "wall": 3.2871221510004034
+   },
+   "pre": {
+    "status": "optimal",
+    "objective": -481.20000000001,
+    "bound": -481.20000000001,
+    "node_count": 231,
+    "wall": 3.318201302000489
+   }
+  },
+  "nvs13": {
+   "pre": {
+    "status": "optimal",
+    "objective": -585.2,
+    "bound": -585.2,
+    "node_count": 637,
+    "wall": 2.422947576000297
+   },
+   "post": {
+    "status": "optimal",
+    "objective": -585.2,
+    "bound": -585.2,
+    "node_count": 637,
+    "wall": 1.7732599160008249
+   }
+  },
+  "nvs14": {
+   "post": {
+    "status": "optimal",
+    "objective": -40358.15476929995,
+    "bound": -40358.154769299996,
+    "node_count": 129,
+    "wall": 1.0206735700003264
+   },
+   "pre": {
+    "status": "optimal",
+    "objective": -40358.15476929995,
+    "bound": -40358.154769299996,
+    "node_count": 129,
+    "wall": 0.9539272100000744
+   }
+  },
+  "nvs15": {
+   "pre": {
+    "status": "optimal",
+    "objective": 1.0,
+    "bound": 1.0,
+    "node_count": 7,
+    "wall": 0.1067352000000028
+   },
+   "post": {
+    "status": "optimal",
+    "objective": 1.0,
+    "bound": 1.0,
+    "node_count": 7,
+    "wall": 0.10220228500020312
+   }
+  },
+  "nvs21": {
+   "post": {
+    "status": "optimal",
+    "objective": -5.684782628025259,
+    "bound": -5.684782628025259,
+    "node_count": 3,
+    "wall": 8.460657235000326
+   },
+   "pre": {
+    "status": "optimal",
+    "objective": -5.684782628025259,
+    "bound": -5.684782628025259,
+    "node_count": 3,
+    "wall": 8.806042647999675
+   }
+  },
+  "oaer": {
+   "pre": {
+    "status": "optimal",
+    "objective": -1.923098499884843,
+    "bound": -1.923098601139822,
+    "node_count": 3,
+    "wall": 1.5590041499999643
+   },
+   "post": {
+    "status": "optimal",
+    "objective": -1.923098499884843,
+    "bound": -1.923098601139822,
+    "node_count": 3,
+    "wall": 1.3788624789995083
+   }
+  },
+  "st_e11": {
+   "post": {
+    "status": "optimal",
+    "objective": 189.31162974131917,
+    "bound": 189.31162968661766,
+    "node_count": 27,
+    "wall": 4.603981249999379
+   },
+   "pre": {
+    "status": "optimal",
+    "objective": 189.31162974131917,
+    "bound": 189.31162968661766,
+    "node_count": 27,
+    "wall": 4.305659311999989
+   }
+  },
+  "st_e13": {
+   "pre": {
+    "status": "optimal",
+    "objective": 1.9999999825187946,
+    "bound": 1.9999999825187946,
+    "node_count": 1,
+    "wall": 0.31383847699999023
+   },
+   "post": {
+    "status": "optimal",
+    "objective": 1.9999999825187946,
+    "bound": 1.9999999825187946,
+    "node_count": 1,
+    "wall": 0.1715123659996607
+   }
+  },
+  "st_e29": {
+   "post": {
+    "status": "optimal",
+    "objective": -0.9434704942820806,
+    "bound": -0.9434705000000166,
+    "node_count": 5,
+    "wall": 3.8910427969995
+   },
+   "pre": {
+    "status": "optimal",
+    "objective": -0.9434704942820806,
+    "bound": -0.9434705000000166,
+    "node_count": 5,
+    "wall": 3.6767727909991663
+   }
+  },
+  "st_e36": {
+   "pre": {
+    "status": "optimal",
+    "objective": -245.99999999999997,
+    "bound": -246.00000000170422,
+    "node_count": 85,
+    "wall": 13.931134089999432
+   },
+   "post": {
+    "status": "optimal",
+    "objective": -245.99999999999997,
+    "bound": -246.00000000170422,
+    "node_count": 85,
+    "wall": 12.940589094999268
+   }
+  },
+  "st_e38": {
+   "post": {
+    "status": "optimal",
+    "objective": 7197.727116826533,
+    "bound": 7197.727116826533,
+    "node_count": 3,
+    "wall": 1.2507111740005712
+   },
+   "pre": {
+    "status": "optimal",
+    "objective": 7197.727116826533,
+    "bound": 7197.727116826533,
+    "node_count": 3,
+    "wall": 1.0618792739996934
+   }
+  },
+  "st_miqp1": {
+   "pre": {
+    "status": "optimal",
+    "objective": 280.9999999906497,
+    "bound": 280.9999999906497,
+    "node_count": 15,
+    "wall": 0.03008393999971304
+   },
+   "post": {
+    "status": "optimal",
+    "objective": 280.9999999906497,
+    "bound": 280.9999999906497,
+    "node_count": 15,
+    "wall": 0.03842139300013514
+   }
+  },
+  "st_miqp2": {
+   "post": {
+    "status": "optimal",
+    "objective": 2.0,
+    "bound": 2.0,
+    "node_count": 9,
+    "wall": 0.037049591000140936
+   },
+   "pre": {
+    "status": "optimal",
+    "objective": 2.0,
+    "bound": 2.0,
+    "node_count": 9,
+    "wall": 0.03833112299980712
+   }
+  },
+  "st_miqp3": {
+   "pre": {
+    "status": "optimal",
+    "objective": -6.0,
+    "bound": -6.0,
+    "node_count": 1,
+    "wall": 0.016465490999507892
+   },
+   "post": {
+    "status": "optimal",
+    "objective": -6.0,
+    "bound": -6.0,
+    "node_count": 1,
+    "wall": 0.016128648000631074
+   }
+  },
+  "st_miqp4": {
+   "post": {
+    "status": "optimal",
+    "objective": -4574.0000024840665,
+    "bound": -4574.0000024840665,
+    "node_count": 3,
+    "wall": 0.04548691400032112
+   },
+   "pre": {
+    "status": "optimal",
+    "objective": -4574.000004423649,
+    "bound": -4574.000004423649,
+    "node_count": 3,
+    "wall": 0.04147656700024527
+   }
+  },
+  "st_miqp5": {
+   "pre": {
+    "status": "optimal",
+    "objective": -333.8888902720728,
+    "bound": -333.8888902720728,
+    "node_count": 1,
+    "wall": 0.04973499700008688
+   },
+   "post": {
+    "status": "optimal",
+    "objective": -333.88889024868075,
+    "bound": -333.88889024868075,
+    "node_count": 1,
+    "wall": 0.04833077300008881
+   }
+  },
+  "st_test1": {
+   "post": {
+    "status": "optimal",
+    "objective": -1.6495994490692313e-08,
+    "bound": -1.6495994490692313e-08,
+    "node_count": 15,
+    "wall": 0.051483186000041314
+   },
+   "pre": {
+    "status": "optimal",
+    "objective": -1.6495994490692313e-08,
+    "bound": -1.6495994490692313e-08,
+    "node_count": 15,
+    "wall": 0.050760942999659164
+   }
+  },
+  "st_testgr3": {
+   "pre": {
+    "status": "optimal",
+    "objective": -20.59,
+    "bound": -20.59070709795548,
+    "node_count": 549,
+    "wall": 0.42399136400035786
+   },
+   "post": {
+    "status": "optimal",
+    "objective": -20.59,
+    "bound": -20.59070709795548,
+    "node_count": 549,
+    "wall": 0.4482717989994853
+   }
+  },
+  "syn05hfsg": {
+   "post": {
+    "status": "feasible",
+    "objective": 837.732412391107,
+    "bound": 851.0639474502206,
+    "node_count": 59,
+    "wall": 20.131564403000084
+   },
+   "pre": {
+    "status": "feasible",
+    "objective": 837.732412391107,
+    "bound": 851.0639474502206,
+    "node_count": 75,
+    "wall": 20.440045795000515
+   }
+  },
+  "tanksize": {
+   "pre": {
+    "status": "time_limit",
+    "objective": 1.268643752557795,
+    "bound": 1.2565601160167452,
+    "node_count": 2313,
+    "wall": 20.12689332500031
+   },
+   "post": {
+    "status": "time_limit",
+    "objective": 1.268643752557795,
+    "bound": 1.2590946299521892,
+    "node_count": 2812,
+    "wall": 20.1271998430002
+   }
+  },
+  "tls2": {
+   "post": {
+    "status": "feasible",
+    "objective": 11.299999856725538,
+    "bound": 2.0999999901667694,
+    "node_count": 333,
+    "wall": 21.186317167999732
+   },
+   "pre": {
+    "status": "feasible",
+    "objective": 10.299999865440752,
+    "bound": 2.4487125876978726,
+    "node_count": 353,
+    "wall": 20.626865416000328
+   }
+  },
+  "tspn05": {
+   "pre": {
+    "status": "feasible",
+    "objective": 191.2552076849412,
+    "bound": 178.11649276434017,
+    "node_count": 35,
+    "wall": 20.53765499600013
+   },
+   "post": {
+    "status": "feasible",
+    "objective": 191.2552076849412,
+    "bound": 178.11649276434017,
+    "node_count": 35,
+    "wall": 20.121083723000083
+   }
+  },
+  "tspn08": {
+   "post": {
+    "status": "feasible",
+    "objective": 290.56685374735093,
+    "bound": null,
+    "node_count": 1,
+    "wall": 24.533595884000533
+   },
+   "pre": {
+    "status": "feasible",
+    "objective": 290.56685374735093,
+    "bound": null,
+    "node_count": 1,
+    "wall": 22.716204569999718
+   }
+  },
+  "tspn10": {
+   "pre": {
+    "status": "feasible",
+    "objective": 225.1260713973286,
+    "bound": null,
+    "node_count": 1,
+    "wall": 19.841280678999283
+   },
+   "post": {
+    "status": "feasible",
+    "objective": 225.1260713973286,
+    "bound": null,
+    "node_count": 1,
+    "wall": 18.795712611000454
+   }
+  },
+  "tspn12": {
+   "post": {
+    "status": "time_limit",
+    "objective": null,
+    "bound": null,
+    "node_count": 3,
+    "wall": 46.47937336799987
+   },
+   "pre": {
+    "status": "feasible",
+    "objective": 262.64739525060224,
+    "bound": null,
+    "node_count": 1,
+    "wall": 18.630338887000107
+   }
+  }
+ },
+ "diffs": [
+  [
+   "bchoco06",
+   {
+    "bound": [
+     0.9999887833666715,
+     0.9999887833703148
+    ]
+   }
+  ],
+  [
+   "clay0303hfsg",
+   {
+    "node_count": [
+     3,
+     63
+    ]
+   }
+  ],
+  [
+   "contvar",
+   {
+    "bound": [
+     183430.50053431175,
+     180782.8593284799
+    ]
+   }
+  ],
+  [
+   "gbd",
+   {
+    "objective": [
+     2.199999982504936,
+     2.1999999825308127
+    ],
+    "bound": [
+     2.199999982504936,
+     2.1999999825308127
+    ]
+   }
+  ],
+  [
+   "nvs05",
+   {
+    "node_count": [
+     25,
+     33
+    ]
+   }
+  ],
+  [
+   "st_miqp4",
+   {
+    "objective": [
+     -4574.000004423649,
+     -4574.0000024840665
+    ],
+    "bound": [
+     -4574.000004423649,
+     -4574.0000024840665
+    ]
+   }
+  ],
+  [
+   "st_miqp5",
+   {
+    "objective": [
+     -333.8888902720728,
+     -333.88889024868075
+    ],
+    "bound": [
+     -333.8888902720728,
+     -333.88889024868075
+    ]
+   }
+  ],
+  [
+   "syn05hfsg",
+   {
+    "node_count": [
+     75,
+     59
+    ]
+   }
+  ],
+  [
+   "tanksize",
+   {
+    "bound": [
+     1.2565601160167452,
+     1.2590946299521892
+    ],
+    "node_count": [
+     2313,
+     2812
+    ]
+   }
+  ],
+  [
+   "tls2",
+   {
+    "objective": [
+     10.299999865440752,
+     11.299999856725538
+    ],
+    "bound": [
+     2.4487125876978726,
+     2.0999999901667694
+    ],
+    "node_count": [
+     353,
+     333
+    ]
+   }
+  ],
+  [
+   "tspn12",
+   {
+    "status": [
+     "feasible",
+     "time_limit"
+    ],
+    "objective": [
+     262.64739525060224,
+     null
+    ],
+    "node_count": [
+     1,
+     3
+    ]
+   }
+  ]
+ ]
+}

--- a/scratchpad/issue940/panel_corpus.py
+++ b/scratchpad/issue940/panel_corpus.py
@@ -29,12 +29,12 @@ from discopt.modeling import from_nl  # noqa: E402
 
 # §8: assert we loaded the code under test, by file AND by a marker unique to it.
 assert LPP.__file__.startswith("/home/user/discopt/python/"), LPP.__file__
-assert hasattr(LPP, "_reject_impossible_unbounded"), "post-fix marker absent"
+assert hasattr(LPP, "_settle_ambiguous_unbounded"), "post-fix marker absent"
 assert LPP._CONSTR_VIOL_TOL == 1e-8, LPP._CONSTR_VIOL_TOL
 
 _POST_TOL = LPP._CONSTR_VIOL_TOL
-_POST_REJECT = LPP._reject_impossible_unbounded
-_POST_COMPACT = QPP._box_is_compact
+_POST_REJECT = LPP._settle_ambiguous_unbounded
+_POST_RAY = QPP._certify_unbounded_ray
 _IPOPT_DEFAULT_TOL = 1e-4
 
 ROOT = "python/tests/data/minlplib_nl"
@@ -46,13 +46,13 @@ def set_arm(arm):
     if arm == "pre":
         LPP._CONSTR_VIOL_TOL = _IPOPT_DEFAULT_TOL
         QPP._CONSTR_VIOL_TOL = _IPOPT_DEFAULT_TOL
-        LPP._reject_impossible_unbounded = lambda result, lb, ub: result
-        QPP._box_is_compact = lambda lb, ub: False
+        LPP._settle_ambiguous_unbounded = lambda result, c, A, cl, cu, lb, ub, opts: result
+        QPP._certify_unbounded_ray = lambda *a, **k: True
     else:
         LPP._CONSTR_VIOL_TOL = _POST_TOL
         QPP._CONSTR_VIOL_TOL = _POST_TOL
-        LPP._reject_impossible_unbounded = _POST_REJECT
-        QPP._box_is_compact = _POST_COMPACT
+        LPP._settle_ambiguous_unbounded = _POST_REJECT
+        QPP._certify_unbounded_ray = _POST_RAY
 
 
 def solve_one(path, arm):

--- a/scratchpad/issue940/panel_corpus.py
+++ b/scratchpad/issue940/panel_corpus.py
@@ -1,0 +1,107 @@
+"""Issue #940 corpus panel: bound-neutrality over the in-repo .nl corpus.
+
+Per CLAUDE.md §5 regime 1, a change that should not move the search must be shown
+not to. The POUNCE LP+QP change is expected to be inert on this corpus (the
+per-node engine is the Rust simplex, and 0 of these 68 instances classify as a
+pure LP), so anything but an exact status/objective/bound/node_count match is a
+finding.
+
+Both arms run INTERLEAVED in one process (CLAUDE.md §9) — the arm is selected by
+flipping the module globals the backends read, not by two sequential runs against
+two checkouts — so background load cannot land on one arm only. The pre-fix arm is
+reconstructed exactly: POUNCE's own 1e-4 ``constr_viol_tol`` and no compact-box
+refusal.
+
+§6: prints a comparison count and exits non-zero when it is zero.
+"""
+
+import json
+import os
+import sys
+import time
+
+os.environ.setdefault("JAX_PLATFORMS", "cpu")
+os.environ.setdefault("JAX_ENABLE_X64", "1")
+
+import discopt.solvers.lp_pounce as LPP  # noqa: E402
+import discopt.solvers.qp_pounce as QPP  # noqa: E402
+from discopt.modeling import from_nl  # noqa: E402
+
+# §8: assert we loaded the code under test, by file AND by a marker unique to it.
+assert LPP.__file__.startswith("/home/user/discopt/python/"), LPP.__file__
+assert hasattr(LPP, "_reject_impossible_unbounded"), "post-fix marker absent"
+assert LPP._CONSTR_VIOL_TOL == 1e-8, LPP._CONSTR_VIOL_TOL
+
+_POST_TOL = LPP._CONSTR_VIOL_TOL
+_POST_REJECT = LPP._reject_impossible_unbounded
+_POST_COMPACT = QPP._box_is_compact
+_IPOPT_DEFAULT_TOL = 1e-4
+
+ROOT = "python/tests/data/minlplib_nl"
+TIME_LIMIT = 20.0
+
+
+def set_arm(arm):
+    """Select 'pre' (POUNCE's own defaults) or 'post' (the #940 backends)."""
+    if arm == "pre":
+        LPP._CONSTR_VIOL_TOL = _IPOPT_DEFAULT_TOL
+        QPP._CONSTR_VIOL_TOL = _IPOPT_DEFAULT_TOL
+        LPP._reject_impossible_unbounded = lambda result, lb, ub: result
+        QPP._box_is_compact = lambda lb, ub: False
+    else:
+        LPP._CONSTR_VIOL_TOL = _POST_TOL
+        QPP._CONSTR_VIOL_TOL = _POST_TOL
+        LPP._reject_impossible_unbounded = _POST_REJECT
+        QPP._box_is_compact = _POST_COMPACT
+
+
+def solve_one(path, arm):
+    set_arm(arm)
+    t0 = time.perf_counter()
+    res = from_nl(path).solve(time_limit=TIME_LIMIT)
+    return {
+        "status": res.status,
+        "objective": res.objective,
+        "bound": res.bound,
+        "node_count": res.node_count,
+        "wall": time.perf_counter() - t0,
+    }
+
+
+def main(out_path):
+    files = sorted(f for f in os.listdir(ROOT) if f.endswith(".nl"))
+    rows = {}
+    comparisons = 0
+    diffs = []
+    for i, f in enumerate(files, 1):
+        name = f[:-3]
+        p = os.path.join(ROOT, f)
+        # Alternate which arm runs first so a warm-cache or drift effect cannot
+        # systematically favour one of them.
+        order = ("pre", "post") if i % 2 else ("post", "pre")
+        got = {a: solve_one(p, a) for a in order}
+        rows[name] = got
+        comparisons += 1
+        keys = ("status", "objective", "bound", "node_count")
+        same = all(got["pre"][k] == got["post"][k] for k in keys)
+        if not same:
+            diffs.append((name, {k: (got["pre"][k], got["post"][k]) for k in keys
+                                 if got["pre"][k] != got["post"][k]}))
+        print(f"[{i:3d}/{len(files)}] {name:28s} {'SAME' if same else 'DIFF'} "
+              f"pre={got['pre']['status']}/{got['pre']['objective']!r}/"
+              f"n{got['pre']['node_count']} post={got['post']['status']}/"
+              f"{got['post']['objective']!r}/n{got['post']['node_count']}", flush=True)
+
+    json.dump({"rows": rows, "diffs": diffs}, open(out_path, "w"), indent=1)
+    print(f"\nCOMPARISONS_EXECUTED={comparisons}  identical={comparisons - len(diffs)}  "
+          f"differing={len(diffs)}")
+    for name, d in diffs:
+        print(f"  DIFF {name}: {d}")
+    if comparisons == 0:
+        print("PANEL COMPARED NOTHING", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1]))

--- a/scratchpad/issue940/panel_replicate.json
+++ b/scratchpad/issue940/panel_replicate.json
@@ -1,0 +1,596 @@
+{
+ "bchoco06": {
+  "verdict": "QUARANTINE",
+  "optimum": null,
+  "reps": [
+   {
+    "pre": {
+     "status": "time_limit",
+     "objective": null,
+     "bound": 0.9999887833703148,
+     "node_count": 7,
+     "wall": 22.278725989000122
+    },
+    "post": {
+     "status": "time_limit",
+     "objective": null,
+     "bound": 0.9999887833703148,
+     "node_count": 7,
+     "wall": 21.265131154999835
+    }
+   },
+   {
+    "post": {
+     "status": "time_limit",
+     "objective": null,
+     "bound": 0.9999887833666715,
+     "node_count": 7,
+     "wall": 21.284136137000132
+    },
+    "pre": {
+     "status": "time_limit",
+     "objective": null,
+     "bound": 0.9999887833703148,
+     "node_count": 7,
+     "wall": 21.114453488000436
+    }
+   },
+   {
+    "pre": {
+     "status": "time_limit",
+     "objective": null,
+     "bound": 0.9999887833703148,
+     "node_count": 7,
+     "wall": 21.07059298799959
+    },
+    "post": {
+     "status": "time_limit",
+     "objective": null,
+     "bound": 0.9999887833703148,
+     "node_count": 7,
+     "wall": 21.070964898000057
+    }
+   }
+  ]
+ },
+ "clay0303hfsg": {
+  "verdict": "CLEAN",
+  "optimum": 26669.10955143,
+  "reps": [
+   {
+    "pre": {
+     "status": "time_limit",
+     "objective": null,
+     "bound": null,
+     "node_count": 95,
+     "wall": 21.814024835000055
+    },
+    "post": {
+     "status": "time_limit",
+     "objective": null,
+     "bound": null,
+     "node_count": 95,
+     "wall": 21.251528796000457
+    }
+   },
+   {
+    "post": {
+     "status": "time_limit",
+     "objective": null,
+     "bound": null,
+     "node_count": 159,
+     "wall": 21.501222324999617
+    },
+    "pre": {
+     "status": "time_limit",
+     "objective": null,
+     "bound": null,
+     "node_count": 159,
+     "wall": 21.563027747999513
+    }
+   },
+   {
+    "pre": {
+     "status": "time_limit",
+     "objective": null,
+     "bound": null,
+     "node_count": 159,
+     "wall": 21.554702398999325
+    },
+    "post": {
+     "status": "time_limit",
+     "objective": null,
+     "bound": null,
+     "node_count": 159,
+     "wall": 21.567474464000043
+    }
+   }
+  ]
+ },
+ "contvar": {
+  "verdict": "CLEAN",
+  "optimum": null,
+  "reps": [
+   {
+    "pre": {
+     "status": "time_limit",
+     "objective": null,
+     "bound": 183430.50053431175,
+     "node_count": 3,
+     "wall": 21.965850954000416
+    },
+    "post": {
+     "status": "time_limit",
+     "objective": null,
+     "bound": 183430.50053431175,
+     "node_count": 3,
+     "wall": 21.53163203800068
+    }
+   },
+   {
+    "post": {
+     "status": "time_limit",
+     "objective": null,
+     "bound": 183430.50053431175,
+     "node_count": 3,
+     "wall": 21.918906437999794
+    },
+    "pre": {
+     "status": "time_limit",
+     "objective": null,
+     "bound": 183430.50053431175,
+     "node_count": 3,
+     "wall": 22.94343765099984
+    }
+   },
+   {
+    "pre": {
+     "status": "time_limit",
+     "objective": null,
+     "bound": 183430.50053431175,
+     "node_count": 3,
+     "wall": 21.86314364500049
+    },
+    "post": {
+     "status": "time_limit",
+     "objective": null,
+     "bound": 183430.50053431175,
+     "node_count": 3,
+     "wall": 21.723385276000045
+    }
+   }
+  ]
+ },
+ "gbd": {
+  "verdict": "STABLE-DIFF",
+  "optimum": null,
+  "reps": [
+   {
+    "pre": {
+     "status": "optimal",
+     "objective": 2.199999982504936,
+     "bound": 2.199999982504936,
+     "node_count": 3,
+     "wall": 0.04534839399912016
+    },
+    "post": {
+     "status": "optimal",
+     "objective": 2.1999999825308127,
+     "bound": 2.1999999825308127,
+     "node_count": 3,
+     "wall": 0.031762124999659136
+    }
+   },
+   {
+    "post": {
+     "status": "optimal",
+     "objective": 2.1999999825308127,
+     "bound": 2.1999999825308127,
+     "node_count": 3,
+     "wall": 0.02984358699995937
+    },
+    "pre": {
+     "status": "optimal",
+     "objective": 2.199999982504936,
+     "bound": 2.199999982504936,
+     "node_count": 3,
+     "wall": 0.032564516000093136
+    }
+   },
+   {
+    "pre": {
+     "status": "optimal",
+     "objective": 2.199999982504936,
+     "bound": 2.199999982504936,
+     "node_count": 3,
+     "wall": 0.03346098399924813
+    },
+    "post": {
+     "status": "optimal",
+     "objective": 2.1999999825308127,
+     "bound": 2.1999999825308127,
+     "node_count": 3,
+     "wall": 0.038923388000512205
+    }
+   }
+  ]
+ },
+ "nvs05": {
+  "verdict": "QUARANTINE",
+  "optimum": null,
+  "reps": [
+   {
+    "pre": {
+     "status": "feasible",
+     "objective": 8.731956986640078,
+     "bound": 3.5139117087764977,
+     "node_count": 25,
+     "wall": 20.152572226000302
+    },
+    "post": {
+     "status": "feasible",
+     "objective": 8.731956986640078,
+     "bound": 3.5139117087764977,
+     "node_count": 33,
+     "wall": 20.4193791280004
+    }
+   },
+   {
+    "post": {
+     "status": "feasible",
+     "objective": 8.731956986640078,
+     "bound": 3.5139117087764977,
+     "node_count": 25,
+     "wall": 20.096821790999456
+    },
+    "pre": {
+     "status": "feasible",
+     "objective": 8.731956986640078,
+     "bound": 3.5139117087764977,
+     "node_count": 33,
+     "wall": 20.479329019000033
+    }
+   },
+   {
+    "pre": {
+     "status": "feasible",
+     "objective": 8.731956986640078,
+     "bound": 3.5139117087764977,
+     "node_count": 33,
+     "wall": 20.304705008999917
+    },
+    "post": {
+     "status": "feasible",
+     "objective": 8.731956986640078,
+     "bound": 3.5139117087764977,
+     "node_count": 33,
+     "wall": 20.19338899000013
+    }
+   }
+  ]
+ },
+ "st_miqp4": {
+  "verdict": "STABLE-DIFF",
+  "optimum": null,
+  "reps": [
+   {
+    "pre": {
+     "status": "optimal",
+     "objective": -4574.000004423649,
+     "bound": -4574.000004423649,
+     "node_count": 3,
+     "wall": 0.043551748000027146
+    },
+    "post": {
+     "status": "optimal",
+     "objective": -4574.0000024840665,
+     "bound": -4574.0000024840665,
+     "node_count": 3,
+     "wall": 0.04341972200018063
+    }
+   },
+   {
+    "post": {
+     "status": "optimal",
+     "objective": -4574.0000024840665,
+     "bound": -4574.0000024840665,
+     "node_count": 3,
+     "wall": 0.038607106000199565
+    },
+    "pre": {
+     "status": "optimal",
+     "objective": -4574.000004423649,
+     "bound": -4574.000004423649,
+     "node_count": 3,
+     "wall": 0.03836849700019229
+    }
+   },
+   {
+    "pre": {
+     "status": "optimal",
+     "objective": -4574.000004423649,
+     "bound": -4574.000004423649,
+     "node_count": 3,
+     "wall": 0.04992351599958056
+    },
+    "post": {
+     "status": "optimal",
+     "objective": -4574.0000024840665,
+     "bound": -4574.0000024840665,
+     "node_count": 3,
+     "wall": 0.03857986999992136
+    }
+   }
+  ]
+ },
+ "st_miqp5": {
+  "verdict": "STABLE-DIFF",
+  "optimum": null,
+  "reps": [
+   {
+    "pre": {
+     "status": "optimal",
+     "objective": -333.8888902720728,
+     "bound": -333.8888902720728,
+     "node_count": 1,
+     "wall": 0.0454219560006095
+    },
+    "post": {
+     "status": "optimal",
+     "objective": -333.88889024868075,
+     "bound": -333.88889024868075,
+     "node_count": 1,
+     "wall": 0.04639924300045095
+    }
+   },
+   {
+    "post": {
+     "status": "optimal",
+     "objective": -333.88889024868075,
+     "bound": -333.88889024868075,
+     "node_count": 1,
+     "wall": 0.04899067499991361
+    },
+    "pre": {
+     "status": "optimal",
+     "objective": -333.8888902720728,
+     "bound": -333.8888902720728,
+     "node_count": 1,
+     "wall": 0.046760614999584504
+    }
+   },
+   {
+    "pre": {
+     "status": "optimal",
+     "objective": -333.8888902720728,
+     "bound": -333.8888902720728,
+     "node_count": 1,
+     "wall": 0.04518116200051736
+    },
+    "post": {
+     "status": "optimal",
+     "objective": -333.88889024868075,
+     "bound": -333.88889024868075,
+     "node_count": 1,
+     "wall": 0.04521750300045824
+    }
+   }
+  ]
+ },
+ "syn05hfsg": {
+  "verdict": "STABLE-DIFF",
+  "optimum": null,
+  "reps": [
+   {
+    "pre": {
+     "status": "feasible",
+     "objective": 837.732412391107,
+     "bound": 851.063947450158,
+     "node_count": 93,
+     "wall": 20.143515407999985
+    },
+    "post": {
+     "status": "feasible",
+     "objective": 837.732412391107,
+     "bound": 851.0639474502206,
+     "node_count": 75,
+     "wall": 20.147809948999566
+    }
+   },
+   {
+    "post": {
+     "status": "feasible",
+     "objective": 837.732412391107,
+     "bound": 851.0639474502206,
+     "node_count": 67,
+     "wall": 20.17672949200005
+    },
+    "pre": {
+     "status": "feasible",
+     "objective": 837.732412391107,
+     "bound": 851.0639474502201,
+     "node_count": 85,
+     "wall": 20.17180781299976
+    }
+   },
+   {
+    "pre": {
+     "status": "feasible",
+     "objective": 837.732412391107,
+     "bound": 851.0639474502201,
+     "node_count": 79,
+     "wall": 20.117712160999872
+    },
+    "post": {
+     "status": "feasible",
+     "objective": 837.732412391107,
+     "bound": 851.0639474502201,
+     "node_count": 83,
+     "wall": 20.12314328299999
+    }
+   }
+  ]
+ },
+ "tanksize": {
+  "verdict": "STABLE-DIFF",
+  "optimum": null,
+  "reps": [
+   {
+    "pre": {
+     "status": "time_limit",
+     "objective": 1.268643752557795,
+     "bound": 1.2578554884376834,
+     "node_count": 2545,
+     "wall": 20.12710885100023
+    },
+    "post": {
+     "status": "time_limit",
+     "objective": 1.268643752557795,
+     "bound": 1.2594468851681229,
+     "node_count": 2901,
+     "wall": 20.1252385709995
+    }
+   },
+   {
+    "post": {
+     "status": "time_limit",
+     "objective": 1.268643752557795,
+     "bound": 1.2592441702798831,
+     "node_count": 2843,
+     "wall": 20.14317377900079
+    },
+    "pre": {
+     "status": "time_limit",
+     "objective": 1.268643752557795,
+     "bound": 1.2587709659359911,
+     "node_count": 2718,
+     "wall": 20.117999476000477
+    }
+   },
+   {
+    "pre": {
+     "status": "time_limit",
+     "objective": 1.268643752557795,
+     "bound": 1.2591137205545024,
+     "node_count": 2813,
+     "wall": 20.12767620700015
+    },
+    "post": {
+     "status": "time_limit",
+     "objective": 1.268643752557795,
+     "bound": 1.2594400278873694,
+     "node_count": 2891,
+     "wall": 20.362965065000026
+    }
+   }
+  ]
+ },
+ "tls2": {
+  "verdict": "STABLE-DIFF",
+  "optimum": null,
+  "reps": [
+   {
+    "pre": {
+     "status": "feasible",
+     "objective": 10.299999865440752,
+     "bound": 2.4487125876978726,
+     "node_count": 353,
+     "wall": 20.73295799100015
+    },
+    "post": {
+     "status": "feasible",
+     "objective": 11.299999856725538,
+     "bound": 2.0999999901667694,
+     "node_count": 333,
+     "wall": 20.593051967000065
+    }
+   },
+   {
+    "post": {
+     "status": "feasible",
+     "objective": 10.299999865440752,
+     "bound": 2.4487125876978726,
+     "node_count": 353,
+     "wall": 20.660693099000127
+    },
+    "pre": {
+     "status": "feasible",
+     "objective": 6.299999911869455,
+     "bound": 2.4487125876978726,
+     "node_count": 339,
+     "wall": 20.585876978999295
+    }
+   },
+   {
+    "pre": {
+     "status": "feasible",
+     "objective": 10.299999865440752,
+     "bound": 2.4487125876978726,
+     "node_count": 353,
+     "wall": 20.951647835000585
+    },
+    "post": {
+     "status": "feasible",
+     "objective": 6.299999911869455,
+     "bound": 2.4487125876978726,
+     "node_count": 339,
+     "wall": 21.08624554800008
+    }
+   }
+  ]
+ },
+ "tspn12": {
+  "verdict": "CLEAN",
+  "optimum": null,
+  "reps": [
+   {
+    "pre": {
+     "status": "feasible",
+     "objective": 262.64739525060224,
+     "bound": null,
+     "node_count": 1,
+     "wall": 18.39600091000011
+    },
+    "post": {
+     "status": "feasible",
+     "objective": 262.64739525060224,
+     "bound": null,
+     "node_count": 1,
+     "wall": 17.618511687000137
+    }
+   },
+   {
+    "post": {
+     "status": "feasible",
+     "objective": 262.64739525060224,
+     "bound": null,
+     "node_count": 1,
+     "wall": 18.157298946000083
+    },
+    "pre": {
+     "status": "feasible",
+     "objective": 262.64739525060224,
+     "bound": null,
+     "node_count": 1,
+     "wall": 18.108954534000077
+    }
+   },
+   {
+    "pre": {
+     "status": "feasible",
+     "objective": 262.64739525060224,
+     "bound": null,
+     "node_count": 1,
+     "wall": 17.98511323999992
+    },
+    "post": {
+     "status": "feasible",
+     "objective": 262.64739525060224,
+     "bound": null,
+     "node_count": 1,
+     "wall": 18.16853779700068
+    }
+   }
+  ]
+ }
+}

--- a/scratchpad/issue940/panel_replicate.py
+++ b/scratchpad/issue940/panel_replicate.py
@@ -1,0 +1,150 @@
+"""Issue #940: replicate the corpus-panel instances that differed.
+
+The panel runs under a 20s WALL budget, so node counts, the bound at
+termination, and even whether an incumbent was found are throughput-dependent
+and load-sensitive. A single differing run therefore proves nothing. This
+applies the house replication protocol already used for the separation-LP panel
+(see solver.py's note): re-run each decisive instance R times per arm with the
+arms INTERLEAVED, then classify
+
+    STABLE      — the difference reproduces in every replicate
+    QUARANTINE  — replicates disagree; the run was noise, not a signal
+    CLEAN       — the arms agree in every replicate
+
+and, separately from any of that, check SOUNDNESS on every replicate against the
+reference-optima registry: a dual bound may never exceed the true optimum (for a
+minimize sense) and an incumbent may never beat it.
+
+§6: prints an executed-comparison count and exits non-zero when it is zero.
+"""
+
+import json
+import os
+import sys
+import time
+
+os.environ.setdefault("JAX_PLATFORMS", "cpu")
+os.environ.setdefault("JAX_ENABLE_X64", "1")
+
+sys.path.insert(0, "python/tests")
+
+import discopt.solvers.lp_pounce as LPP  # noqa: E402
+import discopt.solvers.qp_pounce as QPP  # noqa: E402
+from discopt.modeling import from_nl  # noqa: E402
+
+assert LPP.__file__.startswith("/home/user/discopt/python/"), LPP.__file__
+assert hasattr(LPP, "_settle_ambiguous_unbounded"), "post-fix marker absent (§8)"
+assert LPP._CONSTR_VIOL_TOL == 1e-8, LPP._CONSTR_VIOL_TOL
+
+_POST_TOL = LPP._CONSTR_VIOL_TOL
+_POST_SETTLE = LPP._settle_ambiguous_unbounded
+_POST_RAY = QPP._certify_unbounded_ray
+_IPOPT_DEFAULT_TOL = 1e-4
+
+ROOT = "python/tests/data/minlplib_nl"
+TIME_LIMIT = 20.0
+REPS = 3
+
+DECISIVE = [
+    "bchoco06", "clay0303hfsg", "contvar", "gbd", "nvs05", "st_miqp4",
+    "st_miqp5", "syn05hfsg", "tanksize", "tls2", "tspn12",
+]
+
+
+def set_arm(arm):
+    if arm == "pre":
+        LPP._CONSTR_VIOL_TOL = _IPOPT_DEFAULT_TOL
+        QPP._CONSTR_VIOL_TOL = _IPOPT_DEFAULT_TOL
+        LPP._settle_ambiguous_unbounded = lambda result, c, A, cl, cu, lb, ub, opts: result
+        QPP._certify_unbounded_ray = lambda *a, **k: True
+    else:
+        LPP._CONSTR_VIOL_TOL = _POST_TOL
+        QPP._CONSTR_VIOL_TOL = _POST_TOL
+        LPP._settle_ambiguous_unbounded = _POST_SETTLE
+        QPP._certify_unbounded_ray = _POST_RAY
+
+
+def solve(name, arm):
+    set_arm(arm)
+    res = from_nl(os.path.join(ROOT, f"{name}.nl")).solve(time_limit=TIME_LIMIT)
+    return {"status": res.status, "objective": res.objective,
+            "bound": res.bound, "node_count": res.node_count}
+
+
+def optimum(name):
+    try:
+        from _optima import known_optimum
+    except ImportError:
+        return None
+    try:
+        return float(known_optimum(name))
+    except KeyError:
+        return None
+
+
+def main():
+    comparisons = 0
+    soundness_checks = 0
+    violations = []
+    out = {}
+
+    for name in DECISIVE:
+        opt = optimum(name)
+        reps = []
+        for r in range(REPS):
+            got = {}
+            for arm in (("pre", "post") if r % 2 == 0 else ("post", "pre")):
+                t0 = time.perf_counter()
+                got[arm] = solve(name, arm)
+                got[arm]["wall"] = time.perf_counter() - t0
+                # Soundness is checked on EVERY run of EVERY arm, independent of
+                # whether the arms happen to agree (CLAUDE.md §1).
+                if opt is not None and got[arm]["bound"] is not None:
+                    soundness_checks += 1
+                    tol = 1e-6 + 1e-4 * abs(opt)
+                    if got[arm]["bound"] > opt + tol:
+                        violations.append(
+                            (name, arm, r, "bound above true optimum",
+                             got[arm]["bound"], opt))
+                if opt is not None and got[arm]["objective"] is not None:
+                    soundness_checks += 1
+                    tol = 1e-6 + 1e-4 * abs(opt)
+                    if got[arm]["objective"] < opt - tol:
+                        violations.append(
+                            (name, arm, r, "incumbent beats true optimum",
+                             got[arm]["objective"], opt))
+            reps.append(got)
+            comparisons += 1
+
+        keys = ("status", "objective", "bound", "node_count")
+        differs = [any(rep["pre"][k] != rep["post"][k] for k in keys) for rep in reps]
+        if not any(differs):
+            verdict = "CLEAN"
+        elif all(differs):
+            verdict = "STABLE-DIFF"
+        else:
+            verdict = "QUARANTINE"
+        out[name] = {"verdict": verdict, "optimum": opt, "reps": reps}
+        print(f"{name:14s} {verdict:12s} opt={opt}", flush=True)
+        for r, rep in enumerate(reps):
+            print(f"    r{r} pre ={rep['pre']['status']:11s} obj={rep['pre']['objective']!r} "
+                  f"bound={rep['pre']['bound']!r} n={rep['pre']['node_count']}")
+            print(f"    r{r} post={rep['post']['status']:11s} obj={rep['post']['objective']!r} "
+                  f"bound={rep['post']['bound']!r} n={rep['post']['node_count']}")
+
+    json.dump(out, open("scratchpad/issue940/panel_replicate.json", "w"), indent=1)
+    print(f"\nCOMPARISONS_EXECUTED={comparisons}  SOUNDNESS_CHECKS={soundness_checks}")
+    print(f"SOUNDNESS VIOLATIONS: {len(violations)}")
+    for v in violations:
+        print(f"   {v}")
+    for verdict in ("CLEAN", "QUARANTINE", "STABLE-DIFF"):
+        names = [n for n, d in out.items() if d["verdict"] == verdict]
+        print(f"  {verdict:12s}: {len(names)}  {names}")
+    if comparisons == 0:
+        print("REPLICATION COMPARED NOTHING", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scratchpad/issue940/panel_soundness.json
+++ b/scratchpad/issue940/panel_soundness.json
@@ -1,0 +1,282 @@
+{
+ "checks": {
+  "bound_vs_optimum": 32,
+  "incumbent_vs_optimum": 32,
+  "bound_vs_incumbent": 32
+ },
+ "violations": [],
+ "rows": {
+  "clay0303hfsg": {
+   "optimum": 26669.10955143,
+   "pre": {
+    "status": "feasible",
+    "objective": 26669.109551433034,
+    "bound": 20947.586912205985,
+    "node_count": 413,
+    "wall": 61.22863919500014
+   },
+   "post": {
+    "status": "feasible",
+    "objective": 26669.109551433034,
+    "bound": 20947.586912205985,
+    "node_count": 413,
+    "wall": 60.38786111199988
+   }
+  },
+  "nvs03": {
+   "optimum": 16.0,
+   "post": {
+    "status": "optimal",
+    "objective": 16.0,
+    "bound": 15.99999972676511,
+    "node_count": 5,
+    "wall": 0.28023842600032367
+   },
+   "pre": {
+    "status": "optimal",
+    "objective": 16.0,
+    "bound": 15.99999972676511,
+    "node_count": 5,
+    "wall": 0.24643181600004027
+   }
+  },
+  "nvs04": {
+   "optimum": 0.72,
+   "pre": {
+    "status": "optimal",
+    "objective": 0.720000000000006,
+    "bound": 0.7199999999999773,
+    "node_count": 5,
+    "wall": 0.554707569999664
+   },
+   "post": {
+    "status": "optimal",
+    "objective": 0.720000000000006,
+    "bound": 0.7199999999999773,
+    "node_count": 5,
+    "wall": 0.4176281989994095
+   }
+  },
+  "nvs06": {
+   "optimum": 1.7703125,
+   "post": {
+    "status": "optimal",
+    "objective": 1.7703125,
+    "bound": 1.7703124999999627,
+    "node_count": 5,
+    "wall": 2.2408112630000687
+   },
+   "pre": {
+    "status": "optimal",
+    "objective": 1.7703125,
+    "bound": 1.7703124999999627,
+    "node_count": 5,
+    "wall": 1.4755240750000667
+   }
+  },
+  "nvs07": {
+   "optimum": 4.0,
+   "pre": {
+    "status": "optimal",
+    "objective": 4.0,
+    "bound": 4.0,
+    "node_count": 5,
+    "wall": 0.10925018499983707
+   },
+   "post": {
+    "status": "optimal",
+    "objective": 4.0,
+    "bound": 4.0,
+    "node_count": 5,
+    "wall": 0.08896967500004394
+   }
+  },
+  "nvs09": {
+   "optimum": -43.13433692,
+   "post": {
+    "status": "optimal",
+    "objective": -43.134336918035295,
+    "bound": -43.13433691803662,
+    "node_count": 5,
+    "wall": 6.424297120999654
+   },
+   "pre": {
+    "status": "optimal",
+    "objective": -43.134336918035295,
+    "bound": -43.13433691803662,
+    "node_count": 5,
+    "wall": 5.978442572999484
+   }
+  },
+  "nvs10": {
+   "optimum": -310.8,
+   "pre": {
+    "status": "optimal",
+    "objective": -310.7999999999999,
+    "bound": -310.7999999999999,
+    "node_count": 5,
+    "wall": 0.19630306500039296
+   },
+   "post": {
+    "status": "optimal",
+    "objective": -310.7999999999999,
+    "bound": -310.7999999999999,
+    "node_count": 5,
+    "wall": 0.18673045199921035
+   }
+  },
+  "nvs11": {
+   "optimum": -431.0,
+   "post": {
+    "status": "optimal",
+    "objective": -431.0000000000085,
+    "bound": -431.0000000000085,
+    "node_count": 55,
+    "wall": 0.8304957640002613
+   },
+   "pre": {
+    "status": "optimal",
+    "objective": -431.0000000000085,
+    "bound": -431.0000000000085,
+    "node_count": 55,
+    "wall": 0.7438973850003094
+   }
+  },
+  "nvs12": {
+   "optimum": -481.2,
+   "pre": {
+    "status": "optimal",
+    "objective": -481.20000000001,
+    "bound": -481.20000000001,
+    "node_count": 231,
+    "wall": 3.587073806999797
+   },
+   "post": {
+    "status": "optimal",
+    "objective": -481.20000000001,
+    "bound": -481.20000000001,
+    "node_count": 231,
+    "wall": 2.7796329760003573
+   }
+  },
+  "nvs13": {
+   "optimum": -585.2,
+   "post": {
+    "status": "optimal",
+    "objective": -585.2,
+    "bound": -585.2,
+    "node_count": 637,
+    "wall": 1.8078183829993577
+   },
+   "pre": {
+    "status": "optimal",
+    "objective": -585.2,
+    "bound": -585.2,
+    "node_count": 637,
+    "wall": 1.831167737999749
+   }
+  },
+  "nvs15": {
+   "optimum": 1.0,
+   "pre": {
+    "status": "optimal",
+    "objective": 1.0,
+    "bound": 1.0,
+    "node_count": 7,
+    "wall": 0.11530026699983864
+   },
+   "post": {
+    "status": "optimal",
+    "objective": 1.0,
+    "bound": 1.0,
+    "node_count": 7,
+    "wall": 0.11630058599985205
+   }
+  },
+  "st_miqp1": {
+   "optimum": 281.0,
+   "post": {
+    "status": "optimal",
+    "objective": 280.9999999906497,
+    "bound": 280.9999999906497,
+    "node_count": 15,
+    "wall": 0.030330910999509797
+   },
+   "pre": {
+    "status": "optimal",
+    "objective": 280.9999999906497,
+    "bound": 280.9999999906497,
+    "node_count": 15,
+    "wall": 0.02870789699954912
+   }
+  },
+  "st_miqp2": {
+   "optimum": 2.0,
+   "pre": {
+    "status": "optimal",
+    "objective": 2.0,
+    "bound": 2.0,
+    "node_count": 9,
+    "wall": 0.03413430399996287
+   },
+   "post": {
+    "status": "optimal",
+    "objective": 2.0,
+    "bound": 2.0,
+    "node_count": 9,
+    "wall": 0.034346633000495785
+   }
+  },
+  "st_miqp3": {
+   "optimum": -6.0,
+   "post": {
+    "status": "optimal",
+    "objective": -6.0,
+    "bound": -6.0,
+    "node_count": 1,
+    "wall": 0.012762714000018605
+   },
+   "pre": {
+    "status": "optimal",
+    "objective": -6.0,
+    "bound": -6.0,
+    "node_count": 1,
+    "wall": 0.011999374999504653
+   }
+  },
+  "st_test1": {
+   "optimum": 0.0,
+   "pre": {
+    "status": "optimal",
+    "objective": -1.6495994490692313e-08,
+    "bound": -1.6495994490692313e-08,
+    "node_count": 15,
+    "wall": 0.05365534700013086
+   },
+   "post": {
+    "status": "optimal",
+    "objective": -1.6495994490692313e-08,
+    "bound": -1.6495994490692313e-08,
+    "node_count": 15,
+    "wall": 0.05773075299930497
+   }
+  },
+  "st_testgr3": {
+   "optimum": -20.59,
+   "post": {
+    "status": "optimal",
+    "objective": -20.59,
+    "bound": -20.59070709795548,
+    "node_count": 549,
+    "wall": 0.44464590300049167
+   },
+   "pre": {
+    "status": "optimal",
+    "objective": -20.59,
+    "bound": -20.59070709795548,
+    "node_count": 549,
+    "wall": 0.42535015500016016
+   }
+  }
+ }
+}

--- a/scratchpad/issue940/panel_soundness.py
+++ b/scratchpad/issue940/panel_soundness.py
@@ -1,0 +1,117 @@
+"""Issue #940: the soundness gate, made to actually fire.
+
+panel_replicate.py reported "0 violations" off SOUNDNESS_CHECKS=0 — every
+decisive instance either had no reference optimum or returned bound=None under
+the 20s budget, so the gate measured nothing (CLAUDE.md §6). This runs it where
+it can execute:
+
+  * the 16 corpus instances carrying a reference optimum in known_optima.toml,
+  * with a budget generous enough to produce a bound and an incumbent,
+  * both arms, interleaved, alternating order,
+
+and asserts, per run:
+
+  1. dual bound <= true optimum + tol      (the literal soundness invariant)
+  2. incumbent >= true optimum - tol       (no super-optimal incumbent)
+  3. bound <= incumbent + tol              (certificate invariant; oracle-free,
+                                            so it fires on every run)
+
+The run FAILS loudly if the executed-assertion count is zero.
+"""
+
+import json
+import os
+import sys
+import time
+
+os.environ.setdefault("JAX_PLATFORMS", "cpu")
+os.environ.setdefault("JAX_ENABLE_X64", "1")
+
+sys.path.insert(0, "python/tests")
+
+import discopt.solvers.lp_pounce as LPP  # noqa: E402
+import discopt.solvers.qp_pounce as QPP  # noqa: E402
+from _optima import known_optimum, optima_registry  # noqa: E402
+from discopt.modeling import from_nl  # noqa: E402
+
+assert LPP.__file__.startswith("/home/user/discopt/python/"), LPP.__file__
+assert hasattr(LPP, "_settle_ambiguous_unbounded"), "post-fix marker absent (§8)"
+assert LPP._CONSTR_VIOL_TOL == 1e-8, LPP._CONSTR_VIOL_TOL
+
+_POST_TOL = LPP._CONSTR_VIOL_TOL
+_POST_SETTLE = LPP._settle_ambiguous_unbounded
+_POST_RAY = QPP._certify_unbounded_ray
+
+ROOT = "python/tests/data/minlplib_nl"
+TIME_LIMIT = 60.0
+
+
+def set_arm(arm):
+    if arm == "pre":
+        LPP._CONSTR_VIOL_TOL = QPP._CONSTR_VIOL_TOL = 1e-4
+        LPP._settle_ambiguous_unbounded = lambda result, c, A, cl, cu, lb, ub, opts: result
+        QPP._certify_unbounded_ray = lambda *a, **k: True
+    else:
+        LPP._CONSTR_VIOL_TOL = QPP._CONSTR_VIOL_TOL = _POST_TOL
+        LPP._settle_ambiguous_unbounded = _POST_SETTLE
+        QPP._certify_unbounded_ray = _POST_RAY
+
+
+def main():
+    corpus = {f[:-3] for f in os.listdir(ROOT) if f.endswith(".nl")}
+    names = sorted(corpus & set(optima_registry()))
+    print(f"instances with a reference optimum: {len(names)}\n{names}\n", flush=True)
+
+    checks = {"bound_vs_optimum": 0, "incumbent_vs_optimum": 0, "bound_vs_incumbent": 0}
+    violations = []
+    out = {}
+
+    for i, name in enumerate(names):
+        opt = float(known_optimum(name))
+        got = {}
+        for arm in (("pre", "post") if i % 2 == 0 else ("post", "pre")):
+            set_arm(arm)
+            t0 = time.perf_counter()
+            r = from_nl(os.path.join(ROOT, f"{name}.nl")).solve(time_limit=TIME_LIMIT)
+            got[arm] = {"status": r.status, "objective": r.objective, "bound": r.bound,
+                        "node_count": r.node_count, "wall": time.perf_counter() - t0}
+            tol = 1e-6 + 1e-4 * abs(opt)
+            if r.bound is not None:
+                checks["bound_vs_optimum"] += 1
+                if r.bound > opt + tol:
+                    violations.append((name, arm, "BOUND ABOVE TRUE OPTIMUM", r.bound, opt))
+            if r.objective is not None:
+                checks["incumbent_vs_optimum"] += 1
+                if r.objective < opt - tol:
+                    violations.append((name, arm, "INCUMBENT BEATS TRUE OPTIMUM",
+                                       r.objective, opt))
+            if r.bound is not None and r.objective is not None:
+                checks["bound_vs_incumbent"] += 1
+                if r.bound > r.objective + tol:
+                    violations.append((name, arm, "BOUND ABOVE INCUMBENT",
+                                       r.bound, r.objective))
+        out[name] = {"optimum": opt, **got}
+        agree = all(got["pre"][k] == got["post"][k]
+                    for k in ("status", "objective", "bound", "node_count"))
+        print(f"[{i + 1:2d}/{len(names)}] {name:22s} opt={opt:<14.8g} "
+              f"{'SAME' if agree else 'DIFF'} "
+              f"pre={got['pre']['status']}/{got['pre']['objective']!r}/b{got['pre']['bound']!r} "
+              f"post={got['post']['status']}/{got['post']['objective']!r}/"
+              f"b{got['post']['bound']!r}", flush=True)
+
+    json.dump({"checks": checks, "violations": violations, "rows": out},
+              open("scratchpad/issue940/panel_soundness.json", "w"), indent=1)
+
+    total = sum(checks.values())
+    print(f"\nEXECUTED_ASSERTIONS={total}  {checks}")
+    print(f"SOUNDNESS VIOLATIONS: {len(violations)}")
+    for v in violations:
+        print(f"   {v}")
+    if total == 0:
+        print("GATE EXECUTED ZERO ASSERTIONS - result is meaningless", file=sys.stderr)
+        return 1
+    return 1 if violations else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scratchpad/issue940/pounce_upstream_repro.py
+++ b/scratchpad/issue940/pounce_upstream_repro.py
@@ -1,0 +1,99 @@
+"""Standalone POUNCE reproduction: an IPM exit of code 3/4 on a well-posed,
+feasible, BOUNDED LP whose optimum scipy finds without difficulty.
+
+No discopt involved — pounce + scipy only, so the report stands on its own.
+
+    min  c'x   s.t.  A x >= b,  0 <= x <= 1e8
+with c, A entries O(1) and b of magnitude ~1e7. The feasible set is a nonempty
+subset of a compact box, so the LP is bounded by construction; scipy's HiGHS
+confirms a finite optimum. POUNCE exits Search_Direction_Becomes_Too_Small (3)
+or Diverging_Iterates (4).
+"""
+
+import sys
+
+import numpy as np
+import pounce
+from scipy.optimize import linprog
+
+_INF = 1e20
+CODES = {0: "Solve_Succeeded", 1: "Solved_To_Acceptable_Level",
+         2: "Infeasible_Problem_Detected", 3: "Search_Direction_Becomes_Too_Small",
+         4: "Diverging_Iterates", -1: "Maximum_Iterations_Exceeded"}
+
+
+class LP:
+    """cyipopt-style callbacks for min c'x with constant Jacobian A."""
+
+    def __init__(self, c, A):
+        self.c, self.A = c, A
+        m, n = A.shape
+        self.jac = A.ravel().astype(float)
+        r, cc = np.meshgrid(np.arange(m), np.arange(n), indexing="ij")
+        self.rows, self.cols = r.ravel(), cc.ravel()
+
+    def objective(self, x):
+        return float(self.c @ x)
+
+    def gradient(self, x):
+        return self.c
+
+    def constraints(self, x):
+        return np.asarray(self.A @ x, dtype=float)
+
+    def jacobian(self, x):
+        return self.jac
+
+    def jacobianstructure(self):
+        return self.rows, self.cols
+
+    def hessian(self, x, lagrange, obj_factor):
+        return np.empty(0)
+
+    def hessianstructure(self):
+        return np.empty(0, dtype=np.intp), np.empty(0, dtype=np.intp)
+
+
+def run(seed, n, m, scale):
+    rng = np.random.default_rng(seed)
+    A = np.abs(rng.uniform(0.5, 5.0, size=(m, n)))       # A x >= b
+    b = scale * np.abs(rng.uniform(0.5, 2.0, size=m)) * n * 0.25
+    c = np.abs(rng.uniform(1.0, 10.0, size=n))
+    hi = 10.0 * scale
+
+    ref = linprog(c, A_ub=-A, b_ub=-b, bounds=[(0.0, hi)] * n, method="highs")
+
+    lb = np.zeros(n)
+    ub = np.full(n, hi)
+    cl = b.copy()
+    cu = np.full(m, _INF)
+    prob = pounce.Problem(n=n, m=m, problem_obj=LP(c, A), lb=lb, ub=ub, cl=cl, cu=cu)
+    prob.add_option("print_level", 0)
+    x, info = prob.solve(np.clip(0.5 * (lb + ub), -1e3, 1e3))
+    code = info.get("status", -100)
+    return code, (ref.status == 0), (float(ref.fun) if ref.status == 0 else None)
+
+
+def main():
+    runs = 0
+    bad = []
+    print(f"{'seed':>4s} {'n':>4s} {'scale':>8s}  {'pounce exit':38s} {'scipy':>10s}")
+    for scale in (1e6, 1e7, 1e8):
+        for n, m in ((20, 10), (40, 20)):
+            for seed in range(8):
+                code, ok, obj = run(seed, n, m, scale)
+                runs += 1
+                if code in (3, 4) and ok:
+                    bad.append((seed, n, scale, code, obj))
+                    print(f"{seed:4d} {n:4d} {scale:8.0e}  {CODES.get(code, code):38s} "
+                          f"{obj:10.4g}", flush=True)
+    print(f"\nRUNS_EXECUTED={runs}")
+    print(f"code 3/4 exits on LPs scipy solves to a finite optimum: {len(bad)}/{runs}")
+    if runs == 0:
+        print("REPRO EXECUTED NOTHING", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scratchpad/issue940/probe_adversarial_timing.py
+++ b/scratchpad/issue940/probe_adversarial_timing.py
@@ -1,0 +1,62 @@
+"""Is test_large_dense_jacobian_no_crash's deadline overrun caused by #940?
+
+The assertion is wall-clock (wall < 48s), so it is exactly the kind of claim
+CLAUDE.md §9 says needs an interleaved A/B and a spread, not a single sequential
+run. Arms are selected by flipping the module globals the POUNCE backends read,
+so both run in one process under identical load, alternating order.
+"""
+import os, sys, time
+os.environ.setdefault("JAX_PLATFORMS", "cpu"); os.environ.setdefault("JAX_ENABLE_X64", "1")
+import numpy as np
+import discopt.modeling as dm
+import discopt.solvers.lp_pounce as LPP
+import discopt.solvers.qp_pounce as QPP
+
+assert LPP._CONSTR_VIOL_TOL == 1e-8
+_POST_TOL, _POST_REJECT, _POST_RAY = (
+    LPP._CONSTR_VIOL_TOL, LPP._settle_ambiguous_unbounded, QPP._certify_unbounded_ray)
+
+
+def set_arm(arm):
+    if arm == "pre":
+        LPP._CONSTR_VIOL_TOL = QPP._CONSTR_VIOL_TOL = 1e-4
+        LPP._settle_ambiguous_unbounded = lambda result, c, A, cl, cu, lb, ub, opts: result
+        QPP._certify_unbounded_ray = lambda *a, **k: True
+    else:
+        LPP._CONSTR_VIOL_TOL = QPP._CONSTR_VIOL_TOL = _POST_TOL
+        LPP._settle_ambiguous_unbounded = _POST_REJECT
+        QPP._certify_unbounded_ray = _POST_RAY
+
+
+def build():
+    n = 1100
+    m = dm.Model("big")
+    xs = [m.continuous(f"x{i}", lb=0.0, ub=5.0) for i in range(n)]
+    bs = [m.binary(f"b{i}") for i in range(0, n, 10)]
+    for i in range(n):
+        m.subject_to(xs[i] * xs[i] + xs[(i + 1) % n] <= 10.0)
+    for k, b in enumerate(bs):
+        m.subject_to(xs[k] + 2.0 * b <= 6.0)
+    m.minimize(dm.sum([xs[i] for i in range(n)]) - dm.sum(bs))
+    return m
+
+
+REPS = 3
+walls = {"pre": [], "post": []}
+RUNS = 0
+for rep in range(REPS):
+    for arm in (("pre", "post") if rep % 2 == 0 else ("post", "pre")):
+        set_arm(arm)
+        t = time.perf_counter()
+        r = build().solve(time_limit=8.0, gap_tolerance=1e-4)
+        w = time.perf_counter() - t
+        RUNS += 1
+        walls[arm].append(w)
+        print(f"rep{rep} {arm:4s} wall={w:6.1f}s status={r.status}", flush=True)
+
+print(f"\nRUNS_EXECUTED={RUNS}   (test asserts wall < 48s)")
+for arm in ("pre", "post"):
+    a = np.array(walls[arm])
+    print(f"  {arm:4s}: mean={a.mean():6.1f}s sd={a.std(ddof=1):5.1f}s "
+          f"min={a.min():6.1f} max={a.max():6.1f}  over_deadline={(a >= 48).sum()}/{len(a)}")
+sys.exit(0 if RUNS else 1)

--- a/scratchpad/issue940/probe_attainable.py
+++ b/scratchpad/issue940/probe_attainable.py
@@ -1,0 +1,61 @@
+"""Issue #940: what constraint tolerance is ATTAINABLE as a function of data scale?
+
+A fixed absolute 1e-9 request is below double-precision noise once the data
+magnitude reaches ~1e6: POUNCE then stops short of its criterion and exits with
+Ipopt code 3/4, which the LP status map turns into a FALSE ``UNBOUNDED`` on a
+bounded LP. Sweep the request against the exact-simplex oracle and find, per data
+scale, the tightest request that still reproduces the oracle's status/objective.
+"""
+
+import os
+import sys
+
+os.environ.setdefault("JAX_PLATFORMS", "cpu")
+os.environ.setdefault("JAX_ENABLE_X64", "1")
+
+import numpy as np  # noqa: E402
+
+import discopt.solvers.lp_pounce as LPP  # noqa: E402
+import discopt.solvers.lp_simplex as LPS  # noqa: E402
+from discopt.solvers import SolveStatus  # noqa: E402
+
+CHECKS = 0
+REQUESTS = [1e-4, 1e-5, 1e-6, 1e-7, 1e-8, 1e-9, 1e-10, 1e-11]
+
+
+def make(n, m, scale, seed):
+    rng = np.random.default_rng(seed)
+    A = -np.abs(rng.uniform(0.5, 5.0, size=(m, n)))
+    b = -scale * np.abs(rng.uniform(0.5, 2.0, size=m)) * n * 0.25
+    c = np.abs(rng.uniform(1.0, 10.0, size=n))
+    return c, A, b, [(0.0, 10.0 * scale)] * n
+
+
+def main():
+    global CHECKS
+    print(f"{'scale':>8s} {'n':>4s} | " + " ".join(f"{r:>9.0e}" for r in REQUESTS))
+    print(" " * 16 + "  (ok = OPTIMAL and matches the simplex oracle; . = mismatch/nonopt)")
+    for scale in (1e0, 1e2, 1e3, 1e4, 1e5, 1e6, 1e7, 1e8):
+        for n, m in ((10, 6), (40, 20)):
+            cells = []
+            for rep in range(3):
+                c, A, b, bounds = make(n, m, scale, seed=int(np.log10(scale)) * 97 + n + rep)
+                ref = LPS.solve_lp(c=c, A_ub=A, b_ub=b, bounds=bounds)
+                row = []
+                for req in REQUESTS:
+                    res = LPP.solve_lp(c=c, A_ub=A, b_ub=b, bounds=bounds,
+                                       options={"constr_viol_tol": req})
+                    CHECKS += 1
+                    good = (res.status == ref.status == SolveStatus.OPTIMAL
+                            and abs(res.objective - ref.objective)
+                            <= 1e-6 * max(1.0, abs(ref.objective)))
+                    row.append(good)
+                cells.append(row)
+            agg = ["ok" if all(c[k] for c in cells) else "." for k in range(len(REQUESTS))]
+            print(f"{scale:8.0e} {n:4d} | " + " ".join(f"{a:>9s}" for a in agg), flush=True)
+    print(f"CHECKS_EXECUTED={CHECKS}")
+    return 0 if CHECKS else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scratchpad/issue940/probe_bounds.py
+++ b/scratchpad/issue940/probe_bounds.py
@@ -1,0 +1,58 @@
+"""Issue #940: does POUNCE's bound_relax_factor also trip the #850 guard?
+
+Ipopt relaxes variable bounds by ``bound_relax_factor*(1+|bound|)`` (default
+1e-8), so on a binding bound of magnitude B the returned x can sit ~1e-8*B
+outside it, while the guard allows only ``1e-6 + 1e-9*|x|``. Measure it.
+"""
+
+import os
+import sys
+
+os.environ.setdefault("JAX_PLATFORMS", "cpu")
+os.environ.setdefault("JAX_ENABLE_X64", "1")
+
+import numpy as np  # noqa: E402
+
+import discopt.solvers.lp_pounce as LPP  # noqa: E402
+from discopt.solvers import SolveStatus  # noqa: E402
+
+assert LPP.__file__.startswith("/home/user/discopt/python/"), LPP.__file__
+CHECKS = 0
+
+
+def run(label, opts):
+    global CHECKS
+    rows = []
+    for B in (1e0, 1e2, 1e4, 1e6, 1e8):
+        n = 4
+        # max sum x  ==  min -sum x, every x pinned at its upper bound B
+        c = -np.ones(n)
+        A_ub = np.ones((1, n))
+        b_ub = np.array([n * B * 10.0])  # non-binding row; the BOUND is what binds
+        bounds = [(0.0, B)] * n
+        res = LPP.solve_lp(c=c, A_ub=A_ub, b_ub=b_ub, bounds=bounds, options=opts)
+        CHECKS += 1
+        if res.status != SolveStatus.OPTIMAL:
+            rows.append((B, res.status.name, float("nan"), float("nan")))
+            continue
+        x = np.asarray(res.x, float)
+        over = float(np.max(x - B))
+        thr = 1e-6 + 1e-9 * float(np.max(np.abs(x)))
+        rows.append((B, "OPTIMAL", over, over / thr))
+    print(f"--- {label}")
+    for B, st, over, ratio in rows:
+        print(f"    ub={B:<8.0e} {st:12s} over_bound={over:12.4g} ratio={ratio:8.3g}"
+              f"{'  <-- GUARD TRIPS' if ratio > 1 else ''}")
+
+
+def main():
+    run("baseline", None)
+    run("constr_viol_tol=1e-9", {"constr_viol_tol": 1e-9})
+    run("constr_viol_tol=1e-9 + bound_relax_factor=0", 
+        {"constr_viol_tol": 1e-9, "bound_relax_factor": 0.0})
+    print(f"CHECKS_EXECUTED={CHECKS}")
+    return 0 if CHECKS else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scratchpad/issue940/probe_drift.py
+++ b/scratchpad/issue940/probe_drift.py
@@ -1,0 +1,80 @@
+"""Issue #940 experiment 3: objective drift of the now-accepted POUNCE LP answer
+against the exact simplex oracle.
+
+Before the fix these LPs were answered by the exact simplex (the guard rejected
+POUNCE's point). After it, POUNCE's own answer is returned. Measure the drift
+against the simplex oracle on exactly that population, plus the residual
+infeasibility, so "the accepted point is as good as the one it replaces" is a
+measurement, not a claim. §6: prints an executed-comparison count.
+"""
+
+import os
+import sys
+
+os.environ.setdefault("JAX_PLATFORMS", "cpu")
+os.environ.setdefault("JAX_ENABLE_X64", "1")
+
+import numpy as np  # noqa: E402
+
+import discopt.solvers.lp_pounce as LPP  # noqa: E402
+import discopt.solvers.lp_simplex as LPS  # noqa: E402
+from discopt.solver import _matrix_solution_feasible  # noqa: E402
+from discopt.solvers import SolveStatus  # noqa: E402
+
+assert LPP.__file__.startswith("/home/user/discopt/python/")
+assert "_CONSTR_VIOL_TOL" in dir(LPP), "measuring the PRE-fix module - marker absent (§8)"
+assert LPP._CONSTR_VIOL_TOL == 1e-8
+
+COMPARISONS = 0
+
+
+def instances():
+    rng = np.random.default_rng(20940)
+    for n, m in ((5, 3), (10, 6), (20, 10), (40, 20)):
+        for scale in (1e0, 1e2, 1e3, 1e4, 1e6):
+            for rep in range(3):
+                A = -np.abs(rng.uniform(0.5, 5.0, size=(m, n)))
+                b = -scale * np.abs(rng.uniform(0.5, 2.0, size=m)) * n * 0.25
+                c = np.abs(rng.uniform(1.0, 10.0, size=n))
+                yield (f"n{n}_s{scale:g}_r{rep}", c, A, b, [(0.0, 10.0 * scale)] * n)
+
+
+def main():
+    global COMPARISONS
+    drifts, viols = [], []
+    worst = None
+    disagree = 0
+    for tag, c, A_ub, b_ub, bounds in instances():
+        rp = LPP.solve_lp(c=c, A_ub=A_ub, b_ub=b_ub, bounds=bounds)
+        rs = LPS.solve_lp(c=c, A_ub=A_ub, b_ub=b_ub, bounds=bounds)
+        if rp.status != SolveStatus.OPTIMAL or rs.status != SolveStatus.OPTIMAL:
+            disagree += 1
+            print(f"  {tag}: status pounce={rp.status.name} simplex={rs.status.name}")
+            continue
+        COMPARISONS += 1
+        rel = abs(rp.objective - rs.objective) / max(1.0, abs(rs.objective))
+        drifts.append(rel)
+        x = np.asarray(rp.x, float)
+        v = float(np.max(np.asarray(A_ub, float) @ x - np.asarray(b_ub, float)))
+        viols.append(v)
+        assert _matrix_solution_feasible(x, A_ub, b_ub, None, None, bounds), tag
+        if worst is None or rel > worst[1]:
+            worst = (tag, rel, rp.objective, rs.objective)
+
+    d = np.array(drifts)
+    print(f"\nCOMPARISONS_EXECUTED={COMPARISONS}  status disagreements={disagree}")
+    print(f"relative objective drift  POUNCE vs exact simplex:")
+    print(f"  max = {d.max():.3e}   p99 = {np.percentile(d, 99):.3e}   "
+          f"median = {np.median(d):.3e}")
+    print(f"  worst instance: {worst[0]}  pounce={worst[2]!r} simplex={worst[3]!r}")
+    print(f"POUNCE residual row violation: max = {max(viols):.3e} "
+          f"(discopt tolerance 1e-6)")
+    print("  (every accepted point also passed _matrix_solution_feasible, asserted above)")
+    if COMPARISONS == 0:
+        print("PROBE MADE ZERO COMPARISONS", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scratchpad/issue940/probe_entry.py
+++ b/scratchpad/issue940/probe_entry.py
@@ -1,0 +1,277 @@
+"""Entry experiment for issue #940.
+
+Measures how often POUNCE's LP point trips the #850 guard
+(``_matrix_solution_feasible``) at the ``_solve_lp_matrix`` call site, and the
+distribution of worst-row violation/threshold ratios.
+
+CLAUDE.md §6: prints an executed-check count and exits non-zero if it is zero.
+CLAUDE.md §7: no exception is swallowed anywhere in the instrument.
+CLAUDE.md §8: asserts module provenance before measuring.
+"""
+
+import os
+import sys
+
+os.environ.setdefault("JAX_PLATFORMS", "cpu")
+os.environ.setdefault("JAX_ENABLE_X64", "1")
+
+import numpy as np  # noqa: E402
+
+import discopt.modeling as dm  # noqa: E402
+import discopt.solver as S  # noqa: E402
+
+# ---- provenance (§8) --------------------------------------------------------
+assert S.__file__.startswith("/home/user/discopt/python/"), S.__file__
+import discopt.solvers.lp_pounce as LPP  # noqa: E402
+
+assert LPP.__file__.startswith("/home/user/discopt/python/"), LPP.__file__
+assert LPP.POUNCE_AVAILABLE, "pounce not installed - the experiment cannot run"
+
+RECORDS = []
+_orig_feasible = S._matrix_solution_feasible
+
+
+def _worst_ratio(x, A_ub, b_ub, A_eq, b_eq, bounds, tol=1e-6, rtol=1e-9):
+    """Worst (violation / threshold) over every row and bound. >1 == guard trips."""
+    x = np.asarray(x, dtype=np.float64)
+    worst = 0.0
+    worst_scale = 0.0
+    if not np.all(np.isfinite(x)):
+        return np.inf, 0.0
+    absx = np.abs(x)
+    for A, b, signed in ((A_ub, b_ub, True), (A_eq, b_eq, False)):
+        if A is None or b is None or not len(b):
+            continue
+        A = np.asarray(A, dtype=np.float64)
+        viol = A @ x - np.asarray(b, dtype=np.float64)
+        if not signed:
+            viol = np.abs(viol)
+        scale = np.abs(A) @ absx
+        ratio = viol / (tol + rtol * scale)
+        k = int(np.argmax(ratio))
+        if ratio[k] > worst:
+            worst, worst_scale = float(ratio[k]), float(scale[k])
+    if bounds is not None:
+        for xi, (lo, hi) in zip(x, bounds):
+            thr = tol + rtol * abs(xi)
+            v = max(lo - xi, xi - hi)
+            if v / thr > worst:
+                worst, worst_scale = float(v / thr), float(abs(xi))
+    return worst, worst_scale
+
+
+def _patched(x, A_ub, b_ub, A_eq, b_eq, bounds, tol=1e-6, rtol=1e-9):
+    ok = _orig_feasible(x, A_ub, b_ub, A_eq, b_eq, bounds, tol=tol, rtol=rtol)
+    ratio, scale = _worst_ratio(x, A_ub, b_ub, A_eq, b_eq, bounds, tol=tol, rtol=rtol)
+    RECORDS.append(
+        {"engine": _CURRENT["engine"], "model": _CURRENT["model"], "ok": ok,
+         "ratio": ratio, "row_scale": scale}
+    )
+    return ok
+
+
+S._matrix_solution_feasible = _patched
+
+# Tag each guard call with the engine that produced the point.
+_CURRENT = {"engine": "?", "model": "?"}
+_orig_solve_lp_matrix = S._solve_lp_matrix
+
+
+def _tagged_solve_lp_matrix(model, t_start, time_limit, solve_lp_fn, engine, **kw):
+    prev = _CURRENT["engine"]
+    _CURRENT["engine"] = engine
+    try:
+        return _orig_solve_lp_matrix(model, t_start, time_limit, solve_lp_fn, engine, **kw)
+    finally:
+        _CURRENT["engine"] = prev
+
+
+S._solve_lp_matrix = _tagged_solve_lp_matrix
+
+
+# ---------------------------------------------------------------- populations
+def notebook_lps():
+    """The four tutorial_lp.ipynb LPs, verbatim from the notebook source."""
+    out = []
+
+    # diet
+    cost = np.array([2.0, 3.5, 8.0, 11.0, 25.0])
+    A = np.array([[3.0, 8.0, 15.0, 22.0, 31.0],
+                  [25.0, 120.0, 200.0, 10.0, 15.0],
+                  [1.0, 0.1, 0.5, 3.0, 5.5],
+                  [250.0, 150.0, 400.0, 200.0, 450.0]])
+    req = np.array([55.0, 800.0, 12.0, 2000.0])
+    m = dm.Model("diet")
+    x = m.continuous("x", shape=(5,), lb=0, ub=10)
+    m.minimize(dm.sum(lambda j: cost[j] * x[j], over=range(5)))
+    for i in range(4):
+        m.subject_to(dm.sum(lambda j: A[i, j] * x[j], over=range(5)) >= req[i], name=f"n{i}")
+    out.append(("nb:diet", m))
+
+    # transport
+    supply = np.array([300.0, 400.0, 500.0])
+    demand = np.array([200.0, 300.0, 250.0, 450.0])
+    sc = np.array([[8.0, 6.0, 10.0, 9.0], [9.0, 12.0, 7.0, 5.0], [14.0, 9.0, 16.0, 4.0]])
+    nw, nc = sc.shape
+    mt = dm.Model("transport")
+    xt = mt.continuous("ship", shape=(nw, nc), lb=0, ub=float(max(supply.max(), demand.max())))
+    mt.minimize(dm.sum(lambda i: dm.sum(lambda j: sc[i, j] * xt[i, j], over=range(nc)),
+                       over=range(nw)))
+    for i in range(nw):
+        mt.subject_to(dm.sum(lambda j: xt[i, j], over=range(nc)) <= supply[i], name=f"s{i}")
+    for j in range(nc):
+        mt.subject_to(dm.sum(lambda i: xt[i, j], over=range(nw)) >= demand[j], name=f"d{j}")
+    out.append(("nb:transport", mt))
+
+    # production
+    profit = np.array([20.0, 30.0, 25.0])
+    usage = np.array([[2.0, 1.0, 3.0], [1.0, 3.0, 2.0], [0.0, 2.0, 1.0], [3.0, 1.0, 2.0]])
+    avail = np.array([120.0, 150.0, 80.0, 180.0])
+    mp = dm.Model("production")
+    xp = mp.continuous("prod", shape=(3,), lb=0)
+    mp.maximize(dm.sum(lambda j: profit[j] * xp[j], over=range(3)))
+    for i in range(4):
+        mp.subject_to(dm.sum(lambda j: usage[i, j] * xp[j], over=range(3)) <= avail[i],
+                      name=f"r{i}")
+    out.append(("nb:production", mp))
+
+    # blending
+    quality = np.array([8.0, 6.0, 4.0, 2.0])
+    crude_cost = np.array([45.0, 35.0, 25.0, 15.0])
+    avail_b = np.array([5000.0] * 4)
+    min_q = np.array([6.0, 4.0])
+    dem = np.array([3000.0, 4000.0])
+    price = np.array([60.0, 40.0])
+    nk, np_ = 4, 2
+    mbl = dm.Model("blending")
+    xb = mbl.continuous("x", shape=(nk, np_), lb=0)
+    rev = dm.sum(lambda j: price[j] * dm.sum(lambda i: xb[i, j], over=range(nk)), over=range(np_))
+    tc = dm.sum(lambda j: dm.sum(lambda i: crude_cost[i] * xb[i, j], over=range(nk)),
+                over=range(np_))
+    mbl.maximize(rev - tc)
+    for i in range(nk):
+        mbl.subject_to(dm.sum(lambda j: xb[i, j], over=range(np_)) <= avail_b[i], name=f"s{i}")
+    for j in range(np_):
+        mbl.subject_to(dm.sum(lambda i: xb[i, j], over=range(nk)) >= dem[j], name=f"d{j}")
+    for j in range(np_):
+        mbl.subject_to(
+            dm.sum(lambda i: (quality[i] - min_q[j]) * xb[i, j], over=range(nk)) >= 0,
+            name=f"q{j}")
+    out.append(("nb:blending", mbl))
+    return out
+
+
+def _matrix_lp(name, c, A_le, b_le, A_ge, b_ge, lb, ub, maximize=False):
+    m = dm.Model(name)
+    n = len(c)
+    x = m.continuous("x", shape=(n,), lb=lb, ub=ub)
+    obj = dm.sum(lambda j: float(c[j]) * x[j], over=range(n))
+    m.maximize(obj) if maximize else m.minimize(obj)
+    for i in range(A_le.shape[0]):
+        row = A_le[i]
+        m.subject_to(dm.sum(lambda j: float(row[j]) * x[j], over=range(n)) <= float(b_le[i]),
+                     name=f"le{i}")
+    for i in range(A_ge.shape[0]):
+        row = A_ge[i]
+        m.subject_to(dm.sum(lambda j: float(row[j]) * x[j], over=range(n)) >= float(b_ge[i]),
+                     name=f"ge{i}")
+    return m
+
+
+def sweep_lps():
+    """Random LPs across size and *data scale*.
+
+    Hypothesis under test: the guard trips as a function of the row term scale
+    ``sum_j |A_ij||x_j|``, not of any property peculiar to the tutorial models.
+    Threshold is ``1e-6 + 1e-9*scale``, so a relative POUNCE accuracy of ~6e-9
+    predicts trips once ``scale`` exceeds a few hundred.
+    """
+    out = []
+    rng = np.random.default_rng(20940)
+    for n, mrows in ((5, 3), (10, 6), (20, 10), (40, 20)):
+        for scale in (1.0, 1e1, 1e2, 1e3, 1e4, 1e6):
+            for rep in range(3):
+                A_ge = np.abs(rng.uniform(0.5, 5.0, size=(mrows, n)))
+                b_ge = scale * np.abs(rng.uniform(0.5, 2.0, size=mrows)) * n * 0.25
+                c = np.abs(rng.uniform(1.0, 10.0, size=n))
+                A_le = np.zeros((0, n))
+                b_le = np.zeros(0)
+                out.append((f"sweep:ge_n{n}_m{mrows}_s{scale:g}_r{rep}",
+                            _matrix_lp("sw", c, A_le, b_le, A_ge, b_ge,
+                                       lb=0.0, ub=float(10.0 * scale))))
+                # <= (resource) form at the same scale
+                A_le2 = np.abs(rng.uniform(0.5, 5.0, size=(mrows, n)))
+                b_le2 = scale * np.abs(rng.uniform(0.5, 2.0, size=mrows)) * n * 0.25
+                out.append((f"sweep:le_n{n}_m{mrows}_s{scale:g}_r{rep}",
+                            _matrix_lp("sw", c, A_le2, b_le2, np.zeros((0, n)), np.zeros(0),
+                                       lb=0.0, ub=float(10.0 * scale), maximize=True)))
+    return out
+
+
+def corpus_lps():
+    """Every ``.nl`` in the in-repo corpus that classifies as an LP."""
+    from discopt._jax.problem_classifier import ProblemClass, classify_problem
+    from discopt.modeling import from_nl
+
+    out = []
+    roots = ["python/tests/data/minlplib_nl", "python/tests/data/minlplib"]
+    paths = []
+    for root in roots:
+        if os.path.isdir(root):
+            paths += [os.path.join(root, f) for f in sorted(os.listdir(root)) if f.endswith(".nl")]
+    for p in paths:
+        model = from_nl(p)
+        if classify_problem(model) == ProblemClass.LP:
+            out.append((f"nl:{os.path.basename(p)}", model))
+    print(f"corpus: scanned {len(paths)} .nl files, {len(out)} classify as LP", flush=True)
+    return out
+
+
+def main():
+    pops = [("notebook", notebook_lps()), ("sweep", sweep_lps()), ("corpus", corpus_lps())]
+    for label, models in pops:
+        for name, model in models:
+            _CURRENT["model"] = name
+            before = len(RECORDS)
+            res = model.solve()
+            recs = RECORDS[before:]
+            fired = [r for r in recs if r["engine"] == "POUNCE" and not r["ok"]]
+            print(f"{label:8s} {name:38s} status={res.status:10s} "
+                  f"guard_calls={len(recs)} pounce_trips={len(fired)} "
+                  f"worst_ratio={max([r['ratio'] for r in recs], default=float('nan')):.3g} "
+                  f"obj={res.objective}", flush=True)
+
+    pounce_recs = [r for r in RECORDS if r["engine"] == "POUNCE"]
+    trips = [r for r in pounce_recs if not r["ok"]]
+    print("\n===== SUMMARY =====")
+    print(f"GUARD_CHECKS_OBSERVED={len(RECORDS)}  POUNCE_CHECKS={len(pounce_recs)}  "
+          f"POUNCE_TRIPS={len(trips)}")
+    if pounce_recs:
+        print(f"trip rate = {100.0 * len(trips) / len(pounce_recs):.1f}% of POUNCE LP solves")
+        ratios = np.array([r["ratio"] for r in pounce_recs])
+        finite = ratios[np.isfinite(ratios)]
+        for q in (50, 75, 90, 95, 99, 100):
+            print(f"  ratio p{q:<3d} = {np.percentile(finite, q):.4g}")
+        print("\n  trips by row scale decade:")
+        import collections
+        by = collections.Counter()
+        tot = collections.Counter()
+        for r in pounce_recs:
+            d = int(np.floor(np.log10(max(r["row_scale"], 1e-12))))
+            tot[d] += 1
+            if not r["ok"]:
+                by[d] += 1
+        for d in sorted(tot):
+            print(f"    1e{d:<3d}: {by[d]:4d}/{tot[d]:<4d} trip")
+    print("\n  tripping models:")
+    for r in trips:
+        print(f"    {r['model']:40s} ratio={r['ratio']:.3g} row_scale={r['row_scale']:.4g}")
+
+    if not RECORDS:
+        print("PROBE FIRED ZERO CHECKS - measurement is meaningless", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scratchpad/issue940/probe_false_unbounded.py
+++ b/scratchpad/issue940/probe_false_unbounded.py
@@ -1,0 +1,47 @@
+"""Does the pre-existing scale-1e7 POUNCE false UNBOUNDED reach a user-visible
+certificate? Model level, both tolerance arms, exact-simplex oracle.
+
+_solve_lp_matrix only DEFERS an UNBOUNDED when a declared bound sits in
+[1e15, 1e20). These bounds are ~1e8, so POUNCE's verdict is certified as-is.
+"""
+import os, sys
+os.environ.setdefault("JAX_PLATFORMS", "cpu"); os.environ.setdefault("JAX_ENABLE_X64", "1")
+import numpy as np
+import discopt.modeling as dm
+import discopt.solvers.lp_pounce as LPP
+import discopt.solvers.lp_simplex as LPS
+from discopt.solvers import SolveStatus
+
+CHECKS = 0
+scale = 1e7
+for rep in (0, 3, 4):
+    rng = np.random.default_rng(20940)
+    # regenerate the same stream position as probe_unbounded for n=20,m=10,scale=1e7
+    n, mrows = 20, 10
+    A = -np.abs(rng.uniform(0.5, 5.0, size=(mrows, n)))
+    b = -scale * np.abs(rng.uniform(0.5, 2.0, size=mrows)) * n * 0.25
+    c = np.abs(rng.uniform(1.0, 10.0, size=n))
+    for _ in range(rep):
+        A = -np.abs(rng.uniform(0.5, 5.0, size=(mrows, n)))
+        b = -scale * np.abs(rng.uniform(0.5, 2.0, size=mrows)) * n * 0.25
+        c = np.abs(rng.uniform(1.0, 10.0, size=n))
+    bounds = [(0.0, 10.0 * scale)] * n
+    ref = LPS.solve_lp(c=c, A_ub=A, b_ub=b, bounds=bounds)
+    old = LPP.solve_lp(c=c, A_ub=A, b_ub=b, bounds=bounds, options={"constr_viol_tol": 1e-4})
+    new = LPP.solve_lp(c=c, A_ub=A, b_ub=b, bounds=bounds)
+    CHECKS += 1
+    if True:
+        # rebuild as a model and solve end to end through nlp_solver="pounce"
+        m = dm.Model("scale1e7")
+        x = m.continuous("x", shape=(n,), lb=0.0, ub=10.0 * scale)
+        m.minimize(dm.sum(lambda j: float(c[j]) * x[j], over=range(n)))
+        for i in range(mrows):
+            row = A[i]
+            m.subject_to(dm.sum(lambda j: float(row[j]) * x[j], over=range(n))
+                         <= float(b[i]), name=f"r{i}")
+        res = m.solve(nlp_solver="pounce")
+        print(f"rep={rep}: matrix simplex={ref.status.name} pounce@1e-4={old.status.name} "
+              f"pounce@{LPP._CONSTR_VIOL_TOL:g}={new.status.name}  ||  model.solve() -> "
+              f"{res.status!r} obj={res.objective!r}  (simplex oracle obj={ref.objective!r})")
+print(f"CHECKS_EXECUTED={CHECKS}")
+sys.exit(0 if CHECKS else 1)

--- a/scratchpad/issue940/probe_gdpopt.py
+++ b/scratchpad/issue940/probe_gdpopt.py
@@ -1,0 +1,39 @@
+"""Is the GDPopt failure caused by bound_relax_factor=0, or by constr_viol_tol,
+or pre-existing? Interleaved arms in one process (CLAUDE.md §9).
+"""
+import os, sys
+os.environ.setdefault("JAX_PLATFORMS", "cpu"); os.environ.setdefault("JAX_ENABLE_X64", "1")
+import discopt.modeling as dm
+import discopt.solvers as S
+
+_orig = S.pounce_option_defaults
+ARMS = {
+    "POUNCE defaults":  {"print_level": 0, "constr_viol_tol": 1e-4, "bound_relax_factor": 1e-8},
+    "cvt only":         {"print_level": 0, "constr_viol_tol": 1e-8, "bound_relax_factor": 1e-8},
+    "brf only":         {"print_level": 0, "constr_viol_tol": 1e-4, "bound_relax_factor": 0.0},
+    "SHIPPED (both)":   {"print_level": 0, "constr_viol_tol": 1e-8, "bound_relax_factor": 0.0},
+}
+
+CHECKS = 0
+def run(arm):
+    S.pounce_option_defaults = lambda: dict(ARMS[arm])
+    # the backends import the symbol directly, so patch those bindings too
+    import discopt.solvers.lp_pounce as LPP, discopt.solvers.qp_pounce as QPP
+    LPP.pounce_option_defaults = S.pounce_option_defaults
+    QPP.pounce_option_defaults = S.pounce_option_defaults
+    m = dm.Model("loa_simple")
+    x = m.continuous("x", lb=0, ub=10)
+    m.either_or([[x <= 3], [x >= 7]], name="choice")
+    m.minimize(x)
+    r = m.solve(time_limit=30, gdp_method="loa")
+    return r.status, r.objective, r.bound
+
+for rep in range(2):
+    for arm in (list(ARMS) if rep % 2 == 0 else list(ARMS)[::-1]):
+        st, obj, bd = run(arm)
+        CHECKS += 1
+        print(f"rep{rep} {arm:18s} status={st:10s} obj={obj!r} bound={bd!r}", flush=True)
+
+S.pounce_option_defaults = _orig
+print(f"CHECKS_EXECUTED={CHECKS}")
+sys.exit(0 if CHECKS else 1)

--- a/scratchpad/issue940/probe_main_battery.py
+++ b/scratchpad/issue940/probe_main_battery.py
@@ -1,0 +1,76 @@
+"""Issue #940: candidate settings against pounce @ main, full LP battery.
+
+Checks each candidate for (a) guard trips, (b) non-convergence, (c) status
+disagreement with the exact simplex oracle. A candidate must fix the trips
+WITHOUT costing convergence or a certificate.
+"""
+import os, sys
+os.environ.setdefault("JAX_PLATFORMS", "cpu"); os.environ.setdefault("JAX_ENABLE_X64", "1")
+import numpy as np
+import discopt.solvers.lp_pounce as LPP
+from discopt.solvers.lp_simplex import solve_lp as simplex
+from discopt.solver import _matrix_solution_feasible
+from discopt.solvers import SolveStatus
+
+CHECKS = 0
+
+def battery():
+    rng = np.random.default_rng(20940)
+    for n, m in ((5, 3), (10, 6), (20, 10), (40, 20)):
+        for scale in (1e0, 1e2, 1e3, 1e4, 1e6, 1e7):
+            for rep in range(2):
+                A = -np.abs(rng.uniform(0.5, 5.0, size=(m, n)))
+                b = -scale * np.abs(rng.uniform(0.5, 2.0, size=m)) * n * 0.25
+                c = np.abs(rng.uniform(1.0, 10.0, size=n))
+                yield (f"n{n}_s{scale:g}_r{rep}", c, A, b, [(0.0, 10.0 * scale)] * n)
+
+INSTANCES = list(battery())
+# The diet LP (the user-visible symptom) too.
+_c = np.array([2.0, 3.5, 8.0, 11.0, 25.0])
+_A = np.array([[3.0, 8.0, 15.0, 22.0, 31.0], [25.0, 120.0, 200.0, 10.0, 15.0],
+               [1.0, 0.1, 0.5, 3.0, 5.5], [250.0, 150.0, 400.0, 200.0, 450.0]])
+_r = np.array([55.0, 800.0, 12.0, 2000.0])
+INSTANCES.append(("diet", _c, -_A, -_r, [(0.0, 10.0)] * 5))
+
+CANDIDATES = {
+    # Every arm must pin BOTH options explicitly: the module default now sets
+    # both, so naming only one silently leaves the other at the shipped value
+    # and the arm label becomes a lie (CLAUDE.md §8).
+    "POUNCE's own defaults": {"constr_viol_tol": 1e-4, "bound_relax_factor": 1e-8},
+    "cvt=1e-8 only": {"constr_viol_tol": 1e-8, "bound_relax_factor": 1e-8},
+    "brf=0 only": {"constr_viol_tol": 1e-4, "bound_relax_factor": 0.0},
+    "BOTH (shipped)": {"constr_viol_tol": 1e-8, "bound_relax_factor": 0.0},
+}
+
+def main():
+    global CHECKS
+    ref = {}
+    for tag, c, A, b, bnds in INSTANCES:
+        ref[tag] = simplex(c=c, A_ub=A, b_ub=b, bounds=bnds)
+    print(f"{'candidate':26s} {'trips':>6s} {'nonopt':>7s} {'status_mismatch':>16s} "
+          f"{'worst_ratio':>12s}  (n={len(INSTANCES)})")
+    for label, opts in CANDIDATES.items():
+        trips = nonopt = mism = 0
+        worst = 0.0
+        for tag, c, A, b, bnds in INSTANCES:
+            r = LPP.solve_lp(c=c, A_ub=A, b_ub=b, bounds=bnds, options=opts or None)
+            CHECKS += 1
+            if r.status != SolveStatus.OPTIMAL:
+                nonopt += 1
+                if ref[tag].status == SolveStatus.OPTIMAL:
+                    mism += 1
+                continue
+            if ref[tag].status != SolveStatus.OPTIMAL:
+                mism += 1
+            x = np.asarray(r.x)
+            if not _matrix_solution_feasible(x, A, b, None, None, bnds):
+                trips += 1
+            v = A @ x - b
+            s = np.abs(A) @ np.abs(x)
+            worst = max(worst, float(np.max(v / (1e-6 + 1e-9 * s))))
+        print(f"{label:26s} {trips:6d} {nonopt:7d} {mism:16d} {worst:12.4g}", flush=True)
+    print(f"\nCHECKS_EXECUTED={CHECKS}")
+    return 0 if CHECKS else 1
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scratchpad/issue940/probe_main_options.py
+++ b/scratchpad/issue940/probe_main_options.py
@@ -1,0 +1,77 @@
+"""Issue #940, against pounce @ git main (what CI actually installs).
+
+The 1e-8 constr_viol_tol request that works on PyPI 0.9.0 does NOT bind on main:
+the violation there is ~8.1e-8 * data scale — a RELATIVE criterion. Find what, if
+anything, binds it to discopt's per-row test.
+
+Provenance (§8): asserts the CI signature is reproduced before measuring anything.
+"""
+import os, sys
+os.environ.setdefault("JAX_PLATFORMS", "cpu"); os.environ.setdefault("JAX_ENABLE_X64", "1")
+import numpy as np
+import discopt.solvers.lp_pounce as LPP
+from discopt.solver import _matrix_solution_feasible
+from discopt.solvers import SolveStatus
+
+CHECKS = 0
+
+
+def case(scale, seed=940, n=20, m=10):
+    rng = np.random.default_rng(seed)
+    A = -np.abs(rng.uniform(0.5, 5.0, size=(m, n)))
+    b = -scale * np.abs(rng.uniform(0.5, 2.0, size=m)) * n * 0.25
+    c = np.abs(rng.uniform(1.0, 10.0, size=n))
+    return c, A, b, [(0.0, 10.0 * scale)] * n
+
+
+# ---- §8 provenance gate: must reproduce CI's numbers, else wrong build --------
+c, A, b, bnds = case(1e2)
+probe = LPP.solve_lp(c=c, A_ub=A, b_ub=b, bounds=bnds)
+sig = float(np.max(A @ np.asarray(probe.x) - b))
+assert abs(sig - 8.096e-06) / 8.096e-06 < 0.01, (
+    f"worst violation {sig:.4g} does not match the CI signature 8.096e-06 — "
+    "this is NOT the build CI runs; abort before measuring")
+print(f"provenance OK: reproduced CI signature {sig:.4g}\n")
+
+CANDIDATES = {
+    "(none - main default)": {},
+    "constr_viol_tol=1e-8": {"constr_viol_tol": 1e-8},
+    "constr_viol_tol=1e-12": {"constr_viol_tol": 1e-12},
+    "tol=1e-10": {"tol": 1e-10},
+    "tol=1e-12": {"tol": 1e-12},
+    "tol=1e-12 + cvt=1e-12": {"tol": 1e-12, "constr_viol_tol": 1e-12},
+    "bound_relax_factor=0": {"bound_relax_factor": 0.0},
+    "bound_relax_factor=0 + tol=1e-12": {"bound_relax_factor": 0.0, "tol": 1e-12},
+    "nlp_scaling_method=none": {"nlp_scaling_method": "none"},
+    "nlp_scaling_method=none + tol=1e-12": {"nlp_scaling_method": "none", "tol": 1e-12},
+    "honor_original_bounds=yes": {"honor_original_bounds": "yes"},
+}
+
+
+def main():
+    global CHECKS
+    print(f"{'candidate':38s} {'trips':>6s} {'worst_viol@1e2':>15s} {'@1e3':>12s} "
+          f"{'@1e4':>12s} {'nonopt':>7s}")
+    for label, opts in CANDIDATES.items():
+        trips = nonopt = 0
+        viols = []
+        for scale in (1e2, 1e3, 1e4):
+            c, A, b, bnds = case(scale)
+            r = LPP.solve_lp(c=c, A_ub=A, b_ub=b, bounds=bnds, options=opts or None)
+            CHECKS += 1
+            if r.status != SolveStatus.OPTIMAL:
+                nonopt += 1
+                viols.append(float("nan"))
+                continue
+            x = np.asarray(r.x)
+            viols.append(float(np.max(A @ x - b)))
+            if not _matrix_solution_feasible(x, A, b, None, None, bnds):
+                trips += 1
+        print(f"{label:38s} {trips:6d} {viols[0]:15.4g} {viols[1]:12.4g} "
+              f"{viols[2]:12.4g} {nonopt:7d}", flush=True)
+    print(f"\nCHECKS_EXECUTED={CHECKS}")
+    return 0 if CHECKS else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scratchpad/issue940/probe_nlp_arm.py
+++ b/scratchpad/issue940/probe_nlp_arm.py
@@ -1,0 +1,59 @@
+"""Verify the review's claim: does the bare-container arm take the NLP path, and
+does it still return a point BELOW its lower bound on this PR's branch?
+
+The review stated the NLP-arm value under this PR as an inference (it was read
+off the unpatched tree). This measures it directly on the branch.
+"""
+import os, sys
+os.environ.setdefault("JAX_PLATFORMS", "cpu"); os.environ.setdefault("JAX_ENABLE_X64", "1")
+import numpy as np
+import discopt.modeling as dm
+import discopt.solvers.lp_pounce as LPP
+
+# §8: on the branch, with the fix present.
+assert LPP.__file__.startswith("/home/user/discopt/python/"), LPP.__file__
+from discopt.solvers import pounce_option_defaults
+assert pounce_option_defaults()["bound_relax_factor"] == 0.0, "not the branch under test"
+
+CHECKS = 0
+seen = set()
+_orig_core = LPP._solve_core
+def traced_core(*a, **k):
+    seen.add("lp_pounce._solve_core")
+    return _orig_core(*a, **k)
+LPP._solve_core = traced_core
+
+try:
+    import discopt.solvers.nlp_pounce as NLPP
+    _orig_nlp = NLPP.solve_nlp
+    def traced_nlp(*a, **k):
+        seen.add("nlp_pounce.solve_nlp")
+        return _orig_nlp(*a, **k)
+    NLPP.solve_nlp = traced_nlp
+except ImportError:
+    pass
+
+
+def run(flat):
+    seen.clear()
+    m = dm.Model()
+    s = m.set("S", [10, 20, 30])
+    y = m.continuous("y", lb=1, ub=5, over=s)
+    m.minimize(dm.sum(y.flat) if flat else dm.sum(y))
+    r = m.solve()
+    x = np.asarray(r.value(y), dtype=np.float64).ravel()
+    return r.objective, x, sorted(seen)
+
+
+print(f"true optimum = 3.0;  lb = 1.0 on every variable\n")
+for flat in (True, False):
+    obj, x, path = run(flat)
+    CHECKS += 1
+    below = float(np.max(1.0 - x))          # >0 means x sits BELOW its lb
+    print(f"flat={str(flat):5s} path={path}")
+    print(f"    obj={obj!r}  err_vs_3.0={obj - 3.0:+.4e}")
+    print(f"    x={x}")
+    print(f"    max lb violation = {below:.4e}  {'<-- BELOW ITS BOUND' if below > 1e-12 else 'ok'}\n")
+
+print(f"CHECKS_EXECUTED={CHECKS}")
+sys.exit(0 if CHECKS else 1)

--- a/scratchpad/issue940/probe_noncompact_hole.py
+++ b/scratchpad/issue940/probe_noncompact_hole.py
@@ -1,0 +1,58 @@
+"""Does the false-UNBOUNDED hole survive OUTSIDE the compact box?
+
+The #940 fix refuses UNBOUNDED only when every bound is finite. If POUNCE's
+ambiguous code-3/4 exit can also be hit on a box with one infinite bound whose
+true status is OPTIMAL, then discopt still manufactures a false certificate and
+the residual defect is discopt's status map, not POUNCE's convergence.
+
+The objective is min c'x with c >= 0 and x >= 0, so no ray can decrease it: the
+LP is bounded below BY CONSTRUCTION regardless of any infinite upper bound.
+"""
+import os, sys
+os.environ.setdefault("JAX_PLATFORMS", "cpu"); os.environ.setdefault("JAX_ENABLE_X64", "1")
+import numpy as np
+import discopt.solvers.lp_pounce as LPP
+from discopt.solvers.lp_simplex import solve_lp as simplex
+from discopt.solvers import SolveStatus
+
+CHECKS = 0
+false_unbounded = []
+for seed in range(30):
+    for n, m, scale in ((20, 10, 1e7), (40, 20, 1e7), (20, 10, 1e8)):
+        rng = np.random.default_rng(seed)
+        A = -np.abs(rng.uniform(0.5, 5.0, size=(m, n)))          # -Ax <= -b  (i.e. Ax >= b)
+        b = -scale * np.abs(rng.uniform(0.5, 2.0, size=m)) * n * 0.25
+        c = np.abs(rng.uniform(1.0, 10.0, size=n))               # c >= 0, minimize
+        # ONE variable left unbounded above -> box is not compact.
+        bounds = [(0.0, np.inf)] + [(0.0, 10.0 * scale)] * (n - 1)
+        ref = simplex(c=c, A_ub=A, b_ub=b, bounds=bounds)
+        res = LPP.solve_lp(c=c, A_ub=A, b_ub=b, bounds=bounds)
+        CHECKS += 1
+        if ref.status == SolveStatus.OPTIMAL and res.status == SolveStatus.UNBOUNDED:
+            false_unbounded.append((seed, n, m, scale, ref.objective))
+
+print(f"CHECKS_EXECUTED={CHECKS}")
+print(f"false UNBOUNDED on a NON-compact box (true status optimal): {len(false_unbounded)}")
+for r in false_unbounded[:6]:
+    print(f"   seed={r[0]} n={r[1]} m={r[2]} scale={r[3]:g}  true optimum={r[4]!r}")
+
+# --- model level: does it reach a user-visible certificate? -------------------
+import discopt.modeling as dm
+rng = np.random.default_rng(0)
+n, m, scale = 20, 10, 1e7
+A = -np.abs(rng.uniform(0.5, 5.0, size=(m, n)))
+b = -scale * np.abs(rng.uniform(0.5, 2.0, size=m)) * n * 0.25
+c = np.abs(rng.uniform(1.0, 10.0, size=n))
+mdl = dm.Model("noncompact")
+x = mdl.continuous("x", shape=(n,), lb=0.0, ub=np.inf)
+mdl.minimize(dm.sum(lambda j: float(c[j]) * x[j], over=range(n)))
+for i in range(m):
+    row = A[i]
+    mdl.subject_to(dm.sum(lambda j: float(row[j]) * x[j], over=range(n)) <= float(b[i]),
+                   name=f"r{i}")
+res = mdl.solve(nlp_solver="pounce")
+ref = simplex(c=c, A_ub=A, b_ub=b, bounds=[(0.0, np.inf)] * n)
+print(f"\nMODEL LEVEL: model.solve() -> {res.status!r} obj={res.objective!r} | "
+      f"exact simplex -> {ref.status.name} obj={ref.objective!r}")
+
+sys.exit(0 if CHECKS else 1)

--- a/scratchpad/issue940/probe_options.py
+++ b/scratchpad/issue940/probe_options.py
@@ -1,0 +1,152 @@
+"""Issue #940 experiment 2: can POUNCE's own LP convergence be made to imply
+discopt's per-row constraint tolerance?
+
+For each candidate option set, solve the tripping LPs directly through
+``lp_pounce.solve_lp`` and record (a) status, (b) worst absolute row violation,
+(c) worst violation/threshold ratio against the #850 guard, (d) iterations and
+wall time. §6: prints an executed-check count and exits non-zero if zero.
+"""
+
+import os
+import sys
+import time
+
+os.environ.setdefault("JAX_PLATFORMS", "cpu")
+os.environ.setdefault("JAX_ENABLE_X64", "1")
+
+import numpy as np  # noqa: E402
+
+import discopt.solvers.lp_pounce as LPP  # noqa: E402
+from discopt.solver import _matrix_solution_feasible  # noqa: E402
+from discopt.solvers import SolveStatus  # noqa: E402
+
+assert LPP.__file__.startswith("/home/user/discopt/python/"), LPP.__file__
+assert LPP.POUNCE_AVAILABLE
+
+CHECKS = 0
+
+
+def worst(x, A_ub, b_ub, A_eq, b_eq, bounds, tol=1e-6, rtol=1e-9):
+    x = np.asarray(x, float)
+    absx = np.abs(x)
+    wv = 0.0
+    wr = 0.0
+    for A, b, signed in ((A_ub, b_ub, True), (A_eq, b_eq, False)):
+        if A is None or b is None or not len(b):
+            continue
+        A = np.asarray(A, float)
+        v = A @ x - np.asarray(b, float)
+        if not signed:
+            v = np.abs(v)
+        s = np.abs(A) @ absx
+        wv = max(wv, float(v.max()))
+        wr = max(wr, float((v / (tol + rtol * s)).max()))
+    for xi, (lo, hi) in zip(x, bounds):
+        v = max(lo - xi, xi - hi)
+        wv = max(wv, float(v))
+        wr = max(wr, float(v / (tol + rtol * abs(xi))))
+    return wv, wr
+
+
+# ---- LP instances (matrix form) reproducing the tripping population ---------
+def diet():
+    c = np.array([2.0, 3.5, 8.0, 11.0, 25.0])
+    A = np.array([[3.0, 8.0, 15.0, 22.0, 31.0],
+                  [25.0, 120.0, 200.0, 10.0, 15.0],
+                  [1.0, 0.1, 0.5, 3.0, 5.5],
+                  [250.0, 150.0, 400.0, 200.0, 450.0]])
+    r = np.array([55.0, 800.0, 12.0, 2000.0])
+    return "diet", c, -A, -r, [(0.0, 10.0)] * 5
+
+
+def transport():
+    supply = np.array([300.0, 400.0, 500.0])
+    demand = np.array([200.0, 300.0, 250.0, 450.0])
+    sc = np.array([[8.0, 6.0, 10.0, 9.0], [9.0, 12.0, 7.0, 5.0], [14.0, 9.0, 16.0, 4.0]])
+    nw, nc = sc.shape
+    n = nw * nc
+    rows, rhs = [], []
+    for i in range(nw):
+        r = np.zeros(n)
+        r[i * nc:(i + 1) * nc] = 1.0
+        rows.append(r)
+        rhs.append(supply[i])
+    for j in range(nc):
+        r = np.zeros(n)
+        r[j::nc] = -1.0
+        rows.append(r)
+        rhs.append(-demand[j])
+    return "transport", sc.ravel(), np.array(rows), np.array(rhs), [(0.0, 500.0)] * n
+
+
+def rand_lp(tag, n, m, scale, seed):
+    rng = np.random.default_rng(seed)
+    A = -np.abs(rng.uniform(0.5, 5.0, size=(m, n)))
+    b = -scale * np.abs(rng.uniform(0.5, 2.0, size=m)) * n * 0.25
+    c = np.abs(rng.uniform(1.0, 10.0, size=n))
+    return tag, c, A, b, [(0.0, 10.0 * scale)] * n
+
+
+INSTANCES = [diet(), transport()]
+for k, (n, m) in enumerate(((5, 3), (10, 6), (20, 10), (40, 20))):
+    for scale in (1e2, 1e3, 1e4):
+        for rep in range(2):
+            INSTANCES.append(rand_lp(f"rand_n{n}_s{scale:g}_r{rep}", n, m, scale,
+                                     1000 + 17 * k + rep + int(np.log10(scale))))
+
+CANDIDATES = {
+    "Ipopt default 1e-4": {"constr_viol_tol": 1e-4},
+    "SHIPPED constr_viol_tol=1e-8": {"constr_viol_tol": 1e-8},
+    "constr_viol_tol=1e-9": {"constr_viol_tol": 1e-9},
+    "constr_viol_tol=1e-11": {"constr_viol_tol": 1e-11},
+    "tol=1e-10": {"tol": 1e-10},
+    "cvt=1e-9 + tol=1e-10": {"constr_viol_tol": 1e-9, "tol": 1e-10},
+    "cvt=1e-9 + acceptable_cvt=1e-9": {
+        "constr_viol_tol": 1e-9, "acceptable_constr_viol_tol": 1e-9},
+    "scaling=none": {"nlp_scaling_method": "none"},
+    "scaling=none + cvt=1e-9": {"nlp_scaling_method": "none", "constr_viol_tol": 1e-9},
+}
+
+
+def main():
+    global CHECKS
+    print(f"{'candidate':34s} {'trips':>6s} {'/n':>4s} {'worst_ratio':>12s} "
+          f"{'worst_viol':>11s} {'nonopt':>6s} {'mean_iter':>9s} {'mean_ms':>8s}")
+    rows = {}
+    for label, opts in CANDIDATES.items():
+        trips = nonopt = 0
+        wr_all, wv_all, iters, times = [], [], [], []
+        for tag, c, A_ub, b_ub, bounds in INSTANCES:
+            t0 = time.perf_counter()
+            res = LPP.solve_lp(c=c, A_ub=A_ub, b_ub=b_ub, bounds=bounds,
+                               options=opts or None)
+            dt = (time.perf_counter() - t0) * 1e3
+            CHECKS += 1
+            if res.status != SolveStatus.OPTIMAL:
+                nonopt += 1
+                continue
+            ok = _matrix_solution_feasible(res.x, A_ub, b_ub, None, None, bounds)
+            wv, wr = worst(res.x, A_ub, b_ub, None, None, bounds)
+            wr_all.append(wr)
+            wv_all.append(wv)
+            iters.append(res.iterations)
+            times.append(dt)
+            if not ok:
+                trips += 1
+        rows[label] = (trips, len(INSTANCES), max(wr_all, default=float("nan")),
+                       max(wv_all, default=float("nan")), nonopt,
+                       float(np.mean(iters)) if iters else float("nan"),
+                       float(np.mean(times)) if times else float("nan"))
+        t, n, wr, wv, no, it, ms = rows[label]
+        print(f"{label:34s} {t:6d} {n:4d} {wr:12.4g} {wv:11.4g} {no:6d} {it:9.1f} {ms:8.2f}",
+              flush=True)
+
+    print(f"\nCHECKS_EXECUTED={CHECKS}")
+    if CHECKS == 0:
+        print("PROBE FIRED ZERO CHECKS", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scratchpad/issue940/probe_qp.py
+++ b/scratchpad/issue940/probe_qp.py
@@ -1,0 +1,71 @@
+"""Issue #940: does the same POUNCE constr_viol_tol mismatch reach the QP path?
+
+The QP call sites in solver.py (``_solve_qp_matrix``) use the SAME #850 guard
+``_matrix_solution_feasible``, and ``qp_pounce.solve_qp`` builds its option dict
+the same way as ``lp_pounce.solve_lp``. Measure rather than assume (CLAUDE.md §4).
+"""
+
+import os
+import sys
+
+os.environ.setdefault("JAX_PLATFORMS", "cpu")
+os.environ.setdefault("JAX_ENABLE_X64", "1")
+
+import numpy as np  # noqa: E402
+
+import discopt.solvers.qp_pounce as QPP  # noqa: E402
+from discopt.solver import _matrix_solution_feasible  # noqa: E402
+from discopt.solvers import SolveStatus  # noqa: E402
+
+assert QPP.__file__.startswith("/home/user/discopt/python/"), QPP.__file__
+assert QPP.POUNCE_AVAILABLE
+
+CHECKS = 0
+
+
+def worst_viol(x, A_ub, b_ub, bounds):
+    x = np.asarray(x, float)
+    v = np.asarray(A_ub, float) @ x - np.asarray(b_ub, float)
+    wv = float(v.max())
+    for xi, (lo, hi) in zip(x, bounds):
+        wv = max(wv, lo - xi, xi - hi)
+    return wv
+
+
+def main():
+    global CHECKS
+    rng = np.random.default_rng(20)
+    for opts_label, opts in (("Ipopt default 1e-4", {"constr_viol_tol": 1e-4}), ("SHIPPED 1e-8", {"constr_viol_tol": 1e-8})):
+        trips = 0
+        worst = 0.0
+        n_inst = 0
+        for n, m in ((5, 3), (10, 6), (20, 10)):
+            for scale in (1e2, 1e3, 1e4):
+                for rep in range(2):
+                    B = rng.normal(size=(n, n))
+                    Q = B @ B.T + n * np.eye(n)
+                    c = -np.abs(rng.uniform(1.0, 10.0, size=n)) * scale
+                    A_ub = -np.abs(rng.uniform(0.5, 5.0, size=(m, n)))
+                    b_ub = -scale * np.abs(rng.uniform(0.5, 2.0, size=m)) * n * 0.25
+                    bounds = [(0.0, 10.0 * scale)] * n
+                    res = QPP.solve_qp(Q=Q, c=c, A_ub=A_ub, b_ub=b_ub, bounds=bounds,
+                                       options=opts)
+                    CHECKS += 1
+                    n_inst += 1
+                    if res.status != SolveStatus.OPTIMAL:
+                        continue
+                    ok = _matrix_solution_feasible(res.x, A_ub, b_ub, None, None, bounds)
+                    worst = max(worst, worst_viol(res.x, A_ub, b_ub, bounds))
+                    if not ok:
+                        trips += 1
+        print(f"{opts_label:12s} guard trips {trips}/{n_inst}  worst_abs_viol={worst:.4g}",
+              flush=True)
+    print(f"CHECKS_EXECUTED={CHECKS}")
+    if CHECKS == 0:
+        print("PROBE FIRED ZERO CHECKS", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scratchpad/issue940/probe_signed.py
+++ b/scratchpad/issue940/probe_signed.py
@@ -1,0 +1,45 @@
+"""Issue #940: SIGNED objective error of the accepted POUNCE point against the
+exact-simplex oracle, both tolerance arms, interleaved in one process.
+
+For a MINIMIZE LP a negative error means the reported objective sits BELOW the
+true optimum (super-optimal, i.e. bought with residual infeasibility) — the
+#850 failure mode. ``_solve_lp_matrix`` reports ``bound = objective``, so this is
+the quantity that decides whether the returned bound is trustworthy.
+"""
+import os, sys
+os.environ.setdefault("JAX_PLATFORMS", "cpu"); os.environ.setdefault("JAX_ENABLE_X64", "1")
+import numpy as np
+import discopt.solvers.lp_pounce as LPP
+from discopt.solvers.lp_simplex import solve_lp as simplex
+from discopt.solvers import SolveStatus
+
+assert LPP._CONSTR_VIOL_TOL == 1e-8
+COMPARISONS = 0
+old_err, new_err = [], []
+rng = np.random.default_rng(20940)
+for n, m in ((5, 3), (10, 6), (20, 10), (40, 20)):
+    for scale in (1e0, 1e2, 1e3, 1e4, 1e5, 1e6):
+        for rep in range(3):
+            A = -np.abs(rng.uniform(0.5, 5.0, size=(m, n)))
+            b = -scale * np.abs(rng.uniform(0.5, 2.0, size=m)) * n * 0.25
+            c = np.abs(rng.uniform(1.0, 10.0, size=n))
+            bounds = [(0.0, 10.0 * scale)] * n
+            ref = simplex(c=c, A_ub=A, b_ub=b, bounds=bounds)
+            if ref.status != SolveStatus.OPTIMAL:
+                continue
+            o = LPP.solve_lp(c=c, A_ub=A, b_ub=b, bounds=bounds,
+                             options={"constr_viol_tol": 1e-4})
+            nw = LPP.solve_lp(c=c, A_ub=A, b_ub=b, bounds=bounds)
+            if o.status != SolveStatus.OPTIMAL or nw.status != SolveStatus.OPTIMAL:
+                continue
+            COMPARISONS += 1
+            d = max(1.0, abs(ref.objective))
+            old_err.append((o.objective - ref.objective) / d)
+            new_err.append((nw.objective - ref.objective) / d)
+for label, e in (("pre-fix  (constr_viol_tol=1e-4)", np.array(old_err)),
+                 ("post-fix (constr_viol_tol=1e-8)", np.array(new_err))):
+    print(f"{label}: signed rel error vs simplex optimum  "
+          f"min={e.min():+.3e}  max={e.max():+.3e}  "
+          f"mean|e|={np.abs(e).mean():.3e}  n_super_optimal={(e < -1e-9).sum()}")
+print(f"COMPARISONS_EXECUTED={COMPARISONS}")
+sys.exit(0 if COMPARISONS else 1)

--- a/scratchpad/issue940/probe_unbounded.py
+++ b/scratchpad/issue940/probe_unbounded.py
@@ -1,0 +1,62 @@
+"""Issue #940: is the POUNCE UNBOUNDED-vs-simplex-OPTIMAL disagreement at data
+scale 1e6 pre-existing, or introduced by constr_viol_tol=1e-9?
+
+Both arms are run in ONE process against the SAME instances, selecting the
+tolerance through the caller option, so the comparison is interleaved and no
+module-provenance ambiguity exists (§8, §9).
+"""
+
+import os
+import sys
+
+os.environ.setdefault("JAX_PLATFORMS", "cpu")
+os.environ.setdefault("JAX_ENABLE_X64", "1")
+
+import numpy as np  # noqa: E402
+
+import discopt.solvers.lp_pounce as LPP  # noqa: E402
+import discopt.solvers.lp_simplex as LPS  # noqa: E402
+from discopt.solvers import SolveStatus  # noqa: E402
+
+assert LPP._CONSTR_VIOL_TOL == 1e-8
+CHECKS = 0
+
+
+def instances():
+    rng = np.random.default_rng(20940)
+    for n, m in ((5, 3), (10, 6), (20, 10), (40, 20)):
+        for scale in (1e0, 1e2, 1e3, 1e4, 1e5, 1e6, 1e7):
+            for rep in range(5):
+                A = -np.abs(rng.uniform(0.5, 5.0, size=(m, n)))
+                b = -scale * np.abs(rng.uniform(0.5, 2.0, size=m)) * n * 0.25
+                c = np.abs(rng.uniform(1.0, 10.0, size=n))
+                yield (f"n{n}_s{scale:g}_r{rep}", c, A, b, [(0.0, 10.0 * scale)] * n)
+
+
+def main():
+    global CHECKS
+    mism_old = mism_new = 0
+    rows = []
+    for tag, c, A_ub, b_ub, bounds in instances():
+        ref = LPS.solve_lp(c=c, A_ub=A_ub, b_ub=b_ub, bounds=bounds)
+        old = LPP.solve_lp(c=c, A_ub=A_ub, b_ub=b_ub, bounds=bounds,
+                           options={"constr_viol_tol": 1e-4})  # Ipopt default = pre-fix
+        new = LPP.solve_lp(c=c, A_ub=A_ub, b_ub=b_ub, bounds=bounds)  # post-fix default
+        CHECKS += 1
+        if old.status != ref.status:
+            mism_old += 1
+        if new.status != ref.status:
+            mism_new += 1
+        if old.status != ref.status or new.status != ref.status:
+            rows.append((tag, ref.status.name, old.status.name, new.status.name))
+    print(f"{'instance':22s} {'simplex':10s} {'pounce@1e-4':12s} {'pounce@default':14s}")
+    for r in rows:
+        print(f"{r[0]:22s} {r[1]:10s} {r[2]:12s} {r[3]:12s}")
+    print(f"\nstatus mismatches vs simplex oracle: pre-fix(1e-4)={mism_old}  "
+          f"post-fix({LPP._CONSTR_VIOL_TOL:g})={mism_new}   of {CHECKS} instances")
+    print(f"CHECKS_EXECUTED={CHECKS}")
+    return 0 if CHECKS else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

discopt checks every matrix-form point against `_matrix_solution_feasible` — the #850
Obs 3 guard, `|viol_i| <= 1e-6 + 1e-9*sum_j|A_ij||x_j|`. POUNCE was returning points that
miss it, so the guard correctly threw away *correct* solves, logged a WARNING and
re-solved with the exact simplex.

The issue's kill criterion was "well under ~1% of corpus LP solves → just change the log
level". **Measured 50%** (74/148), including all four `tutorial_lp.ipynb` models. Far
above the threshold, so the fix belongs at the source.

> **This description was rewritten after CI caught a defect in the first attempt.** The
> original framed `constr_viol_tol` as the fix; that is wrong, and the history is in
> [this comment](https://github.com/jkitchin/discopt/pull/943#issuecomment-5223157222).
> Short version: I measured against PyPI `pounce-solver==0.9.0` while CI installs
> `pounce @ git main`, where that option is a **no-op**. Both builds report version
> `0.9.0`, so only a behavioural fingerprint separates them.

### Root cause

Ipopt's **`bound_relax_factor`** (default 1e-8) deliberately relaxes bounds — including
the slack bounds standing in for inequality rows — by `1e-8*(1 + |bound|)`. The engine
converges honestly, but to a **relaxed box**, so the returned point sits outside the
declared one and the violation grows with the data: `|b| ~ 440` → ~4.4e-6, `|b| ~ 44000`
→ ~4.4e-4. That matches the observed 8.1e-6 / 8.1e-5 / 8.1e-4 at data scale 1e2 / 1e3 /
1e4 — a constant ~8.1e-8 *relative* error. **No convergence tolerance can fix this**: the
solver has already converged; the box it converged to is the wrong one.

`constr_viol_tol` addresses a second, independent mechanism (Ipopt's 1e-4 default, two
orders looser than the guard's 1e-6 floor) which dominates on the published wheel.

**Both are set**, because they bind on different builds and `pyproject.toml` admits
`pounce-solver>=0.9` while CI tracks `main`.

### Measurement (49-LP battery, n=5..40, data scale 1e0..1e7, plus the tutorial diet LP)

Every arm pins **both** options explicitly — naming only one leaves the other at the
shipped value and silently mislabels the arm.

|                              | pounce @ main | PyPI 0.9.0 |
|---|---|---|
| POUNCE's own defaults        | 38 trips, 3 nonopt | 23 trips, 3 nonopt |
| `constr_viol_tol=1e-8` alone | **39 trips**, 2 nonopt | 0 trips, 3 nonopt |
| `bound_relax_factor=0` alone | 0 trips, 2 nonopt | *(not measured alone)* |
| **BOTH (shipped)**           | **0 trips, 2 nonopt** | **0 trips, 2 nonopt** |

The residual 2 non-convergences are pre-existing scale-1e7 stalls, present under POUNCE's
own defaults too. `constr_viol_tol=1e-12` was measured and **rejected**: it reaches the
tolerance but breaks convergence on 18 of 49 instances on main.

### Second defect, found on the way and also fixed

POUNCE reaches `UNBOUNDED` only via `_LP_STATUS_MAP`, from Ipopt codes 3/4
(`Search_Direction_Becomes_Too_Small` / `Diverging_Iterates`). Those report a stalled or
diverging iteration; POUNCE never claims unboundedness. The inference was discopt's, and
it was unsound: on `min c'x` with `c >= 0, x >= 0`, where no ray can lower the objective
*by construction*, 42 of 90 instances at data scale 1e7–1e8 were certified `unbounded`,
and `model.solve()` returned `status='unbounded'` for an LP whose exact optimum is 5.1e7.

Rather than stop mapping 3/4 — which would cost the Benders dual seam its feasibility-cut
signal, where an unbounded dual is the normal case — `_certify_unbounded_ray` settles it:
a **feasible** LP is unbounded iff its recession cone holds a direction of strictly
negative cost. That ray LP is always feasible (`d = 0`) and bounded, so it is far easier
than the solve that just failed. For a convex QP it adds `Qd = 0` rows. The test is
one-directional — it can only *withdraw* a verdict — so where Phase-1 has not established
feasibility (`m == 0`, or a failed Phase-1) the gap costs a certificate, never soundness.

This keeps the #850/#937 machinery live rather than orphaning it: POUNCE can still return
`UNBOUNDED`, so the `[1e15, 1e20)` deferral and its diagnostic still apply.

The underlying POUNCE convergence gap is reported upstream at jkitchin/pounce#528.

Closes #940

## Correctness

- [x] Cannot produce a false certificate — and removes one that existed (codes-3/4
      `unbounded`: 42/90 → 0/90 on both compact and non-compact boxes; the model-level
      case now returns `optimal` at 5.1e7, matching the oracle)
- [x] No validation, fallback, or safety guard was weakened to make a check pass

The guard is untouched and remains the arbiter. The change makes returned points *more*
accurate and moves them onto the feasible side of the declared box — it removes small
super-optimalities rather than creating them (see the `test_sets_adversarial` note below).

## Tests run

- [x] `pytest -m smoke` on **pounce @ main** → **909 passed, 16 skipped, 2 xpassed, 0 failed**
- [x] `pytest -m slow python/tests/test_adversarial_recent_fixes.py` → **10 passed, 0 failed**
- [x] `cargo test -p discopt-core` → N/A, no Rust touched
- [x] `ruff check` / `ruff format --check` / `mypy` clean

#940 (14 cases) and #850 (19 cases) suites verified on **both** POUNCE builds.

An earlier adversarial run showed `test_large_dense_jacobian_no_crash` overrunning its 48s
deadline at 72s. That was contention from probes running alongside it — retracted.
Interleaved A/B under clean load: pre 35.1s ±2.1, post 31.3s ±0.8, 0/3 over on both arms.

## Regression test

`python/tests/test_940_pounce_lp_constraint_tolerance.py` — 14 cases, **8 fail on the
pre-fix tree**. It pins **behaviour** (returned point within discopt's tolerance), never
the option names, which is exactly why it caught the `constr_viol_tol`-only version as a
no-op on main instead of going quietly green.

One unrelated test was retolerated, and it is a strengthening, not a weakening:
`test_sets_adversarial::test_sum_indexed_var_equals_sum_flat` compared two identical
models against **each other** at 1e-9 — 1000x tighter than discopt's 1e-6. Measured both
arms against the exact optimum 3.0:

```
pre  (POUNCE defaults)  indexed=2.9999999775  flat=2.9999999775   both -2.25e-8
post (this PR)          indexed=2.9999999775  flat=3.0000000075   flat +7.5e-9
```

The indexed model is bit-identical across arms; the flat model became **3x more accurate**
and moved from super-optimal (below the true optimum, bought by the relaxed bounds) onto
the feasible side. It now asserts both objectives against the ground truth 3.0, not merely
against each other — a cross-model comparison alone passes just as happily when both are
wrong the same way.

## Bound-changing / performance change?

Not a relaxation, cut, or reduction, so no default-off flag — but not strictly
bound-neutral either, so the measurement is here rather than deleted.

Corpus panel, 66 `.nl` instances, arms interleaved: **55/66 identical**. The informative
slice: **46/66 reach `optimal` in both arms — 43 bit-identical, 3 within 4.2e-10 relative**
(all QP/MIQP). The rest sit on `time_limit`/`feasible` instances where a 20s wall budget
makes node counts and terminal bounds nondeterministic; replicated 3x per arm, the three
alarming diffs (`contvar` 1.4% bound, `tspn12` status change, `clay0303hfsg` 3→63 nodes)
all dissolved as load noise.

Soundness gate, 16 registry-covered instances, both arms: **96 executed assertions, 0
violations** (bound ≤ true optimum, incumbent ≥ true optimum, bound ≤ incumbent), all 16
identical across arms.

*Caveat, stated because it matters:* the corpus panel and soundness gate were run on PyPI
0.9.0, before the build discrepancy was found. The suites have since been re-run on main;
those two panels have not.

- Measurement: harnesses vendored under `scratchpad/issue940/`, each printing an
  executed-assertion count and exiting non-zero when it is zero.

## Not included

`nlp_pounce` sets neither option, so NLP incumbents can sit outside a constraint while
discopt's incumbent check uses 1e-6. Left alone deliberately: tightening an NLP's
tolerances risks convergence failures on genuinely hard nonlinear problems and needs its
own differential panel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UuWeYXWdnDWrnQ6EnrXfc8