### PR TITLE
fix(correctness): #945 request bound_relax_factor at the NLP point-consumers, and stop certifying gap closure on out-of-box incumbents

### DIFF
--- a/python/discopt/_jax/primal_heuristics.py
+++ b/python/discopt/_jax/primal_heuristics.py
@@ -27,7 +27,7 @@ from discopt.modeling.core import Model, VarType
 # Re-exported here because callers/docs reference ``primal_heuristics.is_qubo`` /
 # ``qubo_local_search``; ``solve_model`` imports the JAX-free module directly.
 from discopt.qubo_primal import is_qubo, qubo_local_search  # noqa: F401
-from discopt.solvers import NLPResult, SolveStatus
+from discopt.solvers import NLPResult, SolveStatus, pounce_incumbent_options
 
 logger = logging.getLogger(__name__)
 
@@ -42,6 +42,39 @@ logger = logging.getLogger(__name__)
 # capped, unconverged point simply fails the feasibility check and yields no
 # incumbent — it can never inject a wrong one (inject_incumbent re-verifies).
 _HEURISTIC_NLP_MAX_ITER = 300
+
+
+def _heuristic_nlp_options(caller_options: Optional[dict] = None) -> dict:
+    """Base NLP options for a sub-solve in this module (#945).
+
+    Every NLP solve here exists to produce a candidate **incumbent**, so every one
+    of them takes :func:`discopt.solvers.pounce_incumbent_options`: the returned
+    point has to lie inside the box the model declared, or the incumbent it becomes
+    is not a solution of the model the user wrote. Ipopt's default
+    ``bound_relax_factor`` relaxes every bound — including the slack bounds standing
+    in for inequality rows — by ``1e-8*(1 + |bound|)``, and a squared row takes the
+    square root of that: ``(x-3)^2 <= 0`` admits every ``x`` within 1e-4 of 3.
+    Measured on the MindtPy constraint-qualification fixture, whose exact optimum is
+    3.0, ``feasibility_pump`` returned ``x = 2.9999`` and the default ``m.solve()``
+    path certified it ``optimal`` with ``gap = 0.0``; with this seed the same run
+    returns 2.999999998 (``scratchpad/issue945/heuristic_incumbent_box.py``).
+
+    :func:`discopt.solvers.pounce_option_defaults` is deliberately **not** seeded
+    here. The two halves are separable and only this one is wanted: its
+    ``constr_viol_tol = 1e-8`` costs a 31%-worse incumbent and a looser bound on
+    nvs05, entirely on its own (see the measurement in ``nlp_pounce.solve_nlp``).
+
+    Routed through one helper rather than spelled at each call site so a seventh
+    heuristic cannot silently keep Ipopt's default — the #940 lesson, one level up.
+    Caller options are merged *after* the seed, so an explicit request still wins.
+    """
+    opts = pounce_incumbent_options()
+    if caller_options:
+        opts.update(caller_options)
+    opts.setdefault("print_level", 0)
+    opts.setdefault("max_iter", _HEURISTIC_NLP_MAX_ITER)
+    return opts
+
 
 # VOLUME-1 (docs/dev/nlp-solve-volume-2026-07-06.md) + ILS-DEFAULT
 # (docs/dev/ils-default-validation-2026-07-06.md): the objective-improvement
@@ -184,9 +217,7 @@ class MultiStartNLP:
         rng = np.random.default_rng(self._seed)
         starts = _generate_starts(lb, ub, self._n_starts, rng)
 
-        opts = dict(ipopt_options) if ipopt_options else {}
-        opts.setdefault("print_level", 0)
-        opts.setdefault("max_iter", _HEURISTIC_NLP_MAX_ITER)
+        opts = _heuristic_nlp_options(ipopt_options)
         if backend is None:
             from discopt.solvers.nlp_backend import get_nlp_solver
 
@@ -271,9 +302,7 @@ def feasibility_pump(
     if evaluator is None:
         evaluator = cached_evaluator(model)
 
-    opts = dict(ipopt_options) if ipopt_options else {}
-    opts.setdefault("print_level", 0)
-    opts.setdefault("max_iter", _HEURISTIC_NLP_MAX_ITER)
+    opts = _heuristic_nlp_options(ipopt_options)
     if backend is None:
         from discopt.solvers.nlp_backend import get_nlp_solver
 
@@ -472,9 +501,7 @@ def subnlp(
                     v.ub = fixed.copy()
                 offset += sz
 
-        opts = dict(nlp_options) if nlp_options else {}
-        opts.setdefault("print_level", 0)
-        opts.setdefault("max_iter", _HEURISTIC_NLP_MAX_ITER)
+        opts = _heuristic_nlp_options(nlp_options)
         if time_budget is not None and time_budget > 0.0:
             opts.setdefault("max_wall_time", float(time_budget))
 
@@ -596,9 +623,7 @@ def continuous_multistart(
     rng = np.random.default_rng(seed)
     starts = _generate_starts(lb, ub, n_starts, rng)
 
-    opts = dict(nlp_options) if nlp_options else {}
-    opts.setdefault("print_level", 0)
-    opts.setdefault("max_iter", _HEURISTIC_NLP_MAX_ITER)
+    opts = _heuristic_nlp_options(nlp_options)
 
     best_obj = float("inf") if incumbent_obj is None else float(incumbent_obj)
     best_x: Optional[np.ndarray] = None
@@ -880,9 +905,7 @@ def integer_local_search(
         # discards this second (relaxation) restart base. Clip first so every
         # coordinate is a finite, usable start.
         mid = np.clip(0.5 * (np.clip(lb, -1e3, 1e3) + np.clip(ub, -1e3, 1e3)), -1e3, 1e3)
-        relax_opts = dict(nlp_options) if nlp_options else {}
-        relax_opts.setdefault("print_level", 0)
-        relax_opts.setdefault("max_iter", _HEURISTIC_NLP_MAX_ITER)
+        relax_opts = _heuristic_nlp_options(nlp_options)
         budget.charge(NLP_SOLVE)
         relax_res = backend(evaluator, mid, options=relax_opts)
         if relax_res is not None and relax_res.x is not None:
@@ -1367,9 +1390,7 @@ def diving(
     lb0, ub0 = _get_variable_bounds(model)
     slot_map = _flat_slot_map(model)
 
-    opts = dict(nlp_options) if nlp_options else {}
-    opts.setdefault("print_level", 0)
-    opts.setdefault("max_iter", _HEURISTIC_NLP_MAX_ITER)
+    opts = _heuristic_nlp_options(nlp_options)
 
     fixed = np.zeros(int_mask.shape[0], dtype=bool)
     x_cur = np.clip(np.asarray(x_relax, dtype=np.float64), lb0, ub0)

--- a/python/discopt/_jax/primal_heuristics.py
+++ b/python/discopt/_jax/primal_heuristics.py
@@ -1805,6 +1805,13 @@ def local_branching(
         and np.isfinite(node_bound)
         and np.isfinite(incumbent_obj)
     ):
+        # Deliberately NOT the shared certification tolerance from
+        # ``solvers._gap`` (1e-6), despite looking like the same test. This gate
+        # decides whether to SKIP a heuristic, so its safe direction is the
+        # opposite one: a floor tighter than the certificate tolerance runs the
+        # search more often, which costs time and can only ever find a better
+        # incumbent. Widening it here to 1e-6 for consistency would skip more and
+        # is a search-behaviour change owing its own net-positive panel (#945).
         abs_gap = incumbent_obj - float(node_bound)
         denom = max(abs(incumbent_obj), abs(float(node_bound)), 1e-10)
         if abs_gap <= 1e-9 or abs_gap / denom <= gap_tolerance:

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -11776,6 +11776,14 @@ def solve_model(
                     _fix_lb[_off + _k] = _val
                     _fix_ub[_off + _k] = _val
             _polish_opts = dict(opts)
+            # The polished point IS the reported solution when it is adopted below,
+            # so this is an incumbent producer and takes the incumbent options
+            # (#945). Without them the polish can walk the continuous variables
+            # outside the declared box by ``1e-8*(1+|bound|)`` per bound — the very
+            # digits it exists to tighten — and the adopted objective is then
+            # super-optimal. The sibling ``recover_opts`` re-solve at :13848
+            # deliberately does NOT take them: its product is the MULTIPLIERS.
+            _polish_opts.update(pounce_incumbent_options())
             _polish_opts["max_wall_time"] = max(
                 0.1, min(5.0, time_limit - (time.perf_counter() - t_start))
             )
@@ -13834,9 +13842,32 @@ def _solve_nlp_bb(
             sol_flat = _rounded_inc
         x_dict = _unpack_solution(model, sol_flat)
 
-        # Recover relaxation duals at the incumbent by re-solving the NLP with
-        # integer variables fixed. Best-effort — failures leave duals as None
-        # and the examiner falls back to its LSQ recovery.
+        # Refine the incumbent's continuous variables, then recover relaxation
+        # duals at the refined point, by re-solving the NLP with integer variables
+        # fixed. Best-effort — failures leave duals as None and the examiner falls
+        # back to its LSQ recovery.
+        #
+        # This site consumes BOTH products of an NLP solve, and the two want
+        # opposite options (#945), so it takes two solves rather than one:
+        #
+        #   * the refine solve's product is the reported POINT, so it requests
+        #     ``pounce_incumbent_options()``. Ipopt's default ``bound_relax_factor``
+        #     relaxes every bound — including the slack bounds standing in for
+        #     inequality rows — by ``1e-8*(1 + |bound|)``, and on an ill-conditioned
+        #     row that is not a 1e-8 error in the answer: ``(x-3)^2 <= 0`` violated
+        #     by 1e-8 is ``x`` wrong by 1e-4. On the MindtPy constraint-qualification
+        #     fixture (exact optimum 3.0) this single re-solve took a feasible
+        #     incumbent at x = 3 and overwrote it with x = 2.9999, which the search
+        #     then certified ``optimal`` at ``gap = 0``. No feasibility screen can
+        #     catch that — the bad point's worst row violation is 1e-8, well inside
+        #     any sane tolerance — so the fix has to be not to *produce* it.
+        #   * the recover solve's product is the MULTIPLIERS, so it must NOT set it:
+        #     a degenerate feasible set (Slater failing) has no finite multiplier
+        #     without Ipopt's relaxation (#946).
+        #
+        # Order matters: refine first, then recover at the adopted point, so the
+        # duals stay consistent with the primal that is actually reported — which
+        # is what the adoption below exists for.
         try:
             fix_lb = lb.copy()
             fix_ub = ub.copy()
@@ -13850,6 +13881,27 @@ def _solve_nlp_bb(
                 0.1, min(5.0, time_limit - (time.perf_counter() - t_start))
             )
             recover_opts.setdefault("print_level", 0)
+            refine_opts = dict(recover_opts)
+            refine_opts.update(pounce_incumbent_options())
+            nlp_refined = _solve_node_nlp_kkt(
+                evaluator, sol_flat, fix_lb, fix_ub, constraint_bounds, refine_opts
+            )
+            if (
+                nlp_refined.status == SolveStatus.OPTIMAL
+                and nlp_refined.x is not None
+                and np.all(np.isfinite(nlp_refined.x))
+                and nlp_refined.objective is not None
+                and abs(float(nlp_refined.objective) - obj_val) <= 1e-4 * (1.0 + abs(obj_val))
+            ):
+                refined = np.asarray(nlp_refined.x, dtype=float).copy()
+                # Keep integer columns pinned at their (rounded) incumbent
+                # values; only the continuous variables are refined.
+                for off, sz in zip(int_offsets, int_sizes):
+                    for k in range(int(sz)):
+                        refined[off + k] = round(float(sol_flat[off + k]))
+                sol_flat = refined
+                x_dict = _unpack_solution(model, sol_flat)
+                obj_val = float(nlp_refined.objective)
             nlp_recovered = _solve_node_nlp_kkt(
                 evaluator, sol_flat, fix_lb, fix_ub, constraint_bounds, recover_opts
             )
@@ -13876,30 +13928,14 @@ def _solve_nlp_bb(
                             if bound_duals_upper is not None and v.name in bound_duals_upper:
                                 bound_duals_upper[v.name] = np.zeros_like(bound_duals_upper[v.name])
 
-                # Adopt the refined primal from the KKT re-solve. It solves the
-                # same integer-fixed subproblem to tighter precision than the
-                # batched JAX IPM, so the continuous variables (and thus
-                # active-constraint residuals) stay consistent with the
-                # recovered duals — without this, complementarity (mu * residual)
-                # can exceed validation tolerances. Guarded: only adopt an
-                # OPTIMAL re-solve whose objective matches the incumbent, so a
-                # divergent recover can never corrupt the reported solution.
-                if (
-                    nlp_recovered.status == SolveStatus.OPTIMAL
-                    and nlp_recovered.x is not None
-                    and np.all(np.isfinite(nlp_recovered.x))
-                    and nlp_recovered.objective is not None
-                    and abs(float(nlp_recovered.objective) - obj_val) <= 1e-4 * (1.0 + abs(obj_val))
-                ):
-                    refined = np.asarray(nlp_recovered.x, dtype=float).copy()
-                    # Keep integer columns pinned at their (rounded) incumbent
-                    # values; only the continuous variables are refined.
-                    for off, sz in zip(int_offsets, int_sizes):
-                        for k in range(int(sz)):
-                            refined[off + k] = round(float(sol_flat[off + k]))
-                    sol_flat = refined
-                    x_dict = _unpack_solution(model, sol_flat)
-                    obj_val = float(nlp_recovered.objective)
+                # The refined primal was already adopted above, from the
+                # incumbent-options solve, and this recover ran *at* that point —
+                # so the continuous variables (and thus active-constraint
+                # residuals) stay consistent with the recovered duals, which is
+                # what the adoption exists for: without it, complementarity
+                # (mu * residual) can exceed validation tolerances. The recover
+                # solve's own ``x`` is deliberately NOT adopted; it is the output
+                # of a deliberately relaxed box (see the two-solve note above).
         except Exception as _exc:
             logger.debug("NLP-BB dual recovery failed: %s", _exc)
 

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -44,7 +44,7 @@ from discopt.modeling.core import (
 from discopt.solver_tuning import current as _tuning
 from discopt.solver_tuning import reset_current as _reset_tuning
 from discopt.solver_tuning import set_current as _set_tuning
-from discopt.solvers import SolveStatus
+from discopt.solvers import SolveStatus, pounce_option_defaults
 
 # R3a measurement sink (temporary, behavior-neutral). When set to a mutable
 # dict by an experiment harness, the nonconvex B&B path stores the Rust tree's
@@ -14306,9 +14306,10 @@ def _solve_batch_pounce(
 
     # Batch-level options. Whitelist keys POUNCE understands and enforce the
     # per-node wall-time guard (issue #5) used by the serial pounce path.
-    # Deliberately NOT seeded from solvers.pounce_option_defaults: this is the NLP
-    # batch path, and bound_relax_factor=0 there breaks OA/GDPopt gap closure (#945).
-    batch_opts: dict = {"print_level": 0}
+    # Seeded from the shared baseline (#945) so a batched node returns the same
+    # in-the-box point the serial ``nlp_pounce.solve_nlp`` path does — otherwise
+    # batching alone would change which side of a bound an incumbent lands on.
+    batch_opts: dict = pounce_option_defaults()
     for k in ("max_iter", "tol", "acceptable_tol"):
         if options.get(k) is not None:
             batch_opts[k] = options[k]

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -14317,10 +14317,10 @@ def _solve_batch_pounce(
 
     # Batch-level options. Whitelist keys POUNCE understands and enforce the
     # per-node wall-time guard (issue #5) used by the serial pounce path.
-    # Seeded from the shared baseline (#945) so a batched node returns the same
-    # in-the-box point the serial ``nlp_pounce.solve_nlp`` path does — otherwise
-    # batching alone would change which side of a bound an incumbent lands on.
-    batch_opts: dict = pounce_option_defaults()
+    # Left at POUNCE's own baseline, like the serial ``nlp_pounce.solve_nlp`` path
+    # it must agree with: these are B&B node relaxations, not the reported solution,
+    # and neither shared request belongs here (#945 — see the note in nlp_pounce).
+    batch_opts: dict = {"print_level": 0}
     for k in ("max_iter", "tol", "acceptable_tol"):
         if options.get(k) is not None:
             batch_opts[k] = options[k]

--- a/python/discopt/solvers/__init__.py
+++ b/python/discopt/solvers/__init__.py
@@ -199,9 +199,13 @@ POUNCE_BOUND_RELAX_FACTOR = 0.0
 def pounce_option_defaults() -> dict:
     """discopt's baseline POUNCE options: quiet, and inside the declared box.
 
-    THE single source of truth for EVERY POUNCE entry point: the matrix-form
-    backends (``lp_pounce``, ``qp_pounce``, #940) and the NLP path
-    (``nlp_pounce.solve_nlp`` and ``solver.py``'s batch path, #945). Seed it
+    THE single source of truth for the matrix-form backends (``lp_pounce``,
+    ``qp_pounce``, #940), and available to any caller that wants discopt's
+    baseline rather than Ipopt's. It is deliberately NOT applied backend-wide on
+    the NLP path: ``constr_viol_tol = 1e-8`` costs a 31%-worse incumbent and a
+    looser bound on nvs05 entirely on its own (measured in
+    ``nlp_pounce.solve_nlp``), so ``nlp_pounce.solve_nlp`` stays at POUNCE's own
+    baseline and the NLP call sites that want this seed it themselves. Seed it
     *before* merging a caller's options so an explicit request still wins::
 
         opts = pounce_option_defaults()

--- a/python/discopt/solvers/__init__.py
+++ b/python/discopt/solvers/__init__.py
@@ -199,9 +199,10 @@ POUNCE_BOUND_RELAX_FACTOR = 0.0
 def pounce_option_defaults() -> dict:
     """discopt's baseline POUNCE options: quiet, and inside the declared box.
 
-    THE single source of truth for the **matrix-form** backends (``lp_pounce``,
-    ``qp_pounce``). Seed it *before* merging a caller's options so an explicit
-    request still wins::
+    THE single source of truth for EVERY POUNCE entry point: the matrix-form
+    backends (``lp_pounce``, ``qp_pounce``, #940) and the NLP path
+    (``nlp_pounce.solve_nlp`` and ``solver.py``'s batch path, #945). Seed it
+    *before* merging a caller's options so an explicit request still wins::
 
         opts = pounce_option_defaults()
         opts.update(caller_options or {})
@@ -209,15 +210,13 @@ def pounce_option_defaults() -> dict:
     Do not re-spell these values at a call site — a second copy is how one entry
     point silently keeps Ipopt's defaults while the rest move.
 
-    The NLP path (``nlp_pounce.solve_nlp``, and ``solver.py``'s batch path) does
-    NOT use this yet, and so still returns points up to ~7.5e-9 outside their
-    declared bounds. That is not an oversight: pinning ``bound_relax_factor`` to 0
-    there makes incumbents genuinely feasible, which turns ``incumbent - bound``
-    from ``<= 0`` into a small positive number and breaks 12 ``gap == 0 @ 1e-9``
-    assertions across OA / GDPopt / MindtPy parity — those expectations are
-    currently calibrated against a solver that returns slightly-infeasible
-    incumbents. Extending this seed to the NLP path is tracked in #945, together
-    with the gap-closure question it forces.
+    Extending the seed to the NLP path was held back until #945 because it is a
+    certification-semantics change, not just an option: with incumbents genuinely
+    inside their boxes, ``incumbent - bound`` stops being ``<= 0``, and 12
+    ``gap == 0 @ 1e-9`` assertions across OA / GDPopt / MindtPy turned out to be
+    satisfiable only by a solver returning slightly-infeasible incumbents. #945
+    settled that by giving gap closure an absolute criterion at discopt's own
+    ``1e-6`` — see :mod:`discopt.solvers._gap`.
     """
     return {
         "print_level": 0,

--- a/python/discopt/solvers/_gap.py
+++ b/python/discopt/solvers/_gap.py
@@ -1,0 +1,100 @@
+"""Shared optimality-gap accounting for the decomposition solvers (issue #945).
+
+``solvers.oa`` and ``solvers.gdpopt_loa`` each carried a near-copy of the same
+six-line ``_compute_gap``, and the copies disagreed. This module is the single
+definition both now call, so a fix to one is a fix to both.
+
+Three things it gets right that the copies did not:
+
+**1. The absolute criterion is discopt's absolute tolerance, not 1e-9.**
+Both copies closed the gap only at ``ub - lb <= 1e-9``. That floor is tighter
+than discopt's own ``1e-6`` absolute tolerance
+(``validation.feasibility.ABS_TOL``, ``solvers.amp.solve(abs_tol=1e-6)``) and
+tighter than the interior-point method can deliver, so on a problem whose optimum
+sits at ~0 it was only ever beaten by an incumbent that was *not* feasible — see
+(3). The dual test here (``abs_gap <= abs_tol`` OR ``rel_gap <= rel_tol``) is the
+one ``amp.py`` has always used.
+
+**2. A near-zero objective no longer inflates a rounding gap to 100%.**
+``gdpopt_loa`` floored the relative denominator at ``1e-10``, so on ``min x``
+with optimum 0 an honest incumbent of ``2.46e-9`` against a dual bound of ``0``
+produced ``2.46e-9 / 2.46e-9 = 1.0`` — a 100% relative gap on a numerically exact
+solve, which downgraded ``optimal`` to ``feasible``. The absolute criterion in
+(1) now fires first and reports the gap closed. The floors themselves are left as
+each solver had them (see ``denom_floor``): they set the *reporting* scale for an
+unconverged run, and changing OA's is a separate, panel-worthy change.
+
+**3. A dual bound ABOVE the incumbent is no longer clamped to "gap 0".**
+Both copies computed ``abs_gap = max(0.0, ub - lb)``. When the incumbent sits
+below the dual bound — the certificate invariant ``bound <= incumbent`` for a
+minimization, violated — that ``max`` turned a *negative* gap into ``0.0`` and
+the solver reported ``optimal``. That is not a rounding nicety: before #945 the
+MindtPy constraint-qualification fixture (true optimum exactly 3.0) certified
+``optimal`` at objective ``2.9999000025`` — super-optimal by ``1e-4`` — with a
+reported dual bound of ``2.99995``, i.e. ``5e-5`` ABOVE its own incumbent, and a
+reported gap of ``0.0``. Rounding-scale inversions are still absorbed (an
+IPM-converged pair genuinely lands either side of the optimum by ~1 ulp), on the
+same tolerance ``amp._amp_abs_gap_with_bound_tolerance`` uses; anything larger is
+now reported as *not closed* rather than as a certificate.
+"""
+
+from __future__ import annotations
+
+# discopt's absolute optimality tolerance. Same value as
+# ``validation.feasibility.ABS_TOL`` and ``amp.solve``'s ``abs_tol`` default.
+GAP_ABS_TOL = 1e-6
+
+# The ±1e20 sentinel the solvers use for "no bound yet" (never ``inf``).
+BOUND_INF = 1e19
+
+
+def bound_inversion_tolerance(lb: float, ub: float, abs_tol: float = GAP_ABS_TOL) -> float:
+    """How far ``lb`` may exceed ``ub`` before the ordering is *materially* wrong.
+
+    Mirrors :func:`discopt.solvers.amp._amp_abs_gap_with_bound_tolerance` so the
+    three solvers agree on what counts as rounding. Scale-aware, because at
+    ``|obj| ~ 1e6`` an inversion of ``1e-9`` is a single ulp.
+    """
+    scale = max(1.0, abs(lb), abs(ub))
+    return max(10.0 * abs_tol, 1e-8 * scale)
+
+
+def optimality_gap(
+    lb: float,
+    ub: float,
+    *,
+    abs_tol: float = GAP_ABS_TOL,
+    denom_floor: float = 1.0,
+) -> float:
+    """Relative optimality gap between dual bound ``lb`` and incumbent ``ub``.
+
+    Returns exactly ``0.0`` when the gap is closed and ``1.0`` when nothing is
+    known — including when the bound ordering is materially invalid, which is a
+    broken certificate and must never read as "converged".
+
+    Args:
+        lb: Dual (lower) bound, in minimization sense.
+        ub: Incumbent (upper) bound, in minimization sense.
+        abs_tol: Absolute gap at or below which the gap counts as closed.
+        denom_floor: Floor on the relative denominator, i.e. the objective scale
+            below which the *reported* gap becomes the absolute gap. ``oa`` uses
+            ``1.0`` (report the absolute gap for sub-unit objectives); the
+            stricter ``gdpopt_loa`` uses ``1e-10`` (report the gap relative to the
+            objective however small it is). Both are only reached once the
+            absolute criterion above has declined to close the gap.
+    """
+    if ub >= BOUND_INF or lb <= -BOUND_INF:
+        return 1.0
+
+    raw_gap = ub - lb
+    if raw_gap < -bound_inversion_tolerance(lb, ub, abs_tol):
+        # The dual bound is above the incumbent by more than rounding. One of the
+        # two is wrong; clamping to 0.0 here is what let a super-optimal incumbent
+        # be certified (#945). Report "nothing proved" and let the caller's
+        # certification logic decline to say `optimal`.
+        return 1.0
+
+    abs_gap = max(0.0, raw_gap)
+    if abs_gap <= abs_tol:
+        return 0.0
+    return abs_gap / max(abs(ub), abs(lb), denom_floor)

--- a/python/discopt/solvers/gdpopt_loa.py
+++ b/python/discopt/solvers/gdpopt_loa.py
@@ -19,6 +19,7 @@ from discopt.modeling.core import (
     SolveResult,
     VarType,
 )
+from discopt.solvers._gap import optimality_gap
 
 logger = logging.getLogger(__name__)
 
@@ -391,13 +392,14 @@ def solve_gdpopt_loa(
 
 
 def _compute_gap(lb: float, ub: float) -> float:
-    if ub >= 1e19 or lb <= -1e19:
-        return 1.0
-    abs_gap = max(0.0, ub - lb)
-    if abs_gap <= 1e-9:
-        return 0.0
-    denom = max(abs(ub), abs(lb), 1e-10)
-    return abs_gap / denom
+    """LOA's optimality gap — see :mod:`discopt.solvers._gap` for the semantics.
+
+    ``denom_floor=1e-10`` keeps LOA's stricter reporting scale for an
+    *unconverged* run (the gap relative to the objective however small it is).
+    It no longer degenerates on a converged near-zero optimum, because the shared
+    absolute criterion closes the gap before the denominator is reached.
+    """
+    return optimality_gap(lb, ub, denom_floor=1e-10)
 
 
 def _solve_nlp_relaxation(evaluator, lb, ub, nlp_solver: str) -> np.ndarray | None:

--- a/python/discopt/solvers/nlp_pounce.py
+++ b/python/discopt/solvers/nlp_pounce.py
@@ -18,7 +18,7 @@ import numpy as np
 
 from discopt._jax.nlp_evaluator import NLPEvaluator
 from discopt.modeling.core import Model
-from discopt.solvers import NLPResult, SolveStatus
+from discopt.solvers import NLPResult, SolveStatus, pounce_option_defaults
 from discopt.solvers.nlp_ipopt import (
     _IPOPT_STATUS_MAP,
     _infer_constraint_bounds,
@@ -71,17 +71,12 @@ def solve_nlp(
 
     import pounce
 
-    opts = dict(options) if options else {}
-    opts.setdefault("print_level", 0)
-    # NOT seeded from solvers.pounce_option_defaults yet. This path returns points
-    # up to ~7.5e-9 OUTSIDE their declared bounds (Ipopt's bound_relax_factor),
-    # measured in #940 — but pinning that to 0 here makes incumbents genuinely
-    # feasible, which turns `incumbent - bound` from <=0 into a small positive
-    # number and breaks 12 `gap == 0 @ 1e-9` assertions across OA / GDPopt /
-    # MindtPy parity. Those expectations are currently calibrated against a solver
-    # that returns slightly-infeasible incumbents; correcting that is a
-    # certification-semantics change needing its own differential panel. Tracked
-    # in #945 with the full attribution.
+    # Seeded from THE shared baseline so this path returns points inside the box
+    # the caller declared, like every other POUNCE entry point (#940, extended to
+    # the NLP path by #945). A caller's explicit option still wins.
+    opts = pounce_option_defaults()
+    if options:
+        opts.update(options)
 
     n = evaluator.n_variables
     m = evaluator.n_constraints

--- a/python/discopt/solvers/nlp_pounce.py
+++ b/python/discopt/solvers/nlp_pounce.py
@@ -18,7 +18,7 @@ import numpy as np
 
 from discopt._jax.nlp_evaluator import NLPEvaluator
 from discopt.modeling.core import Model
-from discopt.solvers import NLPResult, SolveStatus, pounce_option_defaults
+from discopt.solvers import NLPResult, SolveStatus
 from discopt.solvers.nlp_ipopt import (
     _IPOPT_STATUS_MAP,
     _infer_constraint_bounds,
@@ -71,18 +71,36 @@ def solve_nlp(
 
     import pounce
 
-    # Seeded from THE shared baseline like every other POUNCE entry point, so this
-    # path stops keeping Ipopt's loose `constr_viol_tol` while the rest moved
-    # (#940, extended to the NLP path by #945). A caller's explicit option wins.
+    opts = dict(options) if options else {}
+    opts.setdefault("print_level", 0)
+    # NEITHER of the two shared POUNCE requests is seeded here, and both omissions
+    # are measured rather than assumed (#945):
     #
-    # `bound_relax_factor` is deliberately NOT here — it is not a backend-wide
-    # default, because this one backend serves both consumers of a POINT and
-    # consumers of MULTIPLIERS, and the two want opposite things (see
-    # `solvers.pounce_incumbent_options`). Call sites whose x becomes an incumbent
-    # request it; Benders/GBD recourse, whose duals are the product, must not.
-    opts = pounce_option_defaults()
-    if options:
-        opts.update(options)
+    # `bound_relax_factor = 0` is requested by the call sites whose returned POINT
+    # is the product (`solver._solve_continuous`, `oa._solve_nlp_attempt`,
+    # `gdpopt_loa._solve_nlp_subproblem`) — see `solvers.pounce_incumbent_options`.
+    # Backend-wide it also reaches Benders and GBD recourse, whose product is the
+    # MULTIPLIERS, and a degenerate feasible set has no finite multiplier without
+    # Ipopt's relaxation (#940: two correctness-lane tests, 1.6s -> 79s; #946).
+    #
+    # `constr_viol_tol = 1e-8` is a backend-wide default for the matrix-form
+    # backends but is deliberately NOT routed here. Measured on nvs05 at a 20 s
+    # budget, 4 arms interleaved, 3 reps, ZERO within-arm spread
+    # (scratchpad/issue945/nvs05_attribution.py):
+    #
+    #     print_level only           objective  8.731956987   bound 3.542469244
+    #     + constr_viol_tol=1e-8     objective 12.589492574   bound 3.513753544
+    #     + incumbent options only    objective  8.731956987   bound 3.542469244
+    #
+    # so it costs a 31%-worse incumbent AND a looser bound, entirely on its own.
+    # The incumbent it displaces is genuinely feasible — worst row violation
+    # 1.8e-12, box 0, integrality 0 (nvs05_feasibility.py) — so this is a real
+    # solution lost, not a false one rejected, which is what I had assumed and had
+    # to retract. Against that: it fixes nothing here. The out-of-box defect #945 is
+    # about is `bound_relax_factor`'s, and the arm above shows constr_viol_tol alone
+    # does not touch it (mindtpy_cq stays at 2.9999000025 either way). Sound but not
+    # helpful stays out (CLAUDE.md §5). Route it here only with a measurement
+    # showing a benefit that outweighs nvs05.
 
     n = evaluator.n_variables
     m = evaluator.n_constraints

--- a/python/discopt/solvers/oa.py
+++ b/python/discopt/solvers/oa.py
@@ -32,6 +32,7 @@ from typing import TYPE_CHECKING, Any, Optional, cast
 import numpy as np
 
 from discopt.modeling.core import Constraint, Model, ObjectiveSense, SolveResult, VarType
+from discopt.solvers._gap import optimality_gap
 from discopt.solvers.mip_nlp_candidates import FixedNLPCandidate, FixedNLPCandidateManager
 from discopt.solvers.mip_nlp_options import (
     FP_OPTION_KEYS,
@@ -3635,13 +3636,12 @@ def _build_x_dict(x_flat: np.ndarray, model: Model) -> dict:
 
 
 def _compute_gap(lb: float, ub: float) -> float:
-    if ub >= 1e19 or lb <= -1e19:
-        return 1.0
-    abs_gap = max(0.0, ub - lb)
-    if abs_gap <= 1e-9:
-        return 0.0
-    denom = max(abs(ub), abs(lb), 1.0)
-    return abs_gap / denom
+    """OA's optimality gap — see :mod:`discopt.solvers._gap` for the semantics.
+
+    ``denom_floor=1.0``: below unit objective scale OA reports the absolute gap
+    rather than dividing by a vanishing denominator.
+    """
+    return optimality_gap(lb, ub, denom_floor=1.0)
 
 
 def solve_feasibility_pump(

--- a/python/tests/test_940_pounce_lp_constraint_tolerance.py
+++ b/python/tests/test_940_pounce_lp_constraint_tolerance.py
@@ -24,8 +24,8 @@ the arbiter. These tests pin BEHAVIOUR (the returned point), never the option
 names, which is why they caught a ``constr_viol_tol``-only version of this fix
 being a complete no-op on the build CI actually installs.
 
-8 of these cases fail on the pre-fix tree. The ``nlp_path`` xfail is a live
-marker for #945, not a skip.
+8 of these cases fail on the pre-#940 tree. ``nlp_path`` was a live strict xfail
+until #945 seeded the NLP path from the same baseline; it is now a plain pass.
 """
 
 from __future__ import annotations
@@ -161,23 +161,7 @@ def test_pounce_qp_point_meets_discopt_constraint_tolerance():
     )
 
 
-@pytest.mark.parametrize(
-    "flat",
-    [
-        True,
-        pytest.param(
-            False,
-            marks=pytest.mark.xfail(
-                strict=True,
-                reason="#945: the NLP path is not seeded from pounce_option_defaults yet — "
-                "bound_relax_factor=0 there makes incumbents feasible, which breaks 12 "
-                "gap==0@1e-9 assertions across OA/GDPopt/MindtPy. Kept as a live xfail so "
-                "the defect stays visible and flips to a pass the moment #945 lands.",
-            ),
-        ),
-    ],
-    ids=["lp_path", "nlp_path"],
-)
+@pytest.mark.parametrize("flat", [True, False], ids=["lp_path", "nlp_path"])
 def test_returned_point_stays_inside_its_declared_box(flat):
     """Every POUNCE entry point must return a point inside the declared bounds.
 
@@ -192,7 +176,8 @@ def test_returned_point_stays_inside_its_declared_box(flat):
     while ``dm.sum(y)`` on the bare indexed container routes to the general NLP
     path. Seeding the option in the LP/QP backends alone left this second path
     returning points ~7.5e-9 below ``lb``; the fix lives in
-    ``solvers.pounce_option_defaults`` so every entry point inherits it (#940).
+    ``solvers.pounce_option_defaults`` so every entry point inherits it — the
+    LP/QP backends in #940, the NLP path in #945.
     """
     m = dm.Model()
     s = m.set("S", [10, 20, 30])

--- a/python/tests/test_940_pounce_lp_constraint_tolerance.py
+++ b/python/tests/test_940_pounce_lp_constraint_tolerance.py
@@ -210,9 +210,12 @@ def test_returned_point_stays_inside_its_declared_box(flat):
     paths: ``dm.sum(y.flat)`` classifies linear and routes to ``lp_pounce``,
     while ``dm.sum(y)`` on the bare indexed container routes to the general NLP
     path. Seeding the option in the LP/QP backends alone left this second path
-    returning points ~7.5e-9 below ``lb``; the fix lives in
-    ``solvers.pounce_option_defaults`` so every entry point inherits it — the
-    LP/QP backends in #940, the NLP path in #945.
+    returning points ~7.5e-9 below ``lb``. The fix is NOT one backend-wide default:
+    the LP/QP backends take it from ``solvers.pounce_option_defaults`` (#940), and
+    on the NLP path it is requested by the call sites whose returned POINT is the
+    product (``solvers.pounce_incumbent_options``, #945) — never by
+    ``nlp_pounce.solve_nlp`` itself, which also serves callers whose product is the
+    MULTIPLIERS and who need Ipopt's relaxation to keep them finite.
     """
     m = dm.Model()
     s = m.set("S", [10, 20, 30])

--- a/python/tests/test_945_nlp_box_and_gap_closure.py
+++ b/python/tests/test_945_nlp_box_and_gap_closure.py
@@ -129,6 +129,108 @@ def test_bound_relaxation_damage_is_not_bounded_by_the_relaxation_itself():
     assert res.status != "optimal"
 
 
+@pytest.mark.smoke
+def test_default_solve_path_does_not_certify_a_super_optimal_incumbent():
+    """The same fixture through the DEFAULT ``m.solve()`` path, not ``mip-nlp``.
+
+    Seeding OA and GDPopt-LOA left the entry point users actually hit still doing
+    it: on the MINLP variant (exact optimum 3.0) ``m.solve()`` returned
+    ``objective = 2.9999000090835057`` with ``status='optimal'`` and ``gap = 0.0``
+    — 1.0e-04 below an optimum that a single point pins exactly.
+
+    Attributed to two producers, both fixed:
+
+    * ``primal_heuristics.feasibility_pump`` projected onto the RELAXED box and
+      handed back ``x = 2.9999`` as a candidate incumbent, and
+    * ``_solve_nlp_bb``'s terminal re-solve then adopted its own primal, which
+      came from the relaxed box too — so even with the pump honest (``x = 3``
+      exactly) the answer was overwritten back to 2.9999.
+
+    No feasibility screen catches this: the bad point's worst row violation is
+    1e-8, inside every tolerance discopt has. Only not producing it works.
+
+        pre    obj = 2.9999000090835057   super-optimal by 9.999e-05
+        post   obj = 2.9999999983777133   super-optimal by 1.622e-09
+
+    Both assertions below fail on the pre tree; the second is the one that
+    matters, since a certificate on a point that cannot exist is the CLAUDE.md §1
+    failure.
+    """
+    m = dm.Model("mindtpy_cq_default_path")
+    x = m.continuous("x", lb=1.0, ub=10.0)
+    y = m.binary("y")
+    m.subject_to((x - 3.0) ** 2 <= 50.0 * (1 - y))
+    m.subject_to(x * dm.log(x) + 5.0 <= 50.0 * y)
+    m.minimize(x)
+    res = m.solve(time_limit=60)
+
+    assert res.objective is not None
+    assert res.objective >= 3.0 - 1e-6, (
+        f"objective {res.objective!r} is below the exact optimum 3.0; y=0 leaves "
+        "x*log(x)+5 <= 0 with no root on [1,10], so y=1 and (x-3)^2 <= 0 pins x=3"
+    )
+    if res.status == "optimal":
+        assert res.bound is not None
+        assert res.bound <= res.objective + 1e-5
+
+
+@pytest.mark.smoke
+def test_every_primal_heuristic_requests_the_incumbent_options():
+    """The whole module is a point producer, so the seed is a module-wide rule.
+
+    Six NLP option sites in ``_jax/primal_heuristics.py`` each built their own
+    ``dict(nlp_options)``; one of them (``feasibility_pump``) supplied the
+    super-optimal incumbent above. They are routed through one helper so a
+    seventh heuristic cannot silently keep Ipopt's default — asserted here rather
+    than left to review, because that is the failure mode #940 already had once.
+
+    ``pounce_option_defaults()`` must NOT arrive with it: its ``constr_viol_tol``
+    is separable and costs a 31%-worse incumbent on nvs05 on its own.
+    """
+    import inspect
+
+    from discopt._jax import primal_heuristics as PH
+
+    src = inspect.getsource(PH)
+    assert "pounce_incumbent_options()" in inspect.getsource(PH._heuristic_nlp_options)
+    assert "pounce_option_defaults()" not in src, (
+        "constr_viol_tol is measurably harmful on this path and is not wanted here"
+    )
+    assert PH._heuristic_nlp_options()["bound_relax_factor"] == 0.0
+    # An explicit caller request still wins over the seed.
+    assert PH._heuristic_nlp_options({"bound_relax_factor": 1e-9})["bound_relax_factor"] == 1e-9
+
+    # Every option site routes through the helper; none rebuilds its own dict.
+    n_sites = src.count("_heuristic_nlp_options(")
+    assert n_sites >= 7, f"expected the helper plus 6 call sites, found {n_sites}"
+    assert 'setdefault("max_iter", _HEURISTIC_NLP_MAX_ITER)' not in src.split("def ", 2)[2], (
+        "a heuristic still builds its NLP options inline instead of via the helper"
+    )
+
+
+@pytest.mark.smoke
+def test_nlp_bb_terminal_resolve_separates_its_point_from_its_multipliers():
+    """One call site, two products, two option sets (#945/#946).
+
+    ``_solve_nlp_bb``'s terminal re-solve both refines the reported primal and
+    recovers the duals at it. Those want opposite options, so it takes two solves:
+    the refine one requests the incumbent options, the recover one must not (a
+    degenerate feasible set has no finite multiplier without Ipopt's relaxation).
+    Pinned in both directions so a future edit cannot collapse them back into one.
+    """
+    import inspect
+
+    from discopt import solver as S
+
+    src = inspect.getsource(S._solve_nlp_bb)
+    assert "refine_opts.update(pounce_incumbent_options())" in src
+    # The recover solve stays relaxed, and its own point is not adopted.
+    assert "recover_opts.update(pounce_incumbent_options())" not in src
+    assert "recover_opts.update(" not in src
+    assert "sol_flat = np.asarray(nlp_recovered.x" not in src
+    assert "obj_val = float(nlp_recovered.objective)" not in src
+
+
 # ── (b) gap closure is an honest dual test ───────────────────────────────────
 
 

--- a/python/tests/test_945_nlp_box_and_gap_closure.py
+++ b/python/tests/test_945_nlp_box_and_gap_closure.py
@@ -1,0 +1,167 @@
+"""Issue #945: the NLP path must respect its declared box, and gap closure must
+not be calibrated on incumbents that do not.
+
+Two coupled properties, split out of #940/#943:
+
+**(a)** ``nlp_pounce.solve_nlp`` and ``solver.py``'s POUNCE batch path did not
+seed ``bound_relax_factor``, so they returned points up to ``1e-8*(1 + |bound|)``
+outside their declared variable bounds — Ipopt's default deliberately relaxes
+every bound, including the slack bounds standing in for inequality rows. #943
+fixed the matrix-form ``lp_pounce``/``qp_pounce`` backends; this closes the last
+entry point.
+
+**(b)** With the incumbent honest, ``incumbent - bound`` stops being ``<= 0``, and
+the ``1e-9`` absolute floor in OA's and GDPopt-LOA's gap tests turns out to be
+beatable only by an incumbent that is *not* feasible. The floor is now discopt's
+own ``1e-6`` absolute tolerance, and a materially inverted bound is reported as
+"nothing proved" instead of being clamped to ``gap = 0``.
+
+These tests pin BEHAVIOUR — the returned point, the certificate — not option
+names, so a re-spelling of the option that is a no-op on the installed build
+still fails them (the #940 lesson).
+"""
+
+from __future__ import annotations
+
+import discopt.modeling as dm
+import numpy as np
+import pytest
+from discopt.solvers._gap import GAP_ABS_TOL, optimality_gap
+
+# ── (a) every POUNCE entry point stays inside the declared box ───────────────
+
+
+@pytest.mark.smoke
+def test_nlp_backend_seeds_the_shared_pounce_baseline():
+    """``solve_nlp`` must inherit the shared baseline, not re-spell it.
+
+    A second copy of these values is how one entry point silently keeps Ipopt's
+    defaults while the rest move — which is exactly the state #945 fixed.
+    """
+    import inspect
+
+    from discopt.solvers import nlp_pounce
+
+    src = inspect.getsource(nlp_pounce.solve_nlp)
+    assert "pounce_option_defaults()" in src, (
+        "nlp_pounce.solve_nlp no longer seeds from solvers.pounce_option_defaults"
+    )
+
+
+@pytest.mark.smoke
+def test_nlp_path_point_stays_inside_its_declared_box():
+    """``dm.sum(y)`` over a bare indexed container routes to the general NLP path.
+
+    Before #945 this returned a point ~7.5e-9 BELOW ``lb=1`` and an objective
+    below the true optimum of 3.0 — super-optimal, bought by leaving the box.
+    """
+    m = dm.Model()
+    s = m.set("S", [10, 20, 30])
+    y = m.continuous("y", lb=1.0, ub=5.0, over=s)
+    m.minimize(dm.sum(y))
+    res = m.solve()
+
+    assert res.status == "optimal"
+    x = np.asarray(res.value(y), dtype=np.float64).ravel()
+    assert x.size == 3
+    below = float(np.max(1.0 - x))
+    assert below <= 1e-12, f"returned point sits {below:.3e} below its declared lb=1"
+    assert res.objective >= 3.0 - 1e-12, "objective is below the true optimum of 3.0"
+
+
+@pytest.mark.smoke
+def test_bound_relaxation_damage_is_not_bounded_by_the_relaxation_itself():
+    """A squared row turns a 1e-8 bound relaxation into a 1e-4 error in ``x``.
+
+    This is why ``bound_relax_factor`` cannot be dismissed as "1e-8, therefore
+    negligible": relaxing ``(x-3)^2 <= 0`` to ``<= 1e-8`` admits every ``x``
+    within ``1e-4`` of 3. On the MindtPy constraint-qualification fixture that
+    produced a certified ``optimal`` at 2.9999000025 against an exact optimum of
+    3.0. The row is reproduced here directly so the mechanism is pinned even if
+    the fixture moves.
+    """
+    m = dm.Model("brf_squared_row")
+    x = m.continuous("x", lb=1.0, ub=10.0)
+    m.subject_to((x - 3.0) ** 2 <= 0.0)
+    m.minimize(x)
+    res = m.solve()
+
+    assert res.status in ("optimal", "feasible")
+    # x is pinned to exactly 3 by the row; anything meaningfully below it is the
+    # relaxed box, not a better solution.
+    assert float(np.asarray(res.x["x"])) >= 3.0 - 1e-6
+    assert res.objective >= 3.0 - 1e-6
+
+
+# ── (b) gap closure is an honest dual test ───────────────────────────────────
+
+
+def test_absolute_criterion_matches_discopts_absolute_tolerance():
+    """The absolute floor is 1e-6, not 1e-9.
+
+    ``1e-9`` is tighter than discopt's own absolute tolerance and tighter than the
+    IPM can deliver, so on a near-zero optimum it was only ever beaten by an
+    incumbent outside its box.
+    """
+    assert GAP_ABS_TOL == 1e-6
+    # The honest GDPopt incumbent that used to be reported as a 100% gap.
+    assert optimality_gap(0.0, 2.45888227638e-09, denom_floor=1e-10) == 0.0
+    # Just above the criterion it is a real gap again, not silently absorbed.
+    assert optimality_gap(0.0, 1e-5, denom_floor=1.0) == pytest.approx(1e-5)
+
+
+def test_inverted_bound_is_not_a_closed_gap():
+    """``max(0.0, ub - lb)`` must not turn a broken certificate into ``gap = 0``.
+
+    The numbers are the measured pre-#945 pair from the MindtPy CQ fixture: a
+    dual bound of 2.99995 reported alongside an incumbent of 2.99990, i.e. the
+    bound sitting 5e-5 ABOVE the incumbent it was supposed to bound.
+    """
+    assert optimality_gap(2.99995000083, 2.9999000025) == 1.0
+    # ... while a rounding-scale inversion is still absorbed, as before.
+    assert optimality_gap(4.0, 3.9999999999) == 0.0
+    # Scale-aware: at |obj| ~ 1e6 a 1e-9 inversion is a single ulp.
+    assert optimality_gap(1e6 + 1e-9, 1e6) == 0.0
+
+
+def test_missing_bounds_report_nothing_proved():
+    """The ±1e19 sentinels mean "no bound yet", never a closed gap."""
+    assert optimality_gap(-1e20, 5.0) == 1.0
+    assert optimality_gap(0.0, 1e20) == 1.0
+
+
+def test_oa_and_loa_share_one_gap_definition():
+    """Two near-copies that disagreed are now one definition (#945)."""
+    from discopt.solvers.gdpopt_loa import _compute_gap as loa_gap
+    from discopt.solvers.oa import _compute_gap as oa_gap
+
+    for lb, ub in [(2.0, 4.0), (3.0, 3.0), (-1e20, 5.0), (0.0, 1e20)]:
+        assert oa_gap(lb, ub) == loa_gap(lb, ub), (lb, ub)
+    # Both close an honest near-zero gap that only one of them used to close.
+    assert oa_gap(0.0, 2.4589e-9) == 0.0
+    assert loa_gap(0.0, 2.4589e-9) == 0.0
+
+
+@pytest.mark.smoke
+def test_loa_certifies_a_near_zero_optimum_with_an_honest_incumbent():
+    """``min x`` over ``(x<=3) or (x>=7)``, ``x in [0,10]``: optimum exactly 0.
+
+    Pre-#945 this was certified ``optimal`` at ``-7.5e-09`` — below its own
+    ``lb=0`` and below its own dual bound. With the incumbent inside the box the
+    objective is ``+2.5e-09``, and LOA must still certify it: the absolute
+    criterion, not the degenerate relative one, is what closes this gap.
+    """
+    m = dm.Model("loa_near_zero")
+    x = m.continuous("x", lb=0, ub=10)
+    m.either_or([[x <= 3], [x >= 7]], name="choice")
+    m.minimize(x)
+    r = m.solve(time_limit=30, gdp_method="loa")
+
+    assert r.status == "optimal"
+    assert r.objective == pytest.approx(0.0, abs=1e-5)
+    # The incumbent is inside its box: not below lb=0, and not below the optimum.
+    assert float(np.asarray(r.x["x"])) >= 0.0
+    assert r.objective >= 0.0
+    # Certificate invariant: the dual bound never sits above the incumbent.
+    assert r.bound is not None and r.bound <= r.objective + 1e-9
+    assert r.gap == pytest.approx(0.0, abs=1e-9)

--- a/python/tests/test_945_nlp_box_and_gap_closure.py
+++ b/python/tests/test_945_nlp_box_and_gap_closure.py
@@ -32,19 +32,41 @@ from discopt.solvers._gap import GAP_ABS_TOL, optimality_gap
 
 
 @pytest.mark.smoke
-def test_nlp_backend_seeds_the_shared_pounce_baseline():
-    """``solve_nlp`` must inherit the shared baseline, not re-spell it.
+def test_incumbent_options_are_requested_by_point_consumers_only():
+    """Pin WHERE ``bound_relax_factor`` is requested, because the two sides differ.
 
-    A second copy of these values is how one entry point silently keeps Ipopt's
-    defaults while the rest move — which is exactly the state #945 fixed.
+    The split is not "LP versus NLP", it is what the caller consumes. A call site
+    whose returned POINT becomes a solution needs it inside the declared box; a
+    call site whose MULTIPLIERS are the product must not pin it, because a
+    degenerate feasible set has no finite multiplier without Ipopt's relaxation.
+    Applied backend-wide it costs the Benders dual LP its convergence (#940) and
+    GBD its certification (#946).
+
+    Asserted in both directions, so a future edit cannot quietly move it either
+    way — the companion to
+    ``test_940...::test_option_requests_are_wired_where_the_guard_checks``.
     """
     import inspect
 
-    from discopt.solvers import nlp_pounce
+    from discopt import solver as S
+    from discopt.solvers import gdpopt_loa, nlp_pounce, oa, pounce_incumbent_options
 
-    src = inspect.getsource(nlp_pounce.solve_nlp)
-    assert "pounce_option_defaults()" in src, (
-        "nlp_pounce.solve_nlp no longer seeds from solvers.pounce_option_defaults"
+    assert pounce_incumbent_options()["bound_relax_factor"] == 0.0
+    # A fresh dict each call: a caller mutating it must not poison the next solve.
+    pounce_incumbent_options()["bound_relax_factor"] = 999.0
+    assert pounce_incumbent_options()["bound_relax_factor"] == 0.0
+
+    for fn in (S._solve_continuous, oa._solve_nlp_attempt, gdpopt_loa._solve_nlp_subproblem):
+        assert "pounce_incumbent_options()" in inspect.getsource(fn), (
+            f"{fn.__name__} returns a point that becomes a solution, so it must "
+            "request the incumbent options"
+        )
+
+    # The backend itself must stay neutral: it serves dual consumers too.
+    backend_src = inspect.getsource(nlp_pounce.solve_nlp)
+    assert "pounce_incumbent_options()" not in backend_src, (
+        "bound_relax_factor must NOT be a backend-wide default on the NLP path — "
+        "it reaches Benders/GBD recourse, whose product is the multipliers (#946)"
     )
 
 

--- a/python/tests/test_945_nlp_box_and_gap_closure.py
+++ b/python/tests/test_945_nlp_box_and_gap_closure.py
@@ -75,10 +75,23 @@ def test_bound_relaxation_damage_is_not_bounded_by_the_relaxation_itself():
 
     This is why ``bound_relax_factor`` cannot be dismissed as "1e-8, therefore
     negligible": relaxing ``(x-3)^2 <= 0`` to ``<= 1e-8`` admits every ``x``
-    within ``1e-4`` of 3. On the MindtPy constraint-qualification fixture that
-    produced a certified ``optimal`` at 2.9999000025 against an exact optimum of
-    3.0. The row is reproduced here directly so the mechanism is pinned even if
-    the fixture moves.
+    within ``1e-4`` of 3, because the row squares the excursion. It is the
+    mechanism behind the MindtPy constraint-qualification fixture certifying
+    ``optimal`` at 2.9999000025 against an exact optimum of 3.0, reproduced here
+    directly so it stays pinned even if that fixture moves.
+
+    Measured on this model, both arms interleaved:
+
+        pre-#945   status='optimal'          x = 2.9999000024987788  (1.0e-04 off)
+        post-#945  status='iteration_limit'  x = 2.9999999998864917  (1.1e-10 off)
+
+    The status is part of the finding rather than incidental. ``(x-3)^2 <= 0`` has
+    a single feasible point and therefore empty interior — Slater fails, so this
+    is exactly the degeneracy #849's KKT-residual guard exists to refuse to
+    certify. Pre-#945 that guard could not see it: against the RELAXED box the
+    residuals looked clean, so the solve came back ``optimal``. With the box
+    honest the guard fires and withholds the certificate. So the assertion is that
+    this is NOT certified, not that it is.
     """
     m = dm.Model("brf_squared_row")
     x = m.continuous("x", lb=1.0, ub=10.0)
@@ -86,11 +99,12 @@ def test_bound_relaxation_damage_is_not_bounded_by_the_relaxation_itself():
     m.minimize(x)
     res = m.solve()
 
-    assert res.status in ("optimal", "feasible")
     # x is pinned to exactly 3 by the row; anything meaningfully below it is the
-    # relaxed box, not a better solution.
+    # relaxed box, not a better solution. Fails at 1e-4 on the pre-#945 tree.
     assert float(np.asarray(res.x["x"])) >= 3.0 - 1e-6
     assert res.objective >= 3.0 - 1e-6
+    # A degenerate feasible set must not come back certified (#849).
+    assert res.status != "optimal"
 
 
 # ── (b) gap closure is an honest dual test ───────────────────────────────────

--- a/python/tests/test_gbd.py
+++ b/python/tests/test_gbd.py
@@ -364,6 +364,21 @@ def test_free_recourse_variable():
     assert r.bound is not None and r.bound <= r.objective + 1e-3
 
 
+@pytest.mark.xfail(
+    strict=True,
+    reason="#946: GBD's Lagrangian optimality cut is built from the raw subproblem "
+    "multipliers with no conditioning guard. At the master proposal y=0 the recourse "
+    "constraint becomes x0^2+x1^2 <= 0, whose feasible set is the single point x=0 — "
+    "Slater fails, so no finite multiplier exists and the returned one diverges. Until "
+    "#945 that was masked: Ipopt's bound_relax_factor gave the set an artificial "
+    "interior, the recourse point settled at x~7.1e-5 (violating its own row by 1e-8) "
+    "and the multiplier stayed at 7.1e3. With the point honest at x~6.9e-9 the "
+    "multiplier is 9.8e7 and the cut slope 7.9e8, which carries no usable information "
+    "about eta at any scale — so the master bound stalls at -2 against a true optimum "
+    "of -1. The result stays SOUND (bound -2 is valid, status is iteration_limit, not a "
+    "false 'optimal'); what is lost is certification. Kept STRICT so it flips to a pass "
+    "the moment #946 lands, rather than being loosened into invisibility.",
+)
 def test_linear_objective_nonlinear_constraint():
     """A *linear* objective with a nonlinear convex constraint still routes to GBD.
 

--- a/python/tests/test_mip_nlp.py
+++ b/python/tests/test_mip_nlp.py
@@ -5009,7 +5009,21 @@ def test_mip_nlp_regularized_oa_matches_mindtpy_constraint_qualification(
     assert result.objective == pytest.approx(3.0, abs=1e-3)
     if result.status == "optimal":
         assert result.bound == pytest.approx(3.0, abs=1e-3)
-        assert result.gap == pytest.approx(0.0, abs=1e-9)
+        # Re-baselined by #945. This asserted `gap == 0 @ 1e-9`, which was only
+        # ever satisfiable here because the NLP path returned an incumbent of
+        # 2.9999000025 — 1e-4 BELOW this fixture's exact optimum of 3.0, and 5e-5
+        # below its own reported dual bound of 2.99995 — whereupon
+        # `max(0.0, ub - lb)` clamped the resulting NEGATIVE gap to zero. With the
+        # incumbent honest the gap is a real 1.6e-5, inside the solver's declared
+        # 1e-4 relative tolerance, so that is what is pinned.
+        assert result.gap == pytest.approx(0.0, abs=1e-4)
+        # The certificate invariant the old numbers violated: for a minimization
+        # the dual bound never sits above the incumbent.
+        assert result.bound <= result.objective + 1e-9
+    # y=0 leaves `x*log(x) + 5 <= 0`, which has no root on [1, 10], so y=1 and
+    # `(x-3)^2 <= 0` pins x to exactly 3. Nothing feasible scores below 3.0, so a
+    # smaller objective is a false incumbent, not a better one.
+    assert result.objective >= 3.0 - 1e-6
     assert result.x["x"] == pytest.approx(3.0, abs=1e-3)
     assert result.x["y"] == pytest.approx(1.0, abs=1e-5)
 

--- a/python/tests/test_oa.py
+++ b/python/tests/test_oa.py
@@ -85,9 +85,37 @@ def _mindtpy_duran_grossmann_minlp():
 
 
 def test_compute_gap_uses_absolute_scale_near_zero():
+    """A near-zero objective must not inflate a small gap into a large relative one.
+
+    Re-baselined by #945: the magnitude was 1.99e-8, which now sits *below* the
+    shared absolute criterion (1e-6, discopt's absolute tolerance) and so reads as
+    closed. The property under test is the denominator floor, not that particular
+    magnitude, so it is re-pinned above the absolute floor where the floor is what
+    decides the answer.
+    """
     from discopt.solvers.oa import _compute_gap
 
-    assert _compute_gap(-1.99e-8, 9e-18) == pytest.approx(1.99e-8)
+    # denom = max(9e-18, 1.99e-3, 1.0) = 1.0 -> the ABSOLUTE gap is reported,
+    # rather than 1.99e-3/9e-18 ~ 2e14.
+    assert _compute_gap(-1.99e-3, 9e-18) == pytest.approx(1.99e-3)
+    # Below the absolute criterion the gap is closed outright.
+    assert _compute_gap(-1.99e-8, 9e-18) == 0.0
+
+
+def test_compute_gap_refuses_to_certify_an_inverted_bound():
+    """A dual bound materially ABOVE the incumbent is not a closed gap (#945).
+
+    ``max(0.0, ub - lb)`` used to turn an inverted certificate into ``gap = 0.0``
+    and hence ``status='optimal'``. That is how the MindtPy constraint-qualification
+    fixture certified an incumbent 1e-4 *below* its true optimum of 3.0 while
+    reporting a dual bound 5e-5 above that same incumbent.
+    """
+    from discopt.solvers.oa import _compute_gap
+
+    # The exact pre-#945 inversion: bound 2.99995 above incumbent 2.99990.
+    assert _compute_gap(2.99995000083, 2.9999000025) == 1.0
+    # Rounding-scale inversions are still absorbed, as they always were.
+    assert _compute_gap(4.0, 3.9999999999) == 0.0
 
 
 # ── Convex MINLP ─────────────────────────────────────────────

--- a/python/tests/test_sets_adversarial.py
+++ b/python/tests/test_sets_adversarial.py
@@ -26,27 +26,19 @@ class TestSumProdOverIndexedContainer:
         # vars at lb=1 -> 3.0, NOT 60.0 (= the keys 10+20+30)
         assert r.objective == pytest.approx(3.0, abs=1e-5)
 
-    @pytest.mark.xfail(
-        strict=True,
-        reason="#945: the two arms take different engine paths and only the LP one is "
-        "seeded from pounce_option_defaults, so they no longer agree to 1e-9. Kept "
-        "STRICT at 1e-9 rather than loosened — it flips to a pass when #945 seeds the "
-        "NLP path, and loosening would re-hide the defect (#940 review).",
-    )
     def test_sum_indexed_var_equals_sum_flat(self):
         # The two arms take DIFFERENT engine paths — `dm.sum(y.flat)` classifies
         # linear and goes to lp_pounce, `dm.sum(y)` on the bare container goes to
         # the general NLP path — so this is a real cross-path invariant and the
         # tight 1e-9 bound is worth keeping.
         #
-        # It previously passed for the WRONG reason: both paths returned points
-        # ~7.5e-9 BELOW lb=1 (Ipopt's bound_relax_factor), so both objectives were
-        # 2.25e-8 super-optimal and agreed to 1.4e-11 — two matched errors
-        # cancelling. #940 fixed the LP arm only, so the arms now disagree by
-        # ~3.0e-8 and this fails honestly instead of passing dishonestly. The
-        # ground-truth assertions below are what make the difference visible: a
-        # cross-model comparison alone passes just as happily when both models are
-        # wrong in the same way.
+        # It once passed for the WRONG reason: both paths returned points ~7.5e-9
+        # BELOW lb=1 (Ipopt's bound_relax_factor), so both objectives were 2.25e-8
+        # super-optimal and agreed to 1.4e-11 — two matched errors cancelling.
+        # #940 fixed the LP arm and #945 the NLP arm, so both are now inside their
+        # box and agree for the right reason. The ground-truth assertions below are
+        # what make the difference visible: a cross-model comparison alone passes
+        # just as happily when both models are wrong in the same way.
         m = dm.Model()
         s = m.set("S", [10, 20, 30])
         y = m.continuous("y", lb=1, ub=5, over=s)

--- a/scratchpad/issue945/attribution.py
+++ b/scratchpad/issue945/attribution.py
@@ -1,0 +1,162 @@
+"""#945 attribution probe: what actually changes when the NLP path stops
+returning points outside their declared box.
+
+For each affected fixture, runs BOTH arms in-process and reports
+status / objective / bound / gap, plus two *independent* soundness checks of the
+returned incumbent that do not go through the solver's own guards:
+
+  * ``box_viol``  — max distance of x outside its declared [lb, ub]
+  * ``cert_viol`` — max(0, bound - incumbent): the certificate invariant
+                    ``bound <= incumbent`` for a minimization (CLAUDE.md §1)
+
+Prints an executed-comparison count and exits non-zero if it measured nothing
+(CLAUDE.md §6). Arms are interleaved per fixture, not run as two sequential
+blocks, so a drifting machine cannot masquerade as an arm effect (§9).
+
+Usage:  python -u scratchpad/issue945/attribution.py
+"""
+
+from __future__ import annotations
+
+import inspect
+import pathlib
+import sys
+
+import numpy as np
+
+import discopt.modeling as dm
+import discopt.solvers.nlp_pounce as nlp_pounce
+from discopt.solvers import pounce_option_defaults
+
+# §8: assert which code is under test before measuring anything.
+_SEEDED = "opts = pounce_option_defaults()" in inspect.getsource(nlp_pounce.solve_nlp)
+if not _SEEDED:
+    print(
+        "FATAL: nlp_pounce.solve_nlp is NOT seeded from pounce_option_defaults; "
+        "this probe compares arms of the #945 change and needs the seeded tree.",
+        file=sys.stderr,
+    )
+    sys.exit(2)
+
+# Arms. "main" is EXACTLY what `nlp_pounce.solve_nlp` did before #945: it set
+# print_level only, leaving BOTH constr_viol_tol (Ipopt default 1e-4) and
+# bound_relax_factor (1e-8) at Ipopt's values. Naming only one of them leaves the
+# other at the shipped value and mislabels the arm (the #940 lesson) — "cvt_only"
+# is kept precisely to show how much of the effect each option carries.
+_ARMS = {
+    "main": {"print_level": 0},
+    "cvt": {"print_level": 0, "constr_viol_tol": 1e-8, "bound_relax_factor": 1e-8},
+    "new": None,  # the shipped pounce_option_defaults()
+}
+_REAL = pounce_option_defaults
+
+
+def _install(arm: str) -> None:
+    override = _ARMS[arm]
+    nlp_pounce.pounce_option_defaults = _REAL if override is None else (lambda: dict(override))
+
+
+# ── fixtures ────────────────────────────────────────────────────────────────
+# Copied from the failing tests so the probe is standalone (and so a test-file
+# edit cannot silently change what this measured).
+
+
+_TESTS = pathlib.Path(__file__).resolve().parents[2] / "python" / "tests"
+sys.path.insert(0, str(_TESTS))
+# Import the REAL fixtures rather than re-typing them: a hand-copied model is a
+# different model, and the first draft of this probe measured one (its
+# "mindtpy_simple" had optimum 3.0, the test's has 3.5).
+from test_mip_nlp import (  # noqa: E402
+    _mindtpy_constraint_qualification_example as _mindtpy_cq,
+)
+from test_mip_nlp import _mindtpy_simple_minlp  # noqa: E402
+
+
+def _gdp_simple_disjunction(name="g"):
+    m = dm.Model(name)
+    x = m.continuous("x", lb=0.0, ub=10.0)
+    m.either_or([[x <= 3.0], [x >= 7.0]], name="choice")
+    m.minimize(x)
+    return m
+
+
+# (label, builder, solve kwargs, hand-verified true optimum)
+#   mindtpy_simple : optimum 3.5 (y = (0,1,0), x = (2,2))
+#   mindtpy_cq     : y=0 is infeasible (x·ln x + 5 <= 0 has no root on [1,10]),
+#                    so y=1 forces (x-3)^2 <= 0, i.e. x = 3 exactly. Optimum 3.0.
+#   gdp            : min x over (x<=3) or (x>=7), x in [0,10]. Optimum 0.0.
+_OA = dict(solver="mip-nlp", mip_nlp_method="oa", time_limit=60, max_nodes=100)
+CASES = [
+    ("mindtpy_simple/oa", lambda: _mindtpy_simple_minlp("a"), _OA, 3.5),
+    ("mindtpy_simple/roa-L1", lambda: _mindtpy_simple_minlp("b"), {**_OA, "add_regularization": "level_L1"}, 3.5),
+    ("mindtpy_cq/roa-L1", lambda: _mindtpy_cq("c"), {**_OA, "add_regularization": "level_L1"}, 3.0),
+    ("mindtpy_cq/roa-Linf", lambda: _mindtpy_cq("d"), {**_OA, "add_regularization": "level_L_infinity"}, 3.0),
+    ("mindtpy_cq/roa-gradlag", lambda: _mindtpy_cq("e"), {**_OA, "add_regularization": "grad_lag"}, 3.0),
+    ("gdp_simple_disjunction", _gdp_simple_disjunction, dict(gdp_method="loa", time_limit=30), 0.0),
+]
+
+
+def _box_violation(model, res) -> float:
+    """Max distance of the returned point outside its declared box."""
+    worst = 0.0
+    for v in model._variables:
+        val = np.asarray(res.x[v.name], dtype=np.float64).ravel()
+        lb = np.asarray(v.lb, dtype=np.float64).ravel()
+        ub = np.asarray(v.ub, dtype=np.float64).ravel()
+        lb = np.broadcast_to(lb, val.shape)
+        ub = np.broadcast_to(ub, val.shape)
+        worst = max(worst, float(np.max(lb - val)), float(np.max(val - ub)))
+    return max(0.0, worst)
+
+
+comparisons = 0
+rows = []
+for label, build, kwargs, true_opt in CASES:
+    for arm in ("main", "cvt", "new"):  # interleaved per fixture (§9)
+        _install(arm)
+        model = build()
+        res = model.solve(**kwargs)
+        box = _box_violation(model, res)
+        obj = res.objective
+        bnd = res.bound
+        # Certificate invariant for a minimization: bound <= incumbent.
+        cert = 0.0 if (obj is None or bnd is None) else max(0.0, float(bnd) - float(obj))
+        # Super-optimality: an incumbent BELOW the hand-verified optimum is,
+        # by definition, not a feasible point of the declared problem.
+        sup = 0.0 if obj is None else max(0.0, true_opt - float(obj))
+        # A dual bound above the true optimum has cut the optimum out.
+        bad_bnd = 0.0 if bnd is None else max(0.0, float(bnd) - true_opt)
+        rows.append((label, arm, res.status, obj, bnd, res.gap, box, cert, sup, bad_bnd))
+        comparisons += 1
+_install("new")
+
+hdr = (
+    f"{'fixture':24s} {'arm':5s} {'status':9s} {'objective':>16s} {'bound':>16s} "
+    f"{'gap':>11s} {'box':>9s} {'cert':>9s} {'super_opt':>9s} {'bnd>opt':>9s}"
+)
+print(hdr)
+print("-" * len(hdr))
+violations = 0
+for label, arm, status, obj, bnd, gap, box, cert, sup, bad_bnd in rows:
+    o = "None" if obj is None else f"{obj:.12g}"
+    b = "None" if bnd is None else f"{bnd:.12g}"
+    g = "None" if gap is None else f"{gap:.4e}"
+    flags = []
+    if box > 0:
+        flags.append("OUT-OF-BOX")
+    if cert > 0:
+        flags.append("BOUND>INCUMBENT")
+    if sup > 0:
+        flags.append("SUPER-OPTIMAL")
+    if bad_bnd > 0:
+        flags.append("BOUND>TRUE-OPT")
+    violations += len(flags)
+    print(
+        f"{label:24s} {arm:5s} {status:9s} {o:>16s} {b:>16s} {g:>11s} "
+        f"{box:9.2e} {cert:9.2e} {sup:9.2e} {bad_bnd:9.2e}  {' '.join(flags)}"
+    )
+
+print(f"\nexecuted_comparisons={comparisons} flagged_rows={violations}")
+if comparisons == 0:
+    print("PROBE FIRED NOTHING", file=sys.stderr)
+    sys.exit(2)

--- a/scratchpad/issue945/attribution.py
+++ b/scratchpad/issue945/attribution.py
@@ -22,10 +22,9 @@ import inspect
 import pathlib
 import sys
 
-import numpy as np
-
 import discopt.modeling as dm
 import discopt.solvers.nlp_pounce as nlp_pounce
+import numpy as np
 from discopt.solvers import pounce_option_defaults
 
 # §8: assert which code is under test before measuring anything.

--- a/scratchpad/issue945/entry_bounds.py
+++ b/scratchpad/issue945/entry_bounds.py
@@ -1,0 +1,60 @@
+"""Entry experiment for #945(a): does the NLP path return points outside the box?
+
+Reproduces the issue's evidence table directly. Prints an executed-assertion
+count and exits non-zero if nothing was actually measured (CLAUDE.md §6).
+"""
+
+from __future__ import annotations
+
+import inspect
+import sys
+
+import numpy as np
+
+import discopt.modeling as dm
+import discopt.solvers.nlp_pounce as nlp_pounce
+from discopt import Model
+
+# §8: prove which code is loaded, and which arm it is.
+SEEDED = "opts = pounce_option_defaults()" in inspect.getsource(nlp_pounce.solve_nlp)
+print(f"# discopt      : {dm.__file__}")
+print(f"# nlp_pounce   : {nlp_pounce.__file__}")
+print(f"# NLP arm      : {'SEEDED (bound_relax_factor=0)' if SEEDED else 'UNSEEDED (Ipopt defaults)'}")
+
+checks = 0
+violations = 0
+
+
+def build(flat: bool) -> Model:
+    m = Model()
+    y = m.add_variable("y", shape=(3,), lb=1.0, ub=5.0)
+    m.minimize(dm.sum(y.flat) if flat else dm.sum(y))
+    return m
+
+
+for flat in (True, False):
+    label = "dm.sum(y.flat)" if flat else "dm.sum(y)"
+    m = build(flat)
+    res = m.solve(verbose=False)
+    x = np.asarray(res.x["y"], dtype=float).ravel()
+    below = float(np.max(1.0 - x))  # >0 means below lb=1
+    above = float(np.max(x - 5.0))
+    checks += 2
+    worst = max(below, above)
+    bad = worst > 0.0
+    violations += int(bad)
+    # Super-optimality: the true optimum is exactly 3.0.
+    checks += 1
+    super_opt = 3.0 - float(res.objective)
+    if super_opt > 0.0:
+        violations += 1
+    print(
+        f"{label:16s} obj={res.objective!r:22s} "
+        f"max_outside={worst:.3e} super_optimal_by={super_opt:.3e} "
+        f"{'BAD' if bad or super_opt > 0 else 'ok'}"
+    )
+
+print(f"\nexecuted_assertions={checks} violations={violations}")
+if checks == 0:
+    print("PROBE FIRED NOTHING", file=sys.stderr)
+    sys.exit(2)

--- a/scratchpad/issue945/entry_bounds.py
+++ b/scratchpad/issue945/entry_bounds.py
@@ -12,30 +12,44 @@ import sys
 import discopt.modeling as dm
 import discopt.solvers.nlp_pounce as nlp_pounce
 import numpy as np
-from discopt import Model
+from discopt import Model, solver
 
 # §8: prove which code is loaded, and which arm it is.
-SEEDED = "opts = pounce_option_defaults()" in inspect.getsource(nlp_pounce.solve_nlp)
+# The seed lives at the CALL SITES, not in the backend — #945 settled that the
+# split is what the caller consumes, and `solve_nlp` also serves dual consumers.
+# An earlier version of this marker tested `solve_nlp`'s own source and so was
+# permanently False on the post tree, mislabelling every post run as UNSEEDED.
+SEEDED = "pounce_incumbent_options()" in inspect.getsource(solver._solve_continuous)
 print(f"# discopt      : {dm.__file__}")
 print(f"# nlp_pounce   : {nlp_pounce.__file__}")
-print(f"# NLP arm      : {'SEEDED (bound_relax_factor=0)' if SEEDED else 'UNSEEDED (Ipopt defaults)'}")
+print(
+    f"# NLP arm      : {'SEEDED (bound_relax_factor=0)' if SEEDED else 'UNSEEDED (Ipopt defaults)'}"
+)
 
 checks = 0
 violations = 0
 
 
-def build(flat: bool) -> Model:
+def build(flat: bool):
+    """Same construction as ``test_940...::test_returned_point_stays_inside_its_declared_box``.
+
+    Two API mistakes made this harness unrunnable as vendored — ``Model.add_variable``
+    does not exist and ``solve()`` rejects ``verbose`` (it refuses unknown options
+    rather than swallowing them). Mirroring the test is what keeps the probe and the
+    thing it claims to measure from drifting apart again.
+    """
     m = Model()
-    y = m.add_variable("y", shape=(3,), lb=1.0, ub=5.0)
+    s = m.set("S", [10, 20, 30])
+    y = m.continuous("y", lb=1.0, ub=5.0, over=s)
     m.minimize(dm.sum(y.flat) if flat else dm.sum(y))
-    return m
+    return m, y
 
 
 for flat in (True, False):
     label = "dm.sum(y.flat)" if flat else "dm.sum(y)"
-    m = build(flat)
-    res = m.solve(verbose=False)
-    x = np.asarray(res.x["y"], dtype=float).ravel()
+    m, y = build(flat)
+    res = m.solve()
+    x = np.asarray(res.value(y), dtype=float).ravel()
     below = float(np.max(1.0 - x))  # >0 means below lb=1
     above = float(np.max(x - 5.0))
     checks += 2

--- a/scratchpad/issue945/entry_bounds.py
+++ b/scratchpad/issue945/entry_bounds.py
@@ -9,10 +9,9 @@ from __future__ import annotations
 import inspect
 import sys
 
-import numpy as np
-
 import discopt.modeling as dm
 import discopt.solvers.nlp_pounce as nlp_pounce
+import numpy as np
 from discopt import Model
 
 # §8: prove which code is loaded, and which arm it is.

--- a/scratchpad/issue945/gbd_anchor_probe.py
+++ b/scratchpad/issue945/gbd_anchor_probe.py
@@ -1,0 +1,81 @@
+"""#945 / GBD: dump the ACTUAL (anchor, s) each recourse call produces.
+
+A paper derivation of these numbers is not evidence. ``_recourse`` is a closure
+inside ``solve_gbd`` with no injection seam, so this traps its real return value
+with a return-event trace hook rather than reimplementing its arithmetic (a
+reimplementation can diverge from the code it claims to measure).
+
+Both arms are run; the per-iteration cut sequence is printed for each.
+"""
+
+from __future__ import annotations
+
+import inspect
+import sys
+
+import numpy as np
+
+import discopt.modeling as dm
+import discopt.solvers.nlp_pounce as NLPP
+from discopt.decomposition.benders import solve_benders
+from discopt.solvers import pounce_option_defaults
+
+assert "opts = pounce_option_defaults()" in inspect.getsource(NLPP.solve_nlp), "not the #945 tree"
+
+_PRE = {"print_level": 0}
+_REAL = pounce_option_defaults
+
+records: list[tuple] = []
+_ARM = "pre"
+
+
+def _tracer(frame, event, arg):
+    if event == "call" and frame.f_code.co_name == "_recourse":
+        return _local
+    return None
+
+
+def _local(frame, event, arg):
+    if event == "return" and isinstance(arg, tuple) and len(arg) == 6:
+        kind, v, x_full, anchor, s, rig = arg
+        records.append((_ARM, kind, float(v), np.asarray(x_full).copy(),
+                        float(anchor), np.asarray(s).copy(), bool(rig)))
+    return None
+
+
+def build():
+    m = dm.Model("linnl")
+    y = m.binary("y")
+    x = m.continuous("x", shape=(2,), lb=0, ub=5)
+    m.first_stage(y)
+    m.minimize(3 * y - x[0] - x[1])
+    m.subject_to(x[0] * x[0] + x[1] * x[1] <= 8 * y)
+    return m
+
+
+for arm in ("pre", "post"):
+    _ARM = arm
+    NLPP.pounce_option_defaults = (lambda: dict(_PRE)) if arm == "pre" else _REAL
+    sys.settrace(_tracer)
+    try:
+        r = solve_benders(build(), time_limit=30)
+    finally:
+        sys.settrace(None)
+    print(f"=== arm={arm}: status={r.status} obj={r.objective!r} bound={r.bound!r}", flush=True)
+NLPP.pounce_option_defaults = _REAL
+
+print(f"\n{'arm':5s} {'kind':6s} {'v':>14s} {'anchor':>16s} {'s (master cols)':>22s} {'rig':>5s}")
+print("-" * 74)
+shown: set = set()
+for arm, kind, v, x_full, anchor, s, rig in records:
+    key = (arm, kind, round(v, 12), round(anchor, 12))
+    if key in shown:
+        continue
+    shown.add(key)
+    print(f"{arm:5s} {kind:6s} {v:14.6e} {anchor:16.6e} "
+          f"{np.array2string(s, precision=4):>22s} {rig!s:>5s}")
+
+print(f"\nexecuted_recourse_returns={len(records)}  distinct_shown={len(shown)}")
+if not records:
+    print("PROBE TRAPPED NOTHING — the trace hook never fired", file=sys.stderr)
+    sys.exit(2)

--- a/scratchpad/issue945/gbd_anchor_probe.py
+++ b/scratchpad/issue945/gbd_anchor_probe.py
@@ -13,10 +13,9 @@ from __future__ import annotations
 import inspect
 import sys
 
-import numpy as np
-
 import discopt.modeling as dm
 import discopt.solvers.nlp_pounce as NLPP
+import numpy as np
 from discopt.decomposition.benders import solve_benders
 from discopt.solvers import pounce_option_defaults
 

--- a/scratchpad/issue945/gbd_cut_probe.py
+++ b/scratchpad/issue945/gbd_cut_probe.py
@@ -18,10 +18,9 @@ from __future__ import annotations
 import inspect
 import sys
 
-import numpy as np
-
 import discopt.modeling as dm
 import discopt.solvers.nlp_pounce as NLPP
+import numpy as np
 from discopt.decomposition.benders import solve_benders
 from discopt.solvers import pounce_option_defaults
 

--- a/scratchpad/issue945/gbd_cut_probe.py
+++ b/scratchpad/issue945/gbd_cut_probe.py
@@ -1,0 +1,84 @@
+"""#945 / GBD: attribute the stalled bound to the recourse point at y=0.
+
+Hypothesis: at the master proposal y=0 the recourse constraint `x0^2+x1^2 <= 0`
+forces x=0, where its Jacobian `2x` is also 0 — the LICQ fails and the
+Lagrangian's recourse gradient never cancels. Pre-#945, Ipopt's
+`bound_relax_factor` let the point settle at x ~ 1e-4 instead, where the Jacobian
+is nonzero and the cut came out usable. If so, the cut at y=0 collapses to the
+box-minimum anchor and GBD stops making progress.
+
+Kill criterion: if the y=0 recourse point is x=0 in BOTH arms, or if the cut
+anchor is the same in both, the hypothesis is wrong.
+
+Records every recourse solve in both arms; prints an executed-call count.
+"""
+
+from __future__ import annotations
+
+import inspect
+import sys
+
+import numpy as np
+
+import discopt.modeling as dm
+import discopt.solvers.nlp_pounce as NLPP
+from discopt.decomposition.benders import solve_benders
+from discopt.solvers import pounce_option_defaults
+
+assert "opts = pounce_option_defaults()" in inspect.getsource(NLPP.solve_nlp), "not the #945 tree"
+
+_PRE = {"print_level": 0}
+_REAL = pounce_option_defaults
+_ORIG = NLPP.solve_nlp
+
+calls: list[tuple] = []
+_ARM = "pre"
+
+
+def _tap(evaluator, x0, *a, **k):
+    res = _ORIG(evaluator, x0, *a, **k)
+    if res.x is not None:
+        x = np.asarray(res.x, dtype=np.float64)
+        try:
+            g = np.asarray(evaluator.evaluate_constraints(x), dtype=np.float64)
+            J = np.asarray(evaluator.evaluate_jacobian(x), dtype=np.float64)
+            jnorm = float(np.max(np.abs(J))) if J.size else 0.0
+        except Exception as exc:  # recorded, never swallowed (§7)
+            g, jnorm = f"ERR {exc}", float("nan")
+        mu = None if res.multipliers is None else np.asarray(res.multipliers, dtype=np.float64)
+        calls.append((_ARM, str(res.status), x.copy(), g, jnorm, mu, res.objective))
+    return res
+
+
+NLPP.solve_nlp = _tap
+
+
+def build():
+    m = dm.Model("linnl")
+    y = m.binary("y")
+    x = m.continuous("x", shape=(2,), lb=0, ub=5)
+    m.first_stage(y)
+    m.minimize(3 * y - x[0] - x[1])
+    m.subject_to(x[0] * x[0] + x[1] * x[1] <= 8 * y)
+    return m
+
+
+for arm in ("pre", "post"):
+    _ARM = arm
+    NLPP.pounce_option_defaults = (lambda: dict(_PRE)) if arm == "pre" else _REAL
+    r = solve_benders(build(), time_limit=30)
+    print(f"\n=== arm={arm}: status={r.status} obj={r.objective!r} bound={r.bound!r}")
+NLPP.pounce_option_defaults = _REAL
+
+print(f"\n{'arm':5s} {'status':10s} {'x':>34s} {'g(x)':>16s} {'max|J|':>10s} {'mu':>14s}")
+print("-" * 96)
+for arm, status, x, g, jnorm, mu, obj in calls:
+    xs = np.array2string(x, precision=6, max_line_width=200)
+    gs = np.array2string(np.atleast_1d(g), precision=6) if not isinstance(g, str) else g
+    ms = "None" if mu is None else np.array2string(mu, precision=4)
+    print(f"{arm:5s} {status:10s} {xs:>34s} {gs:>16s} {jnorm:10.3e} {ms:>14s}")
+
+print(f"\nexecuted_recourse_solves={len(calls)}")
+if not calls:
+    print("PROBE TAPPED NOTHING", file=sys.stderr)
+    sys.exit(2)

--- a/scratchpad/issue945/gbd_probe.py
+++ b/scratchpad/issue945/gbd_probe.py
@@ -1,0 +1,55 @@
+"""#945: why does GBD stop converging on test_gbd::test_linear_objective_nonlinear_constraint?
+
+`min 3y - x0 - x1  s.t.  x0^2 + x1^2 <= 8y`, x in [0,5]^2, y binary.
+y=1 -> x0=x1=2 -> objective -1.
+
+Runs the two arms interleaved and dumps the per-iteration LB/UB trace plus the
+subproblem point, so the divergence is attributed rather than guessed at.
+"""
+
+from __future__ import annotations
+
+import inspect
+import logging
+import sys
+
+import discopt.modeling as dm
+import discopt.solvers.nlp_pounce as NLPP
+from discopt.decomposition.benders import solve_benders
+from discopt.solvers import pounce_option_defaults
+
+assert "opts = pounce_option_defaults()" in inspect.getsource(NLPP.solve_nlp), "not the #945 tree"
+
+_PRE = {"print_level": 0}
+_REAL = pounce_option_defaults
+
+
+def build():
+    m = dm.Model("linnl")
+    y = m.binary("y")
+    x = m.continuous("x", shape=(2,), lb=0, ub=5)
+    m.first_stage(y)
+    m.minimize(3 * y - x[0] - x[1])
+    m.subject_to(x[0] * x[0] + x[1] * x[1] <= 8 * y)
+    return m
+
+
+logging.basicConfig(level=logging.INFO, format="    %(message)s", stream=sys.stdout)
+logging.getLogger("discopt.decomposition.benders.gbd").setLevel(logging.INFO)
+
+runs = 0
+for arm in ("pre", "post"):
+    NLPP.pounce_option_defaults = (lambda: dict(_PRE)) if arm == "pre" else _REAL
+    print(f"\n===== arm={arm} =====", flush=True)
+    r = solve_benders(build(), time_limit=30)
+    runs += 1
+    print(
+        f"  RESULT arm={arm} status={r.status} obj={r.objective!r} bound={r.bound!r} "
+        f"gap={r.gap!r}",
+        flush=True,
+    )
+NLPP.pounce_option_defaults = _REAL
+
+print(f"\nexecuted_runs={runs}")
+if runs == 0:
+    sys.exit(2)

--- a/scratchpad/issue945/nvs05_attribution.py
+++ b/scratchpad/issue945/nvs05_attribution.py
@@ -1,0 +1,104 @@
+"""#945: which of the two options costs nvs05 its incumbent?
+
+Replication found nvs05's incumbent reproducibly worse post-#945 (8.7320 ->
+12.5895, zero within-arm spread over 3 reps, both arms `feasible` at a 20 s
+budget). nvs05 goes through the nonconvex B&B path, whose primal heuristics call
+`solve_nlp` DIRECTLY — so the incumbent options (which only reach
+`_solve_continuous`, OA and GDPopt-LOA) cannot be responsible, and the suspect is
+`constr_viol_tol`, which IS a backend-wide default.
+
+Four arms, interleaved, so the answer is attributed rather than assumed:
+
+  main   print_level only                  (Ipopt: cvt 1e-4, brf 1e-8)
+  cvt    constr_viol_tol=1e-8 only         (brf still Ipopt's)
+  inc    incumbent options only            (cvt still Ipopt's)
+  new    what ships
+
+Kill criterion: if `cvt` matches `main`, constr_viol_tol is innocent and the
+suspicion is wrong.
+
+RESULT: it was guilty — `main` == `inc` at 8.7320 and `cvt` == `new` at 12.5895,
+zero within-arm spread. `nvs05_feasibility.py` then falsified the follow-up
+assumption that the cheaper incumbent was bought by a violated row: both points
+are genuinely feasible (worst row 1.8e-12 / 3.6e-12, box 0, integrality 0), so it
+was a real solution lost, not a false one rejected. #945 therefore does NOT route
+constr_viol_tol to the NLP backend. Re-running this probe against the shipped tree
+now shows all four arms identical at 8.7320 — the `cvt` arm has become a no-op
+there, which is the fix, not a broken probe.
+
+§6: prints an executed-run count and exits non-zero if it is zero.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import time
+
+os.environ.setdefault("JAX_PLATFORMS", "cpu")
+os.environ.setdefault("JAX_ENABLE_X64", "1")
+
+import discopt.solver as SOLVER  # noqa: E402
+import discopt.solvers.gdpopt_loa as LOA  # noqa: E402
+import discopt.solvers.nlp_pounce as NLPP  # noqa: E402
+import discopt.solvers.oa as OA  # noqa: E402
+from discopt.modeling import from_nl  # noqa: E402
+from discopt.solvers import pounce_option_defaults  # noqa: E402
+
+_REAL = pounce_option_defaults
+_REAL_INCUMBENT = SOLVER.pounce_incumbent_options
+_CONSUMERS = (SOLVER, OA, LOA)
+
+ARMS = {
+    "main": ({"print_level": 0}, {}),
+    "cvt": ({"print_level": 0, "constr_viol_tol": 1e-8}, {}),
+    "inc": ({"print_level": 0}, None),
+    "new": (None, None),
+}
+
+
+def set_arm(arm):
+    backend, incumbent = ARMS[arm]
+    NLPP.pounce_option_defaults = _REAL if backend is None else (lambda: dict(backend))
+    for mod in _CONSUMERS:
+        mod.pounce_incumbent_options = (
+            _REAL_INCUMBENT if incumbent is None else (lambda: dict(incumbent))
+        )
+        if hasattr(mod, "pounce_option_defaults"):
+            mod.pounce_option_defaults = _REAL if backend is None else (lambda: dict(backend))
+
+
+PATH = "python/tests/data/minlplib_nl/nvs05.nl"
+REPS = int(sys.argv[1]) if len(sys.argv) > 1 else 3
+TL = float(sys.argv[2]) if len(sys.argv) > 2 else 20.0
+
+rows = {a: [] for a in ARMS}
+runs = 0
+for _ in range(REPS):
+    for arm in ARMS:  # interleaved, not four sequential blocks (§9)
+        set_arm(arm)
+        t0 = time.perf_counter()
+        r = from_nl(PATH).solve(time_limit=TL)
+        rows[arm].append((r.status, r.objective, r.bound, r.node_count))
+        runs += 1
+        print(
+            f"  {arm:5s} status={r.status:11s} obj={r.objective!r} bound={r.bound!r} "
+            f"n={r.node_count} wall={time.perf_counter() - t0:.1f}s",
+            flush=True,
+        )
+set_arm("new")
+
+print(f"\n{'arm':6s} {'statuses':16s} {'objective range':>28s} {'bound range':>28s}")
+print("-" * 82)
+for arm, rs in rows.items():
+    st = ",".join(sorted({x[0] for x in rs}))
+    o = [x[1] for x in rs if x[1] is not None]
+    b = [x[2] for x in rs if x[2] is not None]
+    fo = f"{min(o):.10g}..{max(o):.10g}" if o else "—"
+    fb = f"{min(b):.10g}..{max(b):.10g}" if b else "—"
+    print(f"{arm:6s} {st:16s} {fo:>28s} {fb:>28s}")
+
+print(f"\nEXECUTED_RUNS={runs}  reps={REPS}  time_limit={TL}")
+if runs == 0:
+    print("PROBE RAN NOTHING", file=sys.stderr)
+    sys.exit(2)

--- a/scratchpad/issue945/nvs05_feasibility.py
+++ b/scratchpad/issue945/nvs05_feasibility.py
@@ -1,0 +1,109 @@
+"""#945: is nvs05's "better" pre-arm incumbent actually feasible?
+
+`nvs05_attribution.py` isolated the incumbent difference to `constr_viol_tol`:
+Ipopt's default 1e-4 (pre) gives objective 8.7320; discopt's 1e-6-consistent 1e-8
+(post) gives 12.5895. That reads as a 31% regression — but only if 8.7320 is a
+feasible point. Ipopt's 1e-4 is two orders LOOSER than discopt's own constraint
+tolerance, so the whole question is whether the cheaper objective was bought by
+violating a row, which is the defect class this issue is about.
+
+Checks the returned point against the model's own constraints and bounds, with
+`discopt.validation.feasibility` — discopt's arbiter, not a hand-rolled tolerance
+— and prints the worst violation per arm.
+
+Kill criterion: if BOTH incumbents pass the feasibility check, the pre arm's
+8.7320 is genuine and the post arm really does lose a better solution.
+
+§6: prints an executed-check count and exits non-zero if it is zero.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+import numpy as np
+
+os.environ.setdefault("JAX_PLATFORMS", "cpu")
+os.environ.setdefault("JAX_ENABLE_X64", "1")
+
+import discopt.solver as SOLVER  # noqa: E402
+import discopt.solvers.gdpopt_loa as LOA  # noqa: E402
+import discopt.solvers.nlp_pounce as NLPP  # noqa: E402
+import discopt.solvers.oa as OA  # noqa: E402
+from discopt._jax.nlp_evaluator import NLPEvaluator  # noqa: E402
+from discopt.modeling import from_nl  # noqa: E402
+from discopt.solvers import pounce_option_defaults  # noqa: E402
+
+_REAL = pounce_option_defaults
+_REAL_INCUMBENT = SOLVER.pounce_incumbent_options
+_CONSUMERS = (SOLVER, OA, LOA)
+ARMS = {"main": {"print_level": 0}, "new": None}
+
+
+def set_arm(arm):
+    b = ARMS[arm]
+    NLPP.pounce_option_defaults = _REAL if b is None else (lambda: dict(b))
+    for mod in _CONSUMERS:
+        mod.pounce_incumbent_options = _REAL_INCUMBENT if b is None else (lambda: {})
+        if hasattr(mod, "pounce_option_defaults"):
+            mod.pounce_option_defaults = _REAL if b is None else (lambda: dict(b))
+
+
+PATH = "python/tests/data/minlplib_nl/nvs05.nl"
+TL = float(sys.argv[1]) if len(sys.argv) > 1 else 20.0
+
+checks = 0
+for arm in ("main", "new"):
+    set_arm(arm)
+    model = from_nl(PATH)
+    res = model.solve(time_limit=TL)
+    if res.x is None:
+        print(f"{arm}: no incumbent")
+        continue
+
+    x = np.concatenate(
+        [np.asarray(res.x[v.name], dtype=np.float64).ravel() for v in model._variables]
+    )
+    ev = NLPEvaluator(model)
+    g = np.asarray(ev.evaluate_constraints(x), dtype=np.float64)
+    cl, cu = ev.constraint_bounds if hasattr(ev, "constraint_bounds") else (None, None)
+    if cl is None:
+        from discopt.solvers.nlp_ipopt import _infer_constraint_bounds
+
+        cl, cu = _infer_constraint_bounds(ev)
+    cl = np.asarray(cl, dtype=np.float64)
+    cu = np.asarray(cu, dtype=np.float64)
+    row_viol = float(np.max(np.maximum(cl - g, g - cu))) if g.size else 0.0
+
+    lb, ub = ev.variable_bounds
+    lb = np.asarray(lb, dtype=np.float64)
+    ub = np.asarray(ub, dtype=np.float64)
+    box_viol = float(np.max(np.maximum(lb - x, x - ub)))
+
+    # Integrality: nvs05 has general integers; a fractional "integer" is as much a
+    # false incumbent as a violated row.
+    from discopt.modeling.core import VarType
+
+    int_viol = 0.0
+    off = 0
+    for v in model._variables:
+        n = v.size
+        if v.var_type in (VarType.BINARY, VarType.INTEGER):
+            xi = x[off : off + n]
+            int_viol = max(int_viol, float(np.max(np.abs(xi - np.round(xi)))))
+        off += n
+
+    checks += 3
+    worst = max(row_viol, box_viol, int_viol)
+    print(
+        f"{arm:5s} obj={res.objective!r:22s} worst_row={row_viol:.3e} "
+        f"box={box_viol:.3e} integrality={int_viol:.3e}  "
+        f"{'INFEASIBLE past discopt 1e-6' if worst > 1e-6 else 'feasible'}"
+    )
+set_arm("new")
+
+print(f"\nexecuted_checks={checks}")
+if checks == 0:
+    print("PROBE CHECKED NOTHING", file=sys.stderr)
+    sys.exit(2)

--- a/scratchpad/issue945/panel_corpus.json
+++ b/scratchpad/issue945/panel_corpus.json
@@ -5,39 +5,39 @@
     "maximize": false,
     "status": "time_limit",
     "objective": null,
-    "bound": 20282.050738736412,
+    "bound": 20712.174649175664,
     "node_count": 7,
     "gap_certified": false,
-    "wall": 20.86161571499906
+    "wall": 20.15884420904331
    },
    "post": {
     "maximize": false,
     "status": "time_limit",
     "objective": null,
-    "bound": 20282.050738736412,
-    "node_count": 7,
+    "bound": 21475.147700500194,
+    "node_count": 15,
     "gap_certified": false,
-    "wall": 20.753485027998977
+    "wall": 20.18610162503319
    }
   },
   "alan": {
    "post": {
     "maximize": false,
     "status": "optimal",
-    "objective": 2.9249999983013426,
-    "bound": 2.9249999983013426,
+    "objective": 2.924999998301341,
+    "bound": 2.924999998301341,
     "node_count": 21,
     "gap_certified": true,
-    "wall": 0.06835342300109915
+    "wall": 0.023668167006690055
    },
    "pre": {
     "maximize": false,
     "status": "optimal",
-    "objective": 2.9249999983013426,
-    "bound": 2.9249999983013426,
+    "objective": 2.924999998301341,
+    "bound": 2.924999998301341,
     "node_count": 21,
     "gap_certified": true,
-    "wall": 0.058100629001273774
+    "wall": 0.019837208034005016
    }
   },
   "bchoco06": {
@@ -45,19 +45,19 @@
     "maximize": true,
     "status": "time_limit",
     "objective": null,
-    "bound": 0.9999887833703148,
-    "node_count": 7,
+    "bound": 1.000000000000125,
+    "node_count": 3,
     "gap_certified": false,
-    "wall": 21.156143522001003
+    "wall": 20.433878916024696
    },
    "post": {
     "maximize": true,
     "status": "time_limit",
     "objective": null,
-    "bound": 0.9999887833703148,
-    "node_count": 7,
+    "bound": 1.000000000000125,
+    "node_count": 3,
     "gap_certified": false,
-    "wall": 21.04775808500017
+    "wall": 24.98003937501926
    }
   },
   "bchoco07": {
@@ -65,19 +65,19 @@
     "maximize": true,
     "status": "time_limit",
     "objective": null,
-    "bound": 1.000000000000286,
-    "node_count": 7,
+    "bound": 0.9999909483405423,
+    "node_count": 15,
     "gap_certified": false,
-    "wall": 21.59716466200007
+    "wall": 20.30800508300308
    },
    "pre": {
     "maximize": true,
     "status": "time_limit",
     "objective": null,
-    "bound": 1.000000000000286,
-    "node_count": 7,
+    "bound": 0.9999909483405423,
+    "node_count": 15,
     "gap_certified": false,
-    "wall": 21.59804242899918
+    "wall": 20.306305708014406
    }
   },
   "bchoco08": {
@@ -85,19 +85,19 @@
     "maximize": true,
     "status": "time_limit",
     "objective": null,
-    "bound": 1.000000000002788,
+    "bound": 1.0000000000038425,
     "node_count": 7,
     "gap_certified": false,
-    "wall": 32.4324953689993
+    "wall": 20.872869958984666
    },
    "post": {
     "maximize": true,
     "status": "time_limit",
     "objective": null,
-    "bound": 1.000000000002788,
+    "bound": 1.0000000000038425,
     "node_count": 7,
     "gap_certified": false,
-    "wall": 27.874022898000476
+    "wall": 20.276276832970325
    }
   },
   "beuster": {
@@ -105,19 +105,19 @@
     "maximize": false,
     "status": "time_limit",
     "objective": null,
-    "bound": 6395.108328059316,
-    "node_count": 7,
+    "bound": 17801.54887879556,
+    "node_count": 31,
     "gap_certified": false,
-    "wall": 21.35085587499998
+    "wall": 20.599164749961346
    },
    "pre": {
     "maximize": false,
     "status": "time_limit",
     "objective": null,
-    "bound": 6395.108327034645,
-    "node_count": 7,
+    "bound": 17801.54887879556,
+    "node_count": 31,
     "gap_certified": false,
-    "wall": 21.02280981700096
+    "wall": 20.46201924997149
    }
   },
   "casctanks": {
@@ -125,19 +125,19 @@
     "maximize": false,
     "status": "time_limit",
     "objective": null,
-    "bound": -90.17862329759835,
-    "node_count": 3,
+    "bound": 2.9097722176628698,
+    "node_count": 31,
     "gap_certified": false,
-    "wall": 21.07955941900036
+    "wall": 20.459041249996517
    },
    "post": {
     "maximize": false,
     "status": "time_limit",
     "objective": null,
-    "bound": -90.17862329759835,
-    "node_count": 3,
+    "bound": 2.9097722176628698,
+    "node_count": 15,
     "gap_certified": false,
-    "wall": 21.022934431000976
+    "wall": 20.356712125008926
    }
   },
   "chance": {
@@ -148,7 +148,7 @@
     "bound": 29.894378166613386,
     "node_count": 0,
     "gap_certified": true,
-    "wall": 0.1880844879997312
+    "wall": 0.10948704101610929
    },
    "pre": {
     "maximize": false,
@@ -157,7 +157,7 @@
     "bound": 29.894378154271102,
     "node_count": 0,
     "gap_certified": true,
-    "wall": 0.1705907940013276
+    "wall": 0.09824083303101361
    }
   },
   "clay0303hfsg": {
@@ -166,18 +166,18 @@
     "status": "time_limit",
     "objective": null,
     "bound": null,
-    "node_count": 95,
+    "node_count": 319,
     "gap_certified": false,
-    "wall": 20.64232235199961
+    "wall": 20.398560917004943
    },
    "post": {
     "maximize": false,
     "status": "time_limit",
     "objective": null,
     "bound": null,
-    "node_count": 95,
+    "node_count": 287,
     "gap_certified": false,
-    "wall": 21.364085389999673
+    "wall": 20.352453332976438
    }
   },
   "contvar": {
@@ -185,19 +185,19 @@
     "maximize": false,
     "status": "time_limit",
     "objective": null,
-    "bound": 183632.02121055726,
-    "node_count": 3,
+    "bound": 183632.7659824633,
+    "node_count": 7,
     "gap_certified": false,
-    "wall": 21.968097285000113
+    "wall": 27.284093625028618
    },
    "pre": {
     "maximize": false,
     "status": "time_limit",
     "objective": null,
-    "bound": 183632.02121055726,
-    "node_count": 3,
+    "bound": 183632.7659824633,
+    "node_count": 7,
     "gap_certified": false,
-    "wall": 21.651497513999857
+    "wall": 24.344116166990716
    }
   },
   "cvxnonsep_nsig30": {
@@ -208,27 +208,27 @@
     "bound": 130.61841392487688,
     "node_count": 171,
     "gap_certified": true,
-    "wall": 4.114179767000678
+    "wall": 1.320952041016426
    },
    "post": {
     "maximize": false,
     "status": "optimal",
-    "objective": 130.62871116925294,
+    "objective": 130.62871268683435,
     "bound": 130.61841392487688,
     "node_count": 171,
     "gap_certified": true,
-    "wall": 4.689829281000129
+    "wall": 1.27652783296071
    }
   },
   "cvxnonsep_psig30": {
    "post": {
     "maximize": false,
     "status": "optimal",
-    "objective": 78.99885435294289,
+    "objective": 78.99885436526898,
     "bound": 78.99701703820377,
     "node_count": 89,
     "gap_certified": true,
-    "wall": 1.752459473998897
+    "wall": 0.9006080830004066
    },
    "pre": {
     "maximize": false,
@@ -237,38 +237,38 @@
     "bound": 78.99701703820377,
     "node_count": 89,
     "gap_certified": true,
-    "wall": 1.6242167050004355
+    "wall": 0.5196317910449579
    }
   },
   "cvxnonsep_psig40r": {
    "pre": {
     "maximize": false,
     "status": "optimal",
-    "objective": 86.54527995164959,
+    "objective": 86.54527995164958,
     "bound": 86.53873600363832,
-    "node_count": 103,
+    "node_count": 95,
     "gap_certified": true,
-    "wall": 6.555701078999846
+    "wall": 2.0506843749899417
    },
    "post": {
     "maximize": false,
     "status": "optimal",
-    "objective": 86.54527995164959,
-    "bound": 86.53873600363832,
-    "node_count": 103,
+    "objective": 86.54528288283353,
+    "bound": 86.5387360036383,
+    "node_count": 95,
     "gap_certified": true,
-    "wall": 6.816428178999558
+    "wall": 2.091534541978035
    }
   },
   "dispatch": {
    "post": {
     "maximize": false,
     "status": "optimal",
-    "objective": 3155.2879266857854,
-    "bound": 3155.2878615366776,
+    "objective": 3155.2879268631687,
+    "bound": 3155.287861536673,
     "node_count": 23,
     "gap_certified": true,
-    "wall": 0.4005815389991767
+    "wall": 0.46529037499567494
    },
    "pre": {
     "maximize": false,
@@ -277,7 +277,7 @@
     "bound": 3155.2878615366776,
     "node_count": 23,
     "gap_certified": true,
-    "wall": 0.3739400349986681
+    "wall": 0.15692524996120483
    }
   },
   "ex1221": {
@@ -288,7 +288,7 @@
     "bound": 7.667180068813077,
     "node_count": 5,
     "gap_certified": true,
-    "wall": 0.8064225850012008
+    "wall": 0.38447033398551866
    },
    "post": {
     "maximize": false,
@@ -297,18 +297,18 @@
     "bound": 7.667180068813077,
     "node_count": 5,
     "gap_certified": true,
-    "wall": 0.7007486250004149
+    "wall": 0.2866894580074586
    }
   },
   "ex1222": {
    "post": {
     "maximize": false,
     "status": "optimal",
-    "objective": 1.0765430833322625,
-    "bound": 1.0765430463031964,
-    "node_count": 1,
+    "objective": 1.0765430833322618,
+    "bound": 1.0765430833322571,
+    "node_count": 3,
     "gap_certified": true,
-    "wall": 0.5019422189998295
+    "wall": 0.13064320798730478
    },
    "pre": {
     "maximize": false,
@@ -317,7 +317,7 @@
     "bound": 1.0765430463031964,
     "node_count": 1,
     "gap_certified": true,
-    "wall": 0.26799431200015533
+    "wall": 0.10628412500955164
    }
   },
   "ex1224": {
@@ -325,30 +325,30 @@
     "maximize": false,
     "status": "optimal",
     "objective": -0.9434704942820806,
-    "bound": -0.9434705000000166,
+    "bound": -0.9434705000000164,
     "node_count": 5,
     "gap_certified": true,
-    "wall": 2.771524681000301
+    "wall": 0.9285265419748612
    },
    "post": {
     "maximize": false,
     "status": "optimal",
-    "objective": -0.9434704942820806,
-    "bound": -0.9434705000000166,
+    "objective": -0.9434704993121346,
+    "bound": -0.9434705000000165,
     "node_count": 5,
     "gap_certified": true,
-    "wall": 2.5357477289999224
+    "wall": 0.8769470000406727
    }
   },
   "ex1225": {
    "post": {
     "maximize": false,
     "status": "optimal",
-    "objective": 30.999999913557566,
-    "bound": 30.999999913557566,
+    "objective": 31.000000000008843,
+    "bound": 30.999999999999844,
     "node_count": 5,
     "gap_certified": true,
-    "wall": 2.4943522610010405
+    "wall": 0.7443189580226317
    },
    "pre": {
     "maximize": false,
@@ -357,7 +357,7 @@
     "bound": 30.999999913557566,
     "node_count": 5,
     "gap_certified": true,
-    "wall": 3.0981000720003067
+    "wall": 0.7705545829958282
    }
   },
   "ex1226": {
@@ -368,27 +368,27 @@
     "bound": -17.000000003887443,
     "node_count": 3,
     "gap_certified": true,
-    "wall": 0.9011488069991174
+    "wall": 0.24128625000594184
    },
    "post": {
     "maximize": false,
     "status": "optimal",
-    "objective": -17.000000003887443,
-    "bound": -17.000000003887443,
-    "node_count": 3,
+    "objective": -17.000000000000007,
+    "bound": -17.00000000000013,
+    "node_count": 5,
     "gap_certified": true,
-    "wall": 0.8077394409992849
+    "wall": 0.3864867090014741
    }
   },
   "ex14_1_9": {
    "post": {
     "maximize": false,
     "status": "optimal",
-    "objective": -1.9775220540513224e-16,
-    "bound": -1.9775220540513224e-16,
-    "node_count": 3,
+    "objective": 3.7948647471750336e-09,
+    "bound": 0.0,
+    "node_count": 5,
     "gap_certified": true,
-    "wall": 0.34157072699963464
+    "wall": 0.08824958396144211
    },
    "pre": {
     "maximize": false,
@@ -397,7 +397,7 @@
     "bound": -1.9775220540513224e-16,
     "node_count": 3,
     "gap_certified": true,
-    "wall": 0.32864354199955415
+    "wall": 0.10098937503062189
    }
   },
   "fac2": {
@@ -405,30 +405,30 @@
     "maximize": false,
     "status": "optimal",
     "objective": 331837497.8394821,
-    "bound": 331837497.54563797,
+    "bound": 331837497.5456339,
     "node_count": 41,
     "gap_certified": true,
-    "wall": 9.197090076999302
+    "wall": 2.2586874589906074
    },
    "post": {
     "maximize": false,
     "status": "optimal",
-    "objective": 331837497.8394821,
-    "bound": 331837497.54563797,
+    "objective": 331837498.17693394,
+    "bound": 331837497.5456339,
     "node_count": 41,
     "gap_certified": true,
-    "wall": 8.771808849000081
+    "wall": 1.8731694589951076
    }
   },
   "flay02m": {
    "post": {
     "maximize": false,
     "status": "optimal",
-    "objective": 37.94733186383461,
-    "bound": 37.947331804569515,
+    "objective": 37.94733200383462,
+    "bound": 37.94733186379298,
     "node_count": 7,
     "gap_certified": true,
-    "wall": 0.4826830580004753
+    "wall": 0.22171779198106378
    },
    "pre": {
     "maximize": false,
@@ -437,7 +437,7 @@
     "bound": 37.947331804569515,
     "node_count": 7,
     "gap_certified": true,
-    "wall": 0.4870537700007844
+    "wall": 0.13512691599316895
    }
   },
   "flay03m": {
@@ -448,36 +448,36 @@
     "bound": 48.98979470823052,
     "node_count": 111,
     "gap_certified": true,
-    "wall": 7.334201186999053
+    "wall": 1.8101904999930412
    },
    "post": {
     "maximize": false,
     "status": "optimal",
-    "objective": 48.98979479383567,
-    "bound": 48.98979470823052,
+    "objective": 48.9897949738358,
+    "bound": 48.98979479323287,
     "node_count": 111,
     "gap_certified": true,
-    "wall": 7.1553186740002275
+    "wall": 1.6741547919809818
    }
   },
   "gbd": {
    "post": {
     "maximize": false,
     "status": "optimal",
-    "objective": 2.1999999825308127,
-    "bound": 2.1999999825308127,
+    "objective": 2.199999982504936,
+    "bound": 2.199999982504936,
     "node_count": 3,
     "gap_certified": true,
-    "wall": 0.023471718001019326
+    "wall": 0.007882375037297606
    },
    "pre": {
     "maximize": false,
     "status": "optimal",
-    "objective": 2.1999999825308127,
-    "bound": 2.1999999825308127,
+    "objective": 2.199999982504936,
+    "bound": 2.199999982504936,
     "node_count": 3,
     "gap_certified": true,
-    "wall": 0.021934147000138182
+    "wall": 0.007483166002202779
    }
   },
   "gkocis": {
@@ -488,16 +488,16 @@
     "bound": -1.9230988280923489,
     "node_count": 5,
     "gap_certified": true,
-    "wall": 1.3678106690003915
+    "wall": 0.36128087498946115
    },
    "post": {
     "maximize": false,
     "status": "optimal",
-    "objective": -1.9230987798770212,
-    "bound": -1.9230988280923489,
-    "node_count": 5,
+    "objective": -1.9230986924056728,
+    "bound": -1.9230987422706283,
+    "node_count": 7,
     "gap_certified": true,
-    "wall": 1.2579532119998476
+    "wall": 0.4564329590066336
    }
   },
   "hda": {
@@ -505,19 +505,19 @@
     "maximize": false,
     "status": "time_limit",
     "objective": null,
-    "bound": -64473.44240243703,
-    "node_count": 1,
+    "bound": -64473.44240160173,
+    "node_count": 3,
     "gap_certified": false,
-    "wall": 21.057206409999708
+    "wall": 20.51703358296072
    },
    "pre": {
     "maximize": false,
     "status": "time_limit",
     "objective": null,
-    "bound": -64473.44240243703,
-    "node_count": 1,
+    "bound": -64473.44240160173,
+    "node_count": 3,
     "gap_certified": false,
-    "wall": 21.028191478000736
+    "wall": 20.478384374990128
    }
   },
   "heatexch_gen1": {
@@ -528,7 +528,7 @@
     "bound": 38183.5317460179,
     "node_count": 3,
     "gap_certified": false,
-    "wall": 21.632646988000488
+    "wall": 22.378892250009812
    },
    "post": {
     "maximize": false,
@@ -537,18 +537,18 @@
     "bound": 38183.5317460179,
     "node_count": 3,
     "gap_certified": false,
-    "wall": 22.771728911000537
+    "wall": 20.587661208002828
    }
   },
   "heatexch_gen2": {
    "post": {
     "maximize": false,
-    "status": "time_limit",
-    "objective": null,
+    "status": "feasible",
+    "objective": 824551.3269251497,
     "bound": 555767.7902857271,
-    "node_count": 7,
+    "node_count": 3,
     "gap_certified": false,
-    "wall": 20.513917931000833
+    "wall": 20.400821332994383
    },
    "pre": {
     "maximize": false,
@@ -557,7 +557,7 @@
     "bound": 555767.7902857271,
     "node_count": 3,
     "gap_certified": false,
-    "wall": 22.88522019299853
+    "wall": 20.559940458042547
    }
   },
   "heatexch_gen3": {
@@ -568,7 +568,7 @@
     "bound": null,
     "node_count": 3,
     "gap_certified": false,
-    "wall": 31.722223757000393
+    "wall": 28.76060416601831
    },
    "post": {
     "maximize": false,
@@ -577,18 +577,18 @@
     "bound": null,
     "node_count": 3,
     "gap_certified": false,
-    "wall": 30.268358085000727
+    "wall": 29.0618288340047
    }
   },
   "m3": {
    "post": {
     "maximize": false,
     "status": "optimal",
-    "objective": 37.79999966997884,
-    "bound": 37.79999951039201,
-    "node_count": 47,
+    "objective": 37.800000263754725,
+    "bound": 37.7999996700244,
+    "node_count": 53,
     "gap_certified": true,
-    "wall": 5.38149255099961
+    "wall": 1.4006437500356697
    },
    "pre": {
     "maximize": false,
@@ -597,7 +597,7 @@
     "bound": 37.79999951039201,
     "node_count": 47,
     "gap_certified": true,
-    "wall": 4.395422977000635
+    "wall": 1.0566823749686591
    }
   },
   "nvs01": {
@@ -608,7 +608,7 @@
     "bound": 12.46966882156821,
     "node_count": 3,
     "gap_certified": true,
-    "wall": 1.5421696320008778
+    "wall": 0.45666104200063273
    },
    "post": {
     "maximize": false,
@@ -617,7 +617,7 @@
     "bound": 12.46966882156821,
     "node_count": 3,
     "gap_certified": true,
-    "wall": 1.5508252489998995
+    "wall": 0.40370274998713285
    }
   },
   "nvs02": {
@@ -628,7 +628,7 @@
     "bound": 5.96418452307,
     "node_count": 345,
     "gap_certified": true,
-    "wall": 0.43936890399891126
+    "wall": 0.21183724998263642
    },
    "pre": {
     "maximize": false,
@@ -637,7 +637,7 @@
     "bound": 5.96418452307,
     "node_count": 345,
     "gap_certified": true,
-    "wall": 0.40878159500061884
+    "wall": 0.13563837500987574
    }
   },
   "nvs03": {
@@ -648,16 +648,16 @@
     "bound": 15.99999972676511,
     "node_count": 5,
     "gap_certified": true,
-    "wall": 0.1984112530008133
+    "wall": 0.0671741669648327
    },
    "post": {
     "maximize": false,
     "status": "optimal",
     "objective": 16.0,
-    "bound": 15.99999972676511,
-    "node_count": 5,
+    "bound": 16.0,
+    "node_count": 3,
     "gap_certified": true,
-    "wall": 0.19523057600054017
+    "wall": 0.0588020840077661
    }
   },
   "nvs04": {
@@ -668,7 +668,7 @@
     "bound": 0.7199999999999773,
     "node_count": 5,
     "gap_certified": true,
-    "wall": 0.36598496599981445
+    "wall": 0.10041808302048594
    },
    "pre": {
     "maximize": false,
@@ -677,7 +677,7 @@
     "bound": 0.7199999999999773,
     "node_count": 5,
     "gap_certified": true,
-    "wall": 0.30987134499991953
+    "wall": 0.08595849998528138
    }
   },
   "nvs05": {
@@ -685,19 +685,19 @@
     "maximize": false,
     "status": "feasible",
     "objective": 8.731956986640078,
-    "bound": 3.5424692441047068,
-    "node_count": 41,
+    "bound": 3.8053367777828426,
+    "node_count": 131,
     "gap_certified": false,
-    "wall": 20.182268660999398
+    "wall": 20.04697958298493
    },
    "post": {
     "maximize": false,
     "status": "feasible",
-    "objective": 8.731956986640078,
-    "bound": 3.5424692441047068,
-    "node_count": 41,
+    "objective": 8.731956986640789,
+    "bound": 4.099237735891656,
+    "node_count": 155,
     "gap_certified": false,
-    "wall": 20.12048007500016
+    "wall": 20.04612954199547
    }
   },
   "nvs06": {
@@ -708,7 +708,7 @@
     "bound": 1.7703124999999627,
     "node_count": 5,
     "gap_certified": true,
-    "wall": 1.2201087190005637
+    "wall": 0.34974024997791275
    },
    "pre": {
     "maximize": false,
@@ -717,7 +717,7 @@
     "bound": 1.7703124999999627,
     "node_count": 5,
     "gap_certified": true,
-    "wall": 1.502843292999387
+    "wall": 0.314218332991004
    }
   },
   "nvs07": {
@@ -728,7 +728,7 @@
     "bound": 4.0,
     "node_count": 5,
     "gap_certified": true,
-    "wall": 0.06894203599949833
+    "wall": 0.02610087499488145
    },
    "post": {
     "maximize": false,
@@ -737,18 +737,18 @@
     "bound": 4.0,
     "node_count": 5,
     "gap_certified": true,
-    "wall": 0.0659772859999066
+    "wall": 0.026362750038970262
    }
   },
   "nvs08": {
    "post": {
     "maximize": false,
     "status": "optimal",
-    "objective": 23.449727347139827,
-    "bound": 23.44972734516655,
-    "node_count": 3,
+    "objective": 23.449727347978744,
+    "bound": 23.449727347447233,
+    "node_count": 5,
     "gap_certified": true,
-    "wall": 1.4144361870003195
+    "wall": 0.3815501659992151
    },
    "pre": {
     "maximize": false,
@@ -757,7 +757,7 @@
     "bound": 23.44972734516655,
     "node_count": 3,
     "gap_certified": true,
-    "wall": 1.3376553260004584
+    "wall": 0.3503852079738863
    }
   },
   "nvs09": {
@@ -768,16 +768,16 @@
     "bound": -43.13433691803662,
     "node_count": 5,
     "gap_certified": true,
-    "wall": 4.672621407999031
+    "wall": 1.3995527499937452
    },
    "post": {
     "maximize": false,
     "status": "optimal",
-    "objective": -43.134336918035295,
+    "objective": -43.13433691803531,
     "bound": -43.13433691803662,
     "node_count": 5,
     "gap_certified": true,
-    "wall": 4.754440293998414
+    "wall": 1.2800637090113014
    }
   },
   "nvs10": {
@@ -788,7 +788,7 @@
     "bound": -310.7999999999999,
     "node_count": 5,
     "gap_certified": true,
-    "wall": 0.1850798819996271
+    "wall": 0.05135404196335003
    },
    "pre": {
     "maximize": false,
@@ -797,7 +797,7 @@
     "bound": -310.7999999999999,
     "node_count": 5,
     "gap_certified": true,
-    "wall": 0.13099405899993144
+    "wall": 0.05075645900797099
    }
   },
   "nvs11": {
@@ -808,7 +808,7 @@
     "bound": -431.0000000000085,
     "node_count": 55,
     "gap_certified": true,
-    "wall": 0.753779074000704
+    "wall": 0.2248889590264298
    },
    "post": {
     "maximize": false,
@@ -817,7 +817,7 @@
     "bound": -431.0000000000085,
     "node_count": 55,
     "gap_certified": true,
-    "wall": 0.8486461190004775
+    "wall": 0.21808949997648597
    }
   },
   "nvs12": {
@@ -828,7 +828,7 @@
     "bound": -481.20000000001,
     "node_count": 231,
     "gap_certified": true,
-    "wall": 2.704115794000245
+    "wall": 0.8515402500052005
    },
    "pre": {
     "maximize": false,
@@ -837,7 +837,7 @@
     "bound": -481.20000000001,
     "node_count": 231,
     "gap_certified": true,
-    "wall": 2.33796169299967
+    "wall": 0.6787049589911476
    }
   },
   "nvs13": {
@@ -848,7 +848,7 @@
     "bound": -585.2,
     "node_count": 637,
     "gap_certified": true,
-    "wall": 1.4629285850005544
+    "wall": 0.5278392499894835
    },
    "post": {
     "maximize": false,
@@ -857,7 +857,7 @@
     "bound": -585.2,
     "node_count": 637,
     "gap_certified": true,
-    "wall": 1.4282700680014386
+    "wall": 0.6015272089862265
    }
   },
   "nvs14": {
@@ -868,7 +868,7 @@
     "bound": -40358.154769299996,
     "node_count": 129,
     "gap_certified": true,
-    "wall": 0.865303655000389
+    "wall": 0.3201721250079572
    },
    "pre": {
     "maximize": false,
@@ -877,7 +877,7 @@
     "bound": -40358.154769299996,
     "node_count": 129,
     "gap_certified": true,
-    "wall": 0.8515085239996552
+    "wall": 0.31205354194389656
    }
   },
   "nvs15": {
@@ -888,7 +888,7 @@
     "bound": 1.0,
     "node_count": 7,
     "gap_certified": true,
-    "wall": 0.08334700300110853
+    "wall": 0.031345500028692186
    },
    "post": {
     "maximize": false,
@@ -897,18 +897,18 @@
     "bound": 1.0,
     "node_count": 7,
     "gap_certified": true,
-    "wall": 0.08156909700119286
+    "wall": 0.030564250017050654
    }
   },
   "nvs21": {
    "post": {
     "maximize": false,
     "status": "optimal",
-    "objective": -5.684782628025259,
-    "bound": -5.684782628025259,
-    "node_count": 3,
+    "objective": -5.684782416744887,
+    "bound": -5.684782500000104,
+    "node_count": 9,
     "gap_certified": true,
-    "wall": 7.086681823000617
+    "wall": 0.6373233330086805
    },
    "pre": {
     "maximize": false,
@@ -917,38 +917,38 @@
     "bound": -5.684782628025259,
     "node_count": 3,
     "gap_certified": true,
-    "wall": 6.684371395000198
+    "wall": 0.5104961250326596
    }
   },
   "oaer": {
    "pre": {
     "maximize": false,
     "status": "optimal",
-    "objective": -1.923098499884843,
+    "objective": -1.9230984998848466,
     "bound": -1.923098601139822,
     "node_count": 3,
     "gap_certified": true,
-    "wall": 1.0001207739987876
+    "wall": 0.306818499986548
    },
    "post": {
     "maximize": false,
     "status": "optimal",
-    "objective": -1.923098499884843,
-    "bound": -1.923098601139822,
-    "node_count": 3,
+    "objective": -1.923098510129794,
+    "bound": -1.9230985229112711,
+    "node_count": 5,
     "gap_certified": true,
-    "wall": 0.9625405360002333
+    "wall": 0.38240770797710866
    }
   },
   "st_e11": {
    "post": {
     "maximize": false,
     "status": "optimal",
-    "objective": 189.31162974131917,
-    "bound": 189.31162968661766,
-    "node_count": 27,
+    "objective": 189.31162970097128,
+    "bound": 189.311629686619,
+    "node_count": 5,
     "gap_certified": true,
-    "wall": 3.257049719999486
+    "wall": 0.7252116670133546
    },
    "pre": {
     "maximize": false,
@@ -957,7 +957,7 @@
     "bound": 189.31162968661766,
     "node_count": 27,
     "gap_certified": true,
-    "wall": 3.5043417340002634
+    "wall": 0.8819153750082478
    }
   },
   "st_e13": {
@@ -968,36 +968,36 @@
     "bound": 1.9999999825187946,
     "node_count": 1,
     "gap_certified": true,
-    "wall": 0.13843990199893597
+    "wall": 0.0463331249775365
    },
    "post": {
     "maximize": false,
     "status": "optimal",
-    "objective": 1.9999999825187946,
-    "bound": 1.9999999825187946,
+    "objective": 2.000000002518795,
+    "bound": 2.0,
     "node_count": 1,
     "gap_certified": true,
-    "wall": 0.1294228610004211
+    "wall": 0.04156287497607991
    }
   },
   "st_e29": {
    "post": {
     "maximize": false,
     "status": "optimal",
-    "objective": -0.9434704942820806,
-    "bound": -0.9434705000000166,
+    "objective": -0.9434704993121346,
+    "bound": -0.9434705000000165,
     "node_count": 5,
     "gap_certified": true,
-    "wall": 2.970016630999453
+    "wall": 0.7877465829951689
    },
    "pre": {
     "maximize": false,
     "status": "optimal",
     "objective": -0.9434704942820806,
-    "bound": -0.9434705000000166,
+    "bound": -0.9434705000000164,
     "node_count": 5,
     "gap_certified": true,
-    "wall": 2.7799038590001146
+    "wall": 0.7452050420106389
    }
   },
   "st_e36": {
@@ -1005,30 +1005,30 @@
     "maximize": false,
     "status": "optimal",
     "objective": -245.99999999999997,
-    "bound": -246.00000000170422,
+    "bound": -246.00000000170442,
     "node_count": 85,
     "gap_certified": true,
-    "wall": 9.839661432999492
+    "wall": 3.3920822920044884
    },
    "post": {
     "maximize": false,
     "status": "optimal",
     "objective": -245.99999999999997,
-    "bound": -246.00000000170422,
+    "bound": -246.00000000170442,
     "node_count": 85,
     "gap_certified": true,
-    "wall": 9.748952232999727
+    "wall": 3.2264332919730805
    }
   },
   "st_e38": {
    "post": {
     "maximize": false,
     "status": "optimal",
-    "objective": 7197.727116826533,
-    "bound": 7197.727116826533,
+    "objective": 7197.727148526159,
+    "bound": 7197.727148526159,
     "node_count": 3,
     "gap_certified": true,
-    "wall": 0.7476165880016197
+    "wall": 0.24708916700910777
    },
    "pre": {
     "maximize": false,
@@ -1037,7 +1037,7 @@
     "bound": 7197.727116826533,
     "node_count": 3,
     "gap_certified": true,
-    "wall": 0.7652405289991293
+    "wall": 0.22449654201045632
    }
   },
   "st_miqp1": {
@@ -1048,7 +1048,7 @@
     "bound": 280.9999999906497,
     "node_count": 15,
     "gap_certified": true,
-    "wall": 0.021535358999244636
+    "wall": 0.007288207998499274
    },
    "post": {
     "maximize": false,
@@ -1057,7 +1057,7 @@
     "bound": 280.9999999906497,
     "node_count": 15,
     "gap_certified": true,
-    "wall": 0.02053010700001323
+    "wall": 0.007253458024933934
    }
   },
   "st_miqp2": {
@@ -1068,7 +1068,7 @@
     "bound": 2.0,
     "node_count": 9,
     "gap_certified": true,
-    "wall": 0.02448736099904636
+    "wall": 0.009034875023644418
    },
    "pre": {
     "maximize": false,
@@ -1077,7 +1077,7 @@
     "bound": 2.0,
     "node_count": 9,
     "gap_certified": true,
-    "wall": 0.025398279000000912
+    "wall": 0.009177583968266845
    }
   },
   "st_miqp3": {
@@ -1088,7 +1088,7 @@
     "bound": -6.0,
     "node_count": 1,
     "gap_certified": true,
-    "wall": 0.008985454000139725
+    "wall": 0.003653916995972395
    },
    "post": {
     "maximize": false,
@@ -1097,47 +1097,47 @@
     "bound": -6.0,
     "node_count": 1,
     "gap_certified": true,
-    "wall": 0.010443168999699992
+    "wall": 0.0037784589803777635
    }
   },
   "st_miqp4": {
    "post": {
     "maximize": false,
     "status": "optimal",
-    "objective": -4574.0000024840665,
-    "bound": -4574.0000024840665,
+    "objective": -4574.000002484067,
+    "bound": -4574.000002484067,
     "node_count": 3,
     "gap_certified": true,
-    "wall": 0.032428487998913624
+    "wall": 0.009518625040072948
    },
    "pre": {
     "maximize": false,
     "status": "optimal",
-    "objective": -4574.0000024840665,
-    "bound": -4574.0000024840665,
+    "objective": -4574.000002484067,
+    "bound": -4574.000002484067,
     "node_count": 3,
     "gap_certified": true,
-    "wall": 0.030268503998740925
+    "wall": 0.009589541994500905
    }
   },
   "st_miqp5": {
    "pre": {
     "maximize": false,
     "status": "optimal",
-    "objective": -333.88889024868075,
-    "bound": -333.88889024868075,
+    "objective": -333.8888902491578,
+    "bound": -333.8888902491578,
     "node_count": 1,
     "gap_certified": true,
-    "wall": 0.03785257100025774
+    "wall": 0.011504416994284838
    },
    "post": {
     "maximize": false,
     "status": "optimal",
-    "objective": -333.88889024868075,
-    "bound": -333.88889024868075,
+    "objective": -333.8888902491578,
+    "bound": -333.8888902491578,
     "node_count": 1,
     "gap_certified": true,
-    "wall": 0.03559647300062352
+    "wall": 0.011059750046115369
    }
   },
   "st_test1": {
@@ -1148,7 +1148,7 @@
     "bound": -1.6495994490692313e-08,
     "node_count": 15,
     "gap_certified": true,
-    "wall": 0.04169112199997471
+    "wall": 0.012947167037054896
    },
    "pre": {
     "maximize": false,
@@ -1157,7 +1157,7 @@
     "bound": -1.6495994490692313e-08,
     "node_count": 15,
     "gap_certified": true,
-    "wall": 0.03655282199906651
+    "wall": 0.01251724996836856
    }
   },
   "st_testgr3": {
@@ -1168,7 +1168,7 @@
     "bound": -20.59070709795548,
     "node_count": 549,
     "gap_certified": true,
-    "wall": 0.3153328190001048
+    "wall": 0.07895283302059397
    },
    "post": {
     "maximize": false,
@@ -1177,138 +1177,138 @@
     "bound": -20.59070709795548,
     "node_count": 549,
     "gap_certified": true,
-    "wall": 0.3286758020003617
+    "wall": 0.07581474998733029
    }
   },
   "syn05hfsg": {
    "post": {
     "maximize": true,
-    "status": "feasible",
-    "objective": 837.732412391107,
-    "bound": 840.4893941019075,
-    "node_count": 167,
-    "gap_certified": false,
-    "wall": 20.28740770799959
+    "status": "optimal",
+    "objective": 837.7323012718434,
+    "bound": 837.7324008980034,
+    "node_count": 285,
+    "gap_certified": true,
+    "wall": 5.584002582996618
    },
    "pre": {
     "maximize": true,
-    "status": "feasible",
+    "status": "optimal",
     "objective": 837.732412391107,
-    "bound": 838.3878622240098,
-    "node_count": 179,
-    "gap_certified": false,
-    "wall": 20.10448203299893
+    "bound": 837.732412391107,
+    "node_count": 185,
+    "gap_certified": true,
+    "wall": 5.3335105840233155
    }
   },
   "tanksize": {
    "pre": {
     "maximize": false,
-    "status": "time_limit",
-    "objective": 1.268643752557795,
-    "bound": 1.2632541695785504,
-    "node_count": 4306,
+    "status": "optimal",
+    "objective": 1.2686437525577947,
+    "bound": 1.2685440897016123,
+    "node_count": 11451,
     "gap_certified": true,
-    "wall": 20.107069439000043
+    "wall": 17.197832499979995
    },
    "post": {
     "maximize": false,
-    "status": "time_limit",
-    "objective": 1.268643752557795,
-    "bound": 1.2621867811714296,
-    "node_count": 3784,
+    "status": "optimal",
+    "objective": 1.2686437598530085,
+    "bound": 1.2685440895965434,
+    "node_count": 10861,
     "gap_certified": true,
-    "wall": 20.101737228000275
+    "wall": 15.87849150004331
    }
   },
   "tls2": {
    "post": {
     "maximize": false,
-    "status": "feasible",
-    "objective": 5.299999922109238,
-    "bound": 3.1706801036010077,
-    "node_count": 349,
-    "gap_certified": false,
-    "wall": 20.496603259998665
+    "status": "optimal",
+    "objective": 5.2999999999875085,
+    "bound": 5.3,
+    "node_count": 353,
+    "gap_certified": true,
+    "wall": 13.18257750000339
    },
    "pre": {
     "maximize": false,
-    "status": "feasible",
+    "status": "optimal",
     "objective": 5.299999922109238,
-    "bound": 3.2532681850660596,
+    "bound": 5.3,
     "node_count": 353,
-    "gap_certified": false,
-    "wall": 20.344976995000252
+    "gap_certified": true,
+    "wall": 13.021860250039026
    }
   },
   "tspn05": {
    "pre": {
     "maximize": false,
-    "status": "feasible",
-    "objective": 191.2552076848774,
-    "bound": 179.44337578420988,
-    "node_count": 49,
-    "gap_certified": false,
-    "wall": 20.147514609998325
+    "status": "optimal",
+    "objective": 191.25520768494238,
+    "bound": 191.25510622528546,
+    "node_count": 51,
+    "gap_certified": true,
+    "wall": 9.492925582977477
    },
    "post": {
     "maximize": false,
-    "status": "feasible",
-    "objective": 191.2552076848774,
-    "bound": 179.44337578420988,
-    "node_count": 49,
-    "gap_certified": false,
-    "wall": 20.118836876001296
+    "status": "optimal",
+    "objective": 191.25520784466957,
+    "bound": 191.25510622528546,
+    "node_count": 51,
+    "gap_certified": true,
+    "wall": 9.32075629197061
    }
   },
   "tspn08": {
    "post": {
     "maximize": false,
     "status": "feasible",
-    "objective": 290.56685374735093,
+    "objective": 290.5668539675055,
     "bound": null,
     "node_count": 1,
     "gap_certified": false,
-    "wall": 15.3715363350002
+    "wall": 5.83552508399589
    },
    "pre": {
     "maximize": false,
     "status": "feasible",
-    "objective": 290.56685374735093,
+    "objective": 290.56685374735457,
     "bound": null,
     "node_count": 1,
     "gap_certified": false,
-    "wall": 18.034337167000558
+    "wall": 6.066250791947823
    }
   },
   "tspn10": {
    "pre": {
     "maximize": false,
     "status": "feasible",
-    "objective": 225.12607139732842,
+    "objective": 225.1260713973292,
     "bound": null,
     "node_count": 1,
     "gap_certified": false,
-    "wall": 15.533888261999891
+    "wall": 8.225008875015192
    },
    "post": {
     "maximize": false,
     "status": "feasible",
-    "objective": 225.12607139732683,
+    "objective": 225.1260717001685,
     "bound": null,
     "node_count": 1,
     "gap_certified": false,
-    "wall": 21.301305689999936
+    "wall": 7.226137874997221
    }
   },
   "tspn12": {
    "post": {
     "maximize": false,
     "status": "feasible",
-    "objective": 262.64739525060224,
+    "objective": 262.6473957963284,
     "bound": null,
     "node_count": 1,
     "gap_certified": false,
-    "wall": 15.072269878999577
+    "wall": 4.389950249984395
    },
    "pre": {
     "maximize": false,
@@ -1317,17 +1317,30 @@
     "bound": null,
     "node_count": 1,
     "gap_certified": false,
-    "wall": 14.654824365001332
+    "wall": 4.432227334007621
    }
   }
  },
  "diffs": [
   [
-   "beuster",
+   "4stufen",
    {
     "bound": [
-     6395.108327034645,
-     6395.108328059316
+     20712.174649175664,
+     21475.147700500194
+    ],
+    "node_count": [
+     7,
+     15
+    ]
+   }
+  ],
+  [
+   "casctanks",
+   {
+    "node_count": [
+     31,
+     15
     ]
    }
   ],
@@ -1345,50 +1358,421 @@
    }
   ],
   [
-   "heatexch_gen2",
+   "clay0303hfsg",
    {
     "node_count": [
+     319,
+     287
+    ]
+   }
+  ],
+  [
+   "cvxnonsep_nsig30",
+   {
+    "objective": [
+     130.62871116925294,
+     130.62871268683435
+    ]
+   }
+  ],
+  [
+   "cvxnonsep_psig30",
+   {
+    "objective": [
+     78.99885435294289,
+     78.99885436526898
+    ]
+   }
+  ],
+  [
+   "cvxnonsep_psig40r",
+   {
+    "objective": [
+     86.54527995164958,
+     86.54528288283353
+    ],
+    "bound": [
+     86.53873600363832,
+     86.5387360036383
+    ]
+   }
+  ],
+  [
+   "dispatch",
+   {
+    "objective": [
+     3155.2879266857854,
+     3155.2879268631687
+    ],
+    "bound": [
+     3155.2878615366776,
+     3155.287861536673
+    ]
+   }
+  ],
+  [
+   "ex1222",
+   {
+    "objective": [
+     1.0765430833322625,
+     1.0765430833322618
+    ],
+    "bound": [
+     1.0765430463031964,
+     1.0765430833322571
+    ],
+    "node_count": [
+     1,
+     3
+    ]
+   }
+  ],
+  [
+   "ex1224",
+   {
+    "objective": [
+     -0.9434704942820806,
+     -0.9434704993121346
+    ],
+    "bound": [
+     -0.9434705000000164,
+     -0.9434705000000165
+    ]
+   }
+  ],
+  [
+   "ex1225",
+   {
+    "objective": [
+     30.999999913557566,
+     31.000000000008843
+    ],
+    "bound": [
+     30.999999913557566,
+     30.999999999999844
+    ]
+   }
+  ],
+  [
+   "ex1226",
+   {
+    "objective": [
+     -17.000000003887443,
+     -17.000000000000007
+    ],
+    "bound": [
+     -17.000000003887443,
+     -17.00000000000013
+    ],
+    "node_count": [
      3,
+     5
+    ]
+   }
+  ],
+  [
+   "ex14_1_9",
+   {
+    "objective": [
+     -1.9775220540513224e-16,
+     3.7948647471750336e-09
+    ],
+    "bound": [
+     -1.9775220540513224e-16,
+     0.0
+    ],
+    "node_count": [
+     3,
+     5
+    ]
+   }
+  ],
+  [
+   "fac2",
+   {
+    "objective": [
+     331837497.8394821,
+     331837498.17693394
+    ]
+   }
+  ],
+  [
+   "flay02m",
+   {
+    "objective": [
+     37.94733186383461,
+     37.94733200383462
+    ],
+    "bound": [
+     37.947331804569515,
+     37.94733186379298
+    ]
+   }
+  ],
+  [
+   "flay03m",
+   {
+    "objective": [
+     48.98979479383567,
+     48.9897949738358
+    ],
+    "bound": [
+     48.98979470823052,
+     48.98979479323287
+    ]
+   }
+  ],
+  [
+   "gkocis",
+   {
+    "objective": [
+     -1.9230987798770212,
+     -1.9230986924056728
+    ],
+    "bound": [
+     -1.9230988280923489,
+     -1.9230987422706283
+    ],
+    "node_count": [
+     5,
      7
+    ]
+   }
+  ],
+  [
+   "heatexch_gen2",
+   {
+    "status": [
+     "time_limit",
+     "feasible"
+    ],
+    "objective": [
+     null,
+     824551.3269251497
+    ]
+   }
+  ],
+  [
+   "m3",
+   {
+    "objective": [
+     37.79999966997884,
+     37.800000263754725
+    ],
+    "bound": [
+     37.79999951039201,
+     37.7999996700244
+    ],
+    "node_count": [
+     47,
+     53
+    ]
+   }
+  ],
+  [
+   "nvs03",
+   {
+    "bound": [
+     15.99999972676511,
+     16.0
+    ],
+    "node_count": [
+     5,
+     3
+    ]
+   }
+  ],
+  [
+   "nvs05",
+   {
+    "objective": [
+     8.731956986640078,
+     8.731956986640789
+    ],
+    "bound": [
+     3.8053367777828426,
+     4.099237735891656
+    ],
+    "node_count": [
+     131,
+     155
+    ]
+   }
+  ],
+  [
+   "nvs08",
+   {
+    "objective": [
+     23.449727347139827,
+     23.449727347978744
+    ],
+    "bound": [
+     23.44972734516655,
+     23.449727347447233
+    ],
+    "node_count": [
+     3,
+     5
+    ]
+   }
+  ],
+  [
+   "nvs09",
+   {
+    "objective": [
+     -43.134336918035295,
+     -43.13433691803531
+    ]
+   }
+  ],
+  [
+   "nvs21",
+   {
+    "objective": [
+     -5.684782628025259,
+     -5.684782416744887
+    ],
+    "bound": [
+     -5.684782628025259,
+     -5.684782500000104
+    ],
+    "node_count": [
+     3,
+     9
+    ]
+   }
+  ],
+  [
+   "oaer",
+   {
+    "objective": [
+     -1.9230984998848466,
+     -1.923098510129794
+    ],
+    "bound": [
+     -1.923098601139822,
+     -1.9230985229112711
+    ],
+    "node_count": [
+     3,
+     5
+    ]
+   }
+  ],
+  [
+   "st_e11",
+   {
+    "objective": [
+     189.31162974131917,
+     189.31162970097128
+    ],
+    "bound": [
+     189.31162968661766,
+     189.311629686619
+    ],
+    "node_count": [
+     27,
+     5
+    ]
+   }
+  ],
+  [
+   "st_e13",
+   {
+    "objective": [
+     1.9999999825187946,
+     2.000000002518795
+    ],
+    "bound": [
+     1.9999999825187946,
+     2.0
+    ]
+   }
+  ],
+  [
+   "st_e29",
+   {
+    "objective": [
+     -0.9434704942820806,
+     -0.9434704993121346
+    ],
+    "bound": [
+     -0.9434705000000164,
+     -0.9434705000000165
+    ]
+   }
+  ],
+  [
+   "st_e38",
+   {
+    "objective": [
+     7197.727116826533,
+     7197.727148526159
+    ],
+    "bound": [
+     7197.727116826533,
+     7197.727148526159
     ]
    }
   ],
   [
    "syn05hfsg",
    {
+    "objective": [
+     837.732412391107,
+     837.7323012718434
+    ],
     "bound": [
-     838.3878622240098,
-     840.4893941019075
+     837.732412391107,
+     837.7324008980034
     ],
     "node_count": [
-     179,
-     167
+     185,
+     285
     ]
    }
   ],
   [
    "tanksize",
    {
+    "objective": [
+     1.2686437525577947,
+     1.2686437598530085
+    ],
     "bound": [
-     1.2632541695785504,
-     1.2621867811714296
+     1.2685440897016123,
+     1.2685440895965434
     ],
     "node_count": [
-     4306,
-     3784
+     11451,
+     10861
     ]
    }
   ],
   [
    "tls2",
    {
-    "bound": [
-     3.2532681850660596,
-     3.1706801036010077
-    ],
-    "node_count": [
-     353,
-     349
+    "objective": [
+     5.299999922109238,
+     5.2999999999875085
+    ]
+   }
+  ],
+  [
+   "tspn05",
+   {
+    "objective": [
+     191.25520768494238,
+     191.25520784466957
+    ]
+   }
+  ],
+  [
+   "tspn08",
+   {
+    "objective": [
+     290.56685374735457,
+     290.5668539675055
     ]
    }
   ],
@@ -1396,8 +1780,17 @@
    "tspn10",
    {
     "objective": [
-     225.12607139732842,
-     225.12607139732683
+     225.1260713973292,
+     225.1260717001685
+    ]
+   }
+  ],
+  [
+   "tspn12",
+   {
+    "objective": [
+     262.64739525060224,
+     262.6473957963284
     ]
    }
   ]
@@ -1405,8 +1798,8 @@
  "findings": [],
  "cert_regressions": [],
  "solve_nlp_calls": {
-  "pre": 3136,
-  "post": 3163
+  "pre": 4037,
+  "post": 4052
  },
  "time_limit": 20.0
 }

--- a/scratchpad/issue945/panel_corpus.json
+++ b/scratchpad/issue945/panel_corpus.json
@@ -8,7 +8,7 @@
     "bound": 20282.050738736412,
     "node_count": 7,
     "gap_certified": false,
-    "wall": 21.32714018599995
+    "wall": 21.340063814000132
    },
    "post": {
     "maximize": false,
@@ -17,7 +17,7 @@
     "bound": 20282.050738736412,
     "node_count": 7,
     "gap_certified": false,
-    "wall": 20.720571975999974
+    "wall": 20.703717978999975
    }
   },
   "alan": {
@@ -28,7 +28,7 @@
     "bound": 2.9249999983013426,
     "node_count": 21,
     "gap_certified": true,
-    "wall": 0.0697737049999887
+    "wall": 0.07706615500001135
    },
    "pre": {
     "maximize": false,
@@ -37,7 +37,7 @@
     "bound": 2.9249999983013426,
     "node_count": 21,
     "gap_certified": true,
-    "wall": 0.06162336099987442
+    "wall": 0.06102747500017358
    }
   },
   "bchoco06": {
@@ -48,7 +48,7 @@
     "bound": 0.9999887833703148,
     "node_count": 7,
     "gap_certified": false,
-    "wall": 21.838321133999898
+    "wall": 21.067289785999947
    },
    "post": {
     "maximize": true,
@@ -57,7 +57,7 @@
     "bound": 0.9999887833703148,
     "node_count": 7,
     "gap_certified": false,
-    "wall": 21.015788905000136
+    "wall": 21.901819542999874
    }
   },
   "bchoco07": {
@@ -68,7 +68,7 @@
     "bound": 1.000000000000286,
     "node_count": 7,
     "gap_certified": false,
-    "wall": 25.83363056799999
+    "wall": 21.473129479999898
    },
    "pre": {
     "maximize": true,
@@ -77,7 +77,7 @@
     "bound": 1.000000000000286,
     "node_count": 7,
     "gap_certified": false,
-    "wall": 21.417543166000087
+    "wall": 21.438231690000066
    }
   },
   "bchoco08": {
@@ -86,18 +86,18 @@
     "status": "time_limit",
     "objective": null,
     "bound": 1.000000000002788,
-    "node_count": 3,
+    "node_count": 7,
     "gap_certified": false,
-    "wall": 21.386567788000093
+    "wall": 67.47129444099983
    },
    "post": {
     "maximize": true,
     "status": "time_limit",
     "objective": null,
     "bound": 1.000000000002788,
-    "node_count": 3,
+    "node_count": 7,
     "gap_certified": false,
-    "wall": 20.306743565000033
+    "wall": 31.66573628900005
    }
   },
   "beuster": {
@@ -108,16 +108,16 @@
     "bound": 6395.108328059316,
     "node_count": 7,
     "gap_certified": false,
-    "wall": 21.53944314699993
+    "wall": 20.86968129199977
    },
    "pre": {
     "maximize": false,
     "status": "time_limit",
     "objective": null,
-    "bound": 6395.108327034671,
+    "bound": 6395.108328059316,
     "node_count": 7,
     "gap_certified": false,
-    "wall": 21.234007547000147
+    "wall": 21.137492664000092
    }
   },
   "casctanks": {
@@ -126,9 +126,9 @@
     "status": "time_limit",
     "objective": null,
     "bound": -90.17862329759835,
-    "node_count": 1,
+    "node_count": 3,
     "gap_certified": false,
-    "wall": 21.27176078699995
+    "wall": 21.675969455000086
    },
    "post": {
     "maximize": false,
@@ -137,7 +137,7 @@
     "bound": -90.17862329759835,
     "node_count": 3,
     "gap_certified": false,
-    "wall": 25.010035169000048
+    "wall": 21.52435942500051
    }
   },
   "chance": {
@@ -148,7 +148,7 @@
     "bound": 29.894378166613386,
     "node_count": 0,
     "gap_certified": true,
-    "wall": 0.40208159200005866
+    "wall": 0.18263813399971696
    },
    "pre": {
     "maximize": false,
@@ -157,7 +157,7 @@
     "bound": 29.894378154271102,
     "node_count": 0,
     "gap_certified": true,
-    "wall": 0.16450228000007883
+    "wall": 0.16545271100039827
    }
   },
   "clay0303hfsg": {
@@ -166,9 +166,9 @@
     "status": "time_limit",
     "objective": null,
     "bound": null,
-    "node_count": 3,
+    "node_count": 127,
     "gap_certified": false,
-    "wall": 20.643820403999825
+    "wall": 21.00434961800056
    },
    "post": {
     "maximize": false,
@@ -177,7 +177,7 @@
     "bound": null,
     "node_count": 127,
     "gap_certified": false,
-    "wall": 20.99889830500001
+    "wall": 20.736461437999424
    }
   },
   "contvar": {
@@ -185,10 +185,10 @@
     "maximize": false,
     "status": "time_limit",
     "objective": null,
-    "bound": 180782.8593284799,
+    "bound": 183632.02121055726,
     "node_count": 3,
     "gap_certified": false,
-    "wall": 22.113465987000154
+    "wall": 22.349915685999804
    },
    "pre": {
     "maximize": false,
@@ -197,7 +197,7 @@
     "bound": 183632.02121055726,
     "node_count": 3,
     "gap_certified": false,
-    "wall": 21.53963904400007
+    "wall": 21.744284481999784
    }
   },
   "cvxnonsep_nsig30": {
@@ -208,16 +208,16 @@
     "bound": 130.61841392487688,
     "node_count": 171,
     "gap_certified": true,
-    "wall": 5.474517335999963
+    "wall": 4.089018747999944
    },
    "post": {
     "maximize": false,
     "status": "optimal",
-    "objective": 130.62871123822686,
-    "bound": 130.61841401236617,
+    "objective": 130.62871116925294,
+    "bound": 130.61841392487688,
     "node_count": 171,
     "gap_certified": true,
-    "wall": 3.6531784119999884
+    "wall": 3.966168029000073
    }
   },
   "cvxnonsep_psig30": {
@@ -225,10 +225,10 @@
     "maximize": false,
     "status": "optimal",
     "objective": 78.99885435294289,
-    "bound": 78.9970170582728,
+    "bound": 78.99701703820377,
     "node_count": 89,
     "gap_certified": true,
-    "wall": 3.3853175290000763
+    "wall": 1.6343554780005434
    },
    "pre": {
     "maximize": false,
@@ -237,7 +237,7 @@
     "bound": 78.99701703820377,
     "node_count": 89,
     "gap_certified": true,
-    "wall": 1.8419379100000697
+    "wall": 2.0338044550007908
    }
   },
   "cvxnonsep_psig40r": {
@@ -248,27 +248,27 @@
     "bound": 86.53873600363832,
     "node_count": 103,
     "gap_certified": true,
-    "wall": 7.935117317000049
+    "wall": 6.401610296000399
    },
    "post": {
     "maximize": false,
     "status": "optimal",
-    "objective": 86.54527995164958,
-    "bound": 86.5387360184926,
-    "node_count": 95,
+    "objective": 86.54527995164959,
+    "bound": 86.53873600363832,
+    "node_count": 103,
     "gap_certified": true,
-    "wall": 6.1406269019998945
+    "wall": 6.646877549999772
    }
   },
   "dispatch": {
    "post": {
     "maximize": false,
     "status": "optimal",
-    "objective": 3155.2879267317876,
-    "bound": 3155.2878615366767,
+    "objective": 3155.2879266857854,
+    "bound": 3155.2878615366776,
     "node_count": 23,
     "gap_certified": true,
-    "wall": 0.5210910200000853
+    "wall": 0.5983337699999538
    },
    "pre": {
     "maximize": false,
@@ -277,7 +277,7 @@
     "bound": 3155.2878615366776,
     "node_count": 23,
     "gap_certified": true,
-    "wall": 0.38248191299999235
+    "wall": 0.4223917499994059
    }
   },
   "ex1221": {
@@ -288,7 +288,7 @@
     "bound": 7.667180068813077,
     "node_count": 5,
     "gap_certified": true,
-    "wall": 1.088639171000068
+    "wall": 0.847690366000279
    },
    "post": {
     "maximize": false,
@@ -297,7 +297,7 @@
     "bound": 7.667180068813077,
     "node_count": 5,
     "gap_certified": true,
-    "wall": 0.6961785749999763
+    "wall": 0.8767105770002672
    }
   },
   "ex1222": {
@@ -305,10 +305,10 @@
     "maximize": false,
     "status": "optimal",
     "objective": 1.0765430833322625,
-    "bound": 1.0765430463031955,
+    "bound": 1.0765430463031964,
     "node_count": 1,
     "gap_certified": true,
-    "wall": 0.4036420590000489
+    "wall": 0.306689307999477
    },
    "pre": {
     "maximize": false,
@@ -317,7 +317,7 @@
     "bound": 1.0765430463031964,
     "node_count": 1,
     "gap_certified": true,
-    "wall": 0.2393873399998938
+    "wall": 0.23709257100017567
    }
   },
   "ex1224": {
@@ -328,7 +328,7 @@
     "bound": -0.9434705000000166,
     "node_count": 5,
     "gap_certified": true,
-    "wall": 3.1738750510000955
+    "wall": 2.7015993259992683
    },
    "post": {
     "maximize": false,
@@ -337,18 +337,18 @@
     "bound": -0.9434705000000166,
     "node_count": 5,
     "gap_certified": true,
-    "wall": 2.6461232209999253
+    "wall": 2.5378109640005277
    }
   },
   "ex1225": {
    "post": {
     "maximize": false,
     "status": "optimal",
-    "objective": 30.999999948692963,
-    "bound": 30.999999948692963,
+    "objective": 30.999999913557566,
+    "bound": 30.999999913557566,
     "node_count": 5,
     "gap_certified": true,
-    "wall": 3.2333033429999887
+    "wall": 2.4734765289995266
    },
    "pre": {
     "maximize": false,
@@ -357,7 +357,7 @@
     "bound": 30.999999913557566,
     "node_count": 5,
     "gap_certified": true,
-    "wall": 2.7822530089999873
+    "wall": 2.680774093999389
    }
   },
   "ex1226": {
@@ -368,7 +368,7 @@
     "bound": -17.000000003887443,
     "node_count": 3,
     "gap_certified": true,
-    "wall": 1.2791051019999031
+    "wall": 0.7485413469994455
    },
    "post": {
     "maximize": false,
@@ -377,18 +377,18 @@
     "bound": -17.000000003887443,
     "node_count": 3,
     "gap_certified": true,
-    "wall": 1.432167889000084
+    "wall": 0.7260731919996033
    }
   },
   "ex14_1_9": {
    "post": {
     "maximize": false,
     "status": "optimal",
-    "objective": -1.9775220623231286e-16,
-    "bound": -1.9775220623231286e-16,
+    "objective": -1.9775220540513224e-16,
+    "bound": -1.9775220540513224e-16,
     "node_count": 3,
     "gap_certified": true,
-    "wall": 1.1406090880000193
+    "wall": 0.29846733000067616
    },
    "pre": {
     "maximize": false,
@@ -397,7 +397,7 @@
     "bound": -1.9775220540513224e-16,
     "node_count": 3,
     "gap_certified": true,
-    "wall": 0.4209316100000251
+    "wall": 0.28341770699989866
    }
   },
   "fac2": {
@@ -408,27 +408,27 @@
     "bound": 331837497.54563797,
     "node_count": 41,
     "gap_certified": true,
-    "wall": 10.586713098000018
+    "wall": 8.841676842000197
    },
    "post": {
     "maximize": false,
     "status": "optimal",
-    "objective": 331837498.17691857,
-    "bound": 331837497.54565895,
+    "objective": 331837497.8394821,
+    "bound": 331837497.54563797,
     "node_count": 41,
     "gap_certified": true,
-    "wall": 8.704947227000048
+    "wall": 8.715976561999923
    }
   },
   "flay02m": {
    "post": {
     "maximize": false,
     "status": "optimal",
-    "objective": 37.947331863834606,
-    "bound": 37.94733180456953,
+    "objective": 37.94733186383461,
+    "bound": 37.947331804569515,
     "node_count": 7,
     "gap_certified": true,
-    "wall": 0.6680022479999934
+    "wall": 0.5235917359996165
    },
    "pre": {
     "maximize": false,
@@ -437,7 +437,7 @@
     "bound": 37.947331804569515,
     "node_count": 7,
     "gap_certified": true,
-    "wall": 0.44236480800009303
+    "wall": 0.502729496000029
    }
   },
   "flay03m": {
@@ -448,16 +448,16 @@
     "bound": 48.98979470823052,
     "node_count": 111,
     "gap_certified": true,
-    "wall": 7.461430084000085
+    "wall": 9.543892702999983
    },
    "post": {
     "maximize": false,
     "status": "optimal",
-    "objective": 48.98979479383577,
-    "bound": 48.98979470823063,
-    "node_count": 113,
+    "objective": 48.98979479383567,
+    "bound": 48.98979470823052,
+    "node_count": 111,
     "gap_certified": true,
-    "wall": 7.378897106000068
+    "wall": 7.040910736000114
    }
   },
   "gbd": {
@@ -468,7 +468,7 @@
     "bound": 2.1999999825308127,
     "node_count": 3,
     "gap_certified": true,
-    "wall": 0.02703937000001133
+    "wall": 0.02498746299988852
    },
    "pre": {
     "maximize": false,
@@ -477,7 +477,7 @@
     "bound": 2.1999999825308127,
     "node_count": 3,
     "gap_certified": true,
-    "wall": 0.022417828000016016
+    "wall": 0.021001138999963587
    }
   },
   "gkocis": {
@@ -488,16 +488,16 @@
     "bound": -1.9230988280923489,
     "node_count": 5,
     "gap_certified": true,
-    "wall": 1.3983889429998726
+    "wall": 1.4591283479994672
    },
    "post": {
     "maximize": false,
     "status": "optimal",
-    "objective": -1.9230987747401134,
-    "bound": -1.9230988280923498,
+    "objective": -1.9230987798770212,
+    "bound": -1.9230988280923489,
     "node_count": 5,
     "gap_certified": true,
-    "wall": 1.2420297620001293
+    "wall": 1.17010479199962
    }
   },
   "hda": {
@@ -508,7 +508,7 @@
     "bound": -64473.44240243703,
     "node_count": 1,
     "gap_certified": false,
-    "wall": 21.7771964760002
+    "wall": 21.402470478000396
    },
    "pre": {
     "maximize": false,
@@ -517,7 +517,7 @@
     "bound": -64473.44240243703,
     "node_count": 1,
     "gap_certified": false,
-    "wall": 21.071228192000035
+    "wall": 21.099769899999956
    }
   },
   "heatexch_gen1": {
@@ -528,7 +528,7 @@
     "bound": 38183.5317460179,
     "node_count": 3,
     "gap_certified": false,
-    "wall": 24.602463700000044
+    "wall": 21.656159112999376
    },
    "post": {
     "maximize": false,
@@ -537,7 +537,7 @@
     "bound": 38183.5317460179,
     "node_count": 3,
     "gap_certified": false,
-    "wall": 25.374974721999934
+    "wall": 21.572925202999613
    }
   },
   "heatexch_gen2": {
@@ -546,9 +546,9 @@
     "status": "time_limit",
     "objective": null,
     "bound": 555767.7902857271,
-    "node_count": 7,
+    "node_count": 3,
     "gap_certified": false,
-    "wall": 22.050892694999902
+    "wall": 21.984058686000026
    },
    "pre": {
     "maximize": false,
@@ -557,7 +557,7 @@
     "bound": 555767.7902857271,
     "node_count": 3,
     "gap_certified": false,
-    "wall": 21.659613729000057
+    "wall": 21.933579728999575
    }
   },
   "heatexch_gen3": {
@@ -568,7 +568,7 @@
     "bound": null,
     "node_count": 3,
     "gap_certified": false,
-    "wall": 24.805495338000128
+    "wall": 29.739361054000256
    },
    "post": {
     "maximize": false,
@@ -577,18 +577,18 @@
     "bound": null,
     "node_count": 3,
     "gap_certified": false,
-    "wall": 159.09318966699993
+    "wall": 29.96267835800063
    }
   },
   "m3": {
    "post": {
     "maximize": false,
     "status": "optimal",
-    "objective": 37.79999970380645,
-    "bound": 37.79999957378442,
-    "node_count": 41,
+    "objective": 37.79999966997884,
+    "bound": 37.79999951039201,
+    "node_count": 47,
     "gap_certified": true,
-    "wall": 4.161642962000087
+    "wall": 4.658604321999519
    },
    "pre": {
     "maximize": false,
@@ -597,7 +597,7 @@
     "bound": 37.79999951039201,
     "node_count": 47,
     "gap_certified": true,
-    "wall": 5.255348631000061
+    "wall": 4.756032500999936
    }
   },
   "nvs01": {
@@ -608,7 +608,7 @@
     "bound": 12.46966882156821,
     "node_count": 3,
     "gap_certified": true,
-    "wall": 1.6439451590001681
+    "wall": 1.988911017000646
    },
    "post": {
     "maximize": false,
@@ -617,7 +617,7 @@
     "bound": 12.46966882156821,
     "node_count": 3,
     "gap_certified": true,
-    "wall": 1.2853830799999741
+    "wall": 1.5507398740001008
    }
   },
   "nvs02": {
@@ -628,7 +628,7 @@
     "bound": 5.96418452307,
     "node_count": 345,
     "gap_certified": true,
-    "wall": 0.45007736000002296
+    "wall": 0.5207517459994051
    },
    "pre": {
     "maximize": false,
@@ -637,7 +637,7 @@
     "bound": 5.96418452307,
     "node_count": 345,
     "gap_certified": true,
-    "wall": 0.3842895899999803
+    "wall": 0.42628081099974224
    }
   },
   "nvs03": {
@@ -648,16 +648,16 @@
     "bound": 15.99999972676511,
     "node_count": 5,
     "gap_certified": true,
-    "wall": 0.2949178530000154
+    "wall": 0.22198429299987765
    },
    "post": {
     "maximize": false,
     "status": "optimal",
     "objective": 16.0,
-    "bound": 15.99999996676705,
+    "bound": 15.99999972676511,
     "node_count": 5,
     "gap_certified": true,
-    "wall": 0.1825162210000144
+    "wall": 0.18828977399971336
    }
   },
   "nvs04": {
@@ -668,7 +668,7 @@
     "bound": 0.7199999999999773,
     "node_count": 5,
     "gap_certified": true,
-    "wall": 0.43267889300000206
+    "wall": 0.4147367790001226
    },
    "pre": {
     "maximize": false,
@@ -677,7 +677,7 @@
     "bound": 0.7199999999999773,
     "node_count": 5,
     "gap_certified": true,
-    "wall": 0.32748328499997115
+    "wall": 0.35070941199955996
    }
   },
   "nvs05": {
@@ -686,18 +686,18 @@
     "status": "feasible",
     "objective": 8.731956986640078,
     "bound": 3.5424692441047068,
-    "node_count": 41,
+    "node_count": 33,
     "gap_certified": false,
-    "wall": 20.182257691999894
+    "wall": 20.14191485399988
    },
    "post": {
     "maximize": false,
     "status": "feasible",
-    "objective": 12.589492574009626,
-    "bound": 3.513753543700079,
-    "node_count": 33,
+    "objective": 8.731956986640078,
+    "bound": 3.5424692441047068,
+    "node_count": 41,
     "gap_certified": false,
-    "wall": 20.12968590100013
+    "wall": 20.161285596999733
    }
   },
   "nvs06": {
@@ -708,7 +708,7 @@
     "bound": 1.7703124999999627,
     "node_count": 5,
     "gap_certified": true,
-    "wall": 1.5876532459999453
+    "wall": 1.187288453000292
    },
    "pre": {
     "maximize": false,
@@ -717,7 +717,7 @@
     "bound": 1.7703124999999627,
     "node_count": 5,
     "gap_certified": true,
-    "wall": 1.07712272699996
+    "wall": 1.1228943139994954
    }
   },
   "nvs07": {
@@ -728,7 +728,7 @@
     "bound": 4.0,
     "node_count": 5,
     "gap_certified": true,
-    "wall": 0.09569734999990942
+    "wall": 0.07190670799991494
    },
    "post": {
     "maximize": false,
@@ -737,7 +737,7 @@
     "bound": 4.0,
     "node_count": 5,
     "gap_certified": true,
-    "wall": 0.06396703199993681
+    "wall": 0.06876586599992152
    }
   },
   "nvs08": {
@@ -748,7 +748,7 @@
     "bound": 23.44972734516655,
     "node_count": 3,
     "gap_certified": true,
-    "wall": 1.4748921469999914
+    "wall": 1.2100922780000474
    },
    "pre": {
     "maximize": false,
@@ -757,7 +757,7 @@
     "bound": 23.44972734516655,
     "node_count": 3,
     "gap_certified": true,
-    "wall": 1.2505608799999663
+    "wall": 1.1709591640001236
    }
   },
   "nvs09": {
@@ -768,16 +768,16 @@
     "bound": -43.13433691803662,
     "node_count": 5,
     "gap_certified": true,
-    "wall": 6.435507588999826
+    "wall": 4.718927093000275
    },
    "post": {
     "maximize": false,
     "status": "optimal",
-    "objective": -43.13433691803531,
+    "objective": -43.134336918035295,
     "bound": -43.13433691803662,
     "node_count": 5,
     "gap_certified": true,
-    "wall": 4.4610048320000715
+    "wall": 4.314823305999198
    }
   },
   "nvs10": {
@@ -788,7 +788,7 @@
     "bound": -310.7999999999999,
     "node_count": 5,
     "gap_certified": true,
-    "wall": 0.16603770200003964
+    "wall": 0.18428214799951093
    },
    "pre": {
     "maximize": false,
@@ -797,7 +797,7 @@
     "bound": -310.7999999999999,
     "node_count": 5,
     "gap_certified": true,
-    "wall": 0.13045944899999995
+    "wall": 0.15585522099991067
    }
   },
   "nvs11": {
@@ -808,7 +808,7 @@
     "bound": -431.0000000000085,
     "node_count": 55,
     "gap_certified": true,
-    "wall": 1.1448019409999688
+    "wall": 0.7984933790003197
    },
    "post": {
     "maximize": false,
@@ -817,7 +817,7 @@
     "bound": -431.0000000000085,
     "node_count": 55,
     "gap_certified": true,
-    "wall": 0.7152426210000158
+    "wall": 0.6477721329993074
    }
   },
   "nvs12": {
@@ -828,7 +828,7 @@
     "bound": -481.20000000001,
     "node_count": 231,
     "gap_certified": true,
-    "wall": 2.4171318409999003
+    "wall": 2.5677869540004394
    },
    "pre": {
     "maximize": false,
@@ -837,7 +837,7 @@
     "bound": -481.20000000001,
     "node_count": 231,
     "gap_certified": true,
-    "wall": 2.097880950999979
+    "wall": 2.0910330770002474
    }
   },
   "nvs13": {
@@ -848,7 +848,7 @@
     "bound": -585.2,
     "node_count": 637,
     "gap_certified": true,
-    "wall": 1.8591022190000785
+    "wall": 1.6628040579998924
    },
    "post": {
     "maximize": false,
@@ -857,7 +857,7 @@
     "bound": -585.2,
     "node_count": 637,
     "gap_certified": true,
-    "wall": 1.4032217410001522
+    "wall": 1.4816955699998289
    }
   },
   "nvs14": {
@@ -868,7 +868,7 @@
     "bound": -40358.154769299996,
     "node_count": 129,
     "gap_certified": true,
-    "wall": 0.8666135529999792
+    "wall": 0.8479760170002919
    },
    "pre": {
     "maximize": false,
@@ -877,7 +877,7 @@
     "bound": -40358.154769299996,
     "node_count": 129,
     "gap_certified": true,
-    "wall": 0.8534960629999659
+    "wall": 0.84033171900046
    }
   },
   "nvs15": {
@@ -888,7 +888,7 @@
     "bound": 1.0,
     "node_count": 7,
     "gap_certified": true,
-    "wall": 0.07827312700010225
+    "wall": 0.08723134499996377
    },
    "post": {
     "maximize": false,
@@ -897,7 +897,7 @@
     "bound": 1.0,
     "node_count": 7,
     "gap_certified": true,
-    "wall": 0.07677735400011443
+    "wall": 0.08384172800015222
    }
   },
   "nvs21": {
@@ -908,7 +908,7 @@
     "bound": -5.684782628025259,
     "node_count": 3,
     "gap_certified": true,
-    "wall": 8.974388968000085
+    "wall": 7.365921497999807
    },
    "pre": {
     "maximize": false,
@@ -917,7 +917,7 @@
     "bound": -5.684782628025259,
     "node_count": 3,
     "gap_certified": true,
-    "wall": 6.292978661999996
+    "wall": 6.512636297000427
    }
   },
   "oaer": {
@@ -928,27 +928,27 @@
     "bound": -1.923098601139822,
     "node_count": 3,
     "gap_certified": true,
-    "wall": 1.189243807000139
+    "wall": 1.1342668400002367
    },
    "post": {
     "maximize": false,
     "status": "optimal",
-    "objective": -1.9230985115702832,
+    "objective": -1.923098499884843,
     "bound": -1.923098601139822,
     "node_count": 3,
     "gap_certified": true,
-    "wall": 1.2234205120000752
+    "wall": 0.9787721730008343
    }
   },
   "st_e11": {
    "post": {
     "maximize": false,
     "status": "optimal",
-    "objective": 189.31178228026806,
-    "bound": 189.31162968661764,
+    "objective": 189.31162974131917,
+    "bound": 189.31162968661766,
     "node_count": 27,
     "gap_certified": true,
-    "wall": 3.9886188610000772
+    "wall": 3.3105536600005507
    },
    "pre": {
     "maximize": false,
@@ -957,7 +957,7 @@
     "bound": 189.31162968661766,
     "node_count": 27,
     "gap_certified": true,
-    "wall": 3.3204398390000733
+    "wall": 3.151153957999668
    }
   },
   "st_e13": {
@@ -968,7 +968,7 @@
     "bound": 1.9999999825187946,
     "node_count": 1,
     "gap_certified": true,
-    "wall": 0.23803890599992883
+    "wall": 0.1342486370003826
    },
    "post": {
     "maximize": false,
@@ -977,7 +977,7 @@
     "bound": 1.9999999825187946,
     "node_count": 1,
     "gap_certified": true,
-    "wall": 0.1254774509998242
+    "wall": 0.12964829100019415
    }
   },
   "st_e29": {
@@ -988,7 +988,7 @@
     "bound": -0.9434705000000166,
     "node_count": 5,
     "gap_certified": true,
-    "wall": 2.5590663169998606
+    "wall": 2.973738345000129
    },
    "pre": {
     "maximize": false,
@@ -997,7 +997,7 @@
     "bound": -0.9434705000000166,
     "node_count": 5,
     "gap_certified": true,
-    "wall": 2.665116517000115
+    "wall": 2.723435843000516
    }
   },
   "st_e36": {
@@ -1008,7 +1008,7 @@
     "bound": -246.00000000170422,
     "node_count": 85,
     "gap_certified": true,
-    "wall": 10.071021720999852
+    "wall": 9.497817057000248
    },
    "post": {
     "maximize": false,
@@ -1017,7 +1017,7 @@
     "bound": -246.00000000170422,
     "node_count": 85,
     "gap_certified": true,
-    "wall": 9.108315689999927
+    "wall": 8.930255438999666
    }
   },
   "st_e38": {
@@ -1028,7 +1028,7 @@
     "bound": 7197.727116826533,
     "node_count": 3,
     "gap_certified": true,
-    "wall": 0.9304301829999986
+    "wall": 0.8050893419995191
    },
    "pre": {
     "maximize": false,
@@ -1037,7 +1037,7 @@
     "bound": 7197.727116826533,
     "node_count": 3,
     "gap_certified": true,
-    "wall": 0.7120587800000067
+    "wall": 0.7653070249998564
    }
   },
   "st_miqp1": {
@@ -1048,7 +1048,7 @@
     "bound": 280.9999999906497,
     "node_count": 15,
     "gap_certified": true,
-    "wall": 0.02052733999994416
+    "wall": 0.02535302399974171
    },
    "post": {
     "maximize": false,
@@ -1057,7 +1057,7 @@
     "bound": 280.9999999906497,
     "node_count": 15,
     "gap_certified": true,
-    "wall": 0.018686946999878273
+    "wall": 0.020920111000123143
    }
   },
   "st_miqp2": {
@@ -1068,7 +1068,7 @@
     "bound": 2.0,
     "node_count": 9,
     "gap_certified": true,
-    "wall": 0.02447017899999082
+    "wall": 0.027963353999439278
    },
    "pre": {
     "maximize": false,
@@ -1077,7 +1077,7 @@
     "bound": 2.0,
     "node_count": 9,
     "gap_certified": true,
-    "wall": 0.023696365999967384
+    "wall": 0.0295779260004565
    }
   },
   "st_miqp3": {
@@ -1088,7 +1088,7 @@
     "bound": -6.0,
     "node_count": 1,
     "gap_certified": true,
-    "wall": 0.00906364599995868
+    "wall": 0.010991941000611405
    },
    "post": {
     "maximize": false,
@@ -1097,7 +1097,7 @@
     "bound": -6.0,
     "node_count": 1,
     "gap_certified": true,
-    "wall": 0.008847068000022773
+    "wall": 0.010478748000423366
    }
   },
   "st_miqp4": {
@@ -1108,7 +1108,7 @@
     "bound": -4574.0000024840665,
     "node_count": 3,
     "gap_certified": true,
-    "wall": 0.026047281999808547
+    "wall": 0.031087235999621043
    },
    "pre": {
     "maximize": false,
@@ -1117,7 +1117,7 @@
     "bound": -4574.0000024840665,
     "node_count": 3,
     "gap_certified": true,
-    "wall": 0.026393293999944945
+    "wall": 0.028957886999705806
    }
   },
   "st_miqp5": {
@@ -1128,7 +1128,7 @@
     "bound": -333.88889024868075,
     "node_count": 1,
     "gap_certified": true,
-    "wall": 0.0324710889999551
+    "wall": 0.0340186020002875
    },
    "post": {
     "maximize": false,
@@ -1137,7 +1137,7 @@
     "bound": -333.88889024868075,
     "node_count": 1,
     "gap_certified": true,
-    "wall": 0.031452121000029365
+    "wall": 0.03273793999960617
    }
   },
   "st_test1": {
@@ -1148,7 +1148,7 @@
     "bound": -1.6495994490692313e-08,
     "node_count": 15,
     "gap_certified": true,
-    "wall": 0.03626103800002056
+    "wall": 0.03634161800073343
    },
    "pre": {
     "maximize": false,
@@ -1157,7 +1157,7 @@
     "bound": -1.6495994490692313e-08,
     "node_count": 15,
     "gap_certified": true,
-    "wall": 0.035310013999833245
+    "wall": 0.038223362999815436
    }
   },
   "st_testgr3": {
@@ -1168,7 +1168,7 @@
     "bound": -20.59070709795548,
     "node_count": 549,
     "gap_certified": true,
-    "wall": 0.28182646599998407
+    "wall": 0.28243116900011955
    },
    "post": {
     "maximize": false,
@@ -1177,27 +1177,27 @@
     "bound": -20.59070709795548,
     "node_count": 549,
     "gap_certified": true,
-    "wall": 0.2782758789999207
+    "wall": 0.2876941529993928
    }
   },
   "syn05hfsg": {
    "post": {
     "maximize": true,
-    "status": "feasible",
-    "objective": 837.7324083563395,
-    "bound": 838.3878622240098,
-    "node_count": 171,
-    "gap_certified": false,
-    "wall": 20.28268366600014
+    "status": "optimal",
+    "objective": 837.732412391107,
+    "bound": 837.732412391107,
+    "node_count": 185,
+    "gap_certified": true,
+    "wall": 20.022627572999227
    },
    "pre": {
     "maximize": true,
     "status": "feasible",
     "objective": 837.732412391107,
     "bound": 838.3878622240098,
-    "node_count": 181,
+    "node_count": 167,
     "gap_certified": false,
-    "wall": 20.11427130700008
+    "wall": 20.09403269500035
    }
   },
   "tanksize": {
@@ -1205,39 +1205,39 @@
     "maximize": false,
     "status": "time_limit",
     "objective": 1.268643752557795,
-    "bound": 1.2616432205298513,
-    "node_count": 3596,
+    "bound": 1.2630486909987855,
+    "node_count": 4186,
     "gap_certified": true,
-    "wall": 20.114331551000078
+    "wall": 20.11908975499955
    },
    "post": {
     "maximize": false,
     "status": "time_limit",
-    "objective": 1.2686437708530283,
-    "bound": 1.262799393410885,
-    "node_count": 3964,
+    "objective": 1.268643752557795,
+    "bound": 1.263118021659774,
+    "node_count": 4216,
     "gap_certified": true,
-    "wall": 20.109238961000074
+    "wall": 20.102947426000355
    }
   },
   "tls2": {
    "post": {
     "maximize": false,
     "status": "feasible",
-    "objective": 10.299999996297192,
-    "bound": 2.4487125876978713,
+    "objective": 5.299999922109238,
+    "bound": 3.2532681850660596,
     "node_count": 353,
     "gap_certified": false,
-    "wall": 20.732897183999967
+    "wall": 20.111197416999858
    },
    "pre": {
     "maximize": false,
-    "status": "feasible",
+    "status": "optimal",
     "objective": 5.299999922109238,
-    "bound": 3.1706801036010077,
-    "node_count": 349,
-    "gap_certified": false,
-    "wall": 20.800227508000035
+    "bound": 5.3,
+    "node_count": 353,
+    "gap_certified": true,
+    "wall": 20.396457507999912
    }
   },
   "tspn05": {
@@ -1248,27 +1248,27 @@
     "bound": 179.44337578420988,
     "node_count": 49,
     "gap_certified": false,
-    "wall": 20.155364598999768
+    "wall": 20.206236415000603
    },
    "post": {
     "maximize": false,
     "status": "feasible",
-    "objective": 191.2552076848786,
+    "objective": 191.2552076848774,
     "bound": 179.44337578420988,
     "node_count": 49,
     "gap_certified": false,
-    "wall": 20.18219688099998
+    "wall": 20.103172094
    }
   },
   "tspn08": {
    "post": {
     "maximize": false,
     "status": "feasible",
-    "objective": 290.5668537474047,
+    "objective": 290.56685374735093,
     "bound": null,
     "node_count": 1,
     "gap_certified": false,
-    "wall": 19.96056919099965
+    "wall": 15.677741274000255
    },
    "pre": {
     "maximize": false,
@@ -1277,38 +1277,38 @@
     "bound": null,
     "node_count": 1,
     "gap_certified": false,
-    "wall": 16.166508093000175
+    "wall": 15.301717747999646
    }
   },
   "tspn10": {
    "pre": {
     "maximize": false,
     "status": "feasible",
-    "objective": 225.1260713973286,
+    "objective": 225.12607139732683,
     "bound": null,
     "node_count": 1,
     "gap_certified": false,
-    "wall": 15.319980657000087
+    "wall": 20.90029842900003
    },
    "post": {
     "maximize": false,
     "status": "feasible",
-    "objective": 225.12607139732896,
+    "objective": 225.12607139732683,
     "bound": null,
     "node_count": 1,
     "gap_certified": false,
-    "wall": 19.474078835
+    "wall": 14.456912680999267
    }
   },
   "tspn12": {
    "post": {
     "maximize": false,
-    "status": "time_limit",
-    "objective": null,
+    "status": "feasible",
+    "objective": 262.64739525060224,
     "bound": null,
-    "node_count": 3,
+    "node_count": 1,
     "gap_certified": false,
-    "wall": 35.189106618000096
+    "wall": 14.722521587999836
    },
    "pre": {
     "maximize": false,
@@ -1317,29 +1317,11 @@
     "bound": null,
     "node_count": 1,
     "gap_certified": false,
-    "wall": 14.85704738000004
+    "wall": 14.460105023000324
    }
   }
  },
  "diffs": [
-  [
-   "beuster",
-   {
-    "bound": [
-     6395.108327034671,
-     6395.108328059316
-    ]
-   }
-  ],
-  [
-   "casctanks",
-   {
-    "node_count": [
-     1,
-     3
-    ]
-   }
-  ],
   [
    "chance",
    {
@@ -1354,346 +1336,65 @@
    }
   ],
   [
-   "clay0303hfsg",
-   {
-    "node_count": [
-     3,
-     127
-    ]
-   }
-  ],
-  [
-   "contvar",
-   {
-    "bound": [
-     183632.02121055726,
-     180782.8593284799
-    ]
-   }
-  ],
-  [
-   "cvxnonsep_nsig30",
-   {
-    "objective": [
-     130.62871116925294,
-     130.62871123822686
-    ],
-    "bound": [
-     130.61841392487688,
-     130.61841401236617
-    ]
-   }
-  ],
-  [
-   "cvxnonsep_psig30",
-   {
-    "bound": [
-     78.99701703820377,
-     78.9970170582728
-    ]
-   }
-  ],
-  [
-   "cvxnonsep_psig40r",
-   {
-    "objective": [
-     86.54527995164959,
-     86.54527995164958
-    ],
-    "bound": [
-     86.53873600363832,
-     86.5387360184926
-    ],
-    "node_count": [
-     103,
-     95
-    ]
-   }
-  ],
-  [
-   "dispatch",
-   {
-    "objective": [
-     3155.2879266857854,
-     3155.2879267317876
-    ],
-    "bound": [
-     3155.2878615366776,
-     3155.2878615366767
-    ]
-   }
-  ],
-  [
-   "ex1222",
-   {
-    "bound": [
-     1.0765430463031964,
-     1.0765430463031955
-    ]
-   }
-  ],
-  [
-   "ex1225",
-   {
-    "objective": [
-     30.999999913557566,
-     30.999999948692963
-    ],
-    "bound": [
-     30.999999913557566,
-     30.999999948692963
-    ]
-   }
-  ],
-  [
-   "ex14_1_9",
-   {
-    "objective": [
-     -1.9775220540513224e-16,
-     -1.9775220623231286e-16
-    ],
-    "bound": [
-     -1.9775220540513224e-16,
-     -1.9775220623231286e-16
-    ]
-   }
-  ],
-  [
-   "fac2",
-   {
-    "objective": [
-     331837497.8394821,
-     331837498.17691857
-    ],
-    "bound": [
-     331837497.54563797,
-     331837497.54565895
-    ]
-   }
-  ],
-  [
-   "flay02m",
-   {
-    "objective": [
-     37.94733186383461,
-     37.947331863834606
-    ],
-    "bound": [
-     37.947331804569515,
-     37.94733180456953
-    ]
-   }
-  ],
-  [
-   "flay03m",
-   {
-    "objective": [
-     48.98979479383567,
-     48.98979479383577
-    ],
-    "bound": [
-     48.98979470823052,
-     48.98979470823063
-    ],
-    "node_count": [
-     111,
-     113
-    ]
-   }
-  ],
-  [
-   "gkocis",
-   {
-    "objective": [
-     -1.9230987798770212,
-     -1.9230987747401134
-    ],
-    "bound": [
-     -1.9230988280923489,
-     -1.9230988280923498
-    ]
-   }
-  ],
-  [
-   "heatexch_gen2",
-   {
-    "node_count": [
-     3,
-     7
-    ]
-   }
-  ],
-  [
-   "m3",
-   {
-    "objective": [
-     37.79999966997884,
-     37.79999970380645
-    ],
-    "bound": [
-     37.79999951039201,
-     37.79999957378442
-    ],
-    "node_count": [
-     47,
-     41
-    ]
-   }
-  ],
-  [
-   "nvs03",
-   {
-    "bound": [
-     15.99999972676511,
-     15.99999996676705
-    ]
-   }
-  ],
-  [
    "nvs05",
    {
-    "objective": [
-     8.731956986640078,
-     12.589492574009626
-    ],
-    "bound": [
-     3.5424692441047068,
-     3.513753543700079
-    ],
     "node_count": [
-     41,
-     33
-    ]
-   }
-  ],
-  [
-   "nvs09",
-   {
-    "objective": [
-     -43.134336918035295,
-     -43.13433691803531
-    ]
-   }
-  ],
-  [
-   "oaer",
-   {
-    "objective": [
-     -1.923098499884843,
-     -1.9230985115702832
-    ]
-   }
-  ],
-  [
-   "st_e11",
-   {
-    "objective": [
-     189.31162974131917,
-     189.31178228026806
-    ],
-    "bound": [
-     189.31162968661766,
-     189.31162968661764
+     33,
+     41
     ]
    }
   ],
   [
    "syn05hfsg",
    {
-    "objective": [
-     837.732412391107,
-     837.7324083563395
+    "status": [
+     "feasible",
+     "optimal"
+    ],
+    "bound": [
+     838.3878622240098,
+     837.732412391107
     ],
     "node_count": [
-     181,
-     171
+     167,
+     185
     ]
    }
   ],
   [
    "tanksize",
    {
-    "objective": [
-     1.268643752557795,
-     1.2686437708530283
-    ],
     "bound": [
-     1.2616432205298513,
-     1.262799393410885
+     1.2630486909987855,
+     1.263118021659774
     ],
     "node_count": [
-     3596,
-     3964
+     4186,
+     4216
     ]
    }
   ],
   [
    "tls2",
    {
-    "objective": [
-     5.299999922109238,
-     10.299999996297192
+    "status": [
+     "optimal",
+     "feasible"
     ],
     "bound": [
-     3.1706801036010077,
-     2.4487125876978713
-    ],
-    "node_count": [
-     349,
-     353
-    ]
-   }
-  ],
-  [
-   "tspn05",
-   {
-    "objective": [
-     191.2552076848774,
-     191.2552076848786
-    ]
-   }
-  ],
-  [
-   "tspn08",
-   {
-    "objective": [
-     290.56685374735093,
-     290.5668537474047
-    ]
-   }
-  ],
-  [
-   "tspn10",
-   {
-    "objective": [
-     225.1260713973286,
-     225.12607139732896
-    ]
-   }
-  ],
-  [
-   "tspn12",
-   {
-    "status": [
-     "feasible",
-     "time_limit"
-    ],
-    "objective": [
-     262.64739525060224,
-     null
-    ],
-    "node_count": [
-     1,
-     3
+     5.3,
+     3.2532681850660596
     ]
    }
   ]
  ],
  "findings": [],
- "cert_regressions": [],
+ "cert_regressions": [
+  "tls2"
+ ],
  "solve_nlp_calls": {
-  "pre": 3047,
-  "post": 2865
+  "pre": 3229,
+  "post": 3140
  },
  "time_limit": 20.0
 }

--- a/scratchpad/issue945/panel_corpus.json
+++ b/scratchpad/issue945/panel_corpus.json
@@ -2,1194 +2,1335 @@
  "rows": {
   "4stufen": {
    "pre": {
+    "maximize": false,
     "status": "time_limit",
     "objective": null,
     "bound": 20282.050738736412,
     "node_count": 7,
     "gap_certified": false,
-    "wall": 20.867700138999908
+    "wall": 21.32714018599995
    },
    "post": {
+    "maximize": false,
     "status": "time_limit",
     "objective": null,
     "bound": 20282.050738736412,
     "node_count": 7,
     "gap_certified": false,
-    "wall": 20.706769252999948
+    "wall": 20.720571975999974
    }
   },
   "alan": {
    "post": {
+    "maximize": false,
     "status": "optimal",
-    "objective": 2.9249999999513205,
-    "bound": 2.9249999999513205,
+    "objective": 2.9249999983013426,
+    "bound": 2.9249999983013426,
     "node_count": 21,
     "gap_certified": true,
-    "wall": 0.10150536599985571
+    "wall": 0.0697737049999887
    },
    "pre": {
+    "maximize": false,
     "status": "optimal",
-    "objective": 2.9249999999513205,
-    "bound": 2.9249999999513205,
+    "objective": 2.9249999983013426,
+    "bound": 2.9249999983013426,
     "node_count": 21,
     "gap_certified": true,
-    "wall": 0.0947628110000096
+    "wall": 0.06162336099987442
    }
   },
   "bchoco06": {
    "pre": {
+    "maximize": true,
     "status": "time_limit",
     "objective": null,
     "bound": 0.9999887833703148,
     "node_count": 7,
     "gap_certified": false,
-    "wall": 22.010192088000167
+    "wall": 21.838321133999898
    },
    "post": {
+    "maximize": true,
     "status": "time_limit",
     "objective": null,
     "bound": 0.9999887833703148,
     "node_count": 7,
     "gap_certified": false,
-    "wall": 21.29733245500006
+    "wall": 21.015788905000136
    }
   },
   "bchoco07": {
    "post": {
+    "maximize": true,
     "status": "time_limit",
     "objective": null,
     "bound": 1.000000000000286,
     "node_count": 7,
     "gap_certified": false,
-    "wall": 26.272639786000127
+    "wall": 25.83363056799999
    },
    "pre": {
+    "maximize": true,
     "status": "time_limit",
     "objective": null,
     "bound": 1.000000000000286,
     "node_count": 7,
     "gap_certified": false,
-    "wall": 21.568805414000053
+    "wall": 21.417543166000087
    }
   },
   "bchoco08": {
    "pre": {
+    "maximize": true,
     "status": "time_limit",
     "objective": null,
     "bound": 1.000000000002788,
     "node_count": 3,
     "gap_certified": false,
-    "wall": 22.136641505999933
+    "wall": 21.386567788000093
    },
    "post": {
+    "maximize": true,
     "status": "time_limit",
     "objective": null,
     "bound": 1.000000000002788,
     "node_count": 3,
     "gap_certified": false,
-    "wall": 20.3981126770002
+    "wall": 20.306743565000033
    }
   },
   "beuster": {
    "post": {
+    "maximize": false,
     "status": "time_limit",
     "objective": null,
     "bound": 6395.108328059316,
     "node_count": 7,
     "gap_certified": false,
-    "wall": 21.61065829500012
+    "wall": 21.53944314699993
    },
    "pre": {
+    "maximize": false,
     "status": "time_limit",
     "objective": null,
-    "bound": 6395.108328059316,
+    "bound": 6395.108327034671,
     "node_count": 7,
     "gap_certified": false,
-    "wall": 20.883928779999906
+    "wall": 21.234007547000147
    }
   },
   "casctanks": {
    "pre": {
+    "maximize": false,
     "status": "time_limit",
     "objective": null,
     "bound": -90.17862329759835,
     "node_count": 1,
     "gap_certified": false,
-    "wall": 20.934898602999965
+    "wall": 21.27176078699995
    },
    "post": {
+    "maximize": false,
     "status": "time_limit",
     "objective": null,
     "bound": -90.17862329759835,
     "node_count": 3,
     "gap_certified": false,
-    "wall": 27.27564052100024
+    "wall": 25.010035169000048
    }
   },
   "chance": {
    "post": {
+    "maximize": false,
     "status": "optimal",
     "objective": 29.894378166613386,
     "bound": 29.894378166613386,
     "node_count": 0,
     "gap_certified": true,
-    "wall": 0.4639579149998099
+    "wall": 0.40208159200005866
    },
    "pre": {
+    "maximize": false,
     "status": "optimal",
     "objective": 29.894378154271102,
     "bound": 29.894378154271102,
     "node_count": 0,
     "gap_certified": true,
-    "wall": 0.1849188989999675
+    "wall": 0.16450228000007883
    }
   },
   "clay0303hfsg": {
    "pre": {
+    "maximize": false,
     "status": "time_limit",
     "objective": null,
     "bound": null,
     "node_count": 3,
     "gap_certified": false,
-    "wall": 22.36598070800028
+    "wall": 20.643820403999825
    },
    "post": {
+    "maximize": false,
     "status": "time_limit",
     "objective": null,
     "bound": null,
-    "node_count": 95,
+    "node_count": 127,
     "gap_certified": false,
-    "wall": 20.70678265100014
+    "wall": 20.99889830500001
    }
   },
   "contvar": {
    "post": {
+    "maximize": false,
     "status": "time_limit",
     "objective": null,
     "bound": 180782.8593284799,
     "node_count": 3,
     "gap_certified": false,
-    "wall": 22.63025449199995
+    "wall": 22.113465987000154
    },
    "pre": {
+    "maximize": false,
     "status": "time_limit",
     "objective": null,
     "bound": 183632.02121055726,
     "node_count": 3,
     "gap_certified": false,
-    "wall": 24.087252487000114
+    "wall": 21.53963904400007
    }
   },
   "cvxnonsep_nsig30": {
    "pre": {
+    "maximize": false,
     "status": "optimal",
     "objective": 130.62871116925294,
     "bound": 130.61841392487688,
     "node_count": 171,
     "gap_certified": true,
-    "wall": 10.327229632000126
+    "wall": 5.474517335999963
    },
    "post": {
+    "maximize": false,
     "status": "optimal",
-    "objective": 130.62871268683438,
-    "bound": 130.6184154341326,
+    "objective": 130.62871123822686,
+    "bound": 130.61841401236617,
     "node_count": 171,
     "gap_certified": true,
-    "wall": 5.772850220999771
+    "wall": 3.6531784119999884
    }
   },
   "cvxnonsep_psig30": {
    "post": {
+    "maximize": false,
     "status": "optimal",
-    "objective": 78.998854365269,
-    "bound": 78.99701709863874,
+    "objective": 78.99885435294289,
+    "bound": 78.9970170582728,
     "node_count": 89,
     "gap_certified": true,
-    "wall": 3.786479123999925
+    "wall": 3.3853175290000763
    },
    "pre": {
+    "maximize": false,
     "status": "optimal",
     "objective": 78.99885435294289,
     "bound": 78.99701703820377,
     "node_count": 89,
     "gap_certified": true,
-    "wall": 1.8690656310000122
+    "wall": 1.8419379100000697
    }
   },
   "cvxnonsep_psig40r": {
    "pre": {
+    "maximize": false,
     "status": "optimal",
     "objective": 86.54527995164959,
     "bound": 86.53873600363832,
     "node_count": 103,
     "gap_certified": true,
-    "wall": 8.518324066000332
+    "wall": 7.935117317000049
    },
    "post": {
+    "maximize": false,
     "status": "optimal",
-    "objective": 86.54528288283356,
-    "bound": 86.53873904316234,
+    "objective": 86.54527995164958,
+    "bound": 86.5387360184926,
     "node_count": 95,
     "gap_certified": true,
-    "wall": 6.983134777000032
+    "wall": 6.1406269019998945
    }
   },
   "dispatch": {
    "post": {
+    "maximize": false,
     "status": "optimal",
-    "objective": 3155.2879268631687,
-    "bound": 3155.287861536673,
+    "objective": 3155.2879267317876,
+    "bound": 3155.2878615366767,
     "node_count": 23,
     "gap_certified": true,
-    "wall": 0.7959989019996101
+    "wall": 0.5210910200000853
    },
    "pre": {
+    "maximize": false,
     "status": "optimal",
     "objective": 3155.2879266857854,
     "bound": 3155.2878615366776,
     "node_count": 23,
     "gap_certified": true,
-    "wall": 0.38547951100008504
+    "wall": 0.38248191299999235
    }
   },
   "ex1221": {
    "pre": {
+    "maximize": false,
     "status": "optimal",
     "objective": 7.667180068813135,
     "bound": 7.667180068813077,
     "node_count": 5,
     "gap_certified": true,
-    "wall": 1.0075459250001586
+    "wall": 1.088639171000068
    },
    "post": {
+    "maximize": false,
     "status": "optimal",
     "objective": 7.667180068813135,
     "bound": 7.667180068813077,
     "node_count": 5,
     "gap_certified": true,
-    "wall": 0.8329038560000299
+    "wall": 0.6961785749999763
    }
   },
   "ex1222": {
    "post": {
+    "maximize": false,
     "status": "optimal",
-    "objective": 1.0765430833322618,
-    "bound": 1.0765430833322571,
-    "node_count": 3,
+    "objective": 1.0765430833322625,
+    "bound": 1.0765430463031955,
+    "node_count": 1,
     "gap_certified": true,
-    "wall": 0.4204117680001218
+    "wall": 0.4036420590000489
    },
    "pre": {
+    "maximize": false,
     "status": "optimal",
     "objective": 1.0765430833322625,
     "bound": 1.0765430463031964,
     "node_count": 1,
     "gap_certified": true,
-    "wall": 0.25425212400023156
+    "wall": 0.2393873399998938
    }
   },
   "ex1224": {
    "pre": {
+    "maximize": false,
     "status": "optimal",
     "objective": -0.9434704942820806,
     "bound": -0.9434705000000166,
     "node_count": 5,
     "gap_certified": true,
-    "wall": 3.870680566000374
+    "wall": 3.1738750510000955
    },
    "post": {
+    "maximize": false,
     "status": "optimal",
-    "objective": -0.9434704993121346,
-    "bound": -0.9434705000000165,
+    "objective": -0.9434704942820806,
+    "bound": -0.9434705000000166,
     "node_count": 5,
     "gap_certified": true,
-    "wall": 2.945993745999658
+    "wall": 2.6461232209999253
    }
   },
   "ex1225": {
    "post": {
+    "maximize": false,
     "status": "optimal",
-    "objective": 31.000000000008843,
-    "bound": 30.999999999999844,
+    "objective": 30.999999948692963,
+    "bound": 30.999999948692963,
     "node_count": 5,
     "gap_certified": true,
-    "wall": 2.976157606000015
+    "wall": 3.2333033429999887
    },
    "pre": {
+    "maximize": false,
     "status": "optimal",
     "objective": 30.999999913557566,
     "bound": 30.999999913557566,
     "node_count": 5,
     "gap_certified": true,
-    "wall": 2.979208139000093
+    "wall": 2.7822530089999873
    }
   },
   "ex1226": {
    "pre": {
+    "maximize": false,
     "status": "optimal",
     "objective": -17.000000003887443,
     "bound": -17.000000003887443,
     "node_count": 3,
     "gap_certified": true,
-    "wall": 1.0550850290001108
+    "wall": 1.2791051019999031
    },
    "post": {
+    "maximize": false,
     "status": "optimal",
-    "objective": -17.000000000000007,
-    "bound": -17.00000000000013,
-    "node_count": 5,
+    "objective": -17.000000003887443,
+    "bound": -17.000000003887443,
+    "node_count": 3,
     "gap_certified": true,
-    "wall": 1.3592462000001433
+    "wall": 1.432167889000084
    }
   },
   "ex14_1_9": {
    "post": {
+    "maximize": false,
     "status": "optimal",
-    "objective": 2.8370135742179245e-09,
-    "bound": 0.0,
-    "node_count": 5,
+    "objective": -1.9775220623231286e-16,
+    "bound": -1.9775220623231286e-16,
+    "node_count": 3,
     "gap_certified": true,
-    "wall": 0.2728006060001462
+    "wall": 1.1406090880000193
    },
    "pre": {
+    "maximize": false,
     "status": "optimal",
     "objective": -1.9775220540513224e-16,
     "bound": -1.9775220540513224e-16,
     "node_count": 3,
     "gap_certified": true,
-    "wall": 0.35003560699988157
+    "wall": 0.4209316100000251
    }
   },
   "fac2": {
    "pre": {
+    "maximize": false,
     "status": "optimal",
     "objective": 331837497.8394821,
     "bound": 331837497.54563797,
     "node_count": 41,
     "gap_certified": true,
-    "wall": 10.471384882000166
+    "wall": 10.586713098000018
    },
    "post": {
+    "maximize": false,
     "status": "optimal",
-    "objective": 331837498.1769339,
-    "bound": 331837498.1760158,
+    "objective": 331837498.17691857,
+    "bound": 331837497.54565895,
     "node_count": 41,
     "gap_certified": true,
-    "wall": 12.937645874000282
+    "wall": 8.704947227000048
    }
   },
   "flay02m": {
    "post": {
+    "maximize": false,
     "status": "optimal",
-    "objective": 37.94733200383577,
-    "bound": 37.94733193020236,
+    "objective": 37.947331863834606,
+    "bound": 37.94733180456953,
     "node_count": 7,
     "gap_certified": true,
-    "wall": 0.9391262450003524
+    "wall": 0.6680022479999934
    },
    "pre": {
+    "maximize": false,
     "status": "optimal",
     "objective": 37.94733186383461,
     "bound": 37.947331804569515,
     "node_count": 7,
     "gap_certified": true,
-    "wall": 0.49601408899980015
+    "wall": 0.44236480800009303
    }
   },
   "flay03m": {
    "pre": {
+    "maximize": false,
     "status": "optimal",
     "objective": 48.98979479383567,
     "bound": 48.98979470823052,
     "node_count": 111,
     "gap_certified": true,
-    "wall": 8.738355416000104
+    "wall": 7.461430084000085
    },
    "post": {
+    "maximize": false,
     "status": "optimal",
-    "objective": 48.989794973836744,
-    "bound": 48.98979486747301,
+    "objective": 48.98979479383577,
+    "bound": 48.98979470823063,
     "node_count": 113,
     "gap_certified": true,
-    "wall": 9.112262885999826
+    "wall": 7.378897106000068
    }
   },
   "gbd": {
    "post": {
+    "maximize": false,
     "status": "optimal",
-    "objective": 2.1999999995740955,
-    "bound": 2.1999999995740955,
+    "objective": 2.1999999825308127,
+    "bound": 2.1999999825308127,
     "node_count": 3,
     "gap_certified": true,
-    "wall": 0.045054060999973444
+    "wall": 0.02703937000001133
    },
    "pre": {
+    "maximize": false,
     "status": "optimal",
-    "objective": 2.1999999995740955,
-    "bound": 2.1999999995740955,
+    "objective": 2.1999999825308127,
+    "bound": 2.1999999825308127,
     "node_count": 3,
     "gap_certified": true,
-    "wall": 0.03419560600013938
+    "wall": 0.022417828000016016
    }
   },
   "gkocis": {
    "pre": {
+    "maximize": false,
     "status": "optimal",
     "objective": -1.9230987798770212,
     "bound": -1.9230988280923489,
     "node_count": 5,
     "gap_certified": true,
-    "wall": 1.645017875999656
+    "wall": 1.3983889429998726
    },
    "post": {
+    "maximize": false,
     "status": "optimal",
-    "objective": -1.9230986924056728,
-    "bound": -1.9230987422706283,
-    "node_count": 7,
+    "objective": -1.9230987747401134,
+    "bound": -1.9230988280923498,
+    "node_count": 5,
     "gap_certified": true,
-    "wall": 2.338902108000184
+    "wall": 1.2420297620001293
    }
   },
   "hda": {
    "post": {
+    "maximize": false,
     "status": "time_limit",
     "objective": null,
     "bound": -64473.44240243703,
     "node_count": 1,
     "gap_certified": false,
-    "wall": 21.1590209269998
+    "wall": 21.7771964760002
    },
    "pre": {
+    "maximize": false,
     "status": "time_limit",
     "objective": null,
     "bound": -64473.44240243703,
     "node_count": 1,
     "gap_certified": false,
-    "wall": 21.094986974999756
+    "wall": 21.071228192000035
    }
   },
   "heatexch_gen1": {
    "pre": {
+    "maximize": false,
     "status": "time_limit",
     "objective": null,
     "bound": 38183.5317460179,
     "node_count": 3,
     "gap_certified": false,
-    "wall": 22.285185699000067
+    "wall": 24.602463700000044
    },
    "post": {
+    "maximize": false,
     "status": "time_limit",
     "objective": null,
     "bound": 38183.5317460179,
     "node_count": 3,
     "gap_certified": false,
-    "wall": 26.217303968000124
+    "wall": 25.374974721999934
    }
   },
   "heatexch_gen2": {
    "post": {
+    "maximize": false,
     "status": "time_limit",
     "objective": null,
     "bound": 555767.7902857271,
     "node_count": 7,
     "gap_certified": false,
-    "wall": 22.110858305999955
+    "wall": 22.050892694999902
    },
    "pre": {
+    "maximize": false,
     "status": "time_limit",
     "objective": null,
     "bound": 555767.7902857271,
-    "node_count": 7,
+    "node_count": 3,
     "gap_certified": false,
-    "wall": 21.20073213400019
+    "wall": 21.659613729000057
    }
   },
   "heatexch_gen3": {
    "pre": {
+    "maximize": false,
     "status": "time_limit",
     "objective": null,
     "bound": null,
     "node_count": 3,
     "gap_certified": false,
-    "wall": 26.534706085999915
+    "wall": 24.805495338000128
    },
    "post": {
+    "maximize": false,
     "status": "time_limit",
     "objective": null,
     "bound": null,
     "node_count": 3,
     "gap_certified": false,
-    "wall": 204.4960045869998
+    "wall": 159.09318966699993
    }
   },
   "m3": {
    "post": {
+    "maximize": false,
     "status": "optimal",
-    "objective": 37.800000263754704,
-    "bound": 37.800000072787064,
-    "node_count": 53,
+    "objective": 37.79999970380645,
+    "bound": 37.79999957378442,
+    "node_count": 41,
     "gap_certified": true,
-    "wall": 5.847690927999793
+    "wall": 4.161642962000087
    },
    "pre": {
+    "maximize": false,
     "status": "optimal",
     "objective": 37.79999966997884,
     "bound": 37.79999951039201,
     "node_count": 47,
     "gap_certified": true,
-    "wall": 4.307587265000166
+    "wall": 5.255348631000061
    }
   },
   "nvs01": {
    "pre": {
+    "maximize": false,
     "status": "optimal",
     "objective": 12.46966882156821,
     "bound": 12.46966882156821,
     "node_count": 3,
     "gap_certified": true,
-    "wall": 1.755747736000103
+    "wall": 1.6439451590001681
    },
    "post": {
+    "maximize": false,
     "status": "optimal",
     "objective": 12.46966882156821,
     "bound": 12.46966882156821,
     "node_count": 3,
     "gap_certified": true,
-    "wall": 1.3634539760000735
+    "wall": 1.2853830799999741
    }
   },
   "nvs02": {
    "post": {
+    "maximize": false,
     "status": "optimal",
     "objective": 5.96418452307,
     "bound": 5.96418452307,
     "node_count": 345,
     "gap_certified": true,
-    "wall": 0.41730416900009004
+    "wall": 0.45007736000002296
    },
    "pre": {
+    "maximize": false,
     "status": "optimal",
     "objective": 5.96418452307,
     "bound": 5.96418452307,
     "node_count": 345,
     "gap_certified": true,
-    "wall": 0.37162310200028514
+    "wall": 0.3842895899999803
    }
   },
   "nvs03": {
    "pre": {
+    "maximize": false,
     "status": "optimal",
     "objective": 16.0,
     "bound": 15.99999972676511,
     "node_count": 5,
     "gap_certified": true,
-    "wall": 0.1952417030001925
+    "wall": 0.2949178530000154
    },
    "post": {
+    "maximize": false,
     "status": "optimal",
     "objective": 16.0,
-    "bound": 16.0,
-    "node_count": 3,
+    "bound": 15.99999996676705,
+    "node_count": 5,
     "gap_certified": true,
-    "wall": 0.1750783349998528
+    "wall": 0.1825162210000144
    }
   },
   "nvs04": {
    "post": {
+    "maximize": false,
     "status": "optimal",
     "objective": 0.720000000000006,
     "bound": 0.7199999999999773,
     "node_count": 5,
     "gap_certified": true,
-    "wall": 0.49249716800022725
+    "wall": 0.43267889300000206
    },
    "pre": {
+    "maximize": false,
     "status": "optimal",
     "objective": 0.720000000000006,
     "bound": 0.7199999999999773,
     "node_count": 5,
     "gap_certified": true,
-    "wall": 0.34949135599981673
+    "wall": 0.32748328499997115
    }
   },
   "nvs05": {
    "pre": {
+    "maximize": false,
     "status": "feasible",
     "objective": 8.731956986640078,
     "bound": 3.5424692441047068,
-    "node_count": 33,
+    "node_count": 41,
     "gap_certified": false,
-    "wall": 20.248498161000043
+    "wall": 20.182257691999894
    },
    "post": {
+    "maximize": false,
     "status": "feasible",
-    "objective": 8.73195696936806,
-    "bound": 3.5139026016464836,
+    "objective": 12.589492574009626,
+    "bound": 3.513753543700079,
     "node_count": 33,
     "gap_certified": false,
-    "wall": 20.38520216699999
+    "wall": 20.12968590100013
    }
   },
   "nvs06": {
    "post": {
+    "maximize": false,
     "status": "optimal",
     "objective": 1.7703125,
     "bound": 1.7703124999999627,
     "node_count": 5,
     "gap_certified": true,
-    "wall": 1.5734330180002871
+    "wall": 1.5876532459999453
    },
    "pre": {
+    "maximize": false,
     "status": "optimal",
     "objective": 1.7703125,
     "bound": 1.7703124999999627,
     "node_count": 5,
     "gap_certified": true,
-    "wall": 1.1964277829997627
+    "wall": 1.07712272699996
    }
   },
   "nvs07": {
    "pre": {
+    "maximize": false,
     "status": "optimal",
     "objective": 4.0,
     "bound": 4.0,
     "node_count": 5,
     "gap_certified": true,
-    "wall": 0.14979283399998167
+    "wall": 0.09569734999990942
    },
    "post": {
+    "maximize": false,
     "status": "optimal",
     "objective": 4.0,
     "bound": 4.0,
     "node_count": 5,
     "gap_certified": true,
-    "wall": 0.07110062800029482
+    "wall": 0.06396703199993681
    }
   },
   "nvs08": {
    "post": {
-    "status": "optimal",
-    "objective": 23.449727347978744,
-    "bound": 23.449727347447233,
-    "node_count": 5,
-    "gap_certified": true,
-    "wall": 1.8630246170000646
-   },
-   "pre": {
+    "maximize": false,
     "status": "optimal",
     "objective": 23.449727347139827,
     "bound": 23.44972734516655,
     "node_count": 3,
     "gap_certified": true,
-    "wall": 1.455282664999686
+    "wall": 1.4748921469999914
+   },
+   "pre": {
+    "maximize": false,
+    "status": "optimal",
+    "objective": 23.449727347139827,
+    "bound": 23.44972734516655,
+    "node_count": 3,
+    "gap_certified": true,
+    "wall": 1.2505608799999663
    }
   },
   "nvs09": {
    "pre": {
+    "maximize": false,
     "status": "optimal",
     "objective": -43.134336918035295,
     "bound": -43.13433691803662,
     "node_count": 5,
     "gap_certified": true,
-    "wall": 7.549358587999905
+    "wall": 6.435507588999826
    },
    "post": {
+    "maximize": false,
     "status": "optimal",
     "objective": -43.13433691803531,
     "bound": -43.13433691803662,
     "node_count": 5,
     "gap_certified": true,
-    "wall": 5.06351296999992
+    "wall": 4.4610048320000715
    }
   },
   "nvs10": {
    "post": {
+    "maximize": false,
     "status": "optimal",
     "objective": -310.7999999999999,
     "bound": -310.7999999999999,
     "node_count": 5,
     "gap_certified": true,
-    "wall": 0.18107256899975255
+    "wall": 0.16603770200003964
    },
    "pre": {
+    "maximize": false,
     "status": "optimal",
     "objective": -310.7999999999999,
     "bound": -310.7999999999999,
     "node_count": 5,
     "gap_certified": true,
-    "wall": 0.14433151599996563
+    "wall": 0.13045944899999995
    }
   },
   "nvs11": {
    "pre": {
+    "maximize": false,
     "status": "optimal",
     "objective": -431.0000000000085,
     "bound": -431.0000000000085,
     "node_count": 55,
     "gap_certified": true,
-    "wall": 0.6414511250000032
+    "wall": 1.1448019409999688
    },
    "post": {
+    "maximize": false,
     "status": "optimal",
     "objective": -431.0000000000085,
     "bound": -431.0000000000085,
     "node_count": 55,
     "gap_certified": true,
-    "wall": 0.5812574599999607
+    "wall": 0.7152426210000158
    }
   },
   "nvs12": {
    "post": {
+    "maximize": false,
     "status": "optimal",
     "objective": -481.20000000001,
     "bound": -481.20000000001,
     "node_count": 231,
     "gap_certified": true,
-    "wall": 2.1597501929995815
+    "wall": 2.4171318409999003
    },
    "pre": {
+    "maximize": false,
     "status": "optimal",
     "objective": -481.20000000001,
     "bound": -481.20000000001,
     "node_count": 231,
     "gap_certified": true,
-    "wall": 2.078526734999741
+    "wall": 2.097880950999979
    }
   },
   "nvs13": {
    "pre": {
+    "maximize": false,
     "status": "optimal",
     "objective": -585.2,
     "bound": -585.2,
     "node_count": 637,
     "gap_certified": true,
-    "wall": 1.7141908429998693
+    "wall": 1.8591022190000785
    },
    "post": {
+    "maximize": false,
     "status": "optimal",
     "objective": -585.2,
     "bound": -585.2,
     "node_count": 637,
     "gap_certified": true,
-    "wall": 1.6717294449999827
+    "wall": 1.4032217410001522
    }
   },
   "nvs14": {
    "post": {
+    "maximize": false,
     "status": "optimal",
     "objective": -40358.15476929995,
     "bound": -40358.154769299996,
     "node_count": 129,
     "gap_certified": true,
-    "wall": 0.7930625140002121
+    "wall": 0.8666135529999792
    },
    "pre": {
+    "maximize": false,
     "status": "optimal",
     "objective": -40358.15476929995,
     "bound": -40358.154769299996,
     "node_count": 129,
     "gap_certified": true,
-    "wall": 0.9612146969998321
+    "wall": 0.8534960629999659
    }
   },
   "nvs15": {
    "pre": {
+    "maximize": false,
     "status": "optimal",
     "objective": 1.0,
     "bound": 1.0,
     "node_count": 7,
     "gap_certified": true,
-    "wall": 0.08759022100002767
+    "wall": 0.07827312700010225
    },
    "post": {
+    "maximize": false,
     "status": "optimal",
     "objective": 1.0,
     "bound": 1.0,
     "node_count": 7,
     "gap_certified": true,
-    "wall": 0.08692739699972662
+    "wall": 0.07677735400011443
    }
   },
   "nvs21": {
    "post": {
-    "status": "optimal",
-    "objective": -5.684782472248296,
-    "bound": -5.684782500002237,
-    "node_count": 37,
-    "gap_certified": true,
-    "wall": 4.944593620999967
-   },
-   "pre": {
+    "maximize": false,
     "status": "optimal",
     "objective": -5.684782628025259,
     "bound": -5.684782628025259,
     "node_count": 3,
     "gap_certified": true,
-    "wall": 7.143478100000266
+    "wall": 8.974388968000085
+   },
+   "pre": {
+    "maximize": false,
+    "status": "optimal",
+    "objective": -5.684782628025259,
+    "bound": -5.684782628025259,
+    "node_count": 3,
+    "gap_certified": true,
+    "wall": 6.292978661999996
    }
   },
   "oaer": {
    "pre": {
+    "maximize": false,
     "status": "optimal",
     "objective": -1.923098499884843,
     "bound": -1.923098601139822,
     "node_count": 3,
     "gap_certified": true,
-    "wall": 1.4632768280002892
+    "wall": 1.189243807000139
    },
    "post": {
+    "maximize": false,
     "status": "optimal",
-    "objective": -1.9230985101297913,
-    "bound": -1.9230985229112765,
-    "node_count": 5,
+    "objective": -1.9230985115702832,
+    "bound": -1.923098601139822,
+    "node_count": 3,
     "gap_certified": true,
-    "wall": 1.6399173979998523
+    "wall": 1.2234205120000752
    }
   },
   "st_e11": {
    "post": {
+    "maximize": false,
     "status": "optimal",
-    "objective": 189.31162970097128,
-    "bound": 189.311629686619,
-    "node_count": 5,
+    "objective": 189.31178228026806,
+    "bound": 189.31162968661764,
+    "node_count": 27,
     "gap_certified": true,
-    "wall": 1.7492268539999714
+    "wall": 3.9886188610000772
    },
    "pre": {
+    "maximize": false,
     "status": "optimal",
     "objective": 189.31162974131917,
     "bound": 189.31162968661766,
     "node_count": 27,
     "gap_certified": true,
-    "wall": 3.9942719690002377
+    "wall": 3.3204398390000733
    }
   },
   "st_e13": {
    "pre": {
+    "maximize": false,
     "status": "optimal",
     "objective": 1.9999999825187946,
     "bound": 1.9999999825187946,
     "node_count": 1,
     "gap_certified": true,
-    "wall": 0.27426670399972863
+    "wall": 0.23803890599992883
    },
    "post": {
+    "maximize": false,
     "status": "optimal",
-    "objective": 2.0000000025188225,
-    "bound": 2.0,
+    "objective": 1.9999999825187946,
+    "bound": 1.9999999825187946,
     "node_count": 1,
     "gap_certified": true,
-    "wall": 0.1379266369999641
+    "wall": 0.1254774509998242
    }
   },
   "st_e29": {
    "post": {
-    "status": "optimal",
-    "objective": -0.9434704993121346,
-    "bound": -0.9434705000000165,
-    "node_count": 5,
-    "gap_certified": true,
-    "wall": 2.964155441999992
-   },
-   "pre": {
+    "maximize": false,
     "status": "optimal",
     "objective": -0.9434704942820806,
     "bound": -0.9434705000000166,
     "node_count": 5,
     "gap_certified": true,
-    "wall": 2.8933606120003788
+    "wall": 2.5590663169998606
+   },
+   "pre": {
+    "maximize": false,
+    "status": "optimal",
+    "objective": -0.9434704942820806,
+    "bound": -0.9434705000000166,
+    "node_count": 5,
+    "gap_certified": true,
+    "wall": 2.665116517000115
    }
   },
   "st_e36": {
    "pre": {
+    "maximize": false,
     "status": "optimal",
     "objective": -245.99999999999997,
     "bound": -246.00000000170422,
     "node_count": 85,
     "gap_certified": true,
-    "wall": 11.671530211000118
+    "wall": 10.071021720999852
    },
    "post": {
+    "maximize": false,
     "status": "optimal",
-    "objective": -246.0,
+    "objective": -245.99999999999997,
     "bound": -246.00000000170422,
     "node_count": 85,
     "gap_certified": true,
-    "wall": 10.362108264000199
+    "wall": 9.108315689999927
    }
   },
   "st_e38": {
    "post": {
-    "status": "optimal",
-    "objective": 7197.727148526157,
-    "bound": 7197.727148526157,
-    "node_count": 3,
-    "gap_certified": true,
-    "wall": 1.0355117770000106
-   },
-   "pre": {
+    "maximize": false,
     "status": "optimal",
     "objective": 7197.727116826533,
     "bound": 7197.727116826533,
     "node_count": 3,
     "gap_certified": true,
-    "wall": 1.770093886000268
+    "wall": 0.9304301829999986
+   },
+   "pre": {
+    "maximize": false,
+    "status": "optimal",
+    "objective": 7197.727116826533,
+    "bound": 7197.727116826533,
+    "node_count": 3,
+    "gap_certified": true,
+    "wall": 0.7120587800000067
    }
   },
   "st_miqp1": {
    "pre": {
+    "maximize": false,
     "status": "optimal",
     "objective": 280.9999999906497,
     "bound": 280.9999999906497,
     "node_count": 15,
     "gap_certified": true,
-    "wall": 0.21868393500017191
+    "wall": 0.02052733999994416
    },
    "post": {
+    "maximize": false,
     "status": "optimal",
     "objective": 280.9999999906497,
     "bound": 280.9999999906497,
     "node_count": 15,
     "gap_certified": true,
-    "wall": 0.03125743100008549
+    "wall": 0.018686946999878273
    }
   },
   "st_miqp2": {
    "post": {
+    "maximize": false,
     "status": "optimal",
     "objective": 2.0,
     "bound": 2.0,
     "node_count": 9,
     "gap_certified": true,
-    "wall": 0.07676102499999615
+    "wall": 0.02447017899999082
    },
    "pre": {
+    "maximize": false,
     "status": "optimal",
     "objective": 2.0,
     "bound": 2.0,
     "node_count": 9,
     "gap_certified": true,
-    "wall": 0.06837029500002245
+    "wall": 0.023696365999967384
    }
   },
   "st_miqp3": {
    "pre": {
+    "maximize": false,
     "status": "optimal",
     "objective": -6.0,
     "bound": -6.0,
     "node_count": 1,
     "gap_certified": true,
-    "wall": 0.02205712000022686
+    "wall": 0.00906364599995868
    },
    "post": {
+    "maximize": false,
     "status": "optimal",
     "objective": -6.0,
     "bound": -6.0,
     "node_count": 1,
     "gap_certified": true,
-    "wall": 0.01834424799972112
+    "wall": 0.008847068000022773
    }
   },
   "st_miqp4": {
    "post": {
+    "maximize": false,
     "status": "optimal",
-    "objective": -4574.000000000435,
-    "bound": -4574.000000000435,
+    "objective": -4574.0000024840665,
+    "bound": -4574.0000024840665,
     "node_count": 3,
     "gap_certified": true,
-    "wall": 0.09114826299992274
+    "wall": 0.026047281999808547
    },
    "pre": {
+    "maximize": false,
     "status": "optimal",
-    "objective": -4574.000000000435,
-    "bound": -4574.000000000435,
+    "objective": -4574.0000024840665,
+    "bound": -4574.0000024840665,
     "node_count": 3,
     "gap_certified": true,
-    "wall": 0.13341707600011432
+    "wall": 0.026393293999944945
    }
   },
   "st_miqp5": {
    "pre": {
+    "maximize": false,
     "status": "optimal",
-    "objective": -333.88888889644716,
-    "bound": -333.88888889644716,
+    "objective": -333.88889024868075,
+    "bound": -333.88889024868075,
     "node_count": 1,
     "gap_certified": true,
-    "wall": 0.10419316000024992
+    "wall": 0.0324710889999551
    },
    "post": {
+    "maximize": false,
     "status": "optimal",
-    "objective": -333.88888889644716,
-    "bound": -333.88888889644716,
+    "objective": -333.88889024868075,
+    "bound": -333.88889024868075,
     "node_count": 1,
     "gap_certified": true,
-    "wall": 0.062342824999632285
+    "wall": 0.031452121000029365
    }
   },
   "st_test1": {
    "post": {
+    "maximize": false,
     "status": "optimal",
     "objective": -1.6495994490692313e-08,
     "bound": -1.6495994490692313e-08,
     "node_count": 15,
     "gap_certified": true,
-    "wall": 0.08140621399979864
+    "wall": 0.03626103800002056
    },
    "pre": {
+    "maximize": false,
     "status": "optimal",
     "objective": -1.6495994490692313e-08,
     "bound": -1.6495994490692313e-08,
     "node_count": 15,
     "gap_certified": true,
-    "wall": 0.051205858000230364
+    "wall": 0.035310013999833245
    }
   },
   "st_testgr3": {
    "pre": {
+    "maximize": false,
     "status": "optimal",
     "objective": -20.59,
     "bound": -20.59070709795548,
     "node_count": 549,
     "gap_certified": true,
-    "wall": 0.45436429100027453
+    "wall": 0.28182646599998407
    },
    "post": {
+    "maximize": false,
     "status": "optimal",
     "objective": -20.59,
     "bound": -20.59070709795548,
     "node_count": 549,
     "gap_certified": true,
-    "wall": 0.5031579499996042
+    "wall": 0.2782758789999207
    }
   },
   "syn05hfsg": {
    "post": {
+    "maximize": true,
     "status": "feasible",
-    "objective": 837.7323012718434,
-    "bound": 840.4893941019076,
-    "node_count": 215,
+    "objective": 837.7324083563395,
+    "bound": 838.3878622240098,
+    "node_count": 171,
     "gap_certified": false,
-    "wall": 20.24814080499982
+    "wall": 20.28268366600014
    },
    "pre": {
+    "maximize": true,
     "status": "feasible",
     "objective": 837.732412391107,
-    "bound": 840.4893941019081,
-    "node_count": 125,
+    "bound": 838.3878622240098,
+    "node_count": 181,
     "gap_certified": false,
-    "wall": 20.11201671300023
+    "wall": 20.11427130700008
    }
   },
   "tanksize": {
    "pre": {
+    "maximize": false,
     "status": "time_limit",
     "objective": 1.268643752557795,
-    "bound": 1.2609361431125585,
-    "node_count": 3330,
+    "bound": 1.2616432205298513,
+    "node_count": 3596,
     "gap_certified": true,
-    "wall": 20.3181326670001
+    "wall": 20.114331551000078
    },
    "post": {
+    "maximize": false,
     "status": "time_limit",
-    "objective": 1.268643759853009,
-    "bound": 1.2598035867232422,
-    "node_count": 3076,
+    "objective": 1.2686437708530283,
+    "bound": 1.262799393410885,
+    "node_count": 3964,
     "gap_certified": true,
-    "wall": 20.118190193999908
+    "wall": 20.109238961000074
    }
   },
   "tls2": {
    "post": {
+    "maximize": false,
     "status": "feasible",
-    "objective": 10.299999999983916,
-    "bound": 2.448712647787379,
+    "objective": 10.299999996297192,
+    "bound": 2.4487125876978713,
     "node_count": 353,
     "gap_certified": false,
-    "wall": 20.627966677999666
+    "wall": 20.732897183999967
    },
    "pre": {
+    "maximize": false,
     "status": "feasible",
-    "objective": 6.299999911869455,
-    "bound": 2.4487125876978726,
-    "node_count": 339,
+    "objective": 5.299999922109238,
+    "bound": 3.1706801036010077,
+    "node_count": 349,
     "gap_certified": false,
-    "wall": 21.14731124700029
+    "wall": 20.800227508000035
    }
   },
   "tspn05": {
    "pre": {
+    "maximize": false,
     "status": "feasible",
     "objective": 191.2552076848774,
-    "bound": 178.27199442798212,
-    "node_count": 33,
+    "bound": 179.44337578420988,
+    "node_count": 49,
     "gap_certified": false,
-    "wall": 20.15668522499982
+    "wall": 20.155364598999768
    },
    "post": {
+    "maximize": false,
     "status": "feasible",
-    "objective": 191.25520784460605,
-    "bound": 179.0941485386719,
-    "node_count": 53,
+    "objective": 191.2552076848786,
+    "bound": 179.44337578420988,
+    "node_count": 49,
     "gap_certified": false,
-    "wall": 20.138568632999977
+    "wall": 20.18219688099998
    }
   },
   "tspn08": {
    "post": {
+    "maximize": false,
     "status": "feasible",
-    "objective": 290.5668539675022,
+    "objective": 290.5668537474047,
     "bound": null,
     "node_count": 1,
     "gap_certified": false,
-    "wall": 13.85614847700026
+    "wall": 19.96056919099965
    },
    "pre": {
+    "maximize": false,
     "status": "feasible",
     "objective": 290.56685374735093,
     "bound": null,
     "node_count": 1,
     "gap_certified": false,
-    "wall": 17.982297136999932
+    "wall": 16.166508093000175
    }
   },
   "tspn10": {
    "pre": {
+    "maximize": false,
     "status": "feasible",
     "objective": 225.1260713973286,
     "bound": null,
     "node_count": 1,
     "gap_certified": false,
-    "wall": 16.99774281100008
+    "wall": 15.319980657000087
    },
    "post": {
+    "maximize": false,
     "status": "feasible",
-    "objective": 225.12607170016992,
+    "objective": 225.12607139732896,
     "bound": null,
     "node_count": 1,
     "gap_certified": false,
-    "wall": 20.852727699999832
+    "wall": 19.474078835
    }
   },
   "tspn12": {
    "post": {
+    "maximize": false,
     "status": "time_limit",
     "objective": null,
     "bound": null,
     "node_count": 3,
     "gap_certified": false,
-    "wall": 46.11591934199987
+    "wall": 35.189106618000096
    },
    "pre": {
+    "maximize": false,
     "status": "feasible",
     "objective": 262.64739525060224,
     "bound": null,
     "node_count": 1,
     "gap_certified": false,
-    "wall": 15.90270813699999
+    "wall": 14.85704738000004
    }
   }
  },
  "diffs": [
+  [
+   "beuster",
+   {
+    "bound": [
+     6395.108327034671,
+     6395.108328059316
+    ]
+   }
+  ],
   [
    "casctanks",
    {
@@ -1217,7 +1358,7 @@
    {
     "node_count": [
      3,
-     95
+     127
     ]
    }
   ],
@@ -1235,24 +1376,20 @@
    {
     "objective": [
      130.62871116925294,
-     130.62871268683438
+     130.62871123822686
     ],
     "bound": [
      130.61841392487688,
-     130.6184154341326
+     130.61841401236617
     ]
    }
   ],
   [
    "cvxnonsep_psig30",
    {
-    "objective": [
-     78.99885435294289,
-     78.998854365269
-    ],
     "bound": [
      78.99701703820377,
-     78.99701709863874
+     78.9970170582728
     ]
    }
   ],
@@ -1261,11 +1398,11 @@
    {
     "objective": [
      86.54527995164959,
-     86.54528288283356
+     86.54527995164958
     ],
     "bound": [
      86.53873600363832,
-     86.53873904316234
+     86.5387360184926
     ],
     "node_count": [
      103,
@@ -1278,41 +1415,20 @@
    {
     "objective": [
      3155.2879266857854,
-     3155.2879268631687
+     3155.2879267317876
     ],
     "bound": [
      3155.2878615366776,
-     3155.287861536673
+     3155.2878615366767
     ]
    }
   ],
   [
    "ex1222",
    {
-    "objective": [
-     1.0765430833322625,
-     1.0765430833322618
-    ],
     "bound": [
      1.0765430463031964,
-     1.0765430833322571
-    ],
-    "node_count": [
-     1,
-     3
-    ]
-   }
-  ],
-  [
-   "ex1224",
-   {
-    "objective": [
-     -0.9434704942820806,
-     -0.9434704993121346
-    ],
-    "bound": [
-     -0.9434705000000166,
-     -0.9434705000000165
+     1.0765430463031955
     ]
    }
   ],
@@ -1321,28 +1437,11 @@
    {
     "objective": [
      30.999999913557566,
-     31.000000000008843
+     30.999999948692963
     ],
     "bound": [
      30.999999913557566,
-     30.999999999999844
-    ]
-   }
-  ],
-  [
-   "ex1226",
-   {
-    "objective": [
-     -17.000000003887443,
-     -17.000000000000007
-    ],
-    "bound": [
-     -17.000000003887443,
-     -17.00000000000013
-    ],
-    "node_count": [
-     3,
-     5
+     30.999999948692963
     ]
    }
   ],
@@ -1351,15 +1450,11 @@
    {
     "objective": [
      -1.9775220540513224e-16,
-     2.8370135742179245e-09
+     -1.9775220623231286e-16
     ],
     "bound": [
      -1.9775220540513224e-16,
-     0.0
-    ],
-    "node_count": [
-     3,
-     5
+     -1.9775220623231286e-16
     ]
    }
   ],
@@ -1368,11 +1463,11 @@
    {
     "objective": [
      331837497.8394821,
-     331837498.1769339
+     331837498.17691857
     ],
     "bound": [
      331837497.54563797,
-     331837498.1760158
+     331837497.54565895
     ]
    }
   ],
@@ -1381,11 +1476,11 @@
    {
     "objective": [
      37.94733186383461,
-     37.94733200383577
+     37.947331863834606
     ],
     "bound": [
      37.947331804569515,
-     37.94733193020236
+     37.94733180456953
     ]
    }
   ],
@@ -1394,11 +1489,11 @@
    {
     "objective": [
      48.98979479383567,
-     48.989794973836744
+     48.98979479383577
     ],
     "bound": [
      48.98979470823052,
-     48.98979486747301
+     48.98979470823063
     ],
     "node_count": [
      111,
@@ -1411,14 +1506,19 @@
    {
     "objective": [
      -1.9230987798770212,
-     -1.9230986924056728
+     -1.9230987747401134
     ],
     "bound": [
      -1.9230988280923489,
-     -1.9230987422706283
-    ],
+     -1.9230988280923498
+    ]
+   }
+  ],
+  [
+   "heatexch_gen2",
+   {
     "node_count": [
-     5,
+     3,
      7
     ]
    }
@@ -1428,15 +1528,15 @@
    {
     "objective": [
      37.79999966997884,
-     37.800000263754704
+     37.79999970380645
     ],
     "bound": [
      37.79999951039201,
-     37.800000072787064
+     37.79999957378442
     ],
     "node_count": [
      47,
-     53
+     41
     ]
    }
   ],
@@ -1445,11 +1545,7 @@
    {
     "bound": [
      15.99999972676511,
-     16.0
-    ],
-    "node_count": [
-     5,
-     3
+     15.99999996676705
     ]
    }
   ],
@@ -1458,28 +1554,15 @@
    {
     "objective": [
      8.731956986640078,
-     8.73195696936806
+     12.589492574009626
     ],
     "bound": [
      3.5424692441047068,
-     3.5139026016464836
-    ]
-   }
-  ],
-  [
-   "nvs08",
-   {
-    "objective": [
-     23.449727347139827,
-     23.449727347978744
-    ],
-    "bound": [
-     23.44972734516655,
-     23.449727347447233
+     3.513753543700079
     ],
     "node_count": [
-     3,
-     5
+     41,
+     33
     ]
    }
   ],
@@ -1493,36 +1576,11 @@
    }
   ],
   [
-   "nvs21",
-   {
-    "objective": [
-     -5.684782628025259,
-     -5.684782472248296
-    ],
-    "bound": [
-     -5.684782628025259,
-     -5.684782500002237
-    ],
-    "node_count": [
-     3,
-     37
-    ]
-   }
-  ],
-  [
    "oaer",
    {
     "objective": [
      -1.923098499884843,
-     -1.9230985101297913
-    ],
-    "bound": [
-     -1.923098601139822,
-     -1.9230985229112765
-    ],
-    "node_count": [
-     3,
-     5
+     -1.9230985115702832
     ]
    }
   ],
@@ -1531,63 +1589,11 @@
    {
     "objective": [
      189.31162974131917,
-     189.31162970097128
+     189.31178228026806
     ],
     "bound": [
      189.31162968661766,
-     189.311629686619
-    ],
-    "node_count": [
-     27,
-     5
-    ]
-   }
-  ],
-  [
-   "st_e13",
-   {
-    "objective": [
-     1.9999999825187946,
-     2.0000000025188225
-    ],
-    "bound": [
-     1.9999999825187946,
-     2.0
-    ]
-   }
-  ],
-  [
-   "st_e29",
-   {
-    "objective": [
-     -0.9434704942820806,
-     -0.9434704993121346
-    ],
-    "bound": [
-     -0.9434705000000166,
-     -0.9434705000000165
-    ]
-   }
-  ],
-  [
-   "st_e36",
-   {
-    "objective": [
-     -245.99999999999997,
-     -246.0
-    ]
-   }
-  ],
-  [
-   "st_e38",
-   {
-    "objective": [
-     7197.727116826533,
-     7197.727148526157
-    ],
-    "bound": [
-     7197.727116826533,
-     7197.727148526157
+     189.31162968661764
     ]
    }
   ],
@@ -1596,15 +1602,11 @@
    {
     "objective": [
      837.732412391107,
-     837.7323012718434
-    ],
-    "bound": [
-     840.4893941019081,
-     840.4893941019076
+     837.7324083563395
     ],
     "node_count": [
-     125,
-     215
+     181,
+     171
     ]
    }
   ],
@@ -1613,15 +1615,15 @@
    {
     "objective": [
      1.268643752557795,
-     1.268643759853009
+     1.2686437708530283
     ],
     "bound": [
-     1.2609361431125585,
-     1.2598035867232422
+     1.2616432205298513,
+     1.262799393410885
     ],
     "node_count": [
-     3330,
-     3076
+     3596,
+     3964
     ]
    }
   ],
@@ -1629,15 +1631,15 @@
    "tls2",
    {
     "objective": [
-     6.299999911869455,
-     10.299999999983916
+     5.299999922109238,
+     10.299999996297192
     ],
     "bound": [
-     2.4487125876978726,
-     2.448712647787379
+     3.1706801036010077,
+     2.4487125876978713
     ],
     "node_count": [
-     339,
+     349,
      353
     ]
    }
@@ -1647,15 +1649,7 @@
    {
     "objective": [
      191.2552076848774,
-     191.25520784460605
-    ],
-    "bound": [
-     178.27199442798212,
-     179.0941485386719
-    ],
-    "node_count": [
-     33,
-     53
+     191.2552076848786
     ]
    }
   ],
@@ -1664,7 +1658,7 @@
    {
     "objective": [
      290.56685374735093,
-     290.5668539675022
+     290.5668537474047
     ]
    }
   ],
@@ -1673,7 +1667,7 @@
    {
     "objective": [
      225.1260713973286,
-     225.12607170016992
+     225.12607139732896
     ]
    }
   ],
@@ -1698,8 +1692,8 @@
  "findings": [],
  "cert_regressions": [],
  "solve_nlp_calls": {
-  "pre": 2996,
-  "post": 3044
+  "pre": 3047,
+  "post": 2865
  },
  "time_limit": 20.0
 }

--- a/scratchpad/issue945/panel_corpus.json
+++ b/scratchpad/issue945/panel_corpus.json
@@ -8,7 +8,7 @@
     "bound": 20282.050738736412,
     "node_count": 7,
     "gap_certified": false,
-    "wall": 21.340063814000132
+    "wall": 20.86161571499906
    },
    "post": {
     "maximize": false,
@@ -17,7 +17,7 @@
     "bound": 20282.050738736412,
     "node_count": 7,
     "gap_certified": false,
-    "wall": 20.703717978999975
+    "wall": 20.753485027998977
    }
   },
   "alan": {
@@ -28,7 +28,7 @@
     "bound": 2.9249999983013426,
     "node_count": 21,
     "gap_certified": true,
-    "wall": 0.07706615500001135
+    "wall": 0.06835342300109915
    },
    "pre": {
     "maximize": false,
@@ -37,7 +37,7 @@
     "bound": 2.9249999983013426,
     "node_count": 21,
     "gap_certified": true,
-    "wall": 0.06102747500017358
+    "wall": 0.058100629001273774
    }
   },
   "bchoco06": {
@@ -48,7 +48,7 @@
     "bound": 0.9999887833703148,
     "node_count": 7,
     "gap_certified": false,
-    "wall": 21.067289785999947
+    "wall": 21.156143522001003
    },
    "post": {
     "maximize": true,
@@ -57,7 +57,7 @@
     "bound": 0.9999887833703148,
     "node_count": 7,
     "gap_certified": false,
-    "wall": 21.901819542999874
+    "wall": 21.04775808500017
    }
   },
   "bchoco07": {
@@ -68,7 +68,7 @@
     "bound": 1.000000000000286,
     "node_count": 7,
     "gap_certified": false,
-    "wall": 21.473129479999898
+    "wall": 21.59716466200007
    },
    "pre": {
     "maximize": true,
@@ -77,7 +77,7 @@
     "bound": 1.000000000000286,
     "node_count": 7,
     "gap_certified": false,
-    "wall": 21.438231690000066
+    "wall": 21.59804242899918
    }
   },
   "bchoco08": {
@@ -88,7 +88,7 @@
     "bound": 1.000000000002788,
     "node_count": 7,
     "gap_certified": false,
-    "wall": 67.47129444099983
+    "wall": 32.4324953689993
    },
    "post": {
     "maximize": true,
@@ -97,7 +97,7 @@
     "bound": 1.000000000002788,
     "node_count": 7,
     "gap_certified": false,
-    "wall": 31.66573628900005
+    "wall": 27.874022898000476
    }
   },
   "beuster": {
@@ -108,16 +108,16 @@
     "bound": 6395.108328059316,
     "node_count": 7,
     "gap_certified": false,
-    "wall": 20.86968129199977
+    "wall": 21.35085587499998
    },
    "pre": {
     "maximize": false,
     "status": "time_limit",
     "objective": null,
-    "bound": 6395.108328059316,
+    "bound": 6395.108327034645,
     "node_count": 7,
     "gap_certified": false,
-    "wall": 21.137492664000092
+    "wall": 21.02280981700096
    }
   },
   "casctanks": {
@@ -128,7 +128,7 @@
     "bound": -90.17862329759835,
     "node_count": 3,
     "gap_certified": false,
-    "wall": 21.675969455000086
+    "wall": 21.07955941900036
    },
    "post": {
     "maximize": false,
@@ -137,7 +137,7 @@
     "bound": -90.17862329759835,
     "node_count": 3,
     "gap_certified": false,
-    "wall": 21.52435942500051
+    "wall": 21.022934431000976
    }
   },
   "chance": {
@@ -148,7 +148,7 @@
     "bound": 29.894378166613386,
     "node_count": 0,
     "gap_certified": true,
-    "wall": 0.18263813399971696
+    "wall": 0.1880844879997312
    },
    "pre": {
     "maximize": false,
@@ -157,7 +157,7 @@
     "bound": 29.894378154271102,
     "node_count": 0,
     "gap_certified": true,
-    "wall": 0.16545271100039827
+    "wall": 0.1705907940013276
    }
   },
   "clay0303hfsg": {
@@ -166,18 +166,18 @@
     "status": "time_limit",
     "objective": null,
     "bound": null,
-    "node_count": 127,
+    "node_count": 95,
     "gap_certified": false,
-    "wall": 21.00434961800056
+    "wall": 20.64232235199961
    },
    "post": {
     "maximize": false,
     "status": "time_limit",
     "objective": null,
     "bound": null,
-    "node_count": 127,
+    "node_count": 95,
     "gap_certified": false,
-    "wall": 20.736461437999424
+    "wall": 21.364085389999673
    }
   },
   "contvar": {
@@ -188,7 +188,7 @@
     "bound": 183632.02121055726,
     "node_count": 3,
     "gap_certified": false,
-    "wall": 22.349915685999804
+    "wall": 21.968097285000113
    },
    "pre": {
     "maximize": false,
@@ -197,7 +197,7 @@
     "bound": 183632.02121055726,
     "node_count": 3,
     "gap_certified": false,
-    "wall": 21.744284481999784
+    "wall": 21.651497513999857
    }
   },
   "cvxnonsep_nsig30": {
@@ -208,7 +208,7 @@
     "bound": 130.61841392487688,
     "node_count": 171,
     "gap_certified": true,
-    "wall": 4.089018747999944
+    "wall": 4.114179767000678
    },
    "post": {
     "maximize": false,
@@ -217,7 +217,7 @@
     "bound": 130.61841392487688,
     "node_count": 171,
     "gap_certified": true,
-    "wall": 3.966168029000073
+    "wall": 4.689829281000129
    }
   },
   "cvxnonsep_psig30": {
@@ -228,7 +228,7 @@
     "bound": 78.99701703820377,
     "node_count": 89,
     "gap_certified": true,
-    "wall": 1.6343554780005434
+    "wall": 1.752459473998897
    },
    "pre": {
     "maximize": false,
@@ -237,7 +237,7 @@
     "bound": 78.99701703820377,
     "node_count": 89,
     "gap_certified": true,
-    "wall": 2.0338044550007908
+    "wall": 1.6242167050004355
    }
   },
   "cvxnonsep_psig40r": {
@@ -248,7 +248,7 @@
     "bound": 86.53873600363832,
     "node_count": 103,
     "gap_certified": true,
-    "wall": 6.401610296000399
+    "wall": 6.555701078999846
    },
    "post": {
     "maximize": false,
@@ -257,7 +257,7 @@
     "bound": 86.53873600363832,
     "node_count": 103,
     "gap_certified": true,
-    "wall": 6.646877549999772
+    "wall": 6.816428178999558
    }
   },
   "dispatch": {
@@ -268,7 +268,7 @@
     "bound": 3155.2878615366776,
     "node_count": 23,
     "gap_certified": true,
-    "wall": 0.5983337699999538
+    "wall": 0.4005815389991767
    },
    "pre": {
     "maximize": false,
@@ -277,7 +277,7 @@
     "bound": 3155.2878615366776,
     "node_count": 23,
     "gap_certified": true,
-    "wall": 0.4223917499994059
+    "wall": 0.3739400349986681
    }
   },
   "ex1221": {
@@ -288,7 +288,7 @@
     "bound": 7.667180068813077,
     "node_count": 5,
     "gap_certified": true,
-    "wall": 0.847690366000279
+    "wall": 0.8064225850012008
    },
    "post": {
     "maximize": false,
@@ -297,7 +297,7 @@
     "bound": 7.667180068813077,
     "node_count": 5,
     "gap_certified": true,
-    "wall": 0.8767105770002672
+    "wall": 0.7007486250004149
    }
   },
   "ex1222": {
@@ -308,7 +308,7 @@
     "bound": 1.0765430463031964,
     "node_count": 1,
     "gap_certified": true,
-    "wall": 0.306689307999477
+    "wall": 0.5019422189998295
    },
    "pre": {
     "maximize": false,
@@ -317,7 +317,7 @@
     "bound": 1.0765430463031964,
     "node_count": 1,
     "gap_certified": true,
-    "wall": 0.23709257100017567
+    "wall": 0.26799431200015533
    }
   },
   "ex1224": {
@@ -328,7 +328,7 @@
     "bound": -0.9434705000000166,
     "node_count": 5,
     "gap_certified": true,
-    "wall": 2.7015993259992683
+    "wall": 2.771524681000301
    },
    "post": {
     "maximize": false,
@@ -337,7 +337,7 @@
     "bound": -0.9434705000000166,
     "node_count": 5,
     "gap_certified": true,
-    "wall": 2.5378109640005277
+    "wall": 2.5357477289999224
    }
   },
   "ex1225": {
@@ -348,7 +348,7 @@
     "bound": 30.999999913557566,
     "node_count": 5,
     "gap_certified": true,
-    "wall": 2.4734765289995266
+    "wall": 2.4943522610010405
    },
    "pre": {
     "maximize": false,
@@ -357,7 +357,7 @@
     "bound": 30.999999913557566,
     "node_count": 5,
     "gap_certified": true,
-    "wall": 2.680774093999389
+    "wall": 3.0981000720003067
    }
   },
   "ex1226": {
@@ -368,7 +368,7 @@
     "bound": -17.000000003887443,
     "node_count": 3,
     "gap_certified": true,
-    "wall": 0.7485413469994455
+    "wall": 0.9011488069991174
    },
    "post": {
     "maximize": false,
@@ -377,7 +377,7 @@
     "bound": -17.000000003887443,
     "node_count": 3,
     "gap_certified": true,
-    "wall": 0.7260731919996033
+    "wall": 0.8077394409992849
    }
   },
   "ex14_1_9": {
@@ -388,7 +388,7 @@
     "bound": -1.9775220540513224e-16,
     "node_count": 3,
     "gap_certified": true,
-    "wall": 0.29846733000067616
+    "wall": 0.34157072699963464
    },
    "pre": {
     "maximize": false,
@@ -397,7 +397,7 @@
     "bound": -1.9775220540513224e-16,
     "node_count": 3,
     "gap_certified": true,
-    "wall": 0.28341770699989866
+    "wall": 0.32864354199955415
    }
   },
   "fac2": {
@@ -408,7 +408,7 @@
     "bound": 331837497.54563797,
     "node_count": 41,
     "gap_certified": true,
-    "wall": 8.841676842000197
+    "wall": 9.197090076999302
    },
    "post": {
     "maximize": false,
@@ -417,7 +417,7 @@
     "bound": 331837497.54563797,
     "node_count": 41,
     "gap_certified": true,
-    "wall": 8.715976561999923
+    "wall": 8.771808849000081
    }
   },
   "flay02m": {
@@ -428,7 +428,7 @@
     "bound": 37.947331804569515,
     "node_count": 7,
     "gap_certified": true,
-    "wall": 0.5235917359996165
+    "wall": 0.4826830580004753
    },
    "pre": {
     "maximize": false,
@@ -437,7 +437,7 @@
     "bound": 37.947331804569515,
     "node_count": 7,
     "gap_certified": true,
-    "wall": 0.502729496000029
+    "wall": 0.4870537700007844
    }
   },
   "flay03m": {
@@ -448,7 +448,7 @@
     "bound": 48.98979470823052,
     "node_count": 111,
     "gap_certified": true,
-    "wall": 9.543892702999983
+    "wall": 7.334201186999053
    },
    "post": {
     "maximize": false,
@@ -457,7 +457,7 @@
     "bound": 48.98979470823052,
     "node_count": 111,
     "gap_certified": true,
-    "wall": 7.040910736000114
+    "wall": 7.1553186740002275
    }
   },
   "gbd": {
@@ -468,7 +468,7 @@
     "bound": 2.1999999825308127,
     "node_count": 3,
     "gap_certified": true,
-    "wall": 0.02498746299988852
+    "wall": 0.023471718001019326
    },
    "pre": {
     "maximize": false,
@@ -477,7 +477,7 @@
     "bound": 2.1999999825308127,
     "node_count": 3,
     "gap_certified": true,
-    "wall": 0.021001138999963587
+    "wall": 0.021934147000138182
    }
   },
   "gkocis": {
@@ -488,7 +488,7 @@
     "bound": -1.9230988280923489,
     "node_count": 5,
     "gap_certified": true,
-    "wall": 1.4591283479994672
+    "wall": 1.3678106690003915
    },
    "post": {
     "maximize": false,
@@ -497,7 +497,7 @@
     "bound": -1.9230988280923489,
     "node_count": 5,
     "gap_certified": true,
-    "wall": 1.17010479199962
+    "wall": 1.2579532119998476
    }
   },
   "hda": {
@@ -508,7 +508,7 @@
     "bound": -64473.44240243703,
     "node_count": 1,
     "gap_certified": false,
-    "wall": 21.402470478000396
+    "wall": 21.057206409999708
    },
    "pre": {
     "maximize": false,
@@ -517,7 +517,7 @@
     "bound": -64473.44240243703,
     "node_count": 1,
     "gap_certified": false,
-    "wall": 21.099769899999956
+    "wall": 21.028191478000736
    }
   },
   "heatexch_gen1": {
@@ -528,7 +528,7 @@
     "bound": 38183.5317460179,
     "node_count": 3,
     "gap_certified": false,
-    "wall": 21.656159112999376
+    "wall": 21.632646988000488
    },
    "post": {
     "maximize": false,
@@ -537,7 +537,7 @@
     "bound": 38183.5317460179,
     "node_count": 3,
     "gap_certified": false,
-    "wall": 21.572925202999613
+    "wall": 22.771728911000537
    }
   },
   "heatexch_gen2": {
@@ -546,9 +546,9 @@
     "status": "time_limit",
     "objective": null,
     "bound": 555767.7902857271,
-    "node_count": 3,
+    "node_count": 7,
     "gap_certified": false,
-    "wall": 21.984058686000026
+    "wall": 20.513917931000833
    },
    "pre": {
     "maximize": false,
@@ -557,7 +557,7 @@
     "bound": 555767.7902857271,
     "node_count": 3,
     "gap_certified": false,
-    "wall": 21.933579728999575
+    "wall": 22.88522019299853
    }
   },
   "heatexch_gen3": {
@@ -568,7 +568,7 @@
     "bound": null,
     "node_count": 3,
     "gap_certified": false,
-    "wall": 29.739361054000256
+    "wall": 31.722223757000393
    },
    "post": {
     "maximize": false,
@@ -577,7 +577,7 @@
     "bound": null,
     "node_count": 3,
     "gap_certified": false,
-    "wall": 29.96267835800063
+    "wall": 30.268358085000727
    }
   },
   "m3": {
@@ -588,7 +588,7 @@
     "bound": 37.79999951039201,
     "node_count": 47,
     "gap_certified": true,
-    "wall": 4.658604321999519
+    "wall": 5.38149255099961
    },
    "pre": {
     "maximize": false,
@@ -597,7 +597,7 @@
     "bound": 37.79999951039201,
     "node_count": 47,
     "gap_certified": true,
-    "wall": 4.756032500999936
+    "wall": 4.395422977000635
    }
   },
   "nvs01": {
@@ -608,7 +608,7 @@
     "bound": 12.46966882156821,
     "node_count": 3,
     "gap_certified": true,
-    "wall": 1.988911017000646
+    "wall": 1.5421696320008778
    },
    "post": {
     "maximize": false,
@@ -617,7 +617,7 @@
     "bound": 12.46966882156821,
     "node_count": 3,
     "gap_certified": true,
-    "wall": 1.5507398740001008
+    "wall": 1.5508252489998995
    }
   },
   "nvs02": {
@@ -628,7 +628,7 @@
     "bound": 5.96418452307,
     "node_count": 345,
     "gap_certified": true,
-    "wall": 0.5207517459994051
+    "wall": 0.43936890399891126
    },
    "pre": {
     "maximize": false,
@@ -637,7 +637,7 @@
     "bound": 5.96418452307,
     "node_count": 345,
     "gap_certified": true,
-    "wall": 0.42628081099974224
+    "wall": 0.40878159500061884
    }
   },
   "nvs03": {
@@ -648,7 +648,7 @@
     "bound": 15.99999972676511,
     "node_count": 5,
     "gap_certified": true,
-    "wall": 0.22198429299987765
+    "wall": 0.1984112530008133
    },
    "post": {
     "maximize": false,
@@ -657,7 +657,7 @@
     "bound": 15.99999972676511,
     "node_count": 5,
     "gap_certified": true,
-    "wall": 0.18828977399971336
+    "wall": 0.19523057600054017
    }
   },
   "nvs04": {
@@ -668,7 +668,7 @@
     "bound": 0.7199999999999773,
     "node_count": 5,
     "gap_certified": true,
-    "wall": 0.4147367790001226
+    "wall": 0.36598496599981445
    },
    "pre": {
     "maximize": false,
@@ -677,7 +677,7 @@
     "bound": 0.7199999999999773,
     "node_count": 5,
     "gap_certified": true,
-    "wall": 0.35070941199955996
+    "wall": 0.30987134499991953
    }
   },
   "nvs05": {
@@ -686,9 +686,9 @@
     "status": "feasible",
     "objective": 8.731956986640078,
     "bound": 3.5424692441047068,
-    "node_count": 33,
+    "node_count": 41,
     "gap_certified": false,
-    "wall": 20.14191485399988
+    "wall": 20.182268660999398
    },
    "post": {
     "maximize": false,
@@ -697,7 +697,7 @@
     "bound": 3.5424692441047068,
     "node_count": 41,
     "gap_certified": false,
-    "wall": 20.161285596999733
+    "wall": 20.12048007500016
    }
   },
   "nvs06": {
@@ -708,7 +708,7 @@
     "bound": 1.7703124999999627,
     "node_count": 5,
     "gap_certified": true,
-    "wall": 1.187288453000292
+    "wall": 1.2201087190005637
    },
    "pre": {
     "maximize": false,
@@ -717,7 +717,7 @@
     "bound": 1.7703124999999627,
     "node_count": 5,
     "gap_certified": true,
-    "wall": 1.1228943139994954
+    "wall": 1.502843292999387
    }
   },
   "nvs07": {
@@ -728,7 +728,7 @@
     "bound": 4.0,
     "node_count": 5,
     "gap_certified": true,
-    "wall": 0.07190670799991494
+    "wall": 0.06894203599949833
    },
    "post": {
     "maximize": false,
@@ -737,7 +737,7 @@
     "bound": 4.0,
     "node_count": 5,
     "gap_certified": true,
-    "wall": 0.06876586599992152
+    "wall": 0.0659772859999066
    }
   },
   "nvs08": {
@@ -748,7 +748,7 @@
     "bound": 23.44972734516655,
     "node_count": 3,
     "gap_certified": true,
-    "wall": 1.2100922780000474
+    "wall": 1.4144361870003195
    },
    "pre": {
     "maximize": false,
@@ -757,7 +757,7 @@
     "bound": 23.44972734516655,
     "node_count": 3,
     "gap_certified": true,
-    "wall": 1.1709591640001236
+    "wall": 1.3376553260004584
    }
   },
   "nvs09": {
@@ -768,7 +768,7 @@
     "bound": -43.13433691803662,
     "node_count": 5,
     "gap_certified": true,
-    "wall": 4.718927093000275
+    "wall": 4.672621407999031
    },
    "post": {
     "maximize": false,
@@ -777,7 +777,7 @@
     "bound": -43.13433691803662,
     "node_count": 5,
     "gap_certified": true,
-    "wall": 4.314823305999198
+    "wall": 4.754440293998414
    }
   },
   "nvs10": {
@@ -788,7 +788,7 @@
     "bound": -310.7999999999999,
     "node_count": 5,
     "gap_certified": true,
-    "wall": 0.18428214799951093
+    "wall": 0.1850798819996271
    },
    "pre": {
     "maximize": false,
@@ -797,7 +797,7 @@
     "bound": -310.7999999999999,
     "node_count": 5,
     "gap_certified": true,
-    "wall": 0.15585522099991067
+    "wall": 0.13099405899993144
    }
   },
   "nvs11": {
@@ -808,7 +808,7 @@
     "bound": -431.0000000000085,
     "node_count": 55,
     "gap_certified": true,
-    "wall": 0.7984933790003197
+    "wall": 0.753779074000704
    },
    "post": {
     "maximize": false,
@@ -817,7 +817,7 @@
     "bound": -431.0000000000085,
     "node_count": 55,
     "gap_certified": true,
-    "wall": 0.6477721329993074
+    "wall": 0.8486461190004775
    }
   },
   "nvs12": {
@@ -828,7 +828,7 @@
     "bound": -481.20000000001,
     "node_count": 231,
     "gap_certified": true,
-    "wall": 2.5677869540004394
+    "wall": 2.704115794000245
    },
    "pre": {
     "maximize": false,
@@ -837,7 +837,7 @@
     "bound": -481.20000000001,
     "node_count": 231,
     "gap_certified": true,
-    "wall": 2.0910330770002474
+    "wall": 2.33796169299967
    }
   },
   "nvs13": {
@@ -848,7 +848,7 @@
     "bound": -585.2,
     "node_count": 637,
     "gap_certified": true,
-    "wall": 1.6628040579998924
+    "wall": 1.4629285850005544
    },
    "post": {
     "maximize": false,
@@ -857,7 +857,7 @@
     "bound": -585.2,
     "node_count": 637,
     "gap_certified": true,
-    "wall": 1.4816955699998289
+    "wall": 1.4282700680014386
    }
   },
   "nvs14": {
@@ -868,7 +868,7 @@
     "bound": -40358.154769299996,
     "node_count": 129,
     "gap_certified": true,
-    "wall": 0.8479760170002919
+    "wall": 0.865303655000389
    },
    "pre": {
     "maximize": false,
@@ -877,7 +877,7 @@
     "bound": -40358.154769299996,
     "node_count": 129,
     "gap_certified": true,
-    "wall": 0.84033171900046
+    "wall": 0.8515085239996552
    }
   },
   "nvs15": {
@@ -888,7 +888,7 @@
     "bound": 1.0,
     "node_count": 7,
     "gap_certified": true,
-    "wall": 0.08723134499996377
+    "wall": 0.08334700300110853
    },
    "post": {
     "maximize": false,
@@ -897,7 +897,7 @@
     "bound": 1.0,
     "node_count": 7,
     "gap_certified": true,
-    "wall": 0.08384172800015222
+    "wall": 0.08156909700119286
    }
   },
   "nvs21": {
@@ -908,7 +908,7 @@
     "bound": -5.684782628025259,
     "node_count": 3,
     "gap_certified": true,
-    "wall": 7.365921497999807
+    "wall": 7.086681823000617
    },
    "pre": {
     "maximize": false,
@@ -917,7 +917,7 @@
     "bound": -5.684782628025259,
     "node_count": 3,
     "gap_certified": true,
-    "wall": 6.512636297000427
+    "wall": 6.684371395000198
    }
   },
   "oaer": {
@@ -928,7 +928,7 @@
     "bound": -1.923098601139822,
     "node_count": 3,
     "gap_certified": true,
-    "wall": 1.1342668400002367
+    "wall": 1.0001207739987876
    },
    "post": {
     "maximize": false,
@@ -937,7 +937,7 @@
     "bound": -1.923098601139822,
     "node_count": 3,
     "gap_certified": true,
-    "wall": 0.9787721730008343
+    "wall": 0.9625405360002333
    }
   },
   "st_e11": {
@@ -948,7 +948,7 @@
     "bound": 189.31162968661766,
     "node_count": 27,
     "gap_certified": true,
-    "wall": 3.3105536600005507
+    "wall": 3.257049719999486
    },
    "pre": {
     "maximize": false,
@@ -957,7 +957,7 @@
     "bound": 189.31162968661766,
     "node_count": 27,
     "gap_certified": true,
-    "wall": 3.151153957999668
+    "wall": 3.5043417340002634
    }
   },
   "st_e13": {
@@ -968,7 +968,7 @@
     "bound": 1.9999999825187946,
     "node_count": 1,
     "gap_certified": true,
-    "wall": 0.1342486370003826
+    "wall": 0.13843990199893597
    },
    "post": {
     "maximize": false,
@@ -977,7 +977,7 @@
     "bound": 1.9999999825187946,
     "node_count": 1,
     "gap_certified": true,
-    "wall": 0.12964829100019415
+    "wall": 0.1294228610004211
    }
   },
   "st_e29": {
@@ -988,7 +988,7 @@
     "bound": -0.9434705000000166,
     "node_count": 5,
     "gap_certified": true,
-    "wall": 2.973738345000129
+    "wall": 2.970016630999453
    },
    "pre": {
     "maximize": false,
@@ -997,7 +997,7 @@
     "bound": -0.9434705000000166,
     "node_count": 5,
     "gap_certified": true,
-    "wall": 2.723435843000516
+    "wall": 2.7799038590001146
    }
   },
   "st_e36": {
@@ -1008,7 +1008,7 @@
     "bound": -246.00000000170422,
     "node_count": 85,
     "gap_certified": true,
-    "wall": 9.497817057000248
+    "wall": 9.839661432999492
    },
    "post": {
     "maximize": false,
@@ -1017,7 +1017,7 @@
     "bound": -246.00000000170422,
     "node_count": 85,
     "gap_certified": true,
-    "wall": 8.930255438999666
+    "wall": 9.748952232999727
    }
   },
   "st_e38": {
@@ -1028,7 +1028,7 @@
     "bound": 7197.727116826533,
     "node_count": 3,
     "gap_certified": true,
-    "wall": 0.8050893419995191
+    "wall": 0.7476165880016197
    },
    "pre": {
     "maximize": false,
@@ -1037,7 +1037,7 @@
     "bound": 7197.727116826533,
     "node_count": 3,
     "gap_certified": true,
-    "wall": 0.7653070249998564
+    "wall": 0.7652405289991293
    }
   },
   "st_miqp1": {
@@ -1048,7 +1048,7 @@
     "bound": 280.9999999906497,
     "node_count": 15,
     "gap_certified": true,
-    "wall": 0.02535302399974171
+    "wall": 0.021535358999244636
    },
    "post": {
     "maximize": false,
@@ -1057,7 +1057,7 @@
     "bound": 280.9999999906497,
     "node_count": 15,
     "gap_certified": true,
-    "wall": 0.020920111000123143
+    "wall": 0.02053010700001323
    }
   },
   "st_miqp2": {
@@ -1068,7 +1068,7 @@
     "bound": 2.0,
     "node_count": 9,
     "gap_certified": true,
-    "wall": 0.027963353999439278
+    "wall": 0.02448736099904636
    },
    "pre": {
     "maximize": false,
@@ -1077,7 +1077,7 @@
     "bound": 2.0,
     "node_count": 9,
     "gap_certified": true,
-    "wall": 0.0295779260004565
+    "wall": 0.025398279000000912
    }
   },
   "st_miqp3": {
@@ -1088,7 +1088,7 @@
     "bound": -6.0,
     "node_count": 1,
     "gap_certified": true,
-    "wall": 0.010991941000611405
+    "wall": 0.008985454000139725
    },
    "post": {
     "maximize": false,
@@ -1097,7 +1097,7 @@
     "bound": -6.0,
     "node_count": 1,
     "gap_certified": true,
-    "wall": 0.010478748000423366
+    "wall": 0.010443168999699992
    }
   },
   "st_miqp4": {
@@ -1108,7 +1108,7 @@
     "bound": -4574.0000024840665,
     "node_count": 3,
     "gap_certified": true,
-    "wall": 0.031087235999621043
+    "wall": 0.032428487998913624
    },
    "pre": {
     "maximize": false,
@@ -1117,7 +1117,7 @@
     "bound": -4574.0000024840665,
     "node_count": 3,
     "gap_certified": true,
-    "wall": 0.028957886999705806
+    "wall": 0.030268503998740925
    }
   },
   "st_miqp5": {
@@ -1128,7 +1128,7 @@
     "bound": -333.88889024868075,
     "node_count": 1,
     "gap_certified": true,
-    "wall": 0.0340186020002875
+    "wall": 0.03785257100025774
    },
    "post": {
     "maximize": false,
@@ -1137,7 +1137,7 @@
     "bound": -333.88889024868075,
     "node_count": 1,
     "gap_certified": true,
-    "wall": 0.03273793999960617
+    "wall": 0.03559647300062352
    }
   },
   "st_test1": {
@@ -1148,7 +1148,7 @@
     "bound": -1.6495994490692313e-08,
     "node_count": 15,
     "gap_certified": true,
-    "wall": 0.03634161800073343
+    "wall": 0.04169112199997471
    },
    "pre": {
     "maximize": false,
@@ -1157,7 +1157,7 @@
     "bound": -1.6495994490692313e-08,
     "node_count": 15,
     "gap_certified": true,
-    "wall": 0.038223362999815436
+    "wall": 0.03655282199906651
    }
   },
   "st_testgr3": {
@@ -1168,7 +1168,7 @@
     "bound": -20.59070709795548,
     "node_count": 549,
     "gap_certified": true,
-    "wall": 0.28243116900011955
+    "wall": 0.3153328190001048
    },
    "post": {
     "maximize": false,
@@ -1177,27 +1177,27 @@
     "bound": -20.59070709795548,
     "node_count": 549,
     "gap_certified": true,
-    "wall": 0.2876941529993928
+    "wall": 0.3286758020003617
    }
   },
   "syn05hfsg": {
    "post": {
     "maximize": true,
-    "status": "optimal",
+    "status": "feasible",
     "objective": 837.732412391107,
-    "bound": 837.732412391107,
-    "node_count": 185,
-    "gap_certified": true,
-    "wall": 20.022627572999227
+    "bound": 840.4893941019075,
+    "node_count": 167,
+    "gap_certified": false,
+    "wall": 20.28740770799959
    },
    "pre": {
     "maximize": true,
     "status": "feasible",
     "objective": 837.732412391107,
     "bound": 838.3878622240098,
-    "node_count": 167,
+    "node_count": 179,
     "gap_certified": false,
-    "wall": 20.09403269500035
+    "wall": 20.10448203299893
    }
   },
   "tanksize": {
@@ -1205,19 +1205,19 @@
     "maximize": false,
     "status": "time_limit",
     "objective": 1.268643752557795,
-    "bound": 1.2630486909987855,
-    "node_count": 4186,
+    "bound": 1.2632541695785504,
+    "node_count": 4306,
     "gap_certified": true,
-    "wall": 20.11908975499955
+    "wall": 20.107069439000043
    },
    "post": {
     "maximize": false,
     "status": "time_limit",
     "objective": 1.268643752557795,
-    "bound": 1.263118021659774,
-    "node_count": 4216,
+    "bound": 1.2621867811714296,
+    "node_count": 3784,
     "gap_certified": true,
-    "wall": 20.102947426000355
+    "wall": 20.101737228000275
    }
   },
   "tls2": {
@@ -1225,19 +1225,19 @@
     "maximize": false,
     "status": "feasible",
     "objective": 5.299999922109238,
-    "bound": 3.2532681850660596,
-    "node_count": 353,
+    "bound": 3.1706801036010077,
+    "node_count": 349,
     "gap_certified": false,
-    "wall": 20.111197416999858
+    "wall": 20.496603259998665
    },
    "pre": {
     "maximize": false,
-    "status": "optimal",
+    "status": "feasible",
     "objective": 5.299999922109238,
-    "bound": 5.3,
+    "bound": 3.2532681850660596,
     "node_count": 353,
-    "gap_certified": true,
-    "wall": 20.396457507999912
+    "gap_certified": false,
+    "wall": 20.344976995000252
    }
   },
   "tspn05": {
@@ -1248,7 +1248,7 @@
     "bound": 179.44337578420988,
     "node_count": 49,
     "gap_certified": false,
-    "wall": 20.206236415000603
+    "wall": 20.147514609998325
    },
    "post": {
     "maximize": false,
@@ -1257,7 +1257,7 @@
     "bound": 179.44337578420988,
     "node_count": 49,
     "gap_certified": false,
-    "wall": 20.103172094
+    "wall": 20.118836876001296
    }
   },
   "tspn08": {
@@ -1268,7 +1268,7 @@
     "bound": null,
     "node_count": 1,
     "gap_certified": false,
-    "wall": 15.677741274000255
+    "wall": 15.3715363350002
    },
    "pre": {
     "maximize": false,
@@ -1277,18 +1277,18 @@
     "bound": null,
     "node_count": 1,
     "gap_certified": false,
-    "wall": 15.301717747999646
+    "wall": 18.034337167000558
    }
   },
   "tspn10": {
    "pre": {
     "maximize": false,
     "status": "feasible",
-    "objective": 225.12607139732683,
+    "objective": 225.12607139732842,
     "bound": null,
     "node_count": 1,
     "gap_certified": false,
-    "wall": 20.90029842900003
+    "wall": 15.533888261999891
    },
    "post": {
     "maximize": false,
@@ -1297,7 +1297,7 @@
     "bound": null,
     "node_count": 1,
     "gap_certified": false,
-    "wall": 14.456912680999267
+    "wall": 21.301305689999936
    }
   },
   "tspn12": {
@@ -1308,7 +1308,7 @@
     "bound": null,
     "node_count": 1,
     "gap_certified": false,
-    "wall": 14.722521587999836
+    "wall": 15.072269878999577
    },
    "pre": {
     "maximize": false,
@@ -1317,11 +1317,20 @@
     "bound": null,
     "node_count": 1,
     "gap_certified": false,
-    "wall": 14.460105023000324
+    "wall": 14.654824365001332
    }
   }
  },
  "diffs": [
+  [
+   "beuster",
+   {
+    "bound": [
+     6395.108327034645,
+     6395.108328059316
+    ]
+   }
+  ],
   [
    "chance",
    {
@@ -1336,28 +1345,24 @@
    }
   ],
   [
-   "nvs05",
+   "heatexch_gen2",
    {
     "node_count": [
-     33,
-     41
+     3,
+     7
     ]
    }
   ],
   [
    "syn05hfsg",
    {
-    "status": [
-     "feasible",
-     "optimal"
-    ],
     "bound": [
      838.3878622240098,
-     837.732412391107
+     840.4893941019075
     ],
     "node_count": [
-     167,
-     185
+     179,
+     167
     ]
    }
   ],
@@ -1365,36 +1370,43 @@
    "tanksize",
    {
     "bound": [
-     1.2630486909987855,
-     1.263118021659774
+     1.2632541695785504,
+     1.2621867811714296
     ],
     "node_count": [
-     4186,
-     4216
+     4306,
+     3784
     ]
    }
   ],
   [
    "tls2",
    {
-    "status": [
-     "optimal",
-     "feasible"
-    ],
     "bound": [
-     5.3,
-     3.2532681850660596
+     3.2532681850660596,
+     3.1706801036010077
+    ],
+    "node_count": [
+     353,
+     349
+    ]
+   }
+  ],
+  [
+   "tspn10",
+   {
+    "objective": [
+     225.12607139732842,
+     225.12607139732683
     ]
    }
   ]
  ],
  "findings": [],
- "cert_regressions": [
-  "tls2"
- ],
+ "cert_regressions": [],
  "solve_nlp_calls": {
-  "pre": 3229,
-  "post": 3140
+  "pre": 3136,
+  "post": 3163
  },
  "time_limit": 20.0
 }

--- a/scratchpad/issue945/panel_corpus.json
+++ b/scratchpad/issue945/panel_corpus.json
@@ -1,0 +1,1705 @@
+{
+ "rows": {
+  "4stufen": {
+   "pre": {
+    "status": "time_limit",
+    "objective": null,
+    "bound": 20282.050738736412,
+    "node_count": 7,
+    "gap_certified": false,
+    "wall": 20.867700138999908
+   },
+   "post": {
+    "status": "time_limit",
+    "objective": null,
+    "bound": 20282.050738736412,
+    "node_count": 7,
+    "gap_certified": false,
+    "wall": 20.706769252999948
+   }
+  },
+  "alan": {
+   "post": {
+    "status": "optimal",
+    "objective": 2.9249999999513205,
+    "bound": 2.9249999999513205,
+    "node_count": 21,
+    "gap_certified": true,
+    "wall": 0.10150536599985571
+   },
+   "pre": {
+    "status": "optimal",
+    "objective": 2.9249999999513205,
+    "bound": 2.9249999999513205,
+    "node_count": 21,
+    "gap_certified": true,
+    "wall": 0.0947628110000096
+   }
+  },
+  "bchoco06": {
+   "pre": {
+    "status": "time_limit",
+    "objective": null,
+    "bound": 0.9999887833703148,
+    "node_count": 7,
+    "gap_certified": false,
+    "wall": 22.010192088000167
+   },
+   "post": {
+    "status": "time_limit",
+    "objective": null,
+    "bound": 0.9999887833703148,
+    "node_count": 7,
+    "gap_certified": false,
+    "wall": 21.29733245500006
+   }
+  },
+  "bchoco07": {
+   "post": {
+    "status": "time_limit",
+    "objective": null,
+    "bound": 1.000000000000286,
+    "node_count": 7,
+    "gap_certified": false,
+    "wall": 26.272639786000127
+   },
+   "pre": {
+    "status": "time_limit",
+    "objective": null,
+    "bound": 1.000000000000286,
+    "node_count": 7,
+    "gap_certified": false,
+    "wall": 21.568805414000053
+   }
+  },
+  "bchoco08": {
+   "pre": {
+    "status": "time_limit",
+    "objective": null,
+    "bound": 1.000000000002788,
+    "node_count": 3,
+    "gap_certified": false,
+    "wall": 22.136641505999933
+   },
+   "post": {
+    "status": "time_limit",
+    "objective": null,
+    "bound": 1.000000000002788,
+    "node_count": 3,
+    "gap_certified": false,
+    "wall": 20.3981126770002
+   }
+  },
+  "beuster": {
+   "post": {
+    "status": "time_limit",
+    "objective": null,
+    "bound": 6395.108328059316,
+    "node_count": 7,
+    "gap_certified": false,
+    "wall": 21.61065829500012
+   },
+   "pre": {
+    "status": "time_limit",
+    "objective": null,
+    "bound": 6395.108328059316,
+    "node_count": 7,
+    "gap_certified": false,
+    "wall": 20.883928779999906
+   }
+  },
+  "casctanks": {
+   "pre": {
+    "status": "time_limit",
+    "objective": null,
+    "bound": -90.17862329759835,
+    "node_count": 1,
+    "gap_certified": false,
+    "wall": 20.934898602999965
+   },
+   "post": {
+    "status": "time_limit",
+    "objective": null,
+    "bound": -90.17862329759835,
+    "node_count": 3,
+    "gap_certified": false,
+    "wall": 27.27564052100024
+   }
+  },
+  "chance": {
+   "post": {
+    "status": "optimal",
+    "objective": 29.894378166613386,
+    "bound": 29.894378166613386,
+    "node_count": 0,
+    "gap_certified": true,
+    "wall": 0.4639579149998099
+   },
+   "pre": {
+    "status": "optimal",
+    "objective": 29.894378154271102,
+    "bound": 29.894378154271102,
+    "node_count": 0,
+    "gap_certified": true,
+    "wall": 0.1849188989999675
+   }
+  },
+  "clay0303hfsg": {
+   "pre": {
+    "status": "time_limit",
+    "objective": null,
+    "bound": null,
+    "node_count": 3,
+    "gap_certified": false,
+    "wall": 22.36598070800028
+   },
+   "post": {
+    "status": "time_limit",
+    "objective": null,
+    "bound": null,
+    "node_count": 95,
+    "gap_certified": false,
+    "wall": 20.70678265100014
+   }
+  },
+  "contvar": {
+   "post": {
+    "status": "time_limit",
+    "objective": null,
+    "bound": 180782.8593284799,
+    "node_count": 3,
+    "gap_certified": false,
+    "wall": 22.63025449199995
+   },
+   "pre": {
+    "status": "time_limit",
+    "objective": null,
+    "bound": 183632.02121055726,
+    "node_count": 3,
+    "gap_certified": false,
+    "wall": 24.087252487000114
+   }
+  },
+  "cvxnonsep_nsig30": {
+   "pre": {
+    "status": "optimal",
+    "objective": 130.62871116925294,
+    "bound": 130.61841392487688,
+    "node_count": 171,
+    "gap_certified": true,
+    "wall": 10.327229632000126
+   },
+   "post": {
+    "status": "optimal",
+    "objective": 130.62871268683438,
+    "bound": 130.6184154341326,
+    "node_count": 171,
+    "gap_certified": true,
+    "wall": 5.772850220999771
+   }
+  },
+  "cvxnonsep_psig30": {
+   "post": {
+    "status": "optimal",
+    "objective": 78.998854365269,
+    "bound": 78.99701709863874,
+    "node_count": 89,
+    "gap_certified": true,
+    "wall": 3.786479123999925
+   },
+   "pre": {
+    "status": "optimal",
+    "objective": 78.99885435294289,
+    "bound": 78.99701703820377,
+    "node_count": 89,
+    "gap_certified": true,
+    "wall": 1.8690656310000122
+   }
+  },
+  "cvxnonsep_psig40r": {
+   "pre": {
+    "status": "optimal",
+    "objective": 86.54527995164959,
+    "bound": 86.53873600363832,
+    "node_count": 103,
+    "gap_certified": true,
+    "wall": 8.518324066000332
+   },
+   "post": {
+    "status": "optimal",
+    "objective": 86.54528288283356,
+    "bound": 86.53873904316234,
+    "node_count": 95,
+    "gap_certified": true,
+    "wall": 6.983134777000032
+   }
+  },
+  "dispatch": {
+   "post": {
+    "status": "optimal",
+    "objective": 3155.2879268631687,
+    "bound": 3155.287861536673,
+    "node_count": 23,
+    "gap_certified": true,
+    "wall": 0.7959989019996101
+   },
+   "pre": {
+    "status": "optimal",
+    "objective": 3155.2879266857854,
+    "bound": 3155.2878615366776,
+    "node_count": 23,
+    "gap_certified": true,
+    "wall": 0.38547951100008504
+   }
+  },
+  "ex1221": {
+   "pre": {
+    "status": "optimal",
+    "objective": 7.667180068813135,
+    "bound": 7.667180068813077,
+    "node_count": 5,
+    "gap_certified": true,
+    "wall": 1.0075459250001586
+   },
+   "post": {
+    "status": "optimal",
+    "objective": 7.667180068813135,
+    "bound": 7.667180068813077,
+    "node_count": 5,
+    "gap_certified": true,
+    "wall": 0.8329038560000299
+   }
+  },
+  "ex1222": {
+   "post": {
+    "status": "optimal",
+    "objective": 1.0765430833322618,
+    "bound": 1.0765430833322571,
+    "node_count": 3,
+    "gap_certified": true,
+    "wall": 0.4204117680001218
+   },
+   "pre": {
+    "status": "optimal",
+    "objective": 1.0765430833322625,
+    "bound": 1.0765430463031964,
+    "node_count": 1,
+    "gap_certified": true,
+    "wall": 0.25425212400023156
+   }
+  },
+  "ex1224": {
+   "pre": {
+    "status": "optimal",
+    "objective": -0.9434704942820806,
+    "bound": -0.9434705000000166,
+    "node_count": 5,
+    "gap_certified": true,
+    "wall": 3.870680566000374
+   },
+   "post": {
+    "status": "optimal",
+    "objective": -0.9434704993121346,
+    "bound": -0.9434705000000165,
+    "node_count": 5,
+    "gap_certified": true,
+    "wall": 2.945993745999658
+   }
+  },
+  "ex1225": {
+   "post": {
+    "status": "optimal",
+    "objective": 31.000000000008843,
+    "bound": 30.999999999999844,
+    "node_count": 5,
+    "gap_certified": true,
+    "wall": 2.976157606000015
+   },
+   "pre": {
+    "status": "optimal",
+    "objective": 30.999999913557566,
+    "bound": 30.999999913557566,
+    "node_count": 5,
+    "gap_certified": true,
+    "wall": 2.979208139000093
+   }
+  },
+  "ex1226": {
+   "pre": {
+    "status": "optimal",
+    "objective": -17.000000003887443,
+    "bound": -17.000000003887443,
+    "node_count": 3,
+    "gap_certified": true,
+    "wall": 1.0550850290001108
+   },
+   "post": {
+    "status": "optimal",
+    "objective": -17.000000000000007,
+    "bound": -17.00000000000013,
+    "node_count": 5,
+    "gap_certified": true,
+    "wall": 1.3592462000001433
+   }
+  },
+  "ex14_1_9": {
+   "post": {
+    "status": "optimal",
+    "objective": 2.8370135742179245e-09,
+    "bound": 0.0,
+    "node_count": 5,
+    "gap_certified": true,
+    "wall": 0.2728006060001462
+   },
+   "pre": {
+    "status": "optimal",
+    "objective": -1.9775220540513224e-16,
+    "bound": -1.9775220540513224e-16,
+    "node_count": 3,
+    "gap_certified": true,
+    "wall": 0.35003560699988157
+   }
+  },
+  "fac2": {
+   "pre": {
+    "status": "optimal",
+    "objective": 331837497.8394821,
+    "bound": 331837497.54563797,
+    "node_count": 41,
+    "gap_certified": true,
+    "wall": 10.471384882000166
+   },
+   "post": {
+    "status": "optimal",
+    "objective": 331837498.1769339,
+    "bound": 331837498.1760158,
+    "node_count": 41,
+    "gap_certified": true,
+    "wall": 12.937645874000282
+   }
+  },
+  "flay02m": {
+   "post": {
+    "status": "optimal",
+    "objective": 37.94733200383577,
+    "bound": 37.94733193020236,
+    "node_count": 7,
+    "gap_certified": true,
+    "wall": 0.9391262450003524
+   },
+   "pre": {
+    "status": "optimal",
+    "objective": 37.94733186383461,
+    "bound": 37.947331804569515,
+    "node_count": 7,
+    "gap_certified": true,
+    "wall": 0.49601408899980015
+   }
+  },
+  "flay03m": {
+   "pre": {
+    "status": "optimal",
+    "objective": 48.98979479383567,
+    "bound": 48.98979470823052,
+    "node_count": 111,
+    "gap_certified": true,
+    "wall": 8.738355416000104
+   },
+   "post": {
+    "status": "optimal",
+    "objective": 48.989794973836744,
+    "bound": 48.98979486747301,
+    "node_count": 113,
+    "gap_certified": true,
+    "wall": 9.112262885999826
+   }
+  },
+  "gbd": {
+   "post": {
+    "status": "optimal",
+    "objective": 2.1999999995740955,
+    "bound": 2.1999999995740955,
+    "node_count": 3,
+    "gap_certified": true,
+    "wall": 0.045054060999973444
+   },
+   "pre": {
+    "status": "optimal",
+    "objective": 2.1999999995740955,
+    "bound": 2.1999999995740955,
+    "node_count": 3,
+    "gap_certified": true,
+    "wall": 0.03419560600013938
+   }
+  },
+  "gkocis": {
+   "pre": {
+    "status": "optimal",
+    "objective": -1.9230987798770212,
+    "bound": -1.9230988280923489,
+    "node_count": 5,
+    "gap_certified": true,
+    "wall": 1.645017875999656
+   },
+   "post": {
+    "status": "optimal",
+    "objective": -1.9230986924056728,
+    "bound": -1.9230987422706283,
+    "node_count": 7,
+    "gap_certified": true,
+    "wall": 2.338902108000184
+   }
+  },
+  "hda": {
+   "post": {
+    "status": "time_limit",
+    "objective": null,
+    "bound": -64473.44240243703,
+    "node_count": 1,
+    "gap_certified": false,
+    "wall": 21.1590209269998
+   },
+   "pre": {
+    "status": "time_limit",
+    "objective": null,
+    "bound": -64473.44240243703,
+    "node_count": 1,
+    "gap_certified": false,
+    "wall": 21.094986974999756
+   }
+  },
+  "heatexch_gen1": {
+   "pre": {
+    "status": "time_limit",
+    "objective": null,
+    "bound": 38183.5317460179,
+    "node_count": 3,
+    "gap_certified": false,
+    "wall": 22.285185699000067
+   },
+   "post": {
+    "status": "time_limit",
+    "objective": null,
+    "bound": 38183.5317460179,
+    "node_count": 3,
+    "gap_certified": false,
+    "wall": 26.217303968000124
+   }
+  },
+  "heatexch_gen2": {
+   "post": {
+    "status": "time_limit",
+    "objective": null,
+    "bound": 555767.7902857271,
+    "node_count": 7,
+    "gap_certified": false,
+    "wall": 22.110858305999955
+   },
+   "pre": {
+    "status": "time_limit",
+    "objective": null,
+    "bound": 555767.7902857271,
+    "node_count": 7,
+    "gap_certified": false,
+    "wall": 21.20073213400019
+   }
+  },
+  "heatexch_gen3": {
+   "pre": {
+    "status": "time_limit",
+    "objective": null,
+    "bound": null,
+    "node_count": 3,
+    "gap_certified": false,
+    "wall": 26.534706085999915
+   },
+   "post": {
+    "status": "time_limit",
+    "objective": null,
+    "bound": null,
+    "node_count": 3,
+    "gap_certified": false,
+    "wall": 204.4960045869998
+   }
+  },
+  "m3": {
+   "post": {
+    "status": "optimal",
+    "objective": 37.800000263754704,
+    "bound": 37.800000072787064,
+    "node_count": 53,
+    "gap_certified": true,
+    "wall": 5.847690927999793
+   },
+   "pre": {
+    "status": "optimal",
+    "objective": 37.79999966997884,
+    "bound": 37.79999951039201,
+    "node_count": 47,
+    "gap_certified": true,
+    "wall": 4.307587265000166
+   }
+  },
+  "nvs01": {
+   "pre": {
+    "status": "optimal",
+    "objective": 12.46966882156821,
+    "bound": 12.46966882156821,
+    "node_count": 3,
+    "gap_certified": true,
+    "wall": 1.755747736000103
+   },
+   "post": {
+    "status": "optimal",
+    "objective": 12.46966882156821,
+    "bound": 12.46966882156821,
+    "node_count": 3,
+    "gap_certified": true,
+    "wall": 1.3634539760000735
+   }
+  },
+  "nvs02": {
+   "post": {
+    "status": "optimal",
+    "objective": 5.96418452307,
+    "bound": 5.96418452307,
+    "node_count": 345,
+    "gap_certified": true,
+    "wall": 0.41730416900009004
+   },
+   "pre": {
+    "status": "optimal",
+    "objective": 5.96418452307,
+    "bound": 5.96418452307,
+    "node_count": 345,
+    "gap_certified": true,
+    "wall": 0.37162310200028514
+   }
+  },
+  "nvs03": {
+   "pre": {
+    "status": "optimal",
+    "objective": 16.0,
+    "bound": 15.99999972676511,
+    "node_count": 5,
+    "gap_certified": true,
+    "wall": 0.1952417030001925
+   },
+   "post": {
+    "status": "optimal",
+    "objective": 16.0,
+    "bound": 16.0,
+    "node_count": 3,
+    "gap_certified": true,
+    "wall": 0.1750783349998528
+   }
+  },
+  "nvs04": {
+   "post": {
+    "status": "optimal",
+    "objective": 0.720000000000006,
+    "bound": 0.7199999999999773,
+    "node_count": 5,
+    "gap_certified": true,
+    "wall": 0.49249716800022725
+   },
+   "pre": {
+    "status": "optimal",
+    "objective": 0.720000000000006,
+    "bound": 0.7199999999999773,
+    "node_count": 5,
+    "gap_certified": true,
+    "wall": 0.34949135599981673
+   }
+  },
+  "nvs05": {
+   "pre": {
+    "status": "feasible",
+    "objective": 8.731956986640078,
+    "bound": 3.5424692441047068,
+    "node_count": 33,
+    "gap_certified": false,
+    "wall": 20.248498161000043
+   },
+   "post": {
+    "status": "feasible",
+    "objective": 8.73195696936806,
+    "bound": 3.5139026016464836,
+    "node_count": 33,
+    "gap_certified": false,
+    "wall": 20.38520216699999
+   }
+  },
+  "nvs06": {
+   "post": {
+    "status": "optimal",
+    "objective": 1.7703125,
+    "bound": 1.7703124999999627,
+    "node_count": 5,
+    "gap_certified": true,
+    "wall": 1.5734330180002871
+   },
+   "pre": {
+    "status": "optimal",
+    "objective": 1.7703125,
+    "bound": 1.7703124999999627,
+    "node_count": 5,
+    "gap_certified": true,
+    "wall": 1.1964277829997627
+   }
+  },
+  "nvs07": {
+   "pre": {
+    "status": "optimal",
+    "objective": 4.0,
+    "bound": 4.0,
+    "node_count": 5,
+    "gap_certified": true,
+    "wall": 0.14979283399998167
+   },
+   "post": {
+    "status": "optimal",
+    "objective": 4.0,
+    "bound": 4.0,
+    "node_count": 5,
+    "gap_certified": true,
+    "wall": 0.07110062800029482
+   }
+  },
+  "nvs08": {
+   "post": {
+    "status": "optimal",
+    "objective": 23.449727347978744,
+    "bound": 23.449727347447233,
+    "node_count": 5,
+    "gap_certified": true,
+    "wall": 1.8630246170000646
+   },
+   "pre": {
+    "status": "optimal",
+    "objective": 23.449727347139827,
+    "bound": 23.44972734516655,
+    "node_count": 3,
+    "gap_certified": true,
+    "wall": 1.455282664999686
+   }
+  },
+  "nvs09": {
+   "pre": {
+    "status": "optimal",
+    "objective": -43.134336918035295,
+    "bound": -43.13433691803662,
+    "node_count": 5,
+    "gap_certified": true,
+    "wall": 7.549358587999905
+   },
+   "post": {
+    "status": "optimal",
+    "objective": -43.13433691803531,
+    "bound": -43.13433691803662,
+    "node_count": 5,
+    "gap_certified": true,
+    "wall": 5.06351296999992
+   }
+  },
+  "nvs10": {
+   "post": {
+    "status": "optimal",
+    "objective": -310.7999999999999,
+    "bound": -310.7999999999999,
+    "node_count": 5,
+    "gap_certified": true,
+    "wall": 0.18107256899975255
+   },
+   "pre": {
+    "status": "optimal",
+    "objective": -310.7999999999999,
+    "bound": -310.7999999999999,
+    "node_count": 5,
+    "gap_certified": true,
+    "wall": 0.14433151599996563
+   }
+  },
+  "nvs11": {
+   "pre": {
+    "status": "optimal",
+    "objective": -431.0000000000085,
+    "bound": -431.0000000000085,
+    "node_count": 55,
+    "gap_certified": true,
+    "wall": 0.6414511250000032
+   },
+   "post": {
+    "status": "optimal",
+    "objective": -431.0000000000085,
+    "bound": -431.0000000000085,
+    "node_count": 55,
+    "gap_certified": true,
+    "wall": 0.5812574599999607
+   }
+  },
+  "nvs12": {
+   "post": {
+    "status": "optimal",
+    "objective": -481.20000000001,
+    "bound": -481.20000000001,
+    "node_count": 231,
+    "gap_certified": true,
+    "wall": 2.1597501929995815
+   },
+   "pre": {
+    "status": "optimal",
+    "objective": -481.20000000001,
+    "bound": -481.20000000001,
+    "node_count": 231,
+    "gap_certified": true,
+    "wall": 2.078526734999741
+   }
+  },
+  "nvs13": {
+   "pre": {
+    "status": "optimal",
+    "objective": -585.2,
+    "bound": -585.2,
+    "node_count": 637,
+    "gap_certified": true,
+    "wall": 1.7141908429998693
+   },
+   "post": {
+    "status": "optimal",
+    "objective": -585.2,
+    "bound": -585.2,
+    "node_count": 637,
+    "gap_certified": true,
+    "wall": 1.6717294449999827
+   }
+  },
+  "nvs14": {
+   "post": {
+    "status": "optimal",
+    "objective": -40358.15476929995,
+    "bound": -40358.154769299996,
+    "node_count": 129,
+    "gap_certified": true,
+    "wall": 0.7930625140002121
+   },
+   "pre": {
+    "status": "optimal",
+    "objective": -40358.15476929995,
+    "bound": -40358.154769299996,
+    "node_count": 129,
+    "gap_certified": true,
+    "wall": 0.9612146969998321
+   }
+  },
+  "nvs15": {
+   "pre": {
+    "status": "optimal",
+    "objective": 1.0,
+    "bound": 1.0,
+    "node_count": 7,
+    "gap_certified": true,
+    "wall": 0.08759022100002767
+   },
+   "post": {
+    "status": "optimal",
+    "objective": 1.0,
+    "bound": 1.0,
+    "node_count": 7,
+    "gap_certified": true,
+    "wall": 0.08692739699972662
+   }
+  },
+  "nvs21": {
+   "post": {
+    "status": "optimal",
+    "objective": -5.684782472248296,
+    "bound": -5.684782500002237,
+    "node_count": 37,
+    "gap_certified": true,
+    "wall": 4.944593620999967
+   },
+   "pre": {
+    "status": "optimal",
+    "objective": -5.684782628025259,
+    "bound": -5.684782628025259,
+    "node_count": 3,
+    "gap_certified": true,
+    "wall": 7.143478100000266
+   }
+  },
+  "oaer": {
+   "pre": {
+    "status": "optimal",
+    "objective": -1.923098499884843,
+    "bound": -1.923098601139822,
+    "node_count": 3,
+    "gap_certified": true,
+    "wall": 1.4632768280002892
+   },
+   "post": {
+    "status": "optimal",
+    "objective": -1.9230985101297913,
+    "bound": -1.9230985229112765,
+    "node_count": 5,
+    "gap_certified": true,
+    "wall": 1.6399173979998523
+   }
+  },
+  "st_e11": {
+   "post": {
+    "status": "optimal",
+    "objective": 189.31162970097128,
+    "bound": 189.311629686619,
+    "node_count": 5,
+    "gap_certified": true,
+    "wall": 1.7492268539999714
+   },
+   "pre": {
+    "status": "optimal",
+    "objective": 189.31162974131917,
+    "bound": 189.31162968661766,
+    "node_count": 27,
+    "gap_certified": true,
+    "wall": 3.9942719690002377
+   }
+  },
+  "st_e13": {
+   "pre": {
+    "status": "optimal",
+    "objective": 1.9999999825187946,
+    "bound": 1.9999999825187946,
+    "node_count": 1,
+    "gap_certified": true,
+    "wall": 0.27426670399972863
+   },
+   "post": {
+    "status": "optimal",
+    "objective": 2.0000000025188225,
+    "bound": 2.0,
+    "node_count": 1,
+    "gap_certified": true,
+    "wall": 0.1379266369999641
+   }
+  },
+  "st_e29": {
+   "post": {
+    "status": "optimal",
+    "objective": -0.9434704993121346,
+    "bound": -0.9434705000000165,
+    "node_count": 5,
+    "gap_certified": true,
+    "wall": 2.964155441999992
+   },
+   "pre": {
+    "status": "optimal",
+    "objective": -0.9434704942820806,
+    "bound": -0.9434705000000166,
+    "node_count": 5,
+    "gap_certified": true,
+    "wall": 2.8933606120003788
+   }
+  },
+  "st_e36": {
+   "pre": {
+    "status": "optimal",
+    "objective": -245.99999999999997,
+    "bound": -246.00000000170422,
+    "node_count": 85,
+    "gap_certified": true,
+    "wall": 11.671530211000118
+   },
+   "post": {
+    "status": "optimal",
+    "objective": -246.0,
+    "bound": -246.00000000170422,
+    "node_count": 85,
+    "gap_certified": true,
+    "wall": 10.362108264000199
+   }
+  },
+  "st_e38": {
+   "post": {
+    "status": "optimal",
+    "objective": 7197.727148526157,
+    "bound": 7197.727148526157,
+    "node_count": 3,
+    "gap_certified": true,
+    "wall": 1.0355117770000106
+   },
+   "pre": {
+    "status": "optimal",
+    "objective": 7197.727116826533,
+    "bound": 7197.727116826533,
+    "node_count": 3,
+    "gap_certified": true,
+    "wall": 1.770093886000268
+   }
+  },
+  "st_miqp1": {
+   "pre": {
+    "status": "optimal",
+    "objective": 280.9999999906497,
+    "bound": 280.9999999906497,
+    "node_count": 15,
+    "gap_certified": true,
+    "wall": 0.21868393500017191
+   },
+   "post": {
+    "status": "optimal",
+    "objective": 280.9999999906497,
+    "bound": 280.9999999906497,
+    "node_count": 15,
+    "gap_certified": true,
+    "wall": 0.03125743100008549
+   }
+  },
+  "st_miqp2": {
+   "post": {
+    "status": "optimal",
+    "objective": 2.0,
+    "bound": 2.0,
+    "node_count": 9,
+    "gap_certified": true,
+    "wall": 0.07676102499999615
+   },
+   "pre": {
+    "status": "optimal",
+    "objective": 2.0,
+    "bound": 2.0,
+    "node_count": 9,
+    "gap_certified": true,
+    "wall": 0.06837029500002245
+   }
+  },
+  "st_miqp3": {
+   "pre": {
+    "status": "optimal",
+    "objective": -6.0,
+    "bound": -6.0,
+    "node_count": 1,
+    "gap_certified": true,
+    "wall": 0.02205712000022686
+   },
+   "post": {
+    "status": "optimal",
+    "objective": -6.0,
+    "bound": -6.0,
+    "node_count": 1,
+    "gap_certified": true,
+    "wall": 0.01834424799972112
+   }
+  },
+  "st_miqp4": {
+   "post": {
+    "status": "optimal",
+    "objective": -4574.000000000435,
+    "bound": -4574.000000000435,
+    "node_count": 3,
+    "gap_certified": true,
+    "wall": 0.09114826299992274
+   },
+   "pre": {
+    "status": "optimal",
+    "objective": -4574.000000000435,
+    "bound": -4574.000000000435,
+    "node_count": 3,
+    "gap_certified": true,
+    "wall": 0.13341707600011432
+   }
+  },
+  "st_miqp5": {
+   "pre": {
+    "status": "optimal",
+    "objective": -333.88888889644716,
+    "bound": -333.88888889644716,
+    "node_count": 1,
+    "gap_certified": true,
+    "wall": 0.10419316000024992
+   },
+   "post": {
+    "status": "optimal",
+    "objective": -333.88888889644716,
+    "bound": -333.88888889644716,
+    "node_count": 1,
+    "gap_certified": true,
+    "wall": 0.062342824999632285
+   }
+  },
+  "st_test1": {
+   "post": {
+    "status": "optimal",
+    "objective": -1.6495994490692313e-08,
+    "bound": -1.6495994490692313e-08,
+    "node_count": 15,
+    "gap_certified": true,
+    "wall": 0.08140621399979864
+   },
+   "pre": {
+    "status": "optimal",
+    "objective": -1.6495994490692313e-08,
+    "bound": -1.6495994490692313e-08,
+    "node_count": 15,
+    "gap_certified": true,
+    "wall": 0.051205858000230364
+   }
+  },
+  "st_testgr3": {
+   "pre": {
+    "status": "optimal",
+    "objective": -20.59,
+    "bound": -20.59070709795548,
+    "node_count": 549,
+    "gap_certified": true,
+    "wall": 0.45436429100027453
+   },
+   "post": {
+    "status": "optimal",
+    "objective": -20.59,
+    "bound": -20.59070709795548,
+    "node_count": 549,
+    "gap_certified": true,
+    "wall": 0.5031579499996042
+   }
+  },
+  "syn05hfsg": {
+   "post": {
+    "status": "feasible",
+    "objective": 837.7323012718434,
+    "bound": 840.4893941019076,
+    "node_count": 215,
+    "gap_certified": false,
+    "wall": 20.24814080499982
+   },
+   "pre": {
+    "status": "feasible",
+    "objective": 837.732412391107,
+    "bound": 840.4893941019081,
+    "node_count": 125,
+    "gap_certified": false,
+    "wall": 20.11201671300023
+   }
+  },
+  "tanksize": {
+   "pre": {
+    "status": "time_limit",
+    "objective": 1.268643752557795,
+    "bound": 1.2609361431125585,
+    "node_count": 3330,
+    "gap_certified": true,
+    "wall": 20.3181326670001
+   },
+   "post": {
+    "status": "time_limit",
+    "objective": 1.268643759853009,
+    "bound": 1.2598035867232422,
+    "node_count": 3076,
+    "gap_certified": true,
+    "wall": 20.118190193999908
+   }
+  },
+  "tls2": {
+   "post": {
+    "status": "feasible",
+    "objective": 10.299999999983916,
+    "bound": 2.448712647787379,
+    "node_count": 353,
+    "gap_certified": false,
+    "wall": 20.627966677999666
+   },
+   "pre": {
+    "status": "feasible",
+    "objective": 6.299999911869455,
+    "bound": 2.4487125876978726,
+    "node_count": 339,
+    "gap_certified": false,
+    "wall": 21.14731124700029
+   }
+  },
+  "tspn05": {
+   "pre": {
+    "status": "feasible",
+    "objective": 191.2552076848774,
+    "bound": 178.27199442798212,
+    "node_count": 33,
+    "gap_certified": false,
+    "wall": 20.15668522499982
+   },
+   "post": {
+    "status": "feasible",
+    "objective": 191.25520784460605,
+    "bound": 179.0941485386719,
+    "node_count": 53,
+    "gap_certified": false,
+    "wall": 20.138568632999977
+   }
+  },
+  "tspn08": {
+   "post": {
+    "status": "feasible",
+    "objective": 290.5668539675022,
+    "bound": null,
+    "node_count": 1,
+    "gap_certified": false,
+    "wall": 13.85614847700026
+   },
+   "pre": {
+    "status": "feasible",
+    "objective": 290.56685374735093,
+    "bound": null,
+    "node_count": 1,
+    "gap_certified": false,
+    "wall": 17.982297136999932
+   }
+  },
+  "tspn10": {
+   "pre": {
+    "status": "feasible",
+    "objective": 225.1260713973286,
+    "bound": null,
+    "node_count": 1,
+    "gap_certified": false,
+    "wall": 16.99774281100008
+   },
+   "post": {
+    "status": "feasible",
+    "objective": 225.12607170016992,
+    "bound": null,
+    "node_count": 1,
+    "gap_certified": false,
+    "wall": 20.852727699999832
+   }
+  },
+  "tspn12": {
+   "post": {
+    "status": "time_limit",
+    "objective": null,
+    "bound": null,
+    "node_count": 3,
+    "gap_certified": false,
+    "wall": 46.11591934199987
+   },
+   "pre": {
+    "status": "feasible",
+    "objective": 262.64739525060224,
+    "bound": null,
+    "node_count": 1,
+    "gap_certified": false,
+    "wall": 15.90270813699999
+   }
+  }
+ },
+ "diffs": [
+  [
+   "casctanks",
+   {
+    "node_count": [
+     1,
+     3
+    ]
+   }
+  ],
+  [
+   "chance",
+   {
+    "objective": [
+     29.894378154271102,
+     29.894378166613386
+    ],
+    "bound": [
+     29.894378154271102,
+     29.894378166613386
+    ]
+   }
+  ],
+  [
+   "clay0303hfsg",
+   {
+    "node_count": [
+     3,
+     95
+    ]
+   }
+  ],
+  [
+   "contvar",
+   {
+    "bound": [
+     183632.02121055726,
+     180782.8593284799
+    ]
+   }
+  ],
+  [
+   "cvxnonsep_nsig30",
+   {
+    "objective": [
+     130.62871116925294,
+     130.62871268683438
+    ],
+    "bound": [
+     130.61841392487688,
+     130.6184154341326
+    ]
+   }
+  ],
+  [
+   "cvxnonsep_psig30",
+   {
+    "objective": [
+     78.99885435294289,
+     78.998854365269
+    ],
+    "bound": [
+     78.99701703820377,
+     78.99701709863874
+    ]
+   }
+  ],
+  [
+   "cvxnonsep_psig40r",
+   {
+    "objective": [
+     86.54527995164959,
+     86.54528288283356
+    ],
+    "bound": [
+     86.53873600363832,
+     86.53873904316234
+    ],
+    "node_count": [
+     103,
+     95
+    ]
+   }
+  ],
+  [
+   "dispatch",
+   {
+    "objective": [
+     3155.2879266857854,
+     3155.2879268631687
+    ],
+    "bound": [
+     3155.2878615366776,
+     3155.287861536673
+    ]
+   }
+  ],
+  [
+   "ex1222",
+   {
+    "objective": [
+     1.0765430833322625,
+     1.0765430833322618
+    ],
+    "bound": [
+     1.0765430463031964,
+     1.0765430833322571
+    ],
+    "node_count": [
+     1,
+     3
+    ]
+   }
+  ],
+  [
+   "ex1224",
+   {
+    "objective": [
+     -0.9434704942820806,
+     -0.9434704993121346
+    ],
+    "bound": [
+     -0.9434705000000166,
+     -0.9434705000000165
+    ]
+   }
+  ],
+  [
+   "ex1225",
+   {
+    "objective": [
+     30.999999913557566,
+     31.000000000008843
+    ],
+    "bound": [
+     30.999999913557566,
+     30.999999999999844
+    ]
+   }
+  ],
+  [
+   "ex1226",
+   {
+    "objective": [
+     -17.000000003887443,
+     -17.000000000000007
+    ],
+    "bound": [
+     -17.000000003887443,
+     -17.00000000000013
+    ],
+    "node_count": [
+     3,
+     5
+    ]
+   }
+  ],
+  [
+   "ex14_1_9",
+   {
+    "objective": [
+     -1.9775220540513224e-16,
+     2.8370135742179245e-09
+    ],
+    "bound": [
+     -1.9775220540513224e-16,
+     0.0
+    ],
+    "node_count": [
+     3,
+     5
+    ]
+   }
+  ],
+  [
+   "fac2",
+   {
+    "objective": [
+     331837497.8394821,
+     331837498.1769339
+    ],
+    "bound": [
+     331837497.54563797,
+     331837498.1760158
+    ]
+   }
+  ],
+  [
+   "flay02m",
+   {
+    "objective": [
+     37.94733186383461,
+     37.94733200383577
+    ],
+    "bound": [
+     37.947331804569515,
+     37.94733193020236
+    ]
+   }
+  ],
+  [
+   "flay03m",
+   {
+    "objective": [
+     48.98979479383567,
+     48.989794973836744
+    ],
+    "bound": [
+     48.98979470823052,
+     48.98979486747301
+    ],
+    "node_count": [
+     111,
+     113
+    ]
+   }
+  ],
+  [
+   "gkocis",
+   {
+    "objective": [
+     -1.9230987798770212,
+     -1.9230986924056728
+    ],
+    "bound": [
+     -1.9230988280923489,
+     -1.9230987422706283
+    ],
+    "node_count": [
+     5,
+     7
+    ]
+   }
+  ],
+  [
+   "m3",
+   {
+    "objective": [
+     37.79999966997884,
+     37.800000263754704
+    ],
+    "bound": [
+     37.79999951039201,
+     37.800000072787064
+    ],
+    "node_count": [
+     47,
+     53
+    ]
+   }
+  ],
+  [
+   "nvs03",
+   {
+    "bound": [
+     15.99999972676511,
+     16.0
+    ],
+    "node_count": [
+     5,
+     3
+    ]
+   }
+  ],
+  [
+   "nvs05",
+   {
+    "objective": [
+     8.731956986640078,
+     8.73195696936806
+    ],
+    "bound": [
+     3.5424692441047068,
+     3.5139026016464836
+    ]
+   }
+  ],
+  [
+   "nvs08",
+   {
+    "objective": [
+     23.449727347139827,
+     23.449727347978744
+    ],
+    "bound": [
+     23.44972734516655,
+     23.449727347447233
+    ],
+    "node_count": [
+     3,
+     5
+    ]
+   }
+  ],
+  [
+   "nvs09",
+   {
+    "objective": [
+     -43.134336918035295,
+     -43.13433691803531
+    ]
+   }
+  ],
+  [
+   "nvs21",
+   {
+    "objective": [
+     -5.684782628025259,
+     -5.684782472248296
+    ],
+    "bound": [
+     -5.684782628025259,
+     -5.684782500002237
+    ],
+    "node_count": [
+     3,
+     37
+    ]
+   }
+  ],
+  [
+   "oaer",
+   {
+    "objective": [
+     -1.923098499884843,
+     -1.9230985101297913
+    ],
+    "bound": [
+     -1.923098601139822,
+     -1.9230985229112765
+    ],
+    "node_count": [
+     3,
+     5
+    ]
+   }
+  ],
+  [
+   "st_e11",
+   {
+    "objective": [
+     189.31162974131917,
+     189.31162970097128
+    ],
+    "bound": [
+     189.31162968661766,
+     189.311629686619
+    ],
+    "node_count": [
+     27,
+     5
+    ]
+   }
+  ],
+  [
+   "st_e13",
+   {
+    "objective": [
+     1.9999999825187946,
+     2.0000000025188225
+    ],
+    "bound": [
+     1.9999999825187946,
+     2.0
+    ]
+   }
+  ],
+  [
+   "st_e29",
+   {
+    "objective": [
+     -0.9434704942820806,
+     -0.9434704993121346
+    ],
+    "bound": [
+     -0.9434705000000166,
+     -0.9434705000000165
+    ]
+   }
+  ],
+  [
+   "st_e36",
+   {
+    "objective": [
+     -245.99999999999997,
+     -246.0
+    ]
+   }
+  ],
+  [
+   "st_e38",
+   {
+    "objective": [
+     7197.727116826533,
+     7197.727148526157
+    ],
+    "bound": [
+     7197.727116826533,
+     7197.727148526157
+    ]
+   }
+  ],
+  [
+   "syn05hfsg",
+   {
+    "objective": [
+     837.732412391107,
+     837.7323012718434
+    ],
+    "bound": [
+     840.4893941019081,
+     840.4893941019076
+    ],
+    "node_count": [
+     125,
+     215
+    ]
+   }
+  ],
+  [
+   "tanksize",
+   {
+    "objective": [
+     1.268643752557795,
+     1.268643759853009
+    ],
+    "bound": [
+     1.2609361431125585,
+     1.2598035867232422
+    ],
+    "node_count": [
+     3330,
+     3076
+    ]
+   }
+  ],
+  [
+   "tls2",
+   {
+    "objective": [
+     6.299999911869455,
+     10.299999999983916
+    ],
+    "bound": [
+     2.4487125876978726,
+     2.448712647787379
+    ],
+    "node_count": [
+     339,
+     353
+    ]
+   }
+  ],
+  [
+   "tspn05",
+   {
+    "objective": [
+     191.2552076848774,
+     191.25520784460605
+    ],
+    "bound": [
+     178.27199442798212,
+     179.0941485386719
+    ],
+    "node_count": [
+     33,
+     53
+    ]
+   }
+  ],
+  [
+   "tspn08",
+   {
+    "objective": [
+     290.56685374735093,
+     290.5668539675022
+    ]
+   }
+  ],
+  [
+   "tspn10",
+   {
+    "objective": [
+     225.1260713973286,
+     225.12607170016992
+    ]
+   }
+  ],
+  [
+   "tspn12",
+   {
+    "status": [
+     "feasible",
+     "time_limit"
+    ],
+    "objective": [
+     262.64739525060224,
+     null
+    ],
+    "node_count": [
+     1,
+     3
+    ]
+   }
+  ]
+ ],
+ "findings": [],
+ "cert_regressions": [],
+ "solve_nlp_calls": {
+  "pre": 2996,
+  "post": 3044
+ },
+ "time_limit": 20.0
+}

--- a/scratchpad/issue945/panel_corpus.py
+++ b/scratchpad/issue945/panel_corpus.py
@@ -1,0 +1,220 @@
+"""Issue #945 differential panel: seeding the NLP path from pounce_option_defaults.
+
+CLAUDE.md §5 regime 2 (bound-changing): the arms are compared on certification
+soundness first and search behaviour second. For every instance and arm it
+records status / objective / bound / node_count, and checks against the
+authoritative optima registry (``python/tests/data/known_optima.toml``):
+
+  * ``bound_above_opt``  — a dual bound above the reference optimum (min sense)
+                           has cut the optimum out of the search. Fatal.
+  * ``super_optimal``    — an incumbent below the reference optimum is not a
+                           feasible point. Fatal.
+  * ``cert_inverted``    — bound > incumbent, the certificate invariant. Fatal.
+  * certification regression — an instance that reported a *certified* gap in the
+                           pre arm must not lose it in the post arm.
+
+Both arms run INTERLEAVED in one process (§9), alternating which goes first, so
+background load or cache warmth cannot land on one arm only. The pre arm is
+reconstructed exactly as ``nlp_pounce.solve_nlp`` was before #945: ``print_level``
+alone, leaving BOTH ``constr_viol_tol`` (Ipopt default 1e-4) and
+``bound_relax_factor`` (1e-8) at Ipopt's values.
+
+§6: this panel counts the ``solve_nlp`` calls each arm actually made. If that
+count is zero the panel exercised nothing of the change under test and exits
+non-zero — a green "0 differences" from a code path that never ran is the exact
+failure mode this file exists to avoid.
+
+Usage:  python -u scratchpad/issue945/panel_corpus.py out.json [time_limit]
+"""
+
+from __future__ import annotations
+
+import inspect
+import json
+import os
+import sys
+import time
+
+os.environ.setdefault("JAX_PLATFORMS", "cpu")
+os.environ.setdefault("JAX_ENABLE_X64", "1")
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "python", "tests"))
+
+import discopt.solvers.nlp_pounce as NLPP  # noqa: E402
+from _optima import known_optimum  # noqa: E402
+from discopt.modeling import from_nl  # noqa: E402
+from discopt.solvers import pounce_option_defaults  # noqa: E402
+
+# §8: assert we loaded the code under test, by file AND by a marker unique to it.
+assert NLPP.__file__.startswith("/home/user/discopt/python/"), NLPP.__file__
+assert "opts = pounce_option_defaults()" in inspect.getsource(NLPP.solve_nlp), (
+    "post-#945 marker absent: nlp_pounce.solve_nlp is not seeded from the shared "
+    "baseline, so there is no change here to panel"
+)
+
+_PRE_ARM = {"print_level": 0}
+_REAL = pounce_option_defaults
+
+ROOT = "python/tests/data/minlplib_nl"
+
+# Counts solve_nlp entries per arm, so the panel can prove the path ran.
+_CALLS = {"pre": 0, "post": 0}
+_ARM = "post"
+_ORIG_SOLVE_NLP = NLPP.solve_nlp
+
+
+def _counting_solve_nlp(*args, **kwargs):
+    _CALLS[_ARM] += 1
+    return _ORIG_SOLVE_NLP(*args, **kwargs)
+
+
+NLPP.solve_nlp = _counting_solve_nlp
+# The callers import `solve_nlp` lazily inside functions, so patching the module
+# attribute is enough; but solver.py's batch path reads the options directly.
+import discopt.solver as SOLVER  # noqa: E402
+
+_ORIG_BATCH_DEFAULTS = SOLVER.pounce_option_defaults
+
+
+def set_arm(arm: str) -> None:
+    global _ARM
+    _ARM = arm
+    if arm == "pre":
+        NLPP.pounce_option_defaults = lambda: dict(_PRE_ARM)
+        SOLVER.pounce_option_defaults = lambda: dict(_PRE_ARM)
+    else:
+        NLPP.pounce_option_defaults = _REAL
+        SOLVER.pounce_option_defaults = _ORIG_BATCH_DEFAULTS
+
+
+def solve_one(path: str, arm: str, time_limit: float) -> dict:
+    set_arm(arm)
+    t0 = time.perf_counter()
+    try:
+        res = from_nl(path).solve(time_limit=time_limit)
+    except Exception as exc:  # recorded, never swallowed (§7)
+        return {"error": f"{type(exc).__name__}: {exc}", "wall": time.perf_counter() - t0}
+    return {
+        "status": res.status,
+        "objective": res.objective,
+        "bound": res.bound,
+        "node_count": res.node_count,
+        "gap_certified": getattr(res, "gap_certified", None),
+        "wall": time.perf_counter() - t0,
+    }
+
+
+# Reference optima are stored in the instance's own sense; the .nl files in this
+# corpus are all minimizations, which the registry documents.
+_BOUND_SLACK = 1e-6
+_REL_SLACK = 1e-6
+
+
+def _oracle_findings(name: str, r: dict) -> list[str]:
+    """Soundness checks against the reference optimum. Empty list == clean."""
+    if "error" in r:
+        return []
+    opt = known_optimum(name)
+    if opt is None:
+        return []
+    out = []
+    tol = _BOUND_SLACK + _REL_SLACK * abs(opt)
+    b, o = r.get("bound"), r.get("objective")
+    if b is not None and b > opt + tol:
+        out.append(f"bound_above_opt({b:.12g} > {opt:.12g})")
+    if o is not None and o < opt - tol:
+        out.append(f"super_optimal({o:.12g} < {opt:.12g})")
+    if b is not None and o is not None and b > o + tol:
+        out.append(f"cert_inverted(bound {b:.12g} > incumbent {o:.12g})")
+    return out
+
+
+def main(out_path: str, time_limit: float) -> int:
+    files = sorted(f for f in os.listdir(ROOT) if f.endswith(".nl"))
+    rows: dict[str, dict] = {}
+    comparisons = 0
+    oracle_checks = 0
+    diffs: list = []
+    findings: list = []
+    cert_regressions: list = []
+
+    for i, f in enumerate(files, 1):
+        name = f[:-3]
+        p = os.path.join(ROOT, f)
+        # Alternate which arm runs first so drift cannot systematically favour one.
+        order = ("pre", "post") if i % 2 else ("post", "pre")
+        got = {a: solve_one(p, a, time_limit) for a in order}
+        rows[name] = got
+        comparisons += 1
+
+        for arm in ("pre", "post"):
+            fs = _oracle_findings(name, got[arm])
+            if known_optimum(name) is not None and "error" not in got[arm]:
+                oracle_checks += 1
+            for msg in fs:
+                findings.append((name, arm, msg))
+
+        # A certified gap must never be lost.
+        if got["pre"].get("gap_certified") and not got["post"].get("gap_certified"):
+            cert_regressions.append(name)
+
+        keys = ("status", "objective", "bound", "node_count")
+        same = all(got["pre"].get(k) == got["post"].get(k) for k in keys)
+        if not same:
+            diffs.append(
+                (name, {k: (got["pre"].get(k), got["post"].get(k)) for k in keys
+                        if got["pre"].get(k) != got["post"].get(k)})
+            )
+        print(
+            f"[{i:3d}/{len(files)}] {name:28s} {'SAME' if same else 'DIFF'} "
+            f"pre={got['pre'].get('status')}/{got['pre'].get('objective')!r}/"
+            f"n{got['pre'].get('node_count')} "
+            f"post={got['post'].get('status')}/{got['post'].get('objective')!r}/"
+            f"n{got['post'].get('node_count')}",
+            flush=True,
+        )
+
+    json.dump(
+        {
+            "rows": rows,
+            "diffs": diffs,
+            "findings": findings,
+            "cert_regressions": cert_regressions,
+            "solve_nlp_calls": dict(_CALLS),
+            "time_limit": time_limit,
+        },
+        open(out_path, "w"),
+        indent=1,
+    )
+
+    print(
+        f"\nCOMPARISONS_EXECUTED={comparisons}  identical={comparisons - len(diffs)}  "
+        f"differing={len(diffs)}"
+    )
+    print(f"ORACLE_CHECKS_EXECUTED={oracle_checks}  soundness_findings={len(findings)}")
+    print(f"SOLVE_NLP_CALLS pre={_CALLS['pre']} post={_CALLS['post']}")
+    print(f"CERT_REGRESSIONS={len(cert_regressions)} {cert_regressions}")
+    for name, d in diffs:
+        print(f"  DIFF {name}: {d}")
+    for name, arm, msg in findings:
+        print(f"  FINDING {name} [{arm}]: {msg}")
+
+    if comparisons == 0:
+        print("PANEL COMPARED NOTHING", file=sys.stderr)
+        return 1
+    if _CALLS["pre"] == 0 and _CALLS["post"] == 0:
+        print(
+            "PANEL NEVER ENTERED solve_nlp — it measured nothing about the change "
+            "under test; do not read its 0 differences as evidence",
+            file=sys.stderr,
+        )
+        return 1
+    if findings or cert_regressions:
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    out = sys.argv[1]
+    tl = float(sys.argv[2]) if len(sys.argv) > 2 else 20.0
+    sys.exit(main(out, tl))

--- a/scratchpad/issue945/panel_corpus.py
+++ b/scratchpad/issue945/panel_corpus.py
@@ -53,7 +53,11 @@ from discopt.solvers import pounce_option_defaults  # noqa: E402
 # options at the point-consuming call sites and deliberately leaves the backend
 # neutral. An earlier version of this assert named the superseded contract and
 # refused to run once the branch rescoped — which is the guard working.
-assert NLPP.__file__.startswith("/home/user/discopt/python/"), NLPP.__file__
+_REPO_PYTHON = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "python"))
+assert NLPP.__file__.startswith(_REPO_PYTHON + os.sep), (
+    f"loaded discopt from {NLPP.__file__}, not the tree under test at {_REPO_PYTHON} — "
+    "a panel run against an installed copy measures the wrong code (§8)"
+)
 
 # The pre-#945 arm. Reconstructing it takes TWO seams, not one: #945 does NOT put
 # bound_relax_factor in the backend default (that breaks the Benders dual LP — see
@@ -80,22 +84,39 @@ def _counting_solve_nlp(*args, **kwargs):
 NLPP.solve_nlp = _counting_solve_nlp
 # The callers import `solve_nlp` lazily inside functions, so patching the module
 # attribute is enough; but solver.py's batch path reads the options directly.
+import discopt._jax.primal_heuristics as PH  # noqa: E402
 import discopt.solver as SOLVER  # noqa: E402
 import discopt.solvers.gdpopt_loa as LOA  # noqa: E402
 import discopt.solvers.oa as OA  # noqa: E402
 
 # Every module that requests the incumbent options; the arm must cover all of them.
-_CONSUMERS = (SOLVER, OA, LOA)
+# ``PH`` joined the list when the class was closed at the two producers the first
+# pass missed: ``feasibility_pump`` (and its five siblings, all routed through
+# ``PH._heuristic_nlp_options``) and ``_solve_nlp_bb``'s terminal refine solve.
+# Both read the module-global name, so patching the module attribute covers them.
+_CONSUMERS = (SOLVER, OA, LOA, PH)
 _REAL_INCUMBENT = SOLVER.pounce_incumbent_options
 
 # Post-#945 markers, checked here rather than at import of NLPP because the change
 # now lives at the CALL SITES. Absent => there is nothing to panel, and a green
 # "0 differences" would be measuring the same tree twice.
-for _fn in (SOLVER._solve_continuous, OA._solve_nlp_attempt, LOA._solve_nlp_subproblem):
+for _fn in (
+    SOLVER._solve_continuous,
+    OA._solve_nlp_attempt,
+    LOA._solve_nlp_subproblem,
+    PH._heuristic_nlp_options,
+):
     assert "pounce_incumbent_options()" in inspect.getsource(_fn), (
         f"post-#945 marker absent in {_fn.__name__}: the incumbent options are not "
         "requested there, so this panel would compare the pre arm against itself"
     )
+assert "refine_opts.update(pounce_incumbent_options())" in inspect.getsource(
+    SOLVER._solve_nlp_bb
+), (
+    "post marker absent in _solve_nlp_bb: its terminal refine solve is not "
+    "requesting the incumbent options, so this panel would compare the pre arm "
+    "against itself on the default MINLP path"
+)
 assert "pounce_incumbent_options()" not in inspect.getsource(NLPP.solve_nlp), (
     "bound_relax_factor leaked back into the NLP backend default; the pre arm "
     "reconstruction below assumes it is requested only at the call sites"
@@ -225,8 +246,14 @@ def main(out_path: str, time_limit: float) -> int:
         same = all(got["pre"].get(k) == got["post"].get(k) for k in keys)
         if not same:
             diffs.append(
-                (name, {k: (got["pre"].get(k), got["post"].get(k)) for k in keys
-                        if got["pre"].get(k) != got["post"].get(k)})
+                (
+                    name,
+                    {
+                        k: (got["pre"].get(k), got["post"].get(k))
+                        for k in keys
+                        if got["pre"].get(k) != got["post"].get(k)
+                    },
+                )
             )
         print(
             f"[{i:3d}/{len(files)}] {name:28s} {'SAME' if same else 'DIFF'} "

--- a/scratchpad/issue945/panel_corpus.py
+++ b/scratchpad/issue945/panel_corpus.py
@@ -5,11 +5,14 @@ soundness first and search behaviour second. For every instance and arm it
 records status / objective / bound / node_count, and checks against the
 authoritative optima registry (``python/tests/data/known_optima.toml``):
 
-  * ``bound_above_opt``  — a dual bound above the reference optimum (min sense)
-                           has cut the optimum out of the search. Fatal.
-  * ``super_optimal``    — an incumbent below the reference optimum is not a
+  * ``cert_inverted``    — the bound crossed the incumbent (the certificate
+                           invariant). Needs no oracle, so it runs on EVERY solved
+                           instance, and is sense-aware: for a maximization the
+                           bound is the UPPER side. Fatal.
+  * ``bound_past_opt``   — a dual bound beyond the reference optimum has cut the
+                           optimum out of the search. Fatal.
+  * ``super_optimal``    — an incumbent better than the reference optimum is not a
                            feasible point. Fatal.
-  * ``cert_inverted``    — bound > incumbent, the certificate invariant. Fatal.
   * certification regression — an instance that reported a *certified* gap in the
                            pre arm must not lose it in the post arm.
 
@@ -91,10 +94,13 @@ def solve_one(path: str, arm: str, time_limit: float) -> dict:
     set_arm(arm)
     t0 = time.perf_counter()
     try:
-        res = from_nl(path).solve(time_limit=time_limit)
+        model = from_nl(path)
+        maximize = model._objective is not None and str(model._objective.sense).endswith("MAXIMIZE")
+        res = model.solve(time_limit=time_limit)
     except Exception as exc:  # recorded, never swallowed (§7)
         return {"error": f"{type(exc).__name__}: {exc}", "wall": time.perf_counter() - t0}
     return {
+        "maximize": maximize,
         "status": res.status,
         "objective": res.objective,
         "bound": res.bound,
@@ -104,15 +110,16 @@ def solve_one(path: str, arm: str, time_limit: float) -> dict:
     }
 
 
-# Reference optima are stored in the instance's own sense; the .nl files in this
-# corpus are all minimizations, which the registry documents.
+# Reference optima are stored in the instance's own sense, and so are `bound` and
+# `objective`; `maximize` per row is what keeps the comparisons oriented.
 _BOUND_SLACK = 1e-6
 _REL_SLACK = 1e-6
 
 # `known_optimum` raises on an unrecorded instance by design; the registry covers
-# a subset of the 68-file corpus, so look up rather than ask. Instances with no
-# recorded optimum still contribute their pre/post diff, just not an oracle check
-# — which is why the oracle count is printed separately from the comparison count.
+# 16 of this corpus's 66 instances, so look up rather than ask. Instances with no
+# recorded optimum still get the certificate-ordering check and their pre/post
+# diff — which is why the three counts are printed separately rather than as one
+# reassuring total.
 _REGISTRY = optima_registry()
 
 
@@ -121,22 +128,37 @@ def known_optimum(name: str):
     return None if entry is None else entry["optimum"]
 
 
-def _oracle_findings(name: str, r: dict) -> list[str]:
-    """Soundness checks against the reference optimum. Empty list == clean."""
+def _oracle_findings(name: str, r: dict, maximize: bool) -> list[str]:
+    """Soundness checks. Empty list == clean.
+
+    The certificate-ordering check needs no oracle and so is NOT gated on one —
+    the first draft of this panel gated it, which silently skipped it on the 50 of
+    66 instances with no recorded optimum. It is also sense-aware: for a
+    maximization ``bound`` is an UPPER bound, so ``bound >= incumbent`` is the
+    correct ordering there (``syn05hfsg`` is such an instance, and reads as a 2.76
+    "inversion" if the sense is ignored).
+    """
     if "error" in r:
         return []
+    out = []
+    b, o = r.get("bound"), r.get("objective")
+
+    if b is not None and o is not None:
+        scale = _BOUND_SLACK + _REL_SLACK * max(abs(b), abs(o))
+        # In the model's own sense the bound is always the OPTIMISTIC side.
+        crossed = (o - b) if maximize else (b - o)
+        if crossed > scale:
+            sense = "max" if maximize else "min"
+            out.append(f"cert_inverted(bound {b:.12g} vs incumbent {o:.12g}, sense={sense})")
+
     opt = known_optimum(name)
     if opt is None:
-        return []
-    out = []
+        return out
     tol = _BOUND_SLACK + _REL_SLACK * abs(opt)
-    b, o = r.get("bound"), r.get("objective")
-    if b is not None and b > opt + tol:
-        out.append(f"bound_above_opt({b:.12g} > {opt:.12g})")
-    if o is not None and o < opt - tol:
-        out.append(f"super_optimal({o:.12g} < {opt:.12g})")
-    if b is not None and o is not None and b > o + tol:
-        out.append(f"cert_inverted(bound {b:.12g} > incumbent {o:.12g})")
+    if b is not None and (opt - b if maximize else b - opt) > tol:
+        out.append(f"bound_past_opt({b:.12g} vs optimum {opt:.12g})")
+    if o is not None and (o - opt if maximize else opt - o) > tol:
+        out.append(f"super_optimal({o:.12g} vs optimum {opt:.12g})")
     return out
 
 
@@ -145,6 +167,7 @@ def main(out_path: str, time_limit: float) -> int:
     rows: dict[str, dict] = {}
     comparisons = 0
     oracle_checks = 0
+    cert_checks = 0
     diffs: list = []
     findings: list = []
     cert_regressions: list = []
@@ -159,9 +182,15 @@ def main(out_path: str, time_limit: float) -> int:
         comparisons += 1
 
         for arm in ("pre", "post"):
-            fs = _oracle_findings(name, got[arm])
-            if known_optimum(name) is not None and "error" not in got[arm]:
-                oracle_checks += 1
+            r = got[arm]
+            fs = _oracle_findings(name, r, bool(r.get("maximize")))
+            if "error" not in r:
+                # Certificate-ordering check fires on every solved instance; the
+                # oracle comparisons additionally need a recorded optimum.
+                if r.get("bound") is not None and r.get("objective") is not None:
+                    cert_checks += 1
+                if known_optimum(name) is not None:
+                    oracle_checks += 1
             for msg in fs:
                 findings.append((name, arm, msg))
 
@@ -202,6 +231,7 @@ def main(out_path: str, time_limit: float) -> int:
         f"\nCOMPARISONS_EXECUTED={comparisons}  identical={comparisons - len(diffs)}  "
         f"differing={len(diffs)}"
     )
+    print(f"CERT_ORDER_CHECKS_EXECUTED={cert_checks}")
     print(f"ORACLE_CHECKS_EXECUTED={oracle_checks}  soundness_findings={len(findings)}")
     print(f"SOLVE_NLP_CALLS pre={_CALLS['pre']} post={_CALLS['post']}")
     print(f"CERT_REGRESSIONS={len(cert_regressions)} {cert_regressions}")

--- a/scratchpad/issue945/panel_corpus.py
+++ b/scratchpad/issue945/panel_corpus.py
@@ -41,7 +41,7 @@ os.environ.setdefault("JAX_ENABLE_X64", "1")
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "python", "tests"))
 
 import discopt.solvers.nlp_pounce as NLPP  # noqa: E402
-from _optima import known_optimum  # noqa: E402
+from _optima import optima_registry  # noqa: E402
 from discopt.modeling import from_nl  # noqa: E402
 from discopt.solvers import pounce_option_defaults  # noqa: E402
 
@@ -108,6 +108,17 @@ def solve_one(path: str, arm: str, time_limit: float) -> dict:
 # corpus are all minimizations, which the registry documents.
 _BOUND_SLACK = 1e-6
 _REL_SLACK = 1e-6
+
+# `known_optimum` raises on an unrecorded instance by design; the registry covers
+# a subset of the 68-file corpus, so look up rather than ask. Instances with no
+# recorded optimum still contribute their pre/post diff, just not an oracle check
+# — which is why the oracle count is printed separately from the comparison count.
+_REGISTRY = optima_registry()
+
+
+def known_optimum(name: str):
+    entry = _REGISTRY.get(name)
+    return None if entry is None else entry["optimum"]
 
 
 def _oracle_findings(name: str, r: dict) -> list[str]:

--- a/scratchpad/issue945/panel_corpus.py
+++ b/scratchpad/issue945/panel_corpus.py
@@ -49,11 +49,11 @@ from discopt.modeling import from_nl  # noqa: E402
 from discopt.solvers import pounce_option_defaults  # noqa: E402
 
 # §8: assert we loaded the code under test, by file AND by a marker unique to it.
+# The marker tracks the CONTRACT, not a line of code: #945 requests the incumbent
+# options at the point-consuming call sites and deliberately leaves the backend
+# neutral. An earlier version of this assert named the superseded contract and
+# refused to run once the branch rescoped — which is the guard working.
 assert NLPP.__file__.startswith("/home/user/discopt/python/"), NLPP.__file__
-assert "opts = pounce_option_defaults()" in inspect.getsource(NLPP.solve_nlp), (
-    "post-#945 marker absent: nlp_pounce.solve_nlp is not seeded from the shared "
-    "baseline, so there is no change here to panel"
-)
 
 # The pre-#945 arm. Reconstructing it takes TWO seams, not one: #945 does NOT put
 # bound_relax_factor in the backend default (that breaks the Benders dual LP — see
@@ -87,6 +87,19 @@ import discopt.solvers.oa as OA  # noqa: E402
 # Every module that requests the incumbent options; the arm must cover all of them.
 _CONSUMERS = (SOLVER, OA, LOA)
 _REAL_INCUMBENT = SOLVER.pounce_incumbent_options
+
+# Post-#945 markers, checked here rather than at import of NLPP because the change
+# now lives at the CALL SITES. Absent => there is nothing to panel, and a green
+# "0 differences" would be measuring the same tree twice.
+for _fn in (SOLVER._solve_continuous, OA._solve_nlp_attempt, LOA._solve_nlp_subproblem):
+    assert "pounce_incumbent_options()" in inspect.getsource(_fn), (
+        f"post-#945 marker absent in {_fn.__name__}: the incumbent options are not "
+        "requested there, so this panel would compare the pre arm against itself"
+    )
+assert "pounce_incumbent_options()" not in inspect.getsource(NLPP.solve_nlp), (
+    "bound_relax_factor leaked back into the NLP backend default; the pre arm "
+    "reconstruction below assumes it is requested only at the call sites"
+)
 
 
 def set_arm(arm: str) -> None:

--- a/scratchpad/issue945/panel_replicate.json
+++ b/scratchpad/issue945/panel_replicate.json
@@ -1,0 +1,294 @@
+{
+ "results": {
+  "tls2": {
+   "pre": [
+    {
+     "status": "feasible",
+     "objective": 11.299999856725538,
+     "bound": 2.0999999901667694,
+     "node_count": 317,
+     "wall": 20.58546758700004
+    },
+    {
+     "status": "feasible",
+     "objective": 5.299999922109238,
+     "bound": 3.1706801036010077,
+     "node_count": 349,
+     "wall": 20.29251420599985
+    },
+    {
+     "status": "feasible",
+     "objective": 5.299999922109238,
+     "bound": 3.1706801036010077,
+     "node_count": 349,
+     "wall": 20.129551756000183
+    }
+   ],
+   "post": [
+    {
+     "status": "time_limit",
+     "objective": null,
+     "bound": null,
+     "node_count": 191,
+     "wall": 20.062746008999966
+    },
+    {
+     "status": "feasible",
+     "objective": 5.299999999987421,
+     "bound": 3.1706801757442244,
+     "node_count": 349,
+     "wall": 20.466495798000324
+    },
+    {
+     "status": "feasible",
+     "objective": 6.299999999986951,
+     "bound": 2.448712647787379,
+     "node_count": 339,
+     "wall": 20.25244513100006
+    }
+   ]
+  },
+  "tspn12": {
+   "pre": [
+    {
+     "status": "feasible",
+     "objective": 262.64739525060224,
+     "bound": null,
+     "node_count": 1,
+     "wall": 15.048475292000148
+    },
+    {
+     "status": "feasible",
+     "objective": 262.64739525060224,
+     "bound": null,
+     "node_count": 1,
+     "wall": 14.603284948999772
+    },
+    {
+     "status": "feasible",
+     "objective": 262.64739525060224,
+     "bound": null,
+     "node_count": 1,
+     "wall": 15.011169063000125
+    }
+   ],
+   "post": [
+    {
+     "status": "feasible",
+     "objective": 262.64739579632806,
+     "bound": null,
+     "node_count": 1,
+     "wall": 14.460726710000017
+    },
+    {
+     "status": "feasible",
+     "objective": 262.64739579632806,
+     "bound": null,
+     "node_count": 1,
+     "wall": 14.729435125999771
+    },
+    {
+     "status": "feasible",
+     "objective": 262.64739579632806,
+     "bound": null,
+     "node_count": 1,
+     "wall": 14.388469588000135
+    }
+   ]
+  },
+  "nvs05": {
+   "pre": [
+    {
+     "status": "feasible",
+     "objective": 8.731956986640078,
+     "bound": 3.5424692441047068,
+     "node_count": 33,
+     "wall": 20.182479178999984
+    },
+    {
+     "status": "feasible",
+     "objective": 8.731956986640078,
+     "bound": 3.5424692441047068,
+     "node_count": 33,
+     "wall": 20.19236001499985
+    },
+    {
+     "status": "feasible",
+     "objective": 8.731956986640078,
+     "bound": 3.5424692441047068,
+     "node_count": 41,
+     "wall": 20.18917912400002
+    }
+   ],
+   "post": [
+    {
+     "status": "feasible",
+     "objective": 8.73195696936806,
+     "bound": 3.4474066870047313,
+     "node_count": 33,
+     "wall": 20.130246876
+    },
+    {
+     "status": "feasible",
+     "objective": 8.73195696936806,
+     "bound": 3.4474066870047313,
+     "node_count": 33,
+     "wall": 20.17768762700007
+    },
+    {
+     "status": "feasible",
+     "objective": 8.73195696936806,
+     "bound": 3.4474066870047313,
+     "node_count": 33,
+     "wall": 20.15309932299988
+    }
+   ]
+  },
+  "tspn05": {
+   "pre": [
+    {
+     "status": "feasible",
+     "objective": 191.25520768487672,
+     "bound": 173.53395514657217,
+     "node_count": 7,
+     "wall": 20.09491476700032
+    },
+    {
+     "status": "feasible",
+     "objective": 191.2552076848774,
+     "bound": 179.0941485386719,
+     "node_count": 53,
+     "wall": 20.14235947499992
+    },
+    {
+     "status": "feasible",
+     "objective": 191.2552076848774,
+     "bound": 179.0941485386719,
+     "node_count": 53,
+     "wall": 20.16249833200027
+    }
+   ],
+   "post": [
+    {
+     "status": "feasible",
+     "objective": 191.25520784460605,
+     "bound": 178.27199442798212,
+     "node_count": 55,
+     "wall": 20.14882291699996
+    },
+    {
+     "status": "feasible",
+     "objective": 191.25520784460605,
+     "bound": 179.0941485386719,
+     "node_count": 51,
+     "wall": 20.159586920000038
+    },
+    {
+     "status": "feasible",
+     "objective": 191.25520784460605,
+     "bound": 179.0941485386719,
+     "node_count": 53,
+     "wall": 20.14523626500022
+    }
+   ]
+  },
+  "syn05hfsg": {
+   "pre": [
+    {
+     "status": "feasible",
+     "objective": 837.732412391107,
+     "bound": 840.4893941019081,
+     "node_count": 141,
+     "wall": 20.10313659600024
+    },
+    {
+     "status": "feasible",
+     "objective": 837.732412391107,
+     "bound": 840.4893941019076,
+     "node_count": 153,
+     "wall": 20.100324848000128
+    },
+    {
+     "status": "feasible",
+     "objective": 837.732412391107,
+     "bound": 840.4893941019076,
+     "node_count": 151,
+     "wall": 20.110272387999885
+    }
+   ],
+   "post": [
+    {
+     "status": "feasible",
+     "objective": 837.7323012718434,
+     "bound": 838.3878622240098,
+     "node_count": 263,
+     "wall": 20.114805901999716
+    },
+    {
+     "status": "feasible",
+     "objective": 837.7323012718434,
+     "bound": 838.3878622240098,
+     "node_count": 271,
+     "wall": 20.12331308900002
+    },
+    {
+     "status": "feasible",
+     "objective": 837.7323012718434,
+     "bound": 838.3878622240098,
+     "node_count": 271,
+     "wall": 20.22764127900018
+    }
+   ]
+  },
+  "tanksize": {
+   "pre": [
+    {
+     "status": "time_limit",
+     "objective": 1.268643752557795,
+     "bound": 1.2632242633840558,
+     "node_count": 4288,
+     "wall": 20.103840256999774
+    },
+    {
+     "status": "time_limit",
+     "objective": 1.268643752557795,
+     "bound": 1.2630301624081806,
+     "node_count": 4173,
+     "wall": 20.116404237000097
+    },
+    {
+     "status": "time_limit",
+     "objective": 1.268643752557795,
+     "bound": 1.2633778699963651,
+     "node_count": 4354,
+     "wall": 20.101757143999748
+    }
+   ],
+   "post": [
+    {
+     "status": "time_limit",
+     "objective": 1.268643759853009,
+     "bound": 1.2625263455941984,
+     "node_count": 4020,
+     "wall": 20.298664205000023
+    },
+    {
+     "status": "time_limit",
+     "objective": 1.268643759853009,
+     "bound": 1.2628919611659781,
+     "node_count": 4183,
+     "wall": 20.09933725799965
+    },
+    {
+     "status": "time_limit",
+     "objective": 1.268643759853009,
+     "bound": 1.262735798841006,
+     "node_count": 4100,
+     "wall": 20.117776476000017
+    }
+   ]
+  }
+ },
+ "reps": 3,
+ "time_limit": 20.0
+}

--- a/scratchpad/issue945/panel_replicate.json
+++ b/scratchpad/issue945/panel_replicate.json
@@ -1,50 +1,338 @@
 {
  "results": {
-  "tls2": {
+  "contvar": {
    "pre": [
     {
-     "status": "feasible",
-     "objective": 11.299999856725538,
-     "bound": 2.0999999901667694,
-     "node_count": 317,
-     "wall": 20.58546758700004
+     "status": "time_limit",
+     "objective": null,
+     "bound": 183632.02121055726,
+     "node_count": 3,
+     "wall": 21.966746790000343
     },
     {
-     "status": "feasible",
-     "objective": 5.299999922109238,
-     "bound": 3.1706801036010077,
-     "node_count": 349,
-     "wall": 20.29251420599985
+     "status": "time_limit",
+     "objective": null,
+     "bound": 183632.18040315996,
+     "node_count": 3,
+     "wall": 22.600557973000377
     },
     {
-     "status": "feasible",
-     "objective": 5.299999922109238,
-     "bound": 3.1706801036010077,
-     "node_count": 349,
-     "wall": 20.129551756000183
+     "status": "time_limit",
+     "objective": null,
+     "bound": 183632.02121055726,
+     "node_count": 3,
+     "wall": 22.357893702999718
     }
    ],
    "post": [
     {
      "status": "time_limit",
      "objective": null,
-     "bound": null,
-     "node_count": 191,
-     "wall": 20.062746008999966
+     "bound": 183632.18040315996,
+     "node_count": 3,
+     "wall": 23.059128349000275
+    },
+    {
+     "status": "time_limit",
+     "objective": null,
+     "bound": 183430.50053431175,
+     "node_count": 3,
+     "wall": 22.08727708499964
+    },
+    {
+     "status": "time_limit",
+     "objective": null,
+     "bound": 183632.02121055726,
+     "node_count": 3,
+     "wall": 21.394620528999894
+    }
+   ]
+  },
+  "ex1225": {
+   "pre": [
+    {
+     "status": "optimal",
+     "objective": 30.999999913557566,
+     "bound": 30.999999913557566,
+     "node_count": 5,
+     "wall": 2.4458057770002597
+    },
+    {
+     "status": "optimal",
+     "objective": 30.999999913557566,
+     "bound": 30.999999913557566,
+     "node_count": 5,
+     "wall": 2.3281306719995882
+    },
+    {
+     "status": "optimal",
+     "objective": 30.999999913557566,
+     "bound": 30.999999913557566,
+     "node_count": 5,
+     "wall": 2.533555673999672
+    }
+   ],
+   "post": [
+    {
+     "status": "optimal",
+     "objective": 30.999999948692963,
+     "bound": 30.999999948692963,
+     "node_count": 5,
+     "wall": 2.42900134599995
+    },
+    {
+     "status": "optimal",
+     "objective": 30.999999948692963,
+     "bound": 30.999999948692963,
+     "node_count": 5,
+     "wall": 2.48255794600027
+    },
+    {
+     "status": "optimal",
+     "objective": 30.999999948692963,
+     "bound": 30.999999948692963,
+     "node_count": 5,
+     "wall": 2.4410160180000275
+    }
+   ]
+  },
+  "m3": {
+   "pre": [
+    {
+     "status": "optimal",
+     "objective": 37.799999669978845,
+     "bound": 37.79999951039202,
+     "node_count": 47,
+     "wall": 7.701020250000056
+    },
+    {
+     "status": "optimal",
+     "objective": 37.799999669978845,
+     "bound": 37.79999951039202,
+     "node_count": 47,
+     "wall": 7.6758502749999025
+    },
+    {
+     "status": "optimal",
+     "objective": 37.799999669978845,
+     "bound": 37.79999951039202,
+     "node_count": 47,
+     "wall": 7.737198276000072
+    }
+   ],
+   "post": [
+    {
+     "status": "optimal",
+     "objective": 37.79999970380644,
+     "bound": 37.79999957378442,
+     "node_count": 41,
+     "wall": 5.870836144999885
+    },
+    {
+     "status": "optimal",
+     "objective": 37.79999970380644,
+     "bound": 37.79999957378442,
+     "node_count": 41,
+     "wall": 6.139060973999676
+    },
+    {
+     "status": "optimal",
+     "objective": 37.79999970380644,
+     "bound": 37.79999957378442,
+     "node_count": 41,
+     "wall": 5.832039001999874
+    }
+   ]
+  },
+  "nvs03": {
+   "pre": [
+    {
+     "status": "optimal",
+     "objective": 16.0,
+     "bound": 15.99999972676511,
+     "node_count": 5,
+     "wall": 0.2002397370001745
+    },
+    {
+     "status": "optimal",
+     "objective": 16.0,
+     "bound": 15.99999972676511,
+     "node_count": 5,
+     "wall": 0.1801057339998806
+    },
+    {
+     "status": "optimal",
+     "objective": 16.0,
+     "bound": 15.99999972676511,
+     "node_count": 5,
+     "wall": 0.19352301100025215
+    }
+   ],
+   "post": [
+    {
+     "status": "optimal",
+     "objective": 16.0,
+     "bound": 15.99999996676705,
+     "node_count": 5,
+     "wall": 0.18343414199989638
+    },
+    {
+     "status": "optimal",
+     "objective": 16.0,
+     "bound": 15.99999996676705,
+     "node_count": 5,
+     "wall": 0.1760415409999041
+    },
+    {
+     "status": "optimal",
+     "objective": 16.0,
+     "bound": 15.99999996676705,
+     "node_count": 5,
+     "wall": 0.20400574700033758
+    }
+   ]
+  },
+  "nvs05": {
+   "pre": [
+    {
+     "status": "feasible",
+     "objective": 8.731956986640078,
+     "bound": 3.5424692441047068,
+     "node_count": 41,
+     "wall": 20.173445263999838
     },
     {
      "status": "feasible",
-     "objective": 5.299999999987421,
-     "bound": 3.1706801757442244,
+     "objective": 8.731956986640078,
+     "bound": 3.5424692441047068,
+     "node_count": 41,
+     "wall": 20.162235710000004
+    },
+    {
+     "status": "feasible",
+     "objective": 8.731956986640078,
+     "bound": 3.5424692441047068,
+     "node_count": 41,
+     "wall": 20.148775003000083
+    }
+   ],
+   "post": [
+    {
+     "status": "feasible",
+     "objective": 12.589492574009626,
+     "bound": 3.513753543700079,
+     "node_count": 33,
+     "wall": 20.117771083000207
+    },
+    {
+     "status": "feasible",
+     "objective": 12.589492574009626,
+     "bound": 3.513753543700079,
+     "node_count": 33,
+     "wall": 20.17553781000015
+    },
+    {
+     "status": "feasible",
+     "objective": 12.589492574009626,
+     "bound": 3.494691518002833,
+     "node_count": 33,
+     "wall": 20.092665443999977
+    }
+   ]
+  },
+  "tanksize": {
+   "pre": [
+    {
+     "status": "time_limit",
+     "objective": 1.268643752557795,
+     "bound": 1.2633042223672657,
+     "node_count": 4324,
+     "wall": 20.23523669999986
+    },
+    {
+     "status": "time_limit",
+     "objective": 1.268643752557795,
+     "bound": 1.2635583144030644,
+     "node_count": 4485,
+     "wall": 20.231536124000286
+    },
+    {
+     "status": "time_limit",
+     "objective": 1.268643752557795,
+     "bound": 1.2635288830441058,
+     "node_count": 4463,
+     "wall": 20.220829058000163
+    }
+   ],
+   "post": [
+    {
+     "status": "time_limit",
+     "objective": 1.2686437708530283,
+     "bound": 1.2635580253373981,
+     "node_count": 4386,
+     "wall": 20.097855522999907
+    },
+    {
+     "status": "time_limit",
+     "objective": 1.2686437708530283,
+     "bound": 1.263571886620212,
+     "node_count": 4394,
+     "wall": 20.10033474299962
+    },
+    {
+     "status": "time_limit",
+     "objective": 1.2686437708530283,
+     "bound": 1.2629381792946415,
+     "node_count": 4037,
+     "wall": 20.09630309100021
+    }
+   ]
+  },
+  "tls2": {
+   "pre": [
+    {
+     "status": "feasible",
+     "objective": 5.299999922109238,
+     "bound": 3.2532681850660596,
+     "node_count": 353,
+     "wall": 20.163227672000176
+    },
+    {
+     "status": "feasible",
+     "objective": 5.299999922109238,
+     "bound": 3.1706801036010077,
      "node_count": 349,
-     "wall": 20.466495798000324
+     "wall": 20.2978921429999
     },
     {
      "status": "feasible",
-     "objective": 6.299999999986951,
-     "bound": 2.448712647787379,
-     "node_count": 339,
-     "wall": 20.25244513100006
+     "objective": 5.299999922109238,
+     "bound": 3.2532681850660596,
+     "node_count": 353,
+     "wall": 20.726493942999696
+    }
+   ],
+   "post": [
+    {
+     "status": "optimal",
+     "objective": 5.299999996520617,
+     "bound": 5.3,
+     "node_count": 353,
+     "wall": 20.49768623600039
+    },
+    {
+     "status": "optimal",
+     "objective": 5.299999996520617,
+     "bound": 5.3,
+     "node_count": 353,
+     "wall": 20.646659052999894
+    },
+    {
+     "status": "feasible",
+     "objective": 5.299999996520617,
+     "bound": 3.170680103601007,
+     "node_count": 349,
+     "wall": 20.639154293000047
     }
    ]
   },
@@ -55,236 +343,44 @@
      "objective": 262.64739525060224,
      "bound": null,
      "node_count": 1,
-     "wall": 15.048475292000148
+     "wall": 15.182319851000102
     },
     {
      "status": "feasible",
      "objective": 262.64739525060224,
      "bound": null,
      "node_count": 1,
-     "wall": 14.603284948999772
+     "wall": 14.198232381999787
     },
     {
      "status": "feasible",
      "objective": 262.64739525060224,
      "bound": null,
      "node_count": 1,
-     "wall": 15.011169063000125
+     "wall": 13.702092998000353
     }
    ],
    "post": [
     {
      "status": "feasible",
-     "objective": 262.64739579632806,
+     "objective": 262.64739525060213,
      "bound": null,
      "node_count": 1,
-     "wall": 14.460726710000017
+     "wall": 15.082553841999925
     },
     {
      "status": "feasible",
-     "objective": 262.64739579632806,
+     "objective": 262.64739525060213,
      "bound": null,
      "node_count": 1,
-     "wall": 14.729435125999771
+     "wall": 14.59224022599983
     },
     {
      "status": "feasible",
-     "objective": 262.64739579632806,
+     "objective": 262.64739525060213,
      "bound": null,
      "node_count": 1,
-     "wall": 14.388469588000135
-    }
-   ]
-  },
-  "nvs05": {
-   "pre": [
-    {
-     "status": "feasible",
-     "objective": 8.731956986640078,
-     "bound": 3.5424692441047068,
-     "node_count": 33,
-     "wall": 20.182479178999984
-    },
-    {
-     "status": "feasible",
-     "objective": 8.731956986640078,
-     "bound": 3.5424692441047068,
-     "node_count": 33,
-     "wall": 20.19236001499985
-    },
-    {
-     "status": "feasible",
-     "objective": 8.731956986640078,
-     "bound": 3.5424692441047068,
-     "node_count": 41,
-     "wall": 20.18917912400002
-    }
-   ],
-   "post": [
-    {
-     "status": "feasible",
-     "objective": 8.73195696936806,
-     "bound": 3.4474066870047313,
-     "node_count": 33,
-     "wall": 20.130246876
-    },
-    {
-     "status": "feasible",
-     "objective": 8.73195696936806,
-     "bound": 3.4474066870047313,
-     "node_count": 33,
-     "wall": 20.17768762700007
-    },
-    {
-     "status": "feasible",
-     "objective": 8.73195696936806,
-     "bound": 3.4474066870047313,
-     "node_count": 33,
-     "wall": 20.15309932299988
-    }
-   ]
-  },
-  "tspn05": {
-   "pre": [
-    {
-     "status": "feasible",
-     "objective": 191.25520768487672,
-     "bound": 173.53395514657217,
-     "node_count": 7,
-     "wall": 20.09491476700032
-    },
-    {
-     "status": "feasible",
-     "objective": 191.2552076848774,
-     "bound": 179.0941485386719,
-     "node_count": 53,
-     "wall": 20.14235947499992
-    },
-    {
-     "status": "feasible",
-     "objective": 191.2552076848774,
-     "bound": 179.0941485386719,
-     "node_count": 53,
-     "wall": 20.16249833200027
-    }
-   ],
-   "post": [
-    {
-     "status": "feasible",
-     "objective": 191.25520784460605,
-     "bound": 178.27199442798212,
-     "node_count": 55,
-     "wall": 20.14882291699996
-    },
-    {
-     "status": "feasible",
-     "objective": 191.25520784460605,
-     "bound": 179.0941485386719,
-     "node_count": 51,
-     "wall": 20.159586920000038
-    },
-    {
-     "status": "feasible",
-     "objective": 191.25520784460605,
-     "bound": 179.0941485386719,
-     "node_count": 53,
-     "wall": 20.14523626500022
-    }
-   ]
-  },
-  "syn05hfsg": {
-   "pre": [
-    {
-     "status": "feasible",
-     "objective": 837.732412391107,
-     "bound": 840.4893941019081,
-     "node_count": 141,
-     "wall": 20.10313659600024
-    },
-    {
-     "status": "feasible",
-     "objective": 837.732412391107,
-     "bound": 840.4893941019076,
-     "node_count": 153,
-     "wall": 20.100324848000128
-    },
-    {
-     "status": "feasible",
-     "objective": 837.732412391107,
-     "bound": 840.4893941019076,
-     "node_count": 151,
-     "wall": 20.110272387999885
-    }
-   ],
-   "post": [
-    {
-     "status": "feasible",
-     "objective": 837.7323012718434,
-     "bound": 838.3878622240098,
-     "node_count": 263,
-     "wall": 20.114805901999716
-    },
-    {
-     "status": "feasible",
-     "objective": 837.7323012718434,
-     "bound": 838.3878622240098,
-     "node_count": 271,
-     "wall": 20.12331308900002
-    },
-    {
-     "status": "feasible",
-     "objective": 837.7323012718434,
-     "bound": 838.3878622240098,
-     "node_count": 271,
-     "wall": 20.22764127900018
-    }
-   ]
-  },
-  "tanksize": {
-   "pre": [
-    {
-     "status": "time_limit",
-     "objective": 1.268643752557795,
-     "bound": 1.2632242633840558,
-     "node_count": 4288,
-     "wall": 20.103840256999774
-    },
-    {
-     "status": "time_limit",
-     "objective": 1.268643752557795,
-     "bound": 1.2630301624081806,
-     "node_count": 4173,
-     "wall": 20.116404237000097
-    },
-    {
-     "status": "time_limit",
-     "objective": 1.268643752557795,
-     "bound": 1.2633778699963651,
-     "node_count": 4354,
-     "wall": 20.101757143999748
-    }
-   ],
-   "post": [
-    {
-     "status": "time_limit",
-     "objective": 1.268643759853009,
-     "bound": 1.2625263455941984,
-     "node_count": 4020,
-     "wall": 20.298664205000023
-    },
-    {
-     "status": "time_limit",
-     "objective": 1.268643759853009,
-     "bound": 1.2628919611659781,
-     "node_count": 4183,
-     "wall": 20.09933725799965
-    },
-    {
-     "status": "time_limit",
-     "objective": 1.268643759853009,
-     "bound": 1.262735798841006,
-     "node_count": 4100,
-     "wall": 20.117776476000017
+     "wall": 14.571465107000222
     }
    ]
   }

--- a/scratchpad/issue945/panel_replicate.py
+++ b/scratchpad/issue945/panel_replicate.py
@@ -7,8 +7,11 @@ INTERLEAVED (pre, post, pre, post, ...), and reports the spread. §9: a claim ab
 a difference needs a spread, not two numbers.
 
 Reports, per instance and arm: the set of statuses seen, the incumbent range, the
-bound range, and the node-count range. A difference is an arm effect only when the
-arms' ranges do not overlap.
+bound range, and the node-count range.
+
+This script COLLECTS; it does not judge. Its first version also printed a
+verdict column, and that column was wrong — see the RETRACTION at the top of
+``panel_replicate_analyze.py``. Run that on the JSON this writes.
 
 §6: prints an executed-run count and exits non-zero if it is zero.
 
@@ -109,7 +112,6 @@ def main(out: str, reps: int, tl: float) -> int:
 
     print(f"\n{'instance':11s} {'arm':5s} {'statuses':24s} {'objective':>26s} {'bound':>26s} {'nodes':>14s}")
     print("-" * 112)
-    verdicts = []
     for name in TARGETS:
         rngs = {}
         for arm in ("pre", "post"):
@@ -120,26 +122,13 @@ def main(out: str, reps: int, tl: float) -> int:
             n = _rng([r.get("node_count") for r in rs])
             rngs[arm] = (st, o, b, n)
             print(f"{name:11s} {arm:5s} {','.join(st):24s} {_fmt(o):>26s} {_fmt(b):>26s} {_fmt(n,6):>14s}")
-        # Overlapping ranges => the panel's single-run difference was within
-        # this instance's own run-to-run spread, i.e. not an arm effect.
-        def overlap(x, y):
-            if x is None or y is None:
-                return x is None and y is None
-            return not (x[1] < y[0] or y[1] < x[0])
-
-        same_status = set(rngs["pre"][0]) == set(rngs["post"][0])
-        verdict = (
-            "arm effect"
-            if not (same_status and overlap(rngs["pre"][1], rngs["post"][1])
-                    and overlap(rngs["pre"][2], rngs["post"][2]))
-            else "within noise"
-        )
-        verdicts.append((name, verdict))
-        print(f"{'':11s} {'':5s} -> {verdict}")
+        # No verdict here. A bare interval-overlap test with no tolerance called
+        # every instance an "arm effect", including one whose arms differ by 2e-9
+        # relative — a criterion that fires on everything separates nothing.
+        # `panel_replicate_analyze.py` does the judging, against the saved JSON.
 
     print(f"\nEXECUTED_RUNS={runs}  reps={reps}  time_limit={tl}")
-    for n, v in verdicts:
-        print(f"  VERDICT {n}: {v}")
+    print(f"Now run: python -u scratchpad/issue945/panel_replicate_analyze.py {out}")
     if runs == 0:
         print("REPLICATION RAN NOTHING", file=sys.stderr)
         return 1

--- a/scratchpad/issue945/panel_replicate.py
+++ b/scratchpad/issue945/panel_replicate.py
@@ -30,7 +30,9 @@ os.environ.setdefault("JAX_PLATFORMS", "cpu")
 os.environ.setdefault("JAX_ENABLE_X64", "1")
 
 import discopt.solver as SOLVER  # noqa: E402
+import discopt.solvers.gdpopt_loa as LOA  # noqa: E402
 import discopt.solvers.nlp_pounce as NLPP  # noqa: E402
+import discopt.solvers.oa as OA  # noqa: E402
 from discopt.modeling import from_nl  # noqa: E402
 from discopt.solvers import pounce_option_defaults  # noqa: E402
 
@@ -38,33 +40,43 @@ assert "opts = pounce_option_defaults()" in inspect.getsource(NLPP.solve_nlp), (
     "post-#945 marker absent — nothing to replicate"
 )
 
-_PRE_ARM = {"print_level": 0}
+# Same two-seam arm reconstruction as panel_corpus.set_arm: bound_relax_factor is
+# not a backend default post-#945, so neutralizing only the backend would leave the
+# incumbent requests live and mislabel the arm.
+_PRE_BACKEND = {"print_level": 0}
 _REAL = pounce_option_defaults
-_ORIG_BATCH = SOLVER.pounce_option_defaults
+_REAL_INCUMBENT = SOLVER.pounce_incumbent_options
+_CONSUMERS = (SOLVER, OA, LOA)
 
 ROOT = "python/tests/data/minlplib_nl"
 
-# Every instance the corpus panel reported as differing on status, objective or
-# bound in a way that is not pure last-digit drift, plus tspn05 (where the post
-# arm's bound was BETTER) as a control — if replication says everything is noise,
-# a control that moved the other way is what shows the harness can see anything.
-TARGETS = ["tls2", "tspn12", "nvs05", "tspn05", "syn05hfsg", "tanksize"]
+# Every instance the corpus panel reported as differing on STATUS or on a bound
+# by more than last-digit drift. The set includes movers in BOTH directions
+# (nvs03/ex1225 tighter, nvs05/tanksize looser) — a replication harness that only
+# ever chases regressions cannot show it is capable of seeing anything.
+TARGETS = ["contvar", "ex1225", "m3", "nvs03", "nvs05", "tanksize", "tls2", "tspn12"]
 
 
 def set_arm(arm: str) -> None:
-    fn = (lambda: dict(_PRE_ARM)) if arm == "pre" else None
-    NLPP.pounce_option_defaults = fn or _REAL
-    SOLVER.pounce_option_defaults = fn or _ORIG_BATCH
+    pre = arm == "pre"
+    NLPP.pounce_option_defaults = (lambda: dict(_PRE_BACKEND)) if pre else _REAL
+    for mod in _CONSUMERS:
+        mod.pounce_incumbent_options = (lambda: {}) if pre else _REAL_INCUMBENT
+        if hasattr(mod, "pounce_option_defaults"):
+            mod.pounce_option_defaults = (lambda: dict(_PRE_BACKEND)) if pre else _REAL
 
 
 def run(path: str, arm: str, tl: float) -> dict:
     set_arm(arm)
     t0 = time.perf_counter()
     try:
-        r = from_nl(path).solve(time_limit=tl)
+        model = from_nl(path)
+        maximize = model._objective is not None and str(model._objective.sense).endswith("MAXIMIZE")
+        r = model.solve(time_limit=tl)
     except Exception as exc:  # recorded, never swallowed (§7)
         return {"error": f"{type(exc).__name__}: {exc}", "wall": time.perf_counter() - t0}
     return {
+        "maximize": maximize,
         "status": r.status,
         "objective": r.objective,
         "bound": r.bound,

--- a/scratchpad/issue945/panel_replicate.py
+++ b/scratchpad/issue945/panel_replicate.py
@@ -1,0 +1,153 @@
+"""#945 replication: are the panel's time-limited diffs signal or noise?
+
+The corpus panel's differing instances are almost all runs that hit the 20 s
+budget, where the answer depends on how far the search got. A single run cannot
+separate an arm effect from that, so this repeats each instance N times per arm,
+INTERLEAVED (pre, post, pre, post, ...), and reports the spread. §9: a claim about
+a difference needs a spread, not two numbers.
+
+Reports, per instance and arm: the set of statuses seen, the incumbent range, the
+bound range, and the node-count range. A difference is an arm effect only when the
+arms' ranges do not overlap.
+
+§6: prints an executed-run count and exits non-zero if it is zero.
+
+Usage:  python -u scratchpad/issue945/panel_replicate.py out.json [reps] [time_limit]
+"""
+
+from __future__ import annotations
+
+import inspect
+import json
+import os
+import sys
+import time
+
+os.environ.setdefault("JAX_PLATFORMS", "cpu")
+os.environ.setdefault("JAX_ENABLE_X64", "1")
+
+import discopt.solver as SOLVER  # noqa: E402
+import discopt.solvers.nlp_pounce as NLPP  # noqa: E402
+from discopt.modeling import from_nl  # noqa: E402
+from discopt.solvers import pounce_option_defaults  # noqa: E402
+
+assert "opts = pounce_option_defaults()" in inspect.getsource(NLPP.solve_nlp), (
+    "post-#945 marker absent — nothing to replicate"
+)
+
+_PRE_ARM = {"print_level": 0}
+_REAL = pounce_option_defaults
+_ORIG_BATCH = SOLVER.pounce_option_defaults
+
+ROOT = "python/tests/data/minlplib_nl"
+
+# Every instance the corpus panel reported as differing on status, objective or
+# bound in a way that is not pure last-digit drift, plus tspn05 (where the post
+# arm's bound was BETTER) as a control — if replication says everything is noise,
+# a control that moved the other way is what shows the harness can see anything.
+TARGETS = ["tls2", "tspn12", "nvs05", "tspn05", "syn05hfsg", "tanksize"]
+
+
+def set_arm(arm: str) -> None:
+    fn = (lambda: dict(_PRE_ARM)) if arm == "pre" else None
+    NLPP.pounce_option_defaults = fn or _REAL
+    SOLVER.pounce_option_defaults = fn or _ORIG_BATCH
+
+
+def run(path: str, arm: str, tl: float) -> dict:
+    set_arm(arm)
+    t0 = time.perf_counter()
+    try:
+        r = from_nl(path).solve(time_limit=tl)
+    except Exception as exc:  # recorded, never swallowed (§7)
+        return {"error": f"{type(exc).__name__}: {exc}", "wall": time.perf_counter() - t0}
+    return {
+        "status": r.status,
+        "objective": r.objective,
+        "bound": r.bound,
+        "node_count": r.node_count,
+        "wall": time.perf_counter() - t0,
+    }
+
+
+def _rng(vals):
+    vals = [v for v in vals if v is not None]
+    if not vals:
+        return None
+    return (min(vals), max(vals))
+
+
+def _fmt(rg, prec=10):
+    if rg is None:
+        return "—"
+    lo, hi = rg
+    if lo == hi:
+        return f"{lo:.{prec}g}"
+    return f"[{lo:.{prec}g}, {hi:.{prec}g}]"
+
+
+def main(out: str, reps: int, tl: float) -> int:
+    results: dict = {}
+    runs = 0
+    for name in TARGETS:
+        p = os.path.join(ROOT, f"{name}.nl")
+        results[name] = {"pre": [], "post": []}
+        for _ in range(reps):
+            for arm in ("pre", "post"):  # interleaved, not two sequential blocks
+                r = run(p, arm, tl)
+                results[name][arm].append(r)
+                runs += 1
+                print(
+                    f"  {name:10s} {arm:5s} status={str(r.get('status')):11s} "
+                    f"obj={r.get('objective')!r} bound={r.get('bound')!r} "
+                    f"n={r.get('node_count')} wall={r.get('wall', 0):.1f}s",
+                    flush=True,
+                )
+    set_arm("post")
+
+    json.dump({"results": results, "reps": reps, "time_limit": tl}, open(out, "w"), indent=1)
+
+    print(f"\n{'instance':11s} {'arm':5s} {'statuses':24s} {'objective':>26s} {'bound':>26s} {'nodes':>14s}")
+    print("-" * 112)
+    verdicts = []
+    for name in TARGETS:
+        rngs = {}
+        for arm in ("pre", "post"):
+            rs = results[name][arm]
+            st = sorted({str(r.get("status")) for r in rs})
+            o = _rng([r.get("objective") for r in rs])
+            b = _rng([r.get("bound") for r in rs])
+            n = _rng([r.get("node_count") for r in rs])
+            rngs[arm] = (st, o, b, n)
+            print(f"{name:11s} {arm:5s} {','.join(st):24s} {_fmt(o):>26s} {_fmt(b):>26s} {_fmt(n,6):>14s}")
+        # Overlapping ranges => the panel's single-run difference was within
+        # this instance's own run-to-run spread, i.e. not an arm effect.
+        def overlap(x, y):
+            if x is None or y is None:
+                return x is None and y is None
+            return not (x[1] < y[0] or y[1] < x[0])
+
+        same_status = set(rngs["pre"][0]) == set(rngs["post"][0])
+        verdict = (
+            "arm effect"
+            if not (same_status and overlap(rngs["pre"][1], rngs["post"][1])
+                    and overlap(rngs["pre"][2], rngs["post"][2]))
+            else "within noise"
+        )
+        verdicts.append((name, verdict))
+        print(f"{'':11s} {'':5s} -> {verdict}")
+
+    print(f"\nEXECUTED_RUNS={runs}  reps={reps}  time_limit={tl}")
+    for n, v in verdicts:
+        print(f"  VERDICT {n}: {v}")
+    if runs == 0:
+        print("REPLICATION RAN NOTHING", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    o = sys.argv[1]
+    reps = int(sys.argv[2]) if len(sys.argv) > 2 else 3
+    tl = float(sys.argv[3]) if len(sys.argv) > 3 else 20.0
+    sys.exit(main(o, reps, tl))

--- a/scratchpad/issue945/panel_replicate.py
+++ b/scratchpad/issue945/panel_replicate.py
@@ -36,8 +36,16 @@ import discopt.solvers.oa as OA  # noqa: E402
 from discopt.modeling import from_nl  # noqa: E402
 from discopt.solvers import pounce_option_defaults  # noqa: E402
 
-assert "opts = pounce_option_defaults()" in inspect.getsource(NLPP.solve_nlp), (
-    "post-#945 marker absent — nothing to replicate"
+# §8 markers, tracking the CONTRACT rather than a line of code: #945 requests the
+# incumbent options at the point-consuming call sites and leaves the NLP backend
+# neutral. An earlier version named the superseded contract and refused to run once
+# the branch rescoped — the guard working, not a bug.
+for _fn in (SOLVER._solve_continuous, OA._solve_nlp_attempt, LOA._solve_nlp_subproblem):
+    assert "pounce_incumbent_options()" in inspect.getsource(_fn), (
+        f"post-#945 marker absent in {_fn.__name__} — nothing to replicate"
+    )
+assert "pounce_incumbent_options()" not in inspect.getsource(NLPP.solve_nlp), (
+    "bound_relax_factor leaked back into the NLP backend default"
 )
 
 # Same two-seam arm reconstruction as panel_corpus.set_arm: bound_relax_factor is
@@ -50,11 +58,11 @@ _CONSUMERS = (SOLVER, OA, LOA)
 
 ROOT = "python/tests/data/minlplib_nl"
 
-# Every instance the corpus panel reported as differing on STATUS or on a bound
-# by more than last-digit drift. The set includes movers in BOTH directions
-# (nvs03/ex1225 tighter, nvs05/tanksize looser) — a replication harness that only
-# ever chases regressions cannot show it is capable of seeing anything.
-TARGETS = ["contvar", "ex1225", "m3", "nvs03", "nvs05", "tanksize", "tls2", "tspn12"]
+# Every instance the final corpus panel reported as differing. The set deliberately
+# includes movers in BOTH directions — tls2 (panel: certification LOST) and
+# syn05hfsg (panel: certification GAINED) — because a replication harness that only
+# ever chases regressions cannot demonstrate it is capable of seeing anything.
+TARGETS = ["chance", "nvs05", "syn05hfsg", "tanksize", "tls2"]
 
 
 def set_arm(arm: str) -> None:

--- a/scratchpad/issue945/panel_replicate_analyze.py
+++ b/scratchpad/issue945/panel_replicate_analyze.py
@@ -28,7 +28,17 @@ import json
 import sys
 
 REL_FLOOR = 1e-6
-MAXIMIZE = {"syn05hfsg"}
+# Fallback only. The sense decides which direction "tighter" is, so it is read from
+# the run itself when recorded; a hardcoded set is the same hole that made the
+# corpus panel misread syn05hfsg, and it silently rots as TARGETS changes.
+_FALLBACK_MAXIMIZE = {"syn05hfsg"}
+
+
+def _is_max(name, runs):
+    for r in runs:
+        if "maximize" in r:
+            return bool(r["maximize"]), "recorded"
+    return name in _FALLBACK_MAXIMIZE, "FALLBACK (sense not recorded in this run)"
 
 
 def _vals(runs, key):
@@ -47,11 +57,11 @@ def main(path: str) -> int:
 
     print(f"reps={d['reps']}  time_limit={d['time_limit']}s\n")
     for name, arms in res.items():
-        mx = name in MAXIMIZE
         pre, post = arms["pre"], arms["post"]
+        mx, src = _is_max(name, pre + post)
         st_pre = sorted({str(r.get("status")) for r in pre})
         st_post = sorted({str(r.get("status")) for r in post})
-        print(f"{name}  ({'max' if mx else 'min'})")
+        print(f"{name}  ({'max' if mx else 'min'}, sense {src})")
         print(f"   status   pre={','.join(st_pre):22s} post={','.join(st_post)}")
 
         for key in ("objective", "bound"):

--- a/scratchpad/issue945/panel_replicate_analyze.py
+++ b/scratchpad/issue945/panel_replicate_analyze.py
@@ -1,0 +1,99 @@
+"""Re-analysis of panel_replicate.json with a criterion that actually works.
+
+RETRACTION (CLAUDE.md §11). ``panel_replicate.py``'s own verdict column reported
+"arm effect" for all six instances and is WRONG. Its test was "do the arms'
+[min,max] intervals overlap", with no tolerance — so two arms whose objective
+ranges are the single points 262.6473953 and 262.6473958 (a 2e-9 RELATIVE
+difference, and exactly the last-digit drift this change is expected to produce)
+came out as an arm effect. A criterion that fires on every instance distinguishes
+nothing. Do not read that column; read this file.
+
+The replacement asks two separate questions, which the broken version conflated:
+
+  1. Did a STATUS difference reproduce? That is the categorical question, and it
+     is the one the corpus panel actually flagged for tspn12.
+  2. Is the between-arm shift larger than BOTH the within-arm spread and a 1e-6
+     relative floor? Below that floor a difference is real but not a finding —
+     the change moves the NLP point, so the last digits are expected to move.
+
+Bounds are compared in the instance's own sense: syn05hfsg MAXIMIZES, so a LOWER
+upper bound is tighter there.
+
+Reads the saved JSON; no re-solving. Prints an executed-comparison count.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+
+REL_FLOOR = 1e-6
+MAXIMIZE = {"syn05hfsg"}
+
+
+def _vals(runs, key):
+    return [r[key] for r in runs if r.get(key) is not None]
+
+
+def _span(v):
+    return (min(v), max(v)) if v else None
+
+
+def main(path: str) -> int:
+    d = json.load(open(path))
+    res = d["results"]
+    comparisons = 0
+    findings = []
+
+    print(f"reps={d['reps']}  time_limit={d['time_limit']}s\n")
+    for name, arms in res.items():
+        mx = name in MAXIMIZE
+        pre, post = arms["pre"], arms["post"]
+        st_pre = sorted({str(r.get("status")) for r in pre})
+        st_post = sorted({str(r.get("status")) for r in post})
+        print(f"{name}  ({'max' if mx else 'min'})")
+        print(f"   status   pre={','.join(st_pre):22s} post={','.join(st_post)}")
+
+        for key in ("objective", "bound"):
+            a, b = _vals(pre, key), _vals(post, key)
+            comparisons += 1
+            sa, sb = _span(a), _span(b)
+            if not a or not b:
+                print(f"   {key:9s} pre={sa} post={sb}   (absent in one arm)")
+                continue
+            # Within-arm spread vs between-arm shift.
+            spread = max(sa[1] - sa[0], sb[1] - sb[0])
+            mid_a, mid_b = sorted(a)[len(a) // 2], sorted(b)[len(b) // 2]
+            shift = mid_b - mid_a
+            scale = max(1.0, abs(mid_a), abs(mid_b))
+            if abs(shift) <= max(spread, REL_FLOOR * scale):
+                verdict = "within noise"
+            else:
+                if key == "bound":
+                    tighter = (shift < 0) if mx else (shift > 0)
+                    verdict = f"REPRODUCIBLE: post bound {'TIGHTER' if tighter else 'LOOSER'}"
+                else:
+                    verdict = "REPRODUCIBLE shift"
+                findings.append((name, key, mid_a, mid_b, shift / scale))
+            print(
+                f"   {key:9s} pre={sa[0]:.10g}..{sa[1]:.10g}  post={sb[0]:.10g}..{sb[1]:.10g}  "
+                f"shift={shift:+.4g} ({shift / scale:+.2e} rel)  spread={spread:.4g}  -> {verdict}"
+            )
+
+        comparisons += 1
+        if st_pre != st_post:
+            findings.append((name, "status", ",".join(st_pre), ",".join(st_post), None))
+            print("   -> STATUS DIFFERS reproducibly")
+        print()
+
+    print(f"EXECUTED_COMPARISONS={comparisons}  reproducible_findings={len(findings)}")
+    for f in findings:
+        print(f"   {f[0]:11s} {f[1]:9s} {f[2]} -> {f[3]}" + (f"  ({f[4]:+.2e} rel)" if f[4] else ""))
+    if comparisons == 0:
+        print("ANALYSIS COMPARED NOTHING", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1] if len(sys.argv) > 1 else "scratchpad/issue945/panel_replicate.json"))

--- a/scratchpad/issue945/panel_replicate_tls2.json
+++ b/scratchpad/issue945/panel_replicate_tls2.json
@@ -1,0 +1,178 @@
+{
+ "results": {
+  "tls2": {
+   "pre": [
+    {
+     "maximize": false,
+     "status": "time_limit",
+     "objective": null,
+     "bound": null,
+     "node_count": 223,
+     "wall": 20.649897199000407
+    },
+    {
+     "maximize": false,
+     "status": "feasible",
+     "objective": 5.299999922109238,
+     "bound": 3.1706801036010077,
+     "node_count": 349,
+     "wall": 20.340534171999934
+    },
+    {
+     "maximize": false,
+     "status": "feasible",
+     "objective": 5.299999922109238,
+     "bound": 3.2532681850660596,
+     "node_count": 353,
+     "wall": 20.582557998000084
+    },
+    {
+     "maximize": false,
+     "status": "optimal",
+     "objective": 5.299999922109238,
+     "bound": 5.3,
+     "node_count": 353,
+     "wall": 20.853176248000636
+    },
+    {
+     "maximize": false,
+     "status": "feasible",
+     "objective": 10.299999865440752,
+     "bound": 2.4487125876978726,
+     "node_count": 353,
+     "wall": 21.296523277999768
+    }
+   ],
+   "post": [
+    {
+     "maximize": false,
+     "status": "feasible",
+     "objective": 11.299999856725538,
+     "bound": 2.0999999901667694,
+     "node_count": 333,
+     "wall": 20.341765348999616
+    },
+    {
+     "maximize": false,
+     "status": "feasible",
+     "objective": 6.299999911869455,
+     "bound": 2.4487125876978726,
+     "node_count": 339,
+     "wall": 20.360121611000068
+    },
+    {
+     "maximize": false,
+     "status": "feasible",
+     "objective": 5.299999922109238,
+     "bound": 3.2532681850660596,
+     "node_count": 353,
+     "wall": 20.120996880000348
+    },
+    {
+     "maximize": false,
+     "status": "optimal",
+     "objective": 5.299999922109238,
+     "bound": 5.3,
+     "node_count": 353,
+     "wall": 20.775581002999388
+    },
+    {
+     "maximize": false,
+     "status": "feasible",
+     "objective": 5.299999922109238,
+     "bound": 3.2532681850660596,
+     "node_count": 353,
+     "wall": 20.195147497000107
+    }
+   ]
+  },
+  "syn05hfsg": {
+   "pre": [
+    {
+     "maximize": true,
+     "status": "feasible",
+     "objective": 837.732412391107,
+     "bound": 838.3878622240098,
+     "node_count": 171,
+     "wall": 20.113096153999322
+    },
+    {
+     "maximize": true,
+     "status": "feasible",
+     "objective": 837.732412391107,
+     "bound": 838.3878622240098,
+     "node_count": 171,
+     "wall": 20.205919601999994
+    },
+    {
+     "maximize": true,
+     "status": "feasible",
+     "objective": 837.732412391107,
+     "bound": 838.3878622240098,
+     "node_count": 175,
+     "wall": 20.10623350700007
+    },
+    {
+     "maximize": true,
+     "status": "feasible",
+     "objective": 837.732412391107,
+     "bound": 840.4893941019076,
+     "node_count": 145,
+     "wall": 20.114560585999243
+    },
+    {
+     "maximize": true,
+     "status": "feasible",
+     "objective": 837.732412391107,
+     "bound": 838.3878622240098,
+     "node_count": 173,
+     "wall": 20.11311374500019
+    }
+   ],
+   "post": [
+    {
+     "maximize": true,
+     "status": "feasible",
+     "objective": 837.732412391107,
+     "bound": 840.4893941019075,
+     "node_count": 163,
+     "wall": 20.097748850000244
+    },
+    {
+     "maximize": true,
+     "status": "feasible",
+     "objective": 837.732412391107,
+     "bound": 840.4893941019075,
+     "node_count": 167,
+     "wall": 20.098130753000078
+    },
+    {
+     "maximize": true,
+     "status": "feasible",
+     "objective": 837.732412391107,
+     "bound": 838.3878622240098,
+     "node_count": 177,
+     "wall": 20.109626993000347
+    },
+    {
+     "maximize": true,
+     "status": "feasible",
+     "objective": 837.732412391107,
+     "bound": 838.3878622240098,
+     "node_count": 169,
+     "wall": 20.094457588000296
+    },
+    {
+     "maximize": true,
+     "status": "feasible",
+     "objective": 837.732412391107,
+     "bound": 838.3878622240098,
+     "node_count": 175,
+     "wall": 20.11525573600011
+    }
+   ]
+  }
+ },
+ "reps": 5,
+ "time_limit": 20.0
+}

--- a/scratchpad/issue945/panel_superopt_recheck.py
+++ b/scratchpad/issue945/panel_superopt_recheck.py
@@ -1,0 +1,109 @@
+"""Independent re-check of ``panel_corpus.json`` against a *second* oracle (#945).
+
+``panel_corpus.py`` judges soundness against the in-repo registry
+(``python/tests/data/known_optima.toml``), which covers 32 of the 66 corpus
+instances and is the table this repo's certification tests already trust. That
+makes it the right gate, and a poor *witness*: a fix whose whole point is that
+incumbents stop being better-than-possible should be shown moving the number,
+not merely failing to trip a threshold.
+
+So this reads the panel's own output back and scores both arms against
+MINLPLib's ``minlplib.solu`` (``=opt=`` rows only — ``=best=`` is not an oracle)
+at a threshold four orders tighter than the gate's, and prints the signed
+super-optimality per arm. A positive number is an incumbent *better than the
+published global optimum*, which is impossible; the interesting quantity is how
+many instances carry one in each arm, and whether any instance moves the wrong
+way.
+
+Not a gate — ``panel_corpus.py`` is the gate. This is the witness for the PR.
+
+§6: prints ``COMPARED=`` and exits non-zero if it compared nothing, so a moved
+corpus or a renamed key cannot report "0 regressions" from an empty loop.
+§7: no exception handling — a missing panel JSON or solu file must crash.
+
+Usage:
+    python -u scratchpad/issue945/panel_superopt_recheck.py \
+        scratchpad/issue945/panel_corpus.json [path/to/minlplib.solu]
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+
+_DEFAULT_SOLU = os.path.expanduser("~/Dropbox/projects/discopt-minlp-benchmark/minlplib.solu")
+
+# Tight on purpose: the gate uses 1e-6 relative, which every violation this fix
+# removes sits *underneath*. The defect is real at 1e-8, so look at 1e-12.
+_THRESHOLD = 1e-12
+
+
+def load_optima(path: str) -> dict[str, float]:
+    out: dict[str, float] = {}
+    with open(path) as fh:
+        for line in fh:
+            parts = line.split()
+            # "=best=" is an incumbent someone found, not a proven optimum, so it
+            # cannot witness super-optimality. Only "=opt=" rows are an oracle.
+            if len(parts) == 3 and parts[0] == "=opt=":
+                out[parts[1]] = float(parts[2])
+    return out
+
+
+def main() -> int:
+    panel_path = sys.argv[1] if len(sys.argv) > 1 else "scratchpad/issue945/panel_corpus.json"
+    solu_path = sys.argv[2] if len(sys.argv) > 2 else _DEFAULT_SOLU
+    rows = json.load(open(panel_path))["rows"]
+    optima = load_optima(solu_path)
+
+    compared = 0
+    per_arm = {"pre": 0, "post": 0}
+    detail: list[tuple[str, float, float]] = []
+    wrong_way: list[str] = []
+
+    for name in sorted(rows):
+        pre, post = rows[name]["pre"], rows[name]["post"]
+        if name not in optima:
+            continue
+        if pre["objective"] is None or post["objective"] is None:
+            continue
+        opt = optima[name]
+        maximize = bool(pre["maximize"])
+        compared += 1
+
+        def excess(obj: float, _opt: float = opt, _mx: bool = maximize) -> float:
+            """Signed, scaled: > 0 means BETTER than the optimum, i.e. impossible."""
+            raw = (obj - _opt) if _mx else (_opt - obj)
+            return raw / max(1.0, abs(_opt))
+
+        a, b = excess(pre["objective"]), excess(post["objective"])
+        if a > _THRESHOLD:
+            per_arm["pre"] += 1
+        if b > _THRESHOLD:
+            per_arm["post"] += 1
+        if a > _THRESHOLD or b > _THRESHOLD:
+            detail.append((name, a, b))
+        # An instance that was sound in pre and is super-optimal in post is the
+        # only outcome that would sink this change.
+        if a <= _THRESHOLD < b:
+            wrong_way.append(name)
+
+    for name, a, b in detail:
+        tag = "FIXED" if a > _THRESHOLD >= b else ""
+        print(f"  {name:18s} pre={a:+.3e}  post={b:+.3e}  {tag}")
+    print(f"COMPARED={compared}")
+    print(f"SUPER_OPTIMAL_INSTANCES pre={per_arm['pre']}  post={per_arm['post']}")
+    print(f"WRONG_WAY={len(wrong_way)} {wrong_way}")
+
+    if compared == 0:
+        print("FAIL: compared nothing — the panel JSON and the solu share no instance names")
+        return 1
+    if wrong_way:
+        print("FAIL: an instance became super-optimal in the post arm")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Two coupled defects on the NLP path.

**(a) Points outside their declared box.** `bound_relax_factor` (Ipopt's default
`1e-8`) relaxes every bound — including the slack bounds standing in for inequality
rows — so a converged point legitimately sits outside the box the model declared.
#940/#943 fixed the matrix-form LP/QP backends; the NLP path was left for this issue
because the fallout is a certification-semantics change, not an option change.

**(b) Gap closure calibrated on those points.** With incumbents honest,
`incumbent - bound` stops being `<= 0`, and the `1e-9` absolute floor in OA's and
GDPopt-LOA's `_compute_gap` turns out to be beatable only by an incumbent that is not
feasible. The two near-copies are replaced by one definition in `solvers/_gap.py`:

* the absolute criterion is discopt's own `1e-6` (`validation.feasibility.ABS_TOL`,
  `amp.solve(abs_tol=)`), not `1e-9` — the dual `abs OR rel` test `amp.py` has always
  used;
* a dual bound **materially above the incumbent** is reported as "nothing proved"
  rather than clamped to `gap = 0.0` by `max(0.0, ub - lb)`.

Closes #945.

## Where the option is requested, and why that is the whole design

`bound_relax_factor` is **not** a backend-wide default. It lives in a new
`solvers.pounce_incumbent_options()`, requested at the three NLP call sites whose
returned *point* is the product — `solver._solve_continuous` (the model-level NLP
seam, direct analogue of `_solve_lp_pounce`/`_solve_qp_pounce`),
`oa._solve_nlp_attempt`, and `gdpopt_loa._solve_nlp_subproblem`.

The split is not "LP versus NLP". It is **what the caller consumes**:

* a call site whose `x` becomes a solution or incumbent needs it inside the box;
* a call site whose **multipliers** are the product must not pin it. A degenerate
  feasible set (Slater failing, e.g. `x0^2 + x1^2 <= 0`) has *no* finite multiplier;
  Ipopt's relaxation hands it an artificial interior and keeps the dual finite.

That second half is measured, not asserted. #940 found the backend-wide version cost
the Benders dual LP its convergence (two correctness-lane tests, 1.6 s → 79 s). This
branch independently hit the same thing in GBD and traced it — at master proposal
`y = 0` the multiplier goes from `7.07e3` to `9.82e7` and the cut slope to `-7.86e8`,
which carries no usable information about `eta` at any scale, so the master bound
stalls at −2 against a true optimum of −1. Filed as #946, which the final scoping does
not reach; the xfail that pinned it now xpasses and is removed. Row-equilibrating that
cut was checked too — scaling by `1/|s|` reduces it to `-y <= 0`, so the information is
absent, not badly scaled.

## Second pass: the two producers the first pass missed

Review of this PR ([#948 review](https://github.com/jkitchin/discopt/pull/948#issuecomment-5226195369))
found the **default `m.solve()` path** still certifying a super-optimal incumbent on
this PR's own fixture. Byte-identical on `main`, so pre-existing rather than a
regression from the first pass — but it is the same class this PR is named after, on
the entry point users actually hit, so it is fixed here rather than deferred:

```
pre   default  obj=2.9999000090835057  bound=2.9999000090835057  gap=0.0  super-optimal by 9.999e-05
post  default  obj=2.9999999983777133  bound=2.999999999843477   gap=0.0  super-optimal by 1.622e-09
```

Attributed with a trace hook printing `x0 -> x` per `solve_nlp` call, not guessed —
the first attribution in the review was wrong in a way worth recording, because it
named the site that *passed the bad point through* rather than the two that made it:

```
call #5  primal_heuristics.py:324  feasibility_pump    x0=[1.0, 1.0] -> x=[2.9999000090, 1.0]
call #6  solver.py:13853           _solve_node_nlp_kkt x0=[3.0, 1.0] -> x=[2.9999000090, 1.0]
```

Two producers, and fixing either alone leaves the defect standing:

* **`_jax/primal_heuristics`** — `feasibility_pump` projected onto the *relaxed* box
  and handed back `x = 2.9999` as a candidate incumbent. Every NLP solve in that
  module produces a candidate incumbent, so all six option sites now route through
  one `_heuristic_nlp_options()` helper that seeds `pounce_incumbent_options()`. One
  helper rather than six edits is deliberate: a seventh heuristic cannot silently
  keep Ipopt's default. `pounce_option_defaults()` is **not** seeded there — its
  `constr_viol_tol` is separable, and measurably harmful on this path (the nvs05
  numbers below).
* **`solver._solve_nlp_bb`'s terminal re-solve** — it then adopted its *own* primal,
  which came from the relaxed box too, so even with the pump honest (`x = 3` exactly)
  the answer was overwritten straight back to 2.9999. That site consumes **both**
  products of one NLP solve and they want opposite options, so it now takes two
  solves: a refine solve carrying `pounce_incumbent_options()` whose point is adopted,
  then the recover solve *at that adopted point*, left relaxed because its product is
  the multipliers (#946). Duals therefore stay consistent with the primal actually
  reported, which is what the adoption existed for. `_polish_opts` — the sibling
  adoption in the batch path, whose polished point becomes the reported solution —
  takes the incumbent options for the same reason; its sibling `recover_opts` does not.

This is the design rule of this PR applied one level down: the split is not
LP-vs-NLP and not even callee-by-callee, it is **what the caller consumes**. The
`for_incumbent` seam on `solve_nlp` that the review proposed would not have been
enough, because the site that needed splitting is a *caller* that wants a point and
multipliers out of the same solve.

**No feasibility screen could have caught this.** The bad point's worst row violation
is 1e-8 — inside every tolerance discopt has, including
`_check_constraint_feasibility`'s `tol=1e-4` default — while the damage to the answer
is 1e-4, because `(x-3)^2 <= 0` squares the excursion. The only available fix is to
not *produce* the point.

Three stale descriptions of the superseded design (in which `solve_nlp` itself was
seeded) are corrected in the same commit: `pounce_option_defaults`'s docstring, which
claimed to be the source of truth for "EVERY POUNCE entry point ... and the NLP path";
`test_940_pounce_lp_constraint_tolerance`'s docstring; and
`scratchpad/issue945/entry_bounds.py`'s §8 arm marker, which tested `solve_nlp`'s own
source and was therefore permanently `False` on the post tree — it mislabelled every
post run `UNSEEDED`, and the harness could not run at all besides (`Model.add_variable`
does not exist, `solve()` refuses `verbose`). It now mirrors the test it claims to
measure and reports `executed_assertions=6 violations=0`.

## The defect is larger than the issue described

The issue framed (b) as a tolerance question with `~1e-9` numbers. Measured
(`scratchpad/issue945/attribution.py`, 18 comparisons, arms interleaved per fixture):

| fixture | arm | objective | bound | bound−incumbent | vs true optimum |
|---|---|---|---|---|---|
| mindtpy_simple (opt 3.5) | pre | 3.49999998703 | 3.5 | 1.30e-08 | 1.30e-08 **below** |
| | post | 3.50000000364 | 3.5 | 0 | 0 |
| mindtpy_cq (opt 3.0) | pre | **2.9999000025** | 2.99995000083 | **5.00e-05** | **1.00e-04 below** |
| | post | 2.99999999906 | 2.99995332577 | 0 | 9.42e-10 |
| gdp disjunction (opt 0) | pre | −7.54e-09 | 0 | 7.54e-09 | 7.54e-09 below |
| | post | +2.46e-09 | 0 | 0 | 0 |

The constraint-qualification row is the headline: discopt certified `optimal` at
2.9999000025 on a fixture whose optimum is exactly 3.0 — super-optimal by 1e-4, with a
reported dual bound 5e-5 **above its own reported incumbent**, and a reported gap of
`0.0`. That zero was `max(0.0, ub - lb)` clamping a *negative* gap.

`bound_relax_factor`'s damage is not bounded by its own size: `(x-3)^2 <= 0` relaxed by
1e-8 admits every `x` within **1e-4** of 3, because the row squares the excursion.
Reduced to a one-line model:

```
pre    status='optimal'          x = 2.9999000024987788   (1.0e-04 off)
post   status='iteration_limit'  x = 2.9999999998864917   (1.1e-10 off)
```

That also restores **#849's KKT-residual guard**, which previously could not see this
degeneracy at all — measured against the relaxed box the residuals looked clean, so a
problem whose only feasible point is `x = 3` came back certified.

Once the arms were separable it also became visible that **(b) catches the crossing on
its own**: in the pre arm the `mindtpy_cq` rows now return `feasible`, not `optimal`,
because the inversion guard refuses to certify the 5e-5 crossing even with (a) off.
(a) removes the cause; (b) catches it independently.

## Correctness

- [x] Cannot produce a false certificate — this *removes* three classes of one
  (super-optimal incumbent, bound above incumbent, `gap = 0` from a clamped negative
  gap). The absolute criterion widens `1e-9 → 1e-6`, which only bites for
  `|obj| < 0.01`; above that the relative test already allowed it, and `1e-6` is
  discopt's declared absolute tolerance, not a new one.
- [x] No validation, fallback, or safety guard was weakened. The inversion guard is
  strictly *added*; it fires on nothing in the corpus today, by design.

Remaining surface, named rather than implied closed: `amp.py:548/557/565`,
`mpec.py:346`, `_jax/differentiable.py` (5 sites), `gdpopt_loa.py:418` and
`solver.py:7836` still take Ipopt's default `bound_relax_factor`. Not all of them
consume points, and none of them reproduces the defect on this PR's fixture — the AMP
path returns exactly 3.0 — so changing them here would be a fix without a measurement,
which §4 forbids. The rule they need to be audited against is the one this PR
establishes, and the `panel_superopt_recheck.py` numbers above are how the audit would
be judged: the 12 instances still super-optimal in the post arm are where those
producers show up.

The `1e-9`/`1e-10` pair in `_jax/primal_heuristics` is deliberately **not** unified: it
gates whether to SKIP a heuristic, so the tighter floor is the safe direction there.
Commented rather than changed, so a later "consistency" edit cannot silently loosen it.

## What was measured and then dropped

`constr_viol_tol = 1e-8` is a backend-wide default for the matrix-form backends. An
earlier revision of this branch also routed it into `nlp_pounce.solve_nlp`. Replication
caught nvs05's incumbent getting reproducibly worse, so it was attributed
(`nvs05_attribution.py`, 4 arms interleaved, 3 reps, 20 s, **zero** within-arm spread):

```
print_level only            objective  8.731956987   bound 3.542469244   n=41
+ constr_viol_tol=1e-8      objective 12.589492574   bound 3.513753544   n=33
+ incumbent options only    objective  8.731956987   bound 3.542469244   n=41
```

`main == inc` and `cvt == new`: the incumbent options are innocent and
`constr_viol_tol` carries the whole 31% regression alone.

**Retraction (§11).** I then assumed the cheaper incumbent was itself the defect —
bought by a row violated inside Ipopt's loose 1e-4 — which would have made the
regression the fix working. `nvs05_feasibility.py` falsified that against the model's
own constraints: worst row violation 1.8e-12, box 0, integrality 0. Both incumbents are
genuinely feasible. A real solution lost, not a false one rejected.

Measured cost, no measured benefit — it fixes nothing this issue is about (the `cvt`
arm leaves `mindtpy_cq` at 2.9999000025), and the panel found 0 soundness findings in
*both* arms. Sound but not helpful stays out (CLAUDE.md §5, the `DISCOPT_CUT_INHERIT`
lesson). The numbers are recorded in `nlp_pounce.solve_nlp` so re-adding it is a
decision rather than a rediscovery.

## Tests run

Merged `origin/main` (both #943 and #947 landed) and rebuilt — #947 touches
`crates/discopt-python/src/expr_bindings.rs`, so a stale build would have measured the
wrong tree. Both changesets asserted loaded before measuring.

- [x] `pytest -m smoke` → **920 passed, 1 skipped, 2 xpassed** (re-run after the second
      pass, serial, on a machine where `cyipopt` is present — which is why the
      passed/skipped split differs from the 913/15 of the first-pass run in a container
      without it; the 2 xpasses are the same non-strict #756 pair)
- [x] `pytest -m slow python/tests/test_adversarial_recent_fixes.py` → **10 passed**
      in 145.86 s (serial; under `-n 4` `test_large_dense_jacobian_no_crash` fails on
      contention, and passes isolated on this branch and on the base)
- [x] `python/tests/test_945_...` + `test_940_...` + `test_mip_nlp.py` + `test_oa.py`
      + `test_gbd.py`, the files the second pass touches directly → **247 passed**
- [x] `cargo test -p discopt-core` → N/A, no Rust touched by this PR
- [x] `ruff check python/` clean; the 2 files `ruff format --check` would touch
      (`test_log_square_relaxation.py`, `test_mo_augmecon2.py`) are untouched here and
      identical on `main`

Also run:

- CI-fast marker set, full `python/tests/` → **7358 passed, 130 skipped, 5 xfailed,
  2 xpassed, 2 failed**. Both failures are `ModuleNotFoundError: No module named
  'cyipopt'` (absent in this container; CI installs it), and both — plus both xpasses
  (#756, non-strict) — are byte-identical on the base tree.
- **Correctness lane, serial** → **288 passed, 17 skipped, 4 xfailed**. This is the
  lane #940 was caught by after a CI-equivalent command that carried
  `-m "not correctness"`; it is run here deliberately.

## Regression tests

- [x] `python/tests/test_945_nlp_box_and_gap_closure.py` — 11 tests: the NLP path stays
      inside its box, the squared-row amplification, the `1e-6` absolute criterion, the
      inverted-bound refusal, LOA certifying a near-zero optimum honestly, and
      `test_incumbent_options_are_requested_by_point_consumers_only`, which asserts in
      **both** directions — the three point-consumers request the option and the
      backend does not — as the companion to #943's
      `test_option_requests_are_wired_where_the_guard_checks`.
- [x] Three of the 11 are the second pass, and all three fail on the tree without it:
      `test_default_solve_path_does_not_certify_a_super_optimal_incumbent` runs the
      constraint-qualification MINLP through plain `m.solve()` and asserts
      `objective >= 3.0 - 1e-6` plus `bound <= objective` when the status is `optimal`
      — the behavioural test, which does not care how the fix is spelled;
      `test_every_primal_heuristic_requests_the_incumbent_options` pins the one-helper
      structure (`>= 7` call sites route through `_heuristic_nlp_options`, a caller
      override still wins, and `pounce_option_defaults()` is *absent*), so a seventh
      heuristic added later cannot silently keep Ipopt's default; and
      `test_nlp_bb_terminal_resolve_separates_its_point_from_its_multipliers` pins the
      two-solve split in both directions — the refine solve carries the incumbent
      options, the recover solve does not, and the recover solve's own `x`/objective
      are never adopted. All three are in the `smoke` set.

Two strict xfails flip to passes, as they were written to:
`test_940_pounce_lp_constraint_tolerance[nlp_path]` and
`test_sets_adversarial::test_sum_indexed_var_equals_sum_flat`.

Of the 11 assertions (b) breaks, **8 are restored** by the corrected absolute
criterion. The 3 remaining (`mindtpy_cq`) are re-baselined: the old `gap == 0` was the
clamped negative gap above, and the honest value is a 1.6e-5 relative gap inside the
solver's declared 1e-4 tolerance. Each now also pins `objective >= 3.0 - 1e-6` and
`bound <= objective` — the two properties the old numbers violated.

## Differential panel

Not behind a flag: this is a soundness fix, and the flag-OFF path is the false
certificate. Evidence instead. 66 in-repo `.nl` instances, both arms interleaved,
leading arm alternated per instance, 20 s each, **re-run on the tree that ships**
(the earlier panel predates the second pass, so its pre arm no longer reconstructs
the right baseline — `panel_corpus.py` now patches the two new seams as well):

```
COMPARISONS_EXECUTED=66      identical=30  differing=36
CERT_ORDER_CHECKS_EXECUTED=103
ORACLE_CHECKS_EXECUTED=32    soundness_findings=0
CERT_REGRESSIONS=0
SOLVE_NLP_CALLS pre=4037 post=4052
```

The call counter is the point: 4052 entries into `solve_nlp` is what makes "0
findings" mean something rather than reporting a path that never ran. 36 differing
against the first pass's 7 is the expected shape — the first pass touched three call
sites on the OA/LOA/`_solve_continuous` paths; this one touches the default B&B path's
heuristics and its terminal re-solve, which nearly every instance goes through.

**A witness, not just a threshold.** "0 soundness findings" is a bound not tripped, and
a fix whose entire claim is that incumbents stop being better-than-possible should be
shown *moving the number*. `panel_superopt_recheck.py` re-scores both arms of the
panel's own output against a **second, independent oracle** — MINLPLib's
`minlplib.solu`, `=opt=` rows only (`=best=` is an incumbent someone found, not a
proven optimum, so it cannot witness anything) — at `1e-12` relative, four orders
tighter than the gate:

```
COMPARED=50
SUPER_OPTIMAL_INSTANCES pre=24  post=12
WRONG_WAY=0
```

24 of 50 instances reported an incumbent strictly **better than the published global
optimum** before this branch. 12 do after; 12 flip to sound; **zero** move the other
way. Named rather than summarised, so the ones that are *not* fixed stay visible: the
12 remaining are either byte-identical in both arms — `alan`, `ex1221`, `gbd`,
`st_miqp1/4/5`, `st_test1`, which come from producers this PR does not touch — or
reduced (`tls2` 1.47e-08 → 2.36e-12, `st_e38` 4.47e-09 → 6.58e-11, `fac2`
1.09e-09 → 6.95e-11). Those instances are the honest remaining surface, not a claim
this PR closes.

Cost, stated rather than buried. Node counts are a wash in both directions —
`st_e11` 27 → 5, `casctanks` 31 → 15, `tanksize` 11451 → 10861, `clay0303hfsg`
319 → 287, against `syn05hfsg` 185 → 285, `nvs05` 131 → 155 and several 3 → 5.
`nvs05`'s bound tightens 3.805 → 4.099 and `heatexch_gen2` finds an incumbent where
the pre arm found none. Exactly one incumbent is genuinely worse: `syn05hfsg` (a MAX)
drops 837.7324124 → 837.7323013 — but 837.7324124 is *above* the published optimum
837.7324009, so the incumbent that was lost is the impossible one. That is the §5
net-positive bar met on the same run as the cert-clean bar, not asserted separately.

Earlier panels ran at wider scopes — 36 differing backend-wide, 30 with
`constr_viol_tol`, 7 for the first pass alone. One of those runs flagged `tls2` as a
certification regression; 5-rep replication settled it as noise (**both** arms reach
`optimal` on some reps, and it is the *pre* arm that also hits `time_limit`, which post
never does), and no panel since reproduces it. The differing *set* itself moves between
runs, which is the evidence that the time-limited diffs are budget-dependent rather
than arm effects.

Limitation, stated plainly: the full MINLPLib snapshot is not on the CI image, so the
panel is the in-repo corpus and `panel_superopt_recheck.py` needs the local benchmark
snapshot to run at all — it is a scratchpad witness, not a test. Of the 66 instances
only 32 carry a registry optimum (50 have a `solu` one). The counters are printed
separately rather than as one reassuring total.

## Instrument bugs I made, and corrected

Recorded because CLAUDE.md §6–§11 exist for exactly these.

1. The panel gated its bound-vs-incumbent check behind a recorded optimum being
   present, so it silently skipped 50 of 66 instances *while its counter reported them
   checked*. It needs no oracle and now runs on every solved instance with its own
   counter. It was also sense-blind — `syn05hfsg` MAXIMIZES, so its correct
   `bound = 840.49 >= objective = 837.73` read as a 2.76 inversion.
2. `panel_replicate.py`'s verdict column reported "arm effect" for all six instances,
   including one whose arms differ by 2e-9 relative — a bare interval-overlap test with
   no tolerance. Retracted, column removed rather than left to be re-read, judging
   moved to `panel_replicate_analyze.py`.
3. Both harnesses' §8 version markers named the *superseded* contract and refused to
   run after the rescope. That is the guard working — a panel that had quietly kept
   running would have compared the pre arm against itself and reported 0 differences.
   Both now assert the real contract in both directions.
4. `test_945`'s squared-row test asserted a status the solver has no business giving on
   a degenerate problem; it was written but never run in isolation before the suite
   caught it.

## Harnesses

Vendored under `scratchpad/issue945/`, all flipping arms in-process so every number
above can be re-measured: `entry_bounds.py`, `attribution.py`, `panel_corpus.py`,
`panel_replicate.py`, `panel_replicate_analyze.py`, `nvs05_attribution.py`,
`nvs05_feasibility.py`, `panel_superopt_recheck.py`, and three GBD probes (`gbd_probe.py`, `gbd_cut_probe.py`,
`gbd_anchor_probe.py` — the last traps `_recourse`'s real return value with a trace
hook rather than reimplementing its arithmetic).

Note for reviewers re-running these: CI installs `pounce-solver` from git `main` while
this work was measured against the PyPI 0.9.0 wheel, so exact digits may shift.
