### PR TITLE
fix(correctness): #944 curvature walker was blind to array constants

### DIFF
--- a/crates/discopt-python/src/expr_bindings.rs
+++ b/crates/discopt-python/src/expr_bindings.rs
@@ -1498,7 +1498,12 @@ fn convert_expr(
             let base = obj.getattr("base")?;
             let base_id = convert_expr(_py, &base, arena, var_ids, param_ids)?;
             let py_index = obj.getattr("index")?;
-            let index_spec = convert_index_spec(&py_index)?;
+            // The base's shape is needed to normalize Python's negative indices
+            // (`x[-1]`), which `IndexSpec` cannot represent -- its scalar arms are
+            // `usize`. Without it every negative index overflowed the extraction and
+            // aborted the whole conversion (#944).
+            let base_shape = python_shape(&base);
+            let index_spec = convert_index_spec(&py_index, base_shape.as_deref())?;
             Ok(arena.intern(ExprNode::Index {
                 base: base_id,
                 index: index_spec,
@@ -1699,9 +1704,64 @@ fn parse_objective_sense(s: &str) -> PyResult<ObjectiveSense> {
     }
 }
 
+/// Read a Python expression's `.shape` as a list of axis lengths.
+///
+/// Returns `None` when the attribute is missing or is not a tuple of
+/// non-negative ints -- callers then simply lose negative-index normalization
+/// and report the original out-of-range error, which is the pre-existing
+/// behaviour.
+fn python_shape(obj: &Bound<'_, PyAny>) -> Option<Vec<usize>> {
+    let shape = obj.getattr("shape").ok()?;
+    let dims: Vec<isize> = shape.extract().ok()?;
+    if dims.iter().any(|&d| d < 0) {
+        return None;
+    }
+    Some(dims.into_iter().map(|d| d as usize).collect())
+}
+
+/// Normalize one scalar subscript against the length of the axis it indexes.
+///
+/// Python/numpy semantics: a negative `i` means `i + len`, and the result must
+/// land in `[0, len)`. Out-of-range is an `IndexError` -- refused, never clamped
+/// or wrapped, because a wrong-but-in-range slot names a different variable and
+/// is silently accepted by everything downstream (the #941 failure mode).
+///
+/// `axis_len` is `None` when the base's shape could not be read; a non-negative
+/// index passes through unchanged and a negative one is refused with a message
+/// naming the real cause instead of an integer-conversion overflow.
+fn normalize_scalar_index(item: &Bound<'_, PyAny>, axis_len: Option<usize>) -> PyResult<usize> {
+    // bool is a subclass of int in Python, but numpy reads `x[True]` as a mask,
+    // not as `x[1]`; refuse rather than silently disagree with the evaluator.
+    if item.is_instance_of::<pyo3::types::PyBool>() {
+        return Err(PyErr::new::<pyo3::exceptions::PyIndexError, _>(
+            "boolean index is not supported in an expression subscript",
+        ));
+    }
+    let raw: isize = item.extract()?;
+    if raw >= 0 {
+        return Ok(raw as usize);
+    }
+    let len = axis_len.ok_or_else(|| {
+        PyErr::new::<pyo3::exceptions::PyIndexError, _>(format!(
+            "negative index {raw} cannot be resolved: the indexed expression has no shape"
+        ))
+    })?;
+    let shifted = raw + len as isize;
+    if shifted < 0 {
+        return Err(PyErr::new::<pyo3::exceptions::PyIndexError, _>(format!(
+            "index {raw} is out of bounds for axis of length {len}"
+        )));
+    }
+    Ok(shifted as usize)
+}
+
 /// Convert a Python index (int, slice, or tuple of ints/slices) to an
 /// IndexSpec.
-fn convert_index_spec(obj: &Bound<'_, PyAny>) -> PyResult<IndexSpec> {
+///
+/// `base_shape` is the shape of the expression being subscripted, used to turn
+/// Python's negative indices into the non-negative ones `IndexSpec` stores.
+fn convert_index_spec(obj: &Bound<'_, PyAny>, base_shape: Option<&[usize]>) -> PyResult<IndexSpec> {
+    let axis_len = |axis: usize| base_shape.and_then(|s| s.get(axis).copied());
     if obj.is_instance_of::<PyTuple>() {
         let tuple: &Bound<'_, PyTuple> = obj.downcast()?;
         // If every element is a plain int, keep the simple Tuple form.
@@ -1716,25 +1776,27 @@ fn convert_index_spec(obj: &Bound<'_, PyAny>) -> PyResult<IndexSpec> {
         if all_scalar {
             let indices: Vec<usize> = tuple
                 .iter()
-                .map(|item| item.extract::<usize>())
+                .enumerate()
+                .map(|(axis, item)| normalize_scalar_index(&item, axis_len(axis)))
                 .collect::<PyResult<Vec<_>>>()?;
             return Ok(IndexSpec::Tuple(indices));
         }
         let mut elems: Vec<IndexElem> = Vec::with_capacity(tuple.len());
-        for item in tuple.iter() {
+        for (axis, item) in tuple.iter().enumerate() {
             if item.is_instance_of::<PySlice>() {
                 elems.push(slice_to_index_elem(&item)?);
             } else {
-                let i: usize = item.extract()?;
-                elems.push(IndexElem::Scalar(i));
+                elems.push(IndexElem::Scalar(normalize_scalar_index(
+                    &item,
+                    axis_len(axis),
+                )?));
             }
         }
         Ok(IndexSpec::Multi(elems))
     } else if obj.is_instance_of::<PySlice>() {
         Ok(IndexSpec::Multi(vec![slice_to_index_elem(obj)?]))
     } else {
-        let idx: usize = obj.extract()?;
-        Ok(IndexSpec::Scalar(idx))
+        Ok(IndexSpec::Scalar(normalize_scalar_index(obj, axis_len(0))?))
     }
 }
 

--- a/python/discopt/_jax/convexity/rules.py
+++ b/python/discopt/_jax/convexity/rules.py
@@ -533,27 +533,17 @@ def _scalar_value(expr: Expression) -> float:
     return float(np.asarray(expr.value))  # type: ignore[attr-defined]
 
 
-def _const_scale_sign(expr: Expression) -> Optional[int]:
-    """Curvature-scaling sign of a constant factor, scalar **or array**.
+def _finite_const_value(expr: Expression) -> Optional[np.ndarray]:
+    """The value of a concrete, everywhere-finite constant leaf, or ``None``.
 
-    Returns ``+1`` / ``-1`` / ``0`` when every entry of the constant is,
-    respectively, nonnegative (with at least one positive), nonpositive (with at
-    least one negative), or exactly zero — the three cases in which the
-    elementwise product ``c ⊙ f`` scales *every* entry of ``f``'s curvature by
-    one uniform sign, so :func:`~.lattice.scale` applies. Returns ``None`` when
-    ``expr`` is not a concrete constant, holds a non-finite entry, or MIXES
-    signs; the caller may still conclude AFFINE in that last case, since an
-    affine operand stays affine under any constant scaling.
-
-    Entries equal to zero alongside strictly-signed ones do not spoil the
-    verdict: ``0 * f`` is affine, hence both convex and concave, so it never
-    contradicts the strict entries' direction.
-
-    Only 0-d constants used to be recognised (``_is_scalar_const``). That
-    dropped the whole *vectorized* modeling surface to UNKNOWN curvature: a
-    collocation row is ``h ⊙ (A @ x)`` with ``h`` an array of element widths, so
-    every ``discopt.dae`` model classified nonconvex and was routed to spatial
-    McCormick B&B, which does not converge on it (#944).
+    ``None`` means *this operand supports no scaling verdict at all* — it is not a
+    ``Constant``/``Parameter``, its value is not coercible to float64, or it holds
+    an ``inf``/``nan``. Kept separate from :func:`_const_scale_sign`'s "no uniform
+    sign" answer because the two demand opposite handling: a mixed-sign constant
+    still leaves an affine operand affine, whereas a non-finite one must refuse
+    outright (a NaN coefficient would otherwise pass through as AFFINE and read as
+    a proof). Conflating them made the product rule disagree with
+    :func:`_classify_division`, which has always refused non-finite divisors.
     """
     if not isinstance(expr, (Constant, Parameter)):
         return None
@@ -563,6 +553,32 @@ def _const_scale_sign(expr: Expression) -> Optional[int]:
         return None
     if not np.all(np.isfinite(arr)):
         return None
+    return arr
+
+
+def _const_scale_sign(arr: np.ndarray) -> Optional[int]:
+    """Curvature-scaling sign of a finite constant factor, scalar **or array**.
+
+    Returns ``+1`` / ``-1`` / ``0`` when every entry is, respectively, nonnegative
+    (with at least one positive), nonpositive (with at least one negative), or
+    exactly zero — the three cases in which the elementwise product ``c ⊙ f``
+    scales *every* entry of ``f``'s curvature by one uniform sign, so
+    :func:`~.lattice.scale` applies. Returns ``None`` when the entries MIX signs:
+    no single scaling is valid then, though an affine operand still stays affine.
+
+    Entries equal to zero alongside strictly-signed ones do not spoil the
+    verdict: ``0 * f`` is affine, hence both convex and concave, so it never
+    contradicts the strict entries' direction.
+
+    Callers pass a value already screened by :func:`_finite_const_value`; this
+    function answers only the sign question.
+
+    Only 0-d constants used to be recognised (``_is_scalar_const``). That
+    dropped the whole *vectorized* modeling surface to UNKNOWN curvature: a
+    collocation row is ``h ⊙ (A @ x)`` with ``h`` an array of element widths, so
+    every ``discopt.dae`` model classified nonconvex and was routed to spatial
+    McCormick B&B, which does not converge on it (#944).
+    """
     if np.all(arr == 0.0):
         return 0
     if np.all(arr >= 0.0):
@@ -641,10 +657,15 @@ def _classify_product(
     # exactly as a scalar would, and an AFFINE operand survives *any* constant
     # array — including one of mixed sign — because each broadcast entry is
     # ``const * affine`` (#944).
+    # A non-finite constant is refused here rather than falling into the
+    # mixed-sign branch below: `nan * affine` is not affine in any useful sense,
+    # and returning AFFINE for it would emit a *proof* about a broken model. This
+    # matches `_classify_division`, which has always refused non-finite divisors.
     for const_side, other in ((expr.left, right), (expr.right, left)):
-        if not isinstance(const_side, (Constant, Parameter)):
+        arr = _finite_const_value(const_side)
+        if arr is None:
             continue
-        s = _const_scale_sign(const_side)
+        s = _const_scale_sign(arr)
         if s is not None:
             return ExprInfo(scale(other.curvature, s), prod_sign)
         if other.curvature == Curvature.AFFINE:

--- a/python/discopt/_jax/convexity/rules.py
+++ b/python/discopt/_jax/convexity/rules.py
@@ -533,6 +533,70 @@ def _scalar_value(expr: Expression) -> float:
     return float(np.asarray(expr.value))  # type: ignore[attr-defined]
 
 
+def _const_scale_sign(expr: Expression) -> Optional[int]:
+    """Curvature-scaling sign of a constant factor, scalar **or array**.
+
+    Returns ``+1`` / ``-1`` / ``0`` when every entry of the constant is,
+    respectively, nonnegative (with at least one positive), nonpositive (with at
+    least one negative), or exactly zero — the three cases in which the
+    elementwise product ``c ⊙ f`` scales *every* entry of ``f``'s curvature by
+    one uniform sign, so :func:`~.lattice.scale` applies. Returns ``None`` when
+    ``expr`` is not a concrete constant, holds a non-finite entry, or MIXES
+    signs; the caller may still conclude AFFINE in that last case, since an
+    affine operand stays affine under any constant scaling.
+
+    Entries equal to zero alongside strictly-signed ones do not spoil the
+    verdict: ``0 * f`` is affine, hence both convex and concave, so it never
+    contradicts the strict entries' direction.
+
+    Only 0-d constants used to be recognised (``_is_scalar_const``). That
+    dropped the whole *vectorized* modeling surface to UNKNOWN curvature: a
+    collocation row is ``h ⊙ (A @ x)`` with ``h`` an array of element widths, so
+    every ``discopt.dae`` model classified nonconvex and was routed to spatial
+    McCormick B&B, which does not converge on it (#944).
+    """
+    if not isinstance(expr, (Constant, Parameter)):
+        return None
+    try:
+        arr = np.asarray(expr.value, dtype=np.float64)
+    except (TypeError, ValueError):
+        return None
+    if not np.all(np.isfinite(arr)):
+        return None
+    if np.all(arr == 0.0):
+        return 0
+    if np.all(arr >= 0.0):
+        return 1
+    if np.all(arr <= 0.0):
+        return -1
+    return None
+
+
+def _const_divisor_info(expr: Expression) -> Optional[int]:
+    """Scaling sign of a constant divisor, scalar **or array**.
+
+    Returns ``+1`` when every entry is strictly positive, ``-1`` when every entry
+    is strictly negative, and ``0`` when the entries are all nonzero but mixed in
+    sign (``1/c`` is then well-defined everywhere but carries no single
+    direction). Returns ``None`` — meaning *refuse* — when ``expr`` is not a
+    concrete constant, holds a non-finite entry, or holds an entry at or within
+    ``1e-30`` of zero, matching the scalar guard this generalises.
+    """
+    if not isinstance(expr, (Constant, Parameter)):
+        return None
+    try:
+        arr = np.asarray(expr.value, dtype=np.float64)
+    except (TypeError, ValueError):
+        return None
+    if not np.all(np.isfinite(arr)) or np.any(np.abs(arr) <= 1e-30):
+        return None
+    if np.all(arr > 0.0):
+        return 1
+    if np.all(arr < 0.0):
+        return -1
+    return 0
+
+
 def _classify_binary(expr: BinaryOp, model: Optional[Model], cache: dict) -> ExprInfo:
     left = classify_expr_info(expr.left, model, cache)
     right = classify_expr_info(expr.right, model, cache)
@@ -571,15 +635,20 @@ def _classify_product(
     """Classify ``a * b`` with sign-aware curvature."""
     prod_sign = sign_mul(left.sign, right.sign)
 
-    # Constant scaling on either side → curvature scaled by that sign.
-    if _is_scalar_const(expr.left):
-        val = _scalar_value(expr.left)
-        s = 0 if val == 0 else (1 if val > 0 else -1)
-        return ExprInfo(scale(right.curvature, s), prod_sign)
-    if _is_scalar_const(expr.right):
-        val = _scalar_value(expr.right)
-        s = 0 if val == 0 else (1 if val > 0 else -1)
-        return ExprInfo(scale(left.curvature, s), prod_sign)
+    # Constant scaling on either side → curvature scaled by that sign. The
+    # constant may be an ARRAY (elementwise / broadcast scaling), not only a
+    # 0-d scalar: a uniform entry sign scales the other operand's curvature
+    # exactly as a scalar would, and an AFFINE operand survives *any* constant
+    # array — including one of mixed sign — because each broadcast entry is
+    # ``const * affine`` (#944).
+    for const_side, other in ((expr.left, right), (expr.right, left)):
+        if not isinstance(const_side, (Constant, Parameter)):
+            continue
+        s = _const_scale_sign(const_side)
+        if s is not None:
+            return ExprInfo(scale(other.curvature, s), prod_sign)
+        if other.curvature == Curvature.AFFINE:
+            return ExprInfo(Curvature.AFFINE, prod_sign)
 
     # Square of an affine expression: ``e * e`` with ``e`` affine is convex
     # and nonnegative. Recognising it here (the two operands are the *same*
@@ -618,14 +687,27 @@ def _classify_division(
     cache: dict,
 ) -> ExprInfo:
     """Classify ``a / b``."""
-    # Divide by constant: scale by 1/k.
-    if _is_scalar_const(expr.right):
-        val = _scalar_value(expr.right)
-        if abs(val) <= 1e-30:
+    # Divide by constant: scale by 1/k. As with the product rule, the divisor may
+    # be a constant ARRAY (elementwise / broadcast division by, say, a vector of
+    # finite-element widths); ``1/c`` then has the same uniform sign as ``c``, so
+    # the same scaling applies. Every entry must be bounded away from zero —
+    # a single zero entry makes the quotient undefined there (#944).
+    if isinstance(expr.right, (Constant, Parameter)):
+        s = _const_divisor_info(expr.right)
+        if s is None:
+            # Non-finite, or an entry at/near zero: the quotient is undefined or
+            # numerically meaningless there. Refuse outright rather than fall
+            # through to the reciprocal rule below, whose strict-sign test reads
+            # a zero divisor as strictly signed.
             return ExprInfo(Curvature.UNKNOWN, Sign.UNKNOWN)
-        s = 1 if val > 0 else -1
-        inv_sign = Sign.POS if val > 0 else Sign.NEG
-        return ExprInfo(scale(left.curvature, s), sign_mul(left.sign, inv_sign))
+        if s != 0:
+            inv_sign = Sign.POS if s > 0 else Sign.NEG
+            return ExprInfo(scale(left.curvature, s), sign_mul(left.sign, inv_sign))
+        # Mixed-sign (but everywhere-nonzero) divisor: an affine numerator still
+        # divides entrywise to affine; anything else loses its curvature.
+        if left.curvature == Curvature.AFFINE:
+            return ExprInfo(Curvature.AFFINE, Sign.UNKNOWN)
+        return ExprInfo(Curvature.UNKNOWN, Sign.UNKNOWN)
 
     # Reciprocal with constant numerator and strictly-signed denominator.
     # 1/u is convex + nonincreasing on u>0; concave + nonincreasing on

--- a/python/tests/test_944_array_constant_curvature.py
+++ b/python/tests/test_944_array_constant_curvature.py
@@ -163,12 +163,39 @@ class TestArrayConstantScaling:
         assert checked == 2, checked
 
     def test_non_finite_constant_refuses(self):
-        m, x = self._model()
+        """`inf`/`nan` coefficients refuse for EVERY operand curvature and arity.
+
+        The affine arm is the one that matters. A first cut of this fix screened
+        non-finite inside the sign helper, whose ``None`` then fell straight into
+        the mixed-sign branch and returned AFFINE for `nan * affine` -- emitting a
+        *proof* about a broken model, and (for an array constant) looser than the
+        pre-fix walker, which had no array branch at all and answered UNKNOWN.
+        Both directions are pinned here so neither can drift back.
+
+        `_classify_division` has always refused non-finite divisors; these
+        assertions are what keep the product rule agreeing with it.
+        """
         checked = 0
-        for c in (np.array([1.0, np.inf, 3.0]), np.array([1.0, np.nan, 3.0])):
-            assert classify_expr(c * _sq(x), m, {}) == Curvature.UNKNOWN, c
-            checked += 1
-        assert checked == 2, checked
+        for c in (
+            np.array([1.0, np.inf, 3.0]),
+            np.array([1.0, np.nan, 3.0]),
+            np.inf,
+            -np.inf,
+            np.nan,
+        ):
+            for operand_is_convex in (False, True):
+                m, x = self._model()
+                operand = _sq(x) if operand_is_convex else x
+                assert classify_expr(c * operand, m, {}) == Curvature.UNKNOWN, (
+                    c,
+                    operand_is_convex,
+                )
+                assert classify_expr(operand / c, m, {}) == Curvature.UNKNOWN, (
+                    c,
+                    operand_is_convex,
+                )
+                checked += 2
+        assert checked == 20, checked
 
     def test_scalar_behaviour_is_unchanged(self):
         """The pre-existing 0-d cases must classify exactly as before."""
@@ -235,6 +262,23 @@ class TestNegativeIndexReachesTheRepr:
         with pytest.raises(IndexError):
             model_to_repr(m, getattr(m, "_builder", None))
 
+    def test_boolean_subscript_is_refused(self):
+        """`x[True]` now raises instead of resolving as `x[1]` -- pin it deliberately.
+
+        `bool` is a subclass of `int`, so the old `usize` extraction accepted
+        `True` and named slot 1. numpy reads a bool as a *mask*, not an index, so
+        that silently disagreed with the evaluator the relaxation is built against.
+        Refusing is the intended behaviour, not an oversight -- this test exists so
+        a future reader does not "restore" the old one.
+        """
+        from discopt.modeling.core import IndexExpression
+
+        m = dm.Model("boolidx")
+        x = m.continuous("x", shape=(3,), lb=0, ub=1)
+        m.minimize(IndexExpression(x, True) * 1.0)
+        with pytest.raises(IndexError):
+            model_to_repr(m, getattr(m, "_builder", None))
+
     def test_classification_survives_a_negative_index(self):
         """A negative index must not demote a QP to ``NLP`` (the silent degradation)."""
         from discopt._jax.problem_classifier import ProblemClass, classify_problem
@@ -290,13 +334,19 @@ class TestMinimumEnergyTerminates:
         assert all(mask), f"a linear collocation row classified nonconvex: {mask}"
         assert is_convex
 
-    @pytest.mark.slow
     def test_solves_to_certified_optimality_without_branching(self):
         """0 nodes, certified optimal, and the objective matches the Riccati value.
 
         Before the fix this ran ~9k nodes without certifying and blew an 800 s
         pytest timeout. The ``time_limit`` here is what makes a regression report
         as a failed assertion rather than as a harness timeout (issue item 3).
+
+        Deliberately NOT ``@pytest.mark.slow``. This is the one test that asserts
+        the *routing* rather than the classification, so it is the one that would
+        have caught #944 -- and every CI lane deselects ``slow``, which would have
+        left the fix's actual claim unexercised there. It costs ~2 s now that the
+        model takes the convex path, and the ``time_limit`` bounds the worst case
+        at 120 s, so a regression fails an assertion instead of hanging the lane.
         """
         m, dae = _minimum_energy_model(T=2.0)
         result = m.solve(time_limit=120)

--- a/python/tests/test_944_array_constant_curvature.py
+++ b/python/tests/test_944_array_constant_curvature.py
@@ -1,0 +1,329 @@
+"""#944: a convex QP written with the vectorized DAE API never terminated.
+
+``test_dae.py::TestOptimalControl::test_minimum_energy`` — a 100-variable convex
+QP with 79 linear rows and no integer variables — ran past an 800 s pytest
+timeout on ``main``, and the same construct in ``docs/notebooks/tutorial_dae.ipynb``
+hit an ``nbclient`` ``CellTimeoutError`` after 600 s. Both were routed to spatial
+McCormick Branch-and-Bound (~9k nodes, never certifying) instead of to the single
+convex NLP solve the model deserves.
+
+Root cause: the curvature walker's constant-scaling rules keyed on
+``_is_scalar_const``, which requires ``ndim == 0``. Every constant produced by
+the *vectorized* modeling API is an array, so the collocation row
+
+    (x @ A) - h ⊙ (-x[:, 1:] + u[:, None])          # h.shape == (nfe, 1)
+
+fell to ``Curvature.UNKNOWN`` at the ``h ⊙ (...)`` node — an affine body the
+walker could not see was affine. ``classify_model`` then reported the model
+nonconvex, the convex-NLP fast path in ``solver.solve_model`` declined it, and
+the sound-but-hopeless spatial path took over.
+
+This is a *class* defect, not a DAE one: every array coefficient in the model —
+element widths, collocation weights, quadrature weights, any ``numpy`` array
+multiplying an expression — was invisible to the rule.
+
+Soundness argument for the fix. For an elementwise (broadcast) product
+``c ⊙ f`` with ``c`` constant, entry ``k`` is ``c_i * f_j``, a *scalar* constant
+times a scalar expression:
+
+* ``f`` affine  ⇒ every entry affine, for ANY ``c`` (mixed signs included);
+* ``f`` convex and every ``c`` entry ≥ 0  ⇒ every entry convex;
+* ``f`` convex and every ``c`` entry ≤ 0  ⇒ every entry concave;
+* ``f`` non-affine and ``c`` mixed in sign ⇒ refuse (UNKNOWN).
+
+Zero entries never spoil a verdict (``0 * f`` is affine, hence both convex and
+concave). Division carries the same rule with the extra requirement that no
+entry sits at or within 1e-30 of zero.
+
+The second defect fixed here is in the Rust bridge: ``convert_index_spec``
+extracted every scalar subscript as ``usize``, so ``x[-1]`` raised
+``OverflowError: can't convert negative int to unsigned`` and aborted
+``model_to_repr`` outright. ``classify_problem`` catches that and falls back to
+``NLP``/``MINLP``, so every model using a negative index silently lost its
+LP/QP/MILP classification. This is the same family as #941 (which fixed the
+Python-side flat-slot resolvers) at the one site #941 did not reach.
+"""
+
+from __future__ import annotations
+
+import os
+
+os.environ.setdefault("JAX_PLATFORMS", "cpu")
+os.environ.setdefault("JAX_ENABLE_X64", "1")
+
+import discopt  # noqa: E402
+import discopt.modeling as dm  # noqa: E402
+import numpy as np  # noqa: E402
+import pytest  # noqa: E402
+from discopt._jax.convexity import classify_model  # noqa: E402
+from discopt._jax.convexity.lattice import Curvature  # noqa: E402
+from discopt._jax.convexity.rules import classify_expr  # noqa: E402
+from discopt._jax.nlp_evaluator import cached_evaluator  # noqa: E402
+from discopt._rust import model_to_repr  # noqa: E402
+
+# Load gate (CLAUDE.md §8): assert both the file under test and a marker unique
+# to this version, so a stale install cannot pass this file vacuously.
+assert "discopt" in discopt.__file__, discopt.__file__
+from discopt._jax.convexity import rules as _rules  # noqa: E402
+
+assert hasattr(_rules, "_const_scale_sign"), (
+    f"loaded a discopt without the #944 array-constant curvature rule: {_rules.__file__}"
+)
+
+
+def _sq(expr):
+    """``expr ** 2`` — convex, non-affine, for probing the scaling rules."""
+    return expr * expr
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Unit: the curvature rule itself
+# ──────────────────────────────────────────────────────────────────────
+
+
+class TestArrayConstantScaling:
+    """``c ⊙ f`` and ``f / c`` for a constant ARRAY ``c``."""
+
+    @staticmethod
+    def _model():
+        m = dm.Model("scale")
+        x = m.continuous("x", shape=(3,), lb=-5, ub=5)
+        return m, x
+
+    def test_affine_survives_any_constant_array(self):
+        """An affine operand stays affine under any constant array — even mixed."""
+        checked = 0
+        for c in (
+            np.array([1.0, 2.0, 3.0]),  # all positive
+            np.array([-1.0, -2.0, -3.0]),  # all negative
+            np.array([1.0, -2.0, 3.0]),  # MIXED — still affine
+            np.array([0.0, 0.0, 0.0]),  # all zero
+            np.array([0.0, 2.0, 0.0]),  # zeros alongside positives
+        ):
+            m, x = self._model()
+            for expr in (c * x, x * c):
+                assert classify_expr(expr, m, {}) == Curvature.AFFINE, c
+                checked += 1
+        assert checked == 10, checked  # anti-vacuity (§6)
+
+    def test_convex_operand_scales_by_uniform_sign(self):
+        checked = 0
+        cases = [
+            (np.array([1.0, 2.0, 3.0]), Curvature.CONVEX),
+            (np.array([0.0, 2.0, 0.0]), Curvature.CONVEX),  # zeros are harmless
+            (np.array([-1.0, -2.0, -3.0]), Curvature.CONCAVE),
+            (np.array([-1.0, 0.0, -3.0]), Curvature.CONCAVE),
+            (np.array([0.0, 0.0, 0.0]), Curvature.AFFINE),  # 0 * anything
+        ]
+        for c, want in cases:
+            m, x = self._model()
+            for expr in (c * _sq(x), _sq(x) * c):
+                assert classify_expr(expr, m, {}) == want, (c, want)
+                checked += 1
+        assert checked == 10, checked
+
+    def test_mixed_sign_constant_refuses_on_nonaffine_operand(self):
+        """No single scaling is valid, so the verdict must be UNKNOWN, not a guess.
+
+        This is the soundness direction: claiming CONVEX here would let the
+        solver certify a local optimum as global.
+        """
+        m, x = self._model()
+        c = np.array([1.0, -2.0, 3.0])
+        checked = 0
+        for expr in (c * _sq(x), _sq(x) * c):
+            assert classify_expr(expr, m, {}) == Curvature.UNKNOWN
+            checked += 1
+        assert checked == 2, checked
+
+    def test_division_by_constant_array(self):
+        checked = 0
+        cases = [
+            (np.array([1.0, 2.0, 4.0]), Curvature.CONVEX),
+            (np.array([-1.0, -2.0, -4.0]), Curvature.CONCAVE),
+            (np.array([1.0, -2.0, 4.0]), Curvature.UNKNOWN),  # mixed, non-affine
+        ]
+        for c, want in cases:
+            m, x = self._model()
+            assert classify_expr(_sq(x) / c, m, {}) == want, (c, want)
+            checked += 1
+        # An affine numerator divides entrywise to affine even for a mixed divisor.
+        m, x = self._model()
+        assert classify_expr(x / np.array([1.0, -2.0, 4.0]), m, {}) == Curvature.AFFINE
+        checked += 1
+        assert checked == 4, checked
+
+    def test_division_by_array_with_a_zero_entry_refuses(self):
+        """One zero entry makes the quotient undefined there — refuse, don't scale."""
+        m, x = self._model()
+        checked = 0
+        for c in (np.array([1.0, 0.0, 4.0]), np.array([2.0, 1e-31, 4.0])):
+            assert classify_expr(_sq(x) / c, m, {}) == Curvature.UNKNOWN, c
+            checked += 1
+        assert checked == 2, checked
+
+    def test_non_finite_constant_refuses(self):
+        m, x = self._model()
+        checked = 0
+        for c in (np.array([1.0, np.inf, 3.0]), np.array([1.0, np.nan, 3.0])):
+            assert classify_expr(c * _sq(x), m, {}) == Curvature.UNKNOWN, c
+            checked += 1
+        assert checked == 2, checked
+
+    def test_scalar_behaviour_is_unchanged(self):
+        """The pre-existing 0-d cases must classify exactly as before."""
+        m, x = self._model()
+        checked = 0
+        for k, want in (
+            (2.0, Curvature.CONVEX),
+            (-2.0, Curvature.CONCAVE),
+            (0.0, Curvature.AFFINE),
+        ):
+            assert classify_expr(k * _sq(x), m, {}) == want, k
+            assert classify_expr(_sq(x) * k, m, {}) == want, k
+            assert classify_expr(k * x, m, {}) == Curvature.AFFINE, k
+            checked += 3
+        assert classify_expr(_sq(x) / 2.0, m, {}) == Curvature.CONVEX
+        assert classify_expr(_sq(x) / -2.0, m, {}) == Curvature.CONCAVE
+        checked += 2
+        assert checked == 11, checked
+
+
+# ──────────────────────────────────────────────────────────────────────
+# The Rust bridge: negative subscripts
+# ──────────────────────────────────────────────────────────────────────
+
+
+class TestNegativeIndexReachesTheRepr:
+    """``model_to_repr`` must accept ``x[-1]`` and resolve it the way numpy does."""
+
+    @pytest.mark.parametrize("shape", [(4,), (2, 3), (2, 3, 4)])
+    def test_negative_index_resolves_like_numpy(self, shape):
+        """Oracle is numpy's own indexing of an ``arange`` probe, not a reimplementation."""
+        size = int(np.prod(shape))
+        probe = np.arange(size, dtype=float).reshape(shape)
+        checked = 0
+        for flat in range(size):
+            pos = np.unravel_index(flat, shape)
+            neg = tuple(int(p) - int(s) for p, s in zip(pos, shape))
+            want = float(probe[pos])
+            for idx in (pos, neg):
+                key = idx if len(shape) > 1 else idx[0]
+                m = dm.Model("neg")
+                x = m.continuous("x", shape=shape, lb=-100, ub=100)
+                m.minimize(x[key] * 1.0)
+                got = float(cached_evaluator(m).evaluate_objective(probe.ravel()))
+                assert got == want, f"{shape}{key}: got {got}, want {want}"
+                # The whole point of #944's second defect: this used to raise.
+                model_to_repr(m, getattr(m, "_builder", None))
+                checked += 1
+        assert checked == 2 * size, checked  # anti-vacuity (§6)
+
+    def test_out_of_range_negative_index_is_refused(self):
+        """Refuse rather than wrap: a wrong-but-in-range slot names another variable.
+
+        ``x[-4]`` on a shape-(3,) variable is already rejected by the ``__getitem__``
+        guard (#816), so the bridge is exercised through the lazy
+        ``IndexExpression`` constructor the guard deliberately leaves open — the
+        node shape the GAMS/NL importers build.
+        """
+        from discopt.modeling.core import IndexExpression
+
+        m = dm.Model("oob")
+        x = m.continuous("x", shape=(3,), lb=0, ub=1)
+        m.minimize(IndexExpression(x, -4) * 1.0)
+        with pytest.raises(IndexError):
+            model_to_repr(m, getattr(m, "_builder", None))
+
+    def test_classification_survives_a_negative_index(self):
+        """A negative index must not demote a QP to ``NLP`` (the silent degradation)."""
+        from discopt._jax.problem_classifier import ProblemClass, classify_problem
+
+        m = dm.Model("qp_neg")
+        x = m.continuous("x", shape=(3,), lb=-5, ub=5)
+        m.subject_to(x[0] + x[1] + x[2] >= 1.0)
+        m.minimize(x[-1] ** 2 + x[0] ** 2)
+        assert classify_problem(m) == ProblemClass.QP
+
+
+# ──────────────────────────────────────────────────────────────────────
+# End to end: the model from the issue
+# ──────────────────────────────────────────────────────────────────────
+
+
+def _minimum_energy_model(T=2.0, u_bound=3.0, nfe=20, ncp=3):
+    """The issue's model: min ∫₀ᵀ u² dt + 10·x(T)² s.t. ẋ = -x + u, x(0)=1."""
+    from discopt.dae import ContinuousSet, DAEBuilder
+
+    m = dm.Model("min_energy")
+    cs = ContinuousSet("t", bounds=(0, T), nfe=nfe, ncp=ncp)
+    dae = DAEBuilder(m, cs)
+    dae.add_state("x", initial=1.0, bounds=(-5, 5))
+    dae.add_control("u", bounds=(-u_bound, u_bound))
+    dae.set_ode(lambda t, s, a, c: {"x": -s["x"] + c["u"]})
+    dae.discretize()
+    x_var = dae.get_state("x")
+    m.minimize(dae.integral(lambda t, s, a, c: c["u"] ** 2) + 10.0 * x_var[-1, -1] ** 2)
+    return m, dae
+
+
+def _riccati_optimum(T: float, S_T: float) -> float:
+    """Analytic optimal cost of the unconstrained LQR, independent of the solver.
+
+    For ẋ = ax + bu (a = -1, b = 1) with cost ∫₀ᵀ R u² dt + S_T x(T)² and R = 1,
+    the Riccati variable obeys Ṡ = -2aS + b²S²/R = S² + 2S with S(T) = S_T, whose
+    separated solution gives ½·ln(S/(S+2)) = t + C. The optimal cost is
+    S(0)·x(0)² = S(0). The control bound |u| ≤ 3 is inactive along this
+    trajectory, so the box-constrained optimum coincides with it.
+    """
+    c = 0.5 * np.log(S_T / (S_T + 2.0)) - T
+    r = np.exp(2.0 * c)  # = S0 / (S0 + 2)
+    return float(2.0 * r / (1.0 - r))
+
+
+class TestMinimumEnergyTerminates:
+    def test_convexity_is_recognised(self):
+        """The gate that was wrong: this model is convex and must be seen as such."""
+        m, _ = _minimum_energy_model()
+        is_convex, mask = classify_model(m, use_certificate=True)
+        assert mask, "no constraints classified — the probe would be vacuous"
+        assert all(mask), f"a linear collocation row classified nonconvex: {mask}"
+        assert is_convex
+
+    @pytest.mark.slow
+    def test_solves_to_certified_optimality_without_branching(self):
+        """0 nodes, certified optimal, and the objective matches the Riccati value.
+
+        Before the fix this ran ~9k nodes without certifying and blew an 800 s
+        pytest timeout. The ``time_limit`` here is what makes a regression report
+        as a failed assertion rather than as a harness timeout (issue item 3).
+        """
+        m, dae = _minimum_energy_model(T=2.0)
+        result = m.solve(time_limit=120)
+
+        assert result.status == "optimal", result.status
+        assert result.gap_certified is True
+        assert getattr(result, "convex_fast_path", False) is True
+        # A convex model must not branch at all.
+        assert (result.node_count or 0) == 0, result.node_count
+
+        # Independent oracle: the analytic LQR cost. The gap is collocation
+        # discretization error (20 elements, 3 Radau points), not solver error.
+        analytic = _riccati_optimum(T=2.0, S_T=10.0)
+        assert abs(result.objective - analytic) < 1e-3, (result.objective, analytic)
+
+        # And the certificate invariant.
+        assert result.bound <= result.objective + 1e-6
+
+        _, x_vals = dae.extract_solution(result, "x")
+        assert abs(x_vals[-1]) < 0.5
+
+    @pytest.mark.slow
+    def test_notebook_variant_also_terminates(self):
+        """``docs/notebooks/tutorial_dae.ipynb`` cell 11: T = 5, |u| ≤ 2."""
+        m, _ = _minimum_energy_model(T=5.0, u_bound=2.0)
+        result = m.solve(time_limit=120)
+        assert result.status == "optimal", result.status
+        assert (result.node_count or 0) == 0, result.node_count
+        analytic = _riccati_optimum(T=5.0, S_T=10.0)
+        assert abs(result.objective - analytic) < 1e-3, (result.objective, analytic)

--- a/python/tests/test_dae.py
+++ b/python/tests/test_dae.py
@@ -610,7 +610,11 @@ class TestOptimalControl:
         x_var = dae.get_state("x")
         obj = dae.integral(lambda t, s, a, c: c["u"] ** 2)
         m.minimize(obj + 10.0 * x_var[-1, -1] ** 2)
-        result = m.solve()
+        # An explicit time_limit is what makes a regression report as a failed
+        # assertion instead of as a pytest timeout: with no limit this solve ran
+        # past 800 s on the spatial path and the test could report nothing at all
+        # (#944). This is a 100-variable convex QP; it takes a few seconds.
+        result = m.solve(time_limit=120)
         assert result.status == "optimal"
 
         # x should be driven toward 0


### PR DESCRIPTION
## Summary

`test_dae.py::TestOptimalControl::test_minimum_energy` — 100 variables, 79 linear
rows, no integer variables, a convex QP — ran past an 800 s pytest timeout, and the
same construct in `docs/notebooks/tutorial_dae.ipynb` (cell 11) hit an nbclient
`CellTimeoutError` after 600 s. Both were routed to spatial McCormick B&B and
stalled there at ~9k nodes without certifying.

**Root cause.** The constant-scaling rules in the curvature walker keyed on
`_is_scalar_const`, which requires `ndim == 0`. Every constant the *vectorized*
modeling API produces is an array, so the collocation row

```
(x @ A) - h * (-x[:, 1:] + u[:, None])          # h.shape == (nfe, 1)
```

hit `Curvature.UNKNOWN` at the `h * (...)` node — an affine body the walker could
not see was affine. `classify_model` then reported the model nonconvex,
`solve_model`'s convex-NLP fast path declined it, and the sound-but-hopeless
spatial path took over. This is a *class* defect, not a DAE one: element widths,
collocation weights, quadrature weights — any array coefficient at all — were
invisible to the rule.

```
before   status=feasible  nodes=8861  gap_certified=False   >800 s (timeout)
after    status=optimal   nodes=0     gap_certified=True      3.7 s
```

**Second defect, same path.** `convert_index_spec` in the Rust bridge extracted
every scalar subscript as `usize`, so `x[-1]` raised `OverflowError: can't convert
negative int to unsigned` and aborted `model_to_repr` outright. `classify_problem`
catches that and falls back to NLP/MINLP, so every model spelling an index
negatively silently lost its LP/QP/MILP classification — and the objective of the
model above contains `x_var[-1, -1]`. Negative subscripts are now normalized
against the base expression's shape, per axis. This is the one site #941 did not
reach.

`test_minimum_energy` now carries `time_limit=120`, so a regression reports as a
failed assertion rather than as a pytest timeout (issue item 3).

Closes #944

## Correctness

The change adds curvature verdicts the walker previously left UNKNOWN, and each
addition is a proof, not a heuristic. For an elementwise (broadcast) product
`c * f` with `c` a **finite** constant, entry k is `c_i * f_j` — a scalar constant
times a scalar expression:

* `f` affine ⇒ every entry affine, for **any** finite `c` (mixed signs included);
* `f` convex and every `c` entry ≥ 0 ⇒ every entry convex;
* `f` convex and every `c` entry ≤ 0 ⇒ every entry concave;
* `f` non-affine and `c` mixed in sign ⇒ **refuse** (UNKNOWN).

Zero entries never spoil a verdict (`0 * f` is affine, hence both convex and
concave). Division carries the same rule plus the requirement that no entry sits at
or within 1e-30 of zero — and a constant divisor now *returns* from that branch
rather than falling through to the reciprocal rule, whose strict-sign test reads a
zero divisor as strictly signed.

### Non-finite constants (corrected in `e5be547` — the first version of this PR was wrong here)

An earlier revision of this description claimed *"Two directions got stricter …
both now refuse."* That was **false**, and for array constants the first commit was
**looser than `main`**, not stricter. @jkitchin caught it in review. Measured A/B,
`main`'s `rules.py` against the branch's in the same interpreter, each arm
asserting its own marker:

```
case                     main       first commit        now (e5be547)
inf-array  * affine      UNKNOWN    AFFINE  <- looser   UNKNOWN
nan-array  * affine      UNKNOWN    AFFINE  <- looser   UNKNOWN
scalar-inf * affine      AFFINE     AFFINE              UNKNOWN
scalar-nan * affine      AFFINE     AFFINE              UNKNOWN
inf-array  * convex      UNKNOWN    UNKNOWN             UNKNOWN
nan-array  * convex      UNKNOWN    UNKNOWN             UNKNOWN
scalar-inf * convex      CONVEX     UNKNOWN             UNKNOWN
scalar-nan * convex      CONCAVE    UNKNOWN             UNKNOWN
```

Cause: `_const_scale_sign` returned `None` for two unrelated reasons — *"not a
finite constant"* and *"no uniform sign"* — and the caller saw only one `None`, so
it treated the first as the second and fell into the mixed-sign branch. Now split
into `_finite_const_value` (screens the operand) and `_const_scale_sign` (answers
only the sign question). Every arm refuses, matching `_classify_division`, which
always did.

`main`'s `scalar-nan * convex -> CONCAVE` is a genuine latent bug this PR does fix:
`nan > 0` is False, so NaN fell to the negative branch and silently *negated* the
operand's curvature.

The stricter direction (`scalar-inf * affine`, AFFINE → UNKNOWN) is a *new* loss of
verdict relative to `main`, so it got its own blast-radius check — see the corpus
sweep below.

### Index change

An out-of-range subscript is refused rather than clamped or wrapped — a
wrong-but-in-range flat slot names a *different* variable and nothing downstream
errors on it, which is exactly the #941 failure mode. `x[True]` is refused too
(`bool` is an `int` subclass, so the old `usize` extraction named slot 1, while
numpy reads a bool as a mask); that is a deliberate behaviour change and is pinned
by a test.

Downstream effect is that a convex model reaches `_solve_continuous(...,
certify_convex=True)` instead of spatial B&B. That path's certificate rests on
convexity, which is what the walker now proves for this class; the verdict is
box-independent (a constant coefficient array), so it holds on every node box.

- [x] Cannot produce a false certificate
- [x] No validation, fallback, or safety guard was weakened to make a check pass

## Tests run

- [x] `pytest -m smoke` → **909 passed, 16 skipped, 2 xpassed**
- [x] `pytest -m slow python/tests/test_adversarial_recent_fixes.py` → **10 passed**
- [x] `cargo test -p discopt-core` → **583 + 4 + 1 passed, 0 failed**
- [x] `ruff check` / `ruff format --check` clean on every file this PR touches

**Corpus sweep** — `classify_model(m, use_certificate=True)` over all 66 in-repo
`.nl` instances, `main` vs this branch, each arm asserting its own marker, comparing
the model verdict *and* the per-constraint mask:

```
INSTANCES=66   COMPARISONS=132
base convex: 24    fix convex: 24
base ERR:     0    fix ERR:     0
MODEL_VERDICT_FLIPS   = 0
CONSTRAINT_MASK_FLIPS = 0
```

Nothing moves — expected, since the `.nl` importer emits 0-d constants and never the
array coefficients this rule newly understands, but it is what bounds the risk of
both the widened surface and the newly stricter non-finite refusal.

Also run:

- `pytest python/tests/test_dae.py -m ""` (slow included) → **75 passed in 257 s**
  (one test in this file previously blew an 800 s timeout on its own)
- `pytest -k "convex or 936 or 941 or lattice"` → **907 passed, 2 failed**. Both
  failures are `[ipopt]`-parametrized and fail on `ModuleNotFoundError: cyipopt` in
  this container, not on a verdict.
- `docs/notebooks/tutorial_dae.ipynb`, executed cell-by-cell in a fresh kernel with
  `interrupt_on_timeout=True` → **9/9 executable cells pass**, with cell 11 — the
  cell the issue reported as a 600 s timeout — now at **1.1 s**. Cell 9 is excluded;
  see below.

One retraction (CLAUDE.md §11): `test_large_dense_jacobian_no_crash` first failed
its wall-clock assertion at 57 s against a 48 s budget. That was load I created
myself by running a notebook concurrently (§9). Isolated on an idle machine it
passes twice, at **30.2 s** and **27.0 s**.

## Regression test

`python/tests/test_944_array_constant_curvature.py` — 16 tests.

Fail-before/pass-after was measured, not assumed: the pre-fix versions of both
changed files were checked out, the extension rebuilt, and the file re-run with only
its load gate stripped (the gate is *designed* to fail on a baseline build, so
leaving it in would have made the signal vacuous).

```
baseline (main, marker asserted absent)   13 failed, 3 passed
with the fix                              16 passed
```

The 3 that pass on both arms are the conservative-direction guards — mixed-sign
refusal, zero/near-zero divisor refusal, and 0-d scalar behaviour unchanged — so
they *should* be green on both.

`test_solves_to_certified_optimality_without_branching` is deliberately **not**
`@pytest.mark.slow`. Every CI lane deselects `slow`
(`-m "not slow and not correctness and …"` / `-m "correctness and not slow and …"`),
and that is the one test asserting the *routing* rather than the classification — so
with the mark, CI would have proven the classifier changed but not that the model
stops branching. Verified selected: 15/16 collected under the Python-fast marker
expression, 1 deselected. The `time_limit=120` bounds a regression to a failed
assertion instead of a hung lane.

Oracles are external to the solver, not reimplementations:

* **Index resolution** — numpy's own indexing of an `np.arange(size).reshape(shape)`
  probe, over every in-range index of shapes (4,), (2,3) and (2,3,4) in both
  spellings, evaluated through the NLP evaluator *and* pushed through
  `model_to_repr`. 136 resolutions, with the count asserted so the loop cannot pass
  vacuously (§6).
* **End-to-end solve** — the analytic finite-horizon LQR cost, computed outside the
  solver from the Riccati solution of `dS/dt = S² + 2S`, `S(T) = 10`:

  | | analytic J\* | solver |
  |---|---|---|
  | test, T = 2 | 0.03099925 | 0.03102066 |
  | notebook, T = 5 | 7.5741e-05 | 7.5997e-05 |

  The residual is collocation discretization error (20 elements, 3 Radau points).
  The control bound is inactive along both trajectories, so the box-constrained
  optimum coincides with the unconstrained analytic one.

- [x] Added a regression test that fails before / passes after

## Bound-changing / performance change?

N/A as a bound change — no relaxation, cut, or reduction is modified. The effect is
a *routing* change: a model the classifier can now prove convex takes the existing
convex-NLP path instead of spatial B&B. The spatial path itself is byte-identical,
and a model whose convexity is still unproven still goes there.

---

### Not fixed here, and left open

Separate defects surfaced while diagnosing this. None blocks this PR and none is
caused by it.

**Notebook cell 9** estimates a rate constant `k` as a decision variable, making the
collocation rows bilinear in `k·x` — genuinely nonconvex, correctly routed to
spatial B&B, and slow (uncertified at a 45 s limit here). Interleaved A/B with and
without this change:

```
with fix     is_convex=False  mask=[False, True]  obj=0.0015582024997472664  nodes=1331
without fix  is_convex=False  mask=[False, True]  obj=0.0015582024997472664  nodes=1283
```

Identical verdict and identical objective to every digit; the node-count difference
is throughput under a wall-clock limit, not a search-order difference. That cell is
why the notebook sweep above skips index 9.

**`x[:, None]` (numpy newaxis)** is still unsupported by the Rust bridge — `None`
fails `usize` extraction identically before and after this change — so DAE models
with a control keep degrading to convexity-*unknown* classification even though
they now solve correctly via the walker. Supporting it means adding an
`IndexElem::NewAxis` variant and its broadcasting semantics through ~8 consumers in
`discopt-core`; that is an independent feature with real silent-wrong-answer risk,
not something to fold in here.

**`linear_context.py:178`** carries its own `_is_scalar_const` with the identical
`ndim == 0` gate (found by @jkitchin in review). Its failure direction is
abstain-to-box — a looser sign enclosure, never a wrong one — so it cannot produce a
false verdict the way the walker could. Recorded as the other place this class
defect lives.

**Issue item 2 (vectorizing the `solver.py:2500-2530` FBBT triple loop)** was not
attempted. The `i` loop mutates `lb`/`ub` that the inner `k` loop then reads, so it
is a Gauss–Seidel sweep, not a Jacobi one: any vectorization changes summation order
and the bounds themselves, which puts it in CLAUDE.md §5's bound-*changing* regime —
a corpus-wide differential panel, not a refactor. It is also no longer on this
model's path at 0 nodes.