### PR TITLE
test(#950): drive the primal-heuristic deadlines from an injected clock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -189,6 +189,34 @@ The release procedure that produces these entries is documented in
 
 ### Fixed
 
+- **A clock seam for the primal-heuristic deadlines, ending a CI flake**
+  (`test`, #950). `TestLocalBranchingBudget::test_deadline_expiring_mid_round_truncates`
+  failed intermittently on the parallel lane as `assert 0 >= 2`. The mechanism is
+  scheduling, not solver behaviour: `local_branching` stamps
+  `slice_deadline = perf_counter() + submip_time_limit` *before* its first budget
+  poll, and since #912 no sub-NLP may start past that deadline — so any stall
+  longer than the test's 250 ms slice (an xdist worker descheduled on a loaded
+  runner) correctly retires the budget before sub-NLP #1, and the test's
+  wall-clock-dependent assertion could not tell that apart from broken truncation
+  logic. Reproduced deterministically by injecting a 0.30 s stall and changing
+  nothing else: `calls` 2 → 0.
+
+  `primal_heuristics._now()` is now the module's single clock read — every
+  heuristic's deadline stamp and poll goes through it, and every `WorkBudget`
+  built there is handed it via the new `WorkBudget(clock=...)` parameter (default
+  `time.perf_counter`; production passes nothing else). The test drives the
+  deadline from a clock the backend advances, so it pins the truncation
+  *schedule* — radius 0 whole, radius 1 cut after its first sub-NLP — as an exact
+  count rather than racing the machine. Verified by re-running the old and new
+  test bodies under a 0.5 s injected stall: old `calls=0` (the reported failure),
+  new `calls=2` with and without the stall; with the injected clock frozen the
+  enumeration runs all `C(3,1)=3` flips (`calls=4`), which is what proves the
+  seam — and not something else — is what fires the gate. `submip_time_limit`
+  was **not** widened: that would have made the race rarer without removing it,
+  and the budget edge is the test's subject. Production behaviour is unchanged;
+  the #912 wall-budget inventory scanner was taught to see through the seam so a
+  new gate cannot leave the ratchet by routing through `_now()`.
+
 - **A non-zero `Constraint.rhs` was a silent wrong answer through the public API**
   (`fix(correctness)`, #909). `Constraint` is exported in
   `discopt.modeling.__all__`, and `m.subject_to(Constraint(w, ">=", 5.0))` solved

--- a/python/discopt/_jax/primal_heuristics.py
+++ b/python/discopt/_jax/primal_heuristics.py
@@ -31,6 +31,34 @@ from discopt.solvers import NLPResult, SolveStatus, pounce_incumbent_options
 
 logger = logging.getLogger(__name__)
 
+
+def _now() -> float:
+    """The single point where this module reads the wall clock (#950).
+
+    Every deadline in these heuristics — the caller's absolute ``deadline`` and
+    each heuristic's own per-call slice — is stamped and polled through this
+    function, and every :class:`WorkBudget` built here is handed it as its
+    ``clock``. In production it is :func:`time.perf_counter` and nothing else;
+    the indirection is a *seam*, so a test of deadline-edge behaviour can pin
+    the schedule it means to test instead of racing the machine.
+
+    Why it is needed: a heuristic that stamps ``deadline = perf_counter() +
+    slice`` and then polls it decides how much of the search runs from wall
+    time, so a stall *outside* the process — an xdist worker descheduled on a
+    loaded CI runner — changes what the code under test does. That is exactly
+    how ``test_deadline_expiring_mid_round_truncates`` failed as
+    ``assert 0 >= 2``: a 300 ms stall inside local branching's 250 ms slice
+    retired the whole budget before the first sub-NLP, which is *correct*
+    production behaviour (#912: never start a solve past the deadline) and
+    indistinguishable from broken truncation logic. Tests monkeypatch this
+    symbol; production code must never pass a clock of its own. A caller's
+    absolute ``deadline`` argument is measured against this clock, so a test
+    that replaces it must supply any ``deadline`` in the same time base (or,
+    like the test above, none at all).
+    """
+    return time.perf_counter()
+
+
 # Iteration cap for the *sub-NLP* solves inside the primal heuristics (issue #268).
 # These solves only need an approximately feasible point (the heuristic then checks
 # integrality + constraints and lets B&B certify); they do NOT need a tight optimum.
@@ -314,7 +342,7 @@ def feasibility_pump(
         # Always run the first round (a feasible incumbent is the primary goal,
         # worth a small overrun); only the *extra* perturbation rounds are
         # deadline-gated so the pump cannot loop well past a tight ``time_limit``.
-        if deadline is not None and round_idx > 0 and time.perf_counter() >= deadline:
+        if deadline is not None and round_idx > 0 and _now() >= deadline:
             break
         x_try = x_nlp.copy()
 
@@ -629,7 +657,7 @@ def continuous_multistart(
     best_x: Optional[np.ndarray] = None
 
     for i in range(n_starts):
-        remaining = np.inf if deadline is None else deadline - time.perf_counter()
+        remaining = np.inf if deadline is None else deadline - _now()
         if remaining <= 0.05:
             break
         solve_opts = dict(opts)
@@ -746,8 +774,6 @@ def integer_local_search(
     Returns:
         ``(x, obj)`` for the best feasible point found, else ``None``.
     """
-    import time
-
     if evaluator is None:
         evaluator = cached_evaluator(model)
     int_mask = _get_integer_mask(model)
@@ -804,11 +830,15 @@ def integer_local_search(
             solve_budget = _tuning.ils_solve_budget
     if int(eval_budget) > 0 or int(solve_budget) > 0:
         budget = WorkBudget(
-            {EVAL: int(eval_budget), NLP_SOLVE: int(solve_budget)}, deadline=deadline
+            {EVAL: int(eval_budget), NLP_SOLVE: int(solve_budget)},
+            deadline=deadline,
+            clock=_now,
         )
     else:
-        _wall = time.perf_counter() + max(0.0, time_budget)
-        budget = WorkBudget(None, deadline=_wall if deadline is None else min(_wall, deadline))
+        _wall = _now() + max(0.0, time_budget)
+        budget = WorkBudget(
+            None, deadline=_wall if deadline is None else min(_wall, deadline), clock=_now
+        )
 
     def violation(x: np.ndarray) -> float:
         budget.charge(EVAL)
@@ -1074,8 +1104,6 @@ def integer_box_search(
     ``time_limit`` backstop. ``solve_budget=0`` restores the legacy
     ``time_budget`` wall gate.
     """
-    import time
-
     # As in ``one_hot_swap_search``: a non-positive ``time_budget`` is the caller
     # saying there is no budget at all, and #912's deterministic cell budget must
     # not override that.
@@ -1144,10 +1172,12 @@ def integer_box_search(
 
         solve_budget = max(1, round(_BOX_BUDGET_RATIO * _st.current().ils_solve_budget))
     if int(solve_budget) > 0:
-        budget = WorkBudget({NLP_SOLVE: int(solve_budget)}, deadline=deadline)
+        budget = WorkBudget({NLP_SOLVE: int(solve_budget)}, deadline=deadline, clock=_now)
     else:
-        _wall = time.perf_counter() + max(0.0, time_budget)
-        budget = WorkBudget(None, deadline=_wall if deadline is None else min(_wall, deadline))
+        _wall = _now() + max(0.0, time_budget)
+        budget = WorkBudget(
+            None, deadline=_wall if deadline is None else min(_wall, deadline), clock=_now
+        )
     best: Optional[tuple[np.ndarray, float]] = None
     for combo in combos:
         if budget.exhausted():
@@ -1408,7 +1438,7 @@ def diving(
             # sub-NLP and stop the dive when it has passed. Skipping the remaining
             # dive steps is always sound: diving is a primal heuristic and never
             # affects the dual bound.
-            if deadline is not None and time.perf_counter() >= deadline:
+            if deadline is not None and _now() >= deadline:
                 return None
             try:
                 res = backend(evaluator, x_cur, options=opts)
@@ -1840,7 +1870,7 @@ def local_branching(
 
     # Absolute wall past which no further sub-NLP may start. The effective budget
     # is the tighter of the caller's per-call slice and the solver's deadline.
-    slice_deadline = time.perf_counter() + max(0.0, float(submip_time_limit))
+    slice_deadline = _now() + max(0.0, float(submip_time_limit))
     if deadline is not None and np.isfinite(deadline):
         effective_deadline = min(slice_deadline, float(deadline))
     else:
@@ -1850,7 +1880,7 @@ def local_branching(
     if len(binary_idx) > max_binaries:
         if evaluator is None:
             evaluator = cached_evaluator(model)
-        remaining = max(0.0, effective_deadline - time.perf_counter())
+        remaining = max(0.0, effective_deadline - _now())
         return _local_branching_submip(
             model,
             x_incumbent,
@@ -1890,9 +1920,9 @@ def local_branching(
 
         solve_budget = max(1, round(_LB_BUDGET_RATIO * _st.current().ils_solve_budget))
     if int(solve_budget) > 0:
-        budget = WorkBudget({NLP_SOLVE: int(solve_budget)}, deadline=effective_deadline)
+        budget = WorkBudget({NLP_SOLVE: int(solve_budget)}, deadline=effective_deadline, clock=_now)
     else:
-        budget = WorkBudget(None, deadline=effective_deadline)
+        budget = WorkBudget(None, deadline=effective_deadline, clock=_now)
     # Highest radius whose full enumeration we could afford. If the budget runs
     # out mid-schedule we hand the *unexplored* radii to the bounded sub-MIP so
     # the neighbourhood is still searched, just not by brute force.
@@ -1947,7 +1977,7 @@ def local_branching(
     # the Hamming cut as one linear constraint instead of enumerating C(n, r)
     # flips. This keeps the neighbourhood covered without blowing the deadline.
     if truncated_at is not None and truncated_at <= k:
-        remaining = effective_deadline - time.perf_counter()
+        remaining = effective_deadline - _now()
         if remaining >= _LB_SUBMIP_MIN_BUDGET_S:
             submip = _local_branching_submip(
                 model,
@@ -2112,12 +2142,12 @@ def one_hot_swap_search(
 
         eval_budget = max(1, round(_SWAP_BUDGET_RATIO * _st.current().ils_eval_budget))
     if int(eval_budget) > 0:
-        budget = WorkBudget({EVAL: int(eval_budget)}, deadline=deadline)
+        budget = WorkBudget({EVAL: int(eval_budget)}, deadline=deadline, clock=_now)
     else:
-        t_end = time.perf_counter() + max(0.0, float(time_budget))
+        t_end = _now() + max(0.0, float(time_budget))
         if deadline is not None and np.isfinite(deadline):
             t_end = min(t_end, float(deadline))
-        budget = WorkBudget(None, deadline=t_end)
+        budget = WorkBudget(None, deadline=t_end, clock=_now)
 
     def _obj(assign: np.ndarray) -> float:
         budget.charge(EVAL)

--- a/python/discopt/_work_budget.py
+++ b/python/discopt/_work_budget.py
@@ -71,7 +71,7 @@ Usage::
 from __future__ import annotations
 
 import time
-from typing import Mapping, Optional
+from typing import Callable, Mapping, Optional
 
 __all__ = [
     "EVAL",
@@ -96,19 +96,29 @@ class WorkBudget:
             non-positive value, is unlimited — but still counted, so an
             instrumented run can report what an unbounded loop actually did.
             ``None`` means every kind is unlimited.
-        deadline: Optional absolute ``time.perf_counter()`` timestamp. This is
-            the *user's* limit (role 1 above), not a work gate: it is checked in
+        deadline: Optional absolute ``clock()`` timestamp. This is the *user's*
+            limit (role 1 above), not a work gate: it is checked in
             :meth:`exhausted` so a heuristic cannot overrun ``time_limit``, and
             when it is what stopped the loop :attr:`stopped_on` says so.
+        clock: The monotonic clock ``deadline`` is measured against. Defaults to
+            :func:`time.perf_counter`; production code never passes anything
+            else. The seam exists so a *test* of deadline-edge behaviour can
+            drive the deadline from a clock it controls instead of racing the
+            machine: with the real clock, the truncation a test means to pin is
+            a consequence of wall time, so an unrelated scheduling stall (a
+            descheduled xdist worker on a loaded runner) silently changes what
+            the code under test does and the test flakes (#950). ``deadline``
+            and ``clock`` must be expressed in the same time base.
     """
 
-    __slots__ = ("limits", "deadline", "used", "_stopped_on")
+    __slots__ = ("limits", "deadline", "used", "_stopped_on", "_clock")
 
     def __init__(
         self,
         limits: Optional[Mapping[str, int]] = None,
         *,
         deadline: Optional[float] = None,
+        clock: Callable[[], float] = time.perf_counter,
     ):
         self.limits: dict[str, int] = {
             k: int(v) for k, v in (limits or {}).items() if v is not None and int(v) > 0
@@ -116,6 +126,7 @@ class WorkBudget:
         self.deadline: Optional[float] = deadline
         self.used: dict[str, int] = {}
         self._stopped_on: Optional[str] = None
+        self._clock: Callable[[], float] = clock
 
     def charge(self, kind: str, count: int = 1) -> None:
         """Record ``count`` operations of ``kind`` as spent."""
@@ -132,7 +143,7 @@ class WorkBudget:
                 if self._stopped_on is None:
                     self._stopped_on = f"work:{kind}"
                 return True
-        if self.deadline is not None and time.perf_counter() >= self.deadline:
+        if self.deadline is not None and self._clock() >= self.deadline:
             if self._stopped_on is None:
                 self._stopped_on = "deadline"
             return True

--- a/python/tests/test_912_wall_budget_inventory.py
+++ b/python/tests/test_912_wall_budget_inventory.py
@@ -78,8 +78,13 @@ import pytest
 
 _PKG = Path(__file__).resolve().parents[1] / "discopt"
 
-_MAKE = re.compile(r"(time|_time)\.(perf_counter|monotonic)\(\)\s*\+")
-_ELAPSED = re.compile(r"(time|_time)\.(perf_counter|monotonic)\(\)\s*-\s*\w+[^<>]*[<>]=?")
+# A clock read. ``_now()`` is ``primal_heuristics``' module-level seam over
+# ``time.perf_counter`` (#950) — it is still a wall-clock read, so the scanner
+# must see through it, or routing a new gate through the seam would be a way to
+# leave this inventory silently.
+_CLOCK = r"(?:(?:time|_time)\.(?:perf_counter|monotonic)\(\)|(?<![\w.])_now\(\))"
+_MAKE = re.compile(_CLOCK + r"\s*\+")
+_ELAPSED = re.compile(_CLOCK + r"\s*-\s*\w+[^<>]*[<>]=?")
 
 # (module-relative path, source line, category). See the module docstring.
 KNOWN: tuple[tuple[str, str, str], ...] = (
@@ -276,19 +281,23 @@ KNOWN: tuple[tuple[str, str, str], ...] = (
         "if total_time_limit is not None else None",
         "contract",
     ),
+    # These three read the clock through ``primal_heuristics._now()`` since #950
+    # (one seam, monkeypatchable, so a deadline-edge test pins the schedule it
+    # means to test instead of racing the machine). Same three gates, same
+    # categories — only the spelling of the clock read changed.
     (
         "_jax/primal_heuristics.py",
-        "_wall = time.perf_counter() + max(0.0, time_budget)",
+        "_wall = _now() + max(0.0, time_budget)",
         "legacy",
     ),
     (
         "_jax/primal_heuristics.py",
-        "slice_deadline = time.perf_counter() + max(0.0, float(submip_time_limit))",
+        "slice_deadline = _now() + max(0.0, float(submip_time_limit))",
         "contract",
     ),
     (
         "_jax/primal_heuristics.py",
-        "t_end = time.perf_counter() + max(0.0, float(time_budget))",
+        "t_end = _now() + max(0.0, float(time_budget))",
         "legacy",
     ),
     (

--- a/python/tests/test_912_work_budget.py
+++ b/python/tests/test_912_work_budget.py
@@ -119,6 +119,27 @@ def test_stopped_on_is_latched_at_the_first_stop():
 
 
 @pytest.mark.unit
+def test_deadline_is_measured_against_the_injected_clock():
+    """#950: the backstop reads ``clock``, so a test can pin deadline-edge
+    behaviour instead of racing the machine.
+
+    The default is :func:`time.perf_counter` (the two tests above rely on it);
+    this one drives the same gate from a clock it owns. A real deadline one hour
+    out cannot fire on wall time within this test, so the ``exhausted()`` below
+    is caused by the injected clock and nothing else.
+    """
+    now = {"t": 0.0}
+    b = WorkBudget({EVAL: 10**9}, deadline=3600.0, clock=lambda: now["t"])
+    b.charge(EVAL)
+    assert not b.exhausted()
+    assert b.stopped_on is None
+    now["t"] = 3600.0
+    assert b.exhausted()
+    assert b.stopped_on == "deadline"
+    assert not b.deterministic
+
+
+@pytest.mark.unit
 def test_unknown_kind_is_counted_but_never_gates():
     b = WorkBudget({EVAL: 5})
     b.charge("lp_iteration", 10**6)

--- a/python/tests/test_945_nlp_box_and_gap_closure.py
+++ b/python/tests/test_945_nlp_box_and_gap_closure.py
@@ -203,7 +203,16 @@ def test_every_primal_heuristic_requests_the_incumbent_options():
     # Every option site routes through the helper; none rebuilds its own dict.
     n_sites = src.count("_heuristic_nlp_options(")
     assert n_sites >= 7, f"expected the helper plus 6 call sites, found {n_sites}"
-    assert 'setdefault("max_iter", _HEURISTIC_NLP_MAX_ITER)' not in src.split("def ", 2)[2], (
+    # Everything except the helper itself, which is the one place allowed to set
+    # the cap. Anchored on the helper's own source rather than on "the source
+    # after the second ``def``": that positional slice silently assumed the
+    # helper was the module's first function, so adding any function above it
+    # (#950's ``_now`` clock seam) moved the cut into the helper's body and the
+    # assertion failed on the helper's *own* line. Removing the helper's source
+    # says what the rule means and also covers functions defined above it.
+    helper_src = inspect.getsource(PH._heuristic_nlp_options)
+    assert 'setdefault("max_iter", _HEURISTIC_NLP_MAX_ITER)' in helper_src
+    assert 'setdefault("max_iter", _HEURISTIC_NLP_MAX_ITER)' not in src.replace(helper_src, ""), (
         "a heuristic still builds its NLP options inline instead of via the helper"
     )
 

--- a/python/tests/test_gdpopt_heuristics_core_units.py
+++ b/python/tests/test_gdpopt_heuristics_core_units.py
@@ -963,16 +963,33 @@ class TestLocalBranchingBudget:
         out = ph.local_branching(m, np.array([1.0, 1.0]), submip_time_limit=0.0)
         assert out is None
 
-    def test_deadline_expiring_mid_round_truncates(self):
+    def test_deadline_expiring_mid_round_truncates(self, monkeypatch):
+        """The deadline poll cuts the enumeration off *mid-round*.
+
+        Driven by an injected clock (#950), not by ``time.sleep``. The subject is
+        the truncation *schedule* — radius 0 runs whole, radius 1 starts and is
+        cut after its first sub-NLP — which is a wall-clock-independent intent.
+        Reading the real clock made it a wall-clock-dependent assertion: the
+        slice is stamped before the first budget poll, so any stall longer than
+        the slice (an xdist worker descheduled on a loaded runner) retires the
+        budget before sub-NLP #1 and the test failed as ``assert 0 >= 2`` while
+        the code was behaving exactly as #912 specifies.
+
+        Here the clock only moves when the backend moves it, so the machine
+        cannot change the answer.
+        """
         m = dm.Model("lb3")
         b = m.binary("b", shape=(3,))
         m.minimize(dm.sum(b))
         calls = {"n": 0}
+        fake_t = {"now": 0.0}
+        monkeypatch.setattr(ph, "_now", lambda: fake_t["now"])
 
         def slow_backend(evaluator, x0, options=None):
             calls["n"] += 1
             if calls["n"] >= 2:
-                time.sleep(0.3)
+                # Sub-NLP #2 (the first of radius 1) overruns the 0.25 s slice.
+                fake_t["now"] += 0.3
             raise RuntimeError("no point")
 
         out = ph.local_branching(
@@ -983,8 +1000,11 @@ class TestLocalBranchingBudget:
             submip_time_limit=0.25,
         )
         assert out is None
-        # radius 0 ran, radius 1 started and was cut off by the deadline poll.
-        assert calls["n"] >= 2
+        # radius 0 ran (1 sub-NLP), radius 1 started (sub-NLP 2) and the next
+        # poll saw the deadline. Exact, not ">=": with the clock injected the
+        # count is a function of the schedule alone, so a drift is a real change
+        # in the truncation logic rather than a slow machine.
+        assert calls["n"] == 2
 
     def test_truncation_dispatches_bounded_submip(self, monkeypatch):
         """When a radius round cannot fit the remaining sub-NLP budget, the


### PR DESCRIPTION
## Summary

`TestLocalBranchingBudget::test_deadline_expiring_mid_round_truncates` failed
intermittently on the parallel CI lane as `assert 0 >= 2`. The mechanism is
scheduling, not solver behaviour: `local_branching` stamps
`slice_deadline = perf_counter() + submip_time_limit` **before** its first budget
poll, and since #912 no sub-NLP may start past that deadline — so any stall
longer than the test's 250 ms slice (an xdist worker descheduled on a loaded
runner) correctly retires the whole budget before sub-NLP #1. The test asserted a
wall-clock-*dependent* consequence of a wall-clock-*independent* intent, so that
outcome was indistinguishable from broken truncation logic.

Entry experiment (`probe950_repro.py`), stall injected and nothing else changed:

```
stall=0.00s  out=None  calls=2   old test PASSES
stall=0.30s  out=None  calls=0   old test FAILS -> assert 0 >= 2
```

The fix is the clock seam the issue asks for, applied to the class rather than
the one call site:

- `primal_heuristics._now()` is now the module's single wall-clock read. Every
  deadline stamp and poll in the layer goes through it (`feasibility_pump`,
  `continuous_multistart`, `integer_local_search`, `integer_box_search`,
  `diving`, `local_branching`, `one_hot_swap_search`).
- `WorkBudget(clock=...)` (default `time.perf_counter`) so the budget's deadline
  backstop reads the same clock; every construction in that module passes `_now`.
  Production passes nothing else — behaviour is unchanged.
- The test advances a clock its own backend owns and asserts an **exact** count
  (`calls == 2`): radius 0 whole, radius 1 cut after its first sub-NLP.
  `submip_time_limit` was **not** widened — that makes the race rarer without
  removing it, and the budget edge is precisely the test's subject.

Two source-scanning tests needed matching repairs; neither was weakened:

- `test_912_wall_budget_inventory.py` — the #912 ratchet's regex now sees through
  `_now()`, so routing a new gate through the seam cannot leave the inventory
  silently. Same three primal-heuristic gates, same categories; only the recorded
  spelling of the clock read changed.
- `test_945_nlp_box_and_gap_closure.py` — its "no heuristic sets `max_iter`
  inline" check sliced the module source at the second `def`, silently assuming
  the options helper was the module's first function; adding `_now` above it
  moved the cut into the helper's own body, so it failed on the helper's *own*
  line. Now anchored on the helper's source, which states the rule directly and
  also covers functions defined above it — strictly stronger, and verified to
  bite on injected duplicates both above and below the helper.

Closes #950

## Correctness

No solver math changed. `_now()` returns `time.perf_counter()` and every
production call site passes it (or nothing, keeping the default), so every
deadline is stamped and polled against the same clock it was before; the diff in
`local_branching` and its three siblings is the spelling of the clock read plus
one keyword argument. Nothing about bounds, cuts, relaxations, incumbent
acceptance or certification is touched.

- [x] Cannot produce a false certificate (N/A — no solver-math change)
- [x] No validation, fallback, or safety guard was weakened to make a check pass
      (the two source-scanning checks were repaired to be position-independent;
      the #912 inventory scanner was *widened* to also match the seam)

## Tests run (state the result — numbers, not adjectives)

- [x] `pytest -m smoke` → **916 passed, 16 skipped, 2 xpassed** (413 s)
- [x] `pytest -m slow python/tests/test_adversarial_recent_fixes.py` → **10 passed**
- [x] `cargo test -p discopt-core` → N/A (no Rust touched)
- [x] `ruff check` / `ruff format --check` clean (pinned 0.14.6, whole `python/` tree)

Also: `test_912_work_budget.py`, `test_912_wall_budget_inventory.py`,
`test_gdpopt_heuristics_core_units.py`, `test_945_nlp_box_and_gap_closure.py`,
`test_940_pounce_lp_constraint_tolerance.py`, `test_875_nbt_call_site_budget.py`,
`test_875_root_setup_budget.py`, `test_deadline.py`, `test_issue_267_lns.py`,
`test_f4_root_budget_gate.py` — all pass.

One unrelated observation: `test_large_dense_jacobian_no_crash` failed once in a
full-file run (`wall < budget + 40`, a load-sensitive *contract* assertion — the
whole file took 277 s that round vs 196 s the next) and passed on re-run and in
isolation. Interleaved A/B of that test, seam present vs absent (marker asserted
per arm): **33.2 / 33.9 s with, 32.3 / 32.3 s without** — inside noise, both arms
passing. It is a pre-existing load-sensitive assertion, not this change, and not
fixable by the same seam since its subject *is* wall time.

## Regression test

`test_deadline_expiring_mid_round_truncates` is the test being repaired, so
"fails before / passes after" is demonstrated on the failure condition rather
than on the tree: `probe950_immunity.py` runs the old and new test bodies under
0.0 s and 0.5 s of injected real stall (twice the slice — the condition that
produced the CI failure):

```
old   calls=2 / calls=0    (flakes, exactly as reported)
new   calls=2 / calls=2    (immune)
seam  calls=4 / calls=4    (clock frozen: radius 1 runs all C(3,1)=3 flips)
```

The third arm is the probe-fired check (CLAUDE.md §6): with the injected clock
frozen the enumeration runs the full round, which is what proves the injected
clock — and not something else — is what fires the deadline gate in the `new`
arm. `test_deadline_is_measured_against_the_injected_clock` covers the new
`WorkBudget(clock=...)` parameter directly.

- [x] Added a regression test that fails before / passes after

---
_Generated by [Claude Code](https://claude.ai/code/session_01DsbGpdfWQHXUpo9TkjmYHi)_