### PR TITLE
fix(ci): repair three signals that had stopped signalling

### DIFF
--- a/.github/workflows/amp-integration.yml
+++ b/.github/workflows/amp-integration.yml
@@ -96,3 +96,39 @@ jobs:
           JAX_PLATFORMS: cpu
           JAX_ENABLE_X64: "1"
           PYTEST_MEMORY_LIMIT_MB: "0"
+
+  # This suite failed on EVERY push to main from 2026-07-27 to 2026-08-08 — 40+
+  # consecutive red runs — on a single test, with no issue tracking it. A red X
+  # on a merge commit is not a signal if nothing routes it anywhere. One open
+  # issue, reused rather than duplicated, is.
+  report-failure:
+    name: File/refresh the CI-signal issue
+    needs: amp-integration
+    if: failure() && (github.event_name == 'schedule' || github.event_name == 'push')
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Open or update the tracking issue
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          TITLE: "CI signal down: AMP integration suite is failing on main"
+        run: |
+          set -euo pipefail
+          gh label create ci-signal --force --color B60205 \
+            --description "A CI lane that is supposed to be watching something has stopped watching"
+          printf '%s\n' \
+            "The AMP integration suite failed on \`${GITHUB_REF_NAME}\` (${GITHUB_SHA})." \
+            "" \
+            "Run: ${RUN_URL}" \
+            "" \
+            "While this is red the AMP paths are unguarded on main." \
+            > body.md
+          NUM=$(gh issue list --state open --label ci-signal --json number,title \
+                  --jq "[.[] | select(.title == env.TITLE)][0].number // empty")
+          if [ -n "$NUM" ]; then
+            gh issue comment "$NUM" --body-file body.md
+          else
+            gh issue create --title "$TITLE" --label ci-signal --body-file body.md
+          fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,11 @@ on:
   pull_request:
     branches: [main, feature/mip-nlp-solver]
     types: [opened, synchronize, reopened, ready_for_review, labeled]
+  schedule:
+    # Nightly, 06:20 UTC. Only `python-correctness-nightly` runs on this trigger;
+    # every other job below is gated on `needs.changes`, which is `false` for a
+    # schedule event (no diff to inspect).
+    - cron: "20 6 * * *"
 
 # Cancel superseded runs on the same PR/branch — saves CI minutes when
 # pushes land in quick succession.
@@ -34,6 +39,16 @@ jobs:
         shell: bash
         run: |
           set -uo pipefail
+          if [ "${{ github.event_name }}" = "schedule" ]; then
+            # The nightly trigger exists solely for `python-correctness-nightly`,
+            # which does NOT gate on this output. This is not the "uncertainty"
+            # case the rule below covers — there is no diff to be uncertain
+            # about, and re-running the whole PR matrix nightly would buy nothing
+            # that the last push already proved.
+            echo "code=false" >> "$GITHUB_OUTPUT"
+            echo "=> code=false (schedule: only the nightly correctness lane runs)"
+            exit 0
+          fi
           if [ "${{ github.event_name }}" = "pull_request" ]; then
             git fetch --no-tags --depth=200 origin "${{ github.base_ref }}" || true
             base="$(git merge-base "origin/${{ github.base_ref }}" HEAD 2>/dev/null || true)"
@@ -194,8 +209,15 @@ jobs:
     # #248's nvs16 garbage-bound guard regressed at the #632 uniform-relax cutover
     # and sat unnoticed for a full release cycle because no PR job ran the
     # `correctness` marker. This lane closes that gap. It runs only the cheap
-    # subset (`not slow`); the full known-optima sweep (including `slow`
-    # correctness) remains the nightly `python-coverage` job's responsibility.
+    # subset (`not slow`); the `slow` half is the `python-correctness-nightly`
+    # job below.
+    #
+    # That sentence used to read "remains the nightly `python-coverage` job's
+    # responsibility", and it was false in two ways at once: `python-coverage`
+    # runs `-m "not slow and not correctness ..."`, and this workflow had no
+    # `schedule:` trigger, so there was no nightly. The 153 `slow`+`correctness`
+    # tests ran in NO lane — including the one asserting that ex1252's dual bound
+    # under the #707/#721/#732 reform flags is sound, which is red (#927).
     name: Python correctness (fast subset, 3.12, ubuntu)
     runs-on: ubuntu-latest
     needs: changes
@@ -266,6 +288,110 @@ jobs:
           JAX_PLATFORMS: cpu
           JAX_ENABLE_X64: "1"
           PYTEST_MEMORY_LIMIT_MB: "32768"
+
+  python-correctness-nightly:
+    # The other half of the correctness marker: the 153 tests that are `slow`
+    # AND `correctness`. These are the end-to-end known-optima and soundness
+    # assertions — the ones that solve a real instance and check the certificate
+    # against `minlplib.solu` — and until this job existed they ran in no lane at
+    # all. Nightly rather than per-PR because it is hours, not minutes; the
+    # `not slow` half stays on `python-correctness` for the PR-fast signal.
+    #
+    # Serial for the same reason as `python-correctness`: a soundness lane must
+    # be deterministic, and xdist can order-mask global/claim state.
+    #
+    # `--timeout=900` because these tests pass real `time_limit=` budgets to the
+    # solver (ex1252 uses 200 s) and a per-test timeout below the budget would
+    # fail the harness instead of the assertion.
+    name: Python correctness (slow, nightly, 3.12, ubuntu)
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    timeout-minutes: 360
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: ". -> target"
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install uv
+        run: |
+          python -m pip install --upgrade pip
+          pip install uv
+      - name: Install system dependencies (Ipopt)
+        run: |
+          sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list \
+                     /etc/apt/sources.list.d/azure-cli.list || true
+          for i in 1 2 3; do
+            sudo apt-get update && sudo apt-get install -y --no-install-recommends \
+              coinor-libipopt-dev liblapack-dev libblas-dev gfortran && break
+            echo "apt attempt $i failed; retrying in $((i * 15))s..." >&2
+            sleep $((i * 15))
+          done
+      - name: Install Python dependencies
+        run: |
+          python -m venv .venv
+          source .venv/bin/activate
+          uv pip install maturin
+          uv pip install \
+            jax jaxlib numpy scipy highspy cyipopt openpyxl scikit-learn pyyaml \
+            "pounce-solver @ git+https://github.com/jkitchin/pounce.git@main#subdirectory=python" \
+            pytest pytest-timeout pytest-xdist
+          maturin develop
+      - name: Run pytest (slow correctness, serial)
+        run: |
+          source .venv/bin/activate
+          # `-v` and `python -u` are deliberate: a multi-hour job that only
+          # prints a summary at the end cannot be distinguished from a hung one
+          # (CLAUDE.md §10).
+          scripts/run_memory_capped_pytest.sh pytest python/tests/ \
+            -v --tb=short --timeout=900 -p no:cacheprovider \
+            -m "correctness and slow and not integration and not amp_benchmark and not requires_cyipopt and not memory_heavy" \
+            --ignore=python/tests/test_amp.py \
+            --durations=25
+        env:
+          JAX_PLATFORMS: cpu
+          JAX_ENABLE_X64: "1"
+          PYTHONUNBUFFERED: "1"
+          PYTEST_MEMORY_LIMIT_MB: "32768"
+
+  # Same argument as the other two scheduled lanes: a nightly that fails into an
+  # empty room is not a signal.
+  report-nightly-failure:
+    name: File/refresh the CI-signal issue
+    needs: python-correctness-nightly
+    if: failure() && github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Open or update the tracking issue
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          TITLE: "CI signal down: nightly slow-correctness lane is failing"
+        run: |
+          set -euo pipefail
+          gh label create ci-signal --force --color B60205 \
+            --description "A CI lane that is supposed to be watching something has stopped watching"
+          printf '%s\n' \
+            "The nightly \`slow\`+\`correctness\` lane failed." \
+            "" \
+            "Run: ${RUN_URL}" \
+            "" \
+            "These are the end-to-end certificate assertions. A failure here is a" \
+            "soundness signal until shown otherwise — triage before merging work" \
+            "that touches the same layer." \
+            > body.md
+          NUM=$(gh issue list --state open --label ci-signal --json number,title \
+                  --jq "[.[] | select(.title == env.TITLE)][0].number // empty")
+          if [ -n "$NUM" ]; then
+            gh issue comment "$NUM" --body-file body.md
+          else
+            gh issue create --title "$TITLE" --label ci-signal --body-file body.md
+          fi
 
   python-claims-serial:
     # Relaxation claim-arbitration tests, run SERIALLY (-n0). The federated

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -303,10 +303,15 @@ jobs:
     # `--timeout=900` because these tests pass real `time_limit=` budgets to the
     # solver (ex1252 uses 200 s) and a per-test timeout below the budget would
     # fail the harness instead of the assertion.
+    #
+    # Measured 313 s serially on an M-series laptop (153 selected: 146 passed,
+    # 7 skipped, 1 failed — the failure being #927). `python-correctness` is
+    # ~5 min locally and 23 min on a runner, so budget ~25 min here and leave
+    # headroom for a slower runner rather than a hung solve.
     name: Python correctness (slow, nightly, 3.12, ubuntu)
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
-    timeout-minutes: 360
+    timeout-minutes: 120
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/graduation-gate.yml
+++ b/.github/workflows/graduation-gate.yml
@@ -18,12 +18,25 @@ on:
   schedule:
     # Weekly, Mondays 07:42 UTC. Off the PR-fast path (the cert re-solve is minutes).
     - cron: "42 7 * * 1"
+  # A PR that edits the gate or the registry it reads MUST run the gate. Without
+  # this the only way to find out that an edit broke the invocation was to wait
+  # a week for the cron and then read a log nobody opens — which is exactly how
+  # the `node_reduce` drift stayed live from 2026-07-13 to 2026-08-08.
+  pull_request:
+    paths:
+      - ".github/workflows/graduation-gate.yml"
+      - "discopt_benchmarks/scripts/graduation_gate.py"
+      - "discopt_benchmarks/scripts/generality_sweep.py"
 
 jobs:
   graduation-gate-ci-subset:
     name: cert-neutrality regression guard (vendored panel)
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    # 45 -> 90: dropping the stale hardcoded `--flags` list restored two arms the
+    # copy had lost and added one wired since (`lu_density_route`,
+    # `node_numerical_dual_bound`, `root_build_deadline`), so the gated set is 7
+    # arms, not 5.
+    timeout-minutes: 90
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
@@ -45,9 +58,15 @@ jobs:
       - name: Run the graduation gate CI subset (cert-neutrality + incorrect_count)
         run: |
           source .venv/bin/activate
-          python discopt_benchmarks/scripts/graduation_gate.py \
-            --flags root_fixpoint,node_reduce,psd_cost_gate,lift_zero_spanning,lift_loose_products \
-            --ci-subset
+          # NO `--flags` here, deliberately. The default is
+          # `",".join(generality_sweep.GRADUATION_ARMS)`, so the gated set tracks
+          # the registry instead of a copy of it that drifts. It previously read
+          # `--flags root_fixpoint,node_reduce,psd_cost_gate,...`; `node_reduce`
+          # was deprecated and removed from GRADUATION_ARMS in #581, after which
+          # this step exited 2 on `unknown flag(s): ['node_reduce']` before
+          # gating anything. That silently disabled the cert-neutrality guard for
+          # every scheduled run from 2026-07-13 onward.
+          python discopt_benchmarks/scripts/graduation_gate.py --ci-subset
         env:
           JAX_PLATFORMS: cpu
           JAX_ENABLE_X64: "1"
@@ -59,3 +78,40 @@ jobs:
           name: graduation-gate-ci-subset
           path: reports/graduation_gate_*.json
           if-no-files-found: ignore
+
+  # A scheduled job that fails into an empty room is not a signal. Nobody opens
+  # a weekly run log, so this one reported "unknown flag(s)" for four consecutive
+  # Mondays and the cert-neutrality guard was a no-op the whole time. Surface it
+  # where the work is: one open issue, reused (commented) rather than duplicated.
+  report-failure:
+    name: File/refresh the CI-signal issue
+    needs: graduation-gate-ci-subset
+    if: failure() && github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Open or update the tracking issue
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          TITLE: "CI signal down: flag-graduation gate (scheduled) is failing"
+        run: |
+          set -euo pipefail
+          gh label create ci-signal --force --color B60205 \
+            --description "A CI lane that is supposed to be watching something has stopped watching"
+          printf '%s\n' \
+            "The weekly cert-neutrality regression guard failed." \
+            "" \
+            "Run: ${RUN_URL}" \
+            "" \
+            "Until this is green the guard is proving nothing: a flag that changes a" \
+            "certified objective on the vendored panel would graduate unnoticed." \
+            > body.md
+          NUM=$(gh issue list --state open --label ci-signal --json number,title \
+                  --jq "[.[] | select(.title == env.TITLE)][0].number // empty")
+          if [ -n "$NUM" ]; then
+            gh issue comment "$NUM" --body-file body.md
+          else
+            gh issue create --title "$TITLE" --label ci-signal --body-file body.md
+          fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -189,6 +189,47 @@ The release procedure that produces these entries is documented in
 
 ### Fixed
 
+- **Three CI signals that had stopped signalling** (`ci`). An audit of why #927
+  (an unsound `ex1252` dual bound, asserted by a test in the tree) could sit open
+  found that the lanes meant to catch it were all dark:
+
+  1. **No lane ran `slow` + `correctness` — 153 tests, including every
+     end-to-end certificate assertion.** `python-correctness` runs `not slow`;
+     its comment said the rest was "the nightly `python-coverage` job's
+     responsibility", but that job runs `-m "not slow and not correctness ..."`
+     and `ci.yml` had no `schedule:` trigger at all, so there was no nightly. New
+     `python-correctness-nightly` job (serial, `--timeout=900`, 06:20 UTC) runs
+     exactly that set. `changes` now reports `code=false` on a schedule event so
+     the nightly trigger does not re-run the whole PR matrix.
+  2. **The weekly flag-graduation gate had been exiting 2 before gating
+     anything since 2026-07-13.** The workflow passed a hardcoded
+     `--flags root_fixpoint,node_reduce,...`; `node_reduce` was deprecated out of
+     `GRADUATION_ARMS` in #581, so every scheduled run died on
+     `unknown flag(s): ['node_reduce']` — four consecutive Mondays where the
+     cert-neutrality guard proved nothing. The `--flags` argument is now omitted
+     entirely so the gated set tracks the registry (7 arms, not the copy's 5),
+     and the workflow gained a `pull_request` trigger on its own path so an edit
+     to it is validated by the PR that makes it, not a week later.
+  3. **The AMP integration suite had failed on every push to `main` since
+     2026-07-27** — 40+ consecutive red runs, no tracking issue — on
+     `test_amp_time_limit_with_incumbent_returns_feasible`. The solver contract
+     is intact; the test was the broken part. It drove the timeout by *read
+     ordinal* (`chain([0.0, 0.0], repeat(1.5))`, "the first two reads are before
+     the deadline"), and `monkeypatch.setattr(amp_mod.time, ...)` patches the
+     **global** `time` module, so a burst of ~26 reads inside
+     `nonlinear_bound_tightening`'s budget polling consumed the pre-deadline
+     values. The deadline then blew before any incumbent was stored and
+     `solve_amp` returned through the "no feasible solution found" arm — so the
+     assertion described a path the test no longer executed, and reported it as
+     `assert 'time_limit' == 'feasible'`, which reads as a solver bug. The
+     timeout is now driven by *state* (pre-deadline until an incumbent exists),
+     which no read count can perturb, plus a callback counter so the test cannot
+     pass while measuring nothing (CLAUDE.md §6).
+
+  All three scheduled/main lanes now file-or-refresh a single `ci-signal`-labelled
+  issue on failure. Each of these was red or absent for weeks; none of them
+  reached anyone.
+
 - **A clock seam for the primal-heuristic deadlines, ending a CI flake**
   (`test`, #950). `TestLocalBranchingBudget::test_deadline_expiring_mid_round_truncates`
   failed intermittently on the parallel lane as `assert 0 >= 2`. The mechanism is

--- a/python/tests/test_amp_integration.py
+++ b/python/tests/test_amp_integration.py
@@ -26,7 +26,6 @@ Sections:
 
 from __future__ import annotations
 
-import itertools
 import logging
 import os
 import warnings
@@ -3501,12 +3500,38 @@ class TestCurrentCodeWeaknesses:
         from discopt._jax.milp_relaxation import MilpRelaxationResult
         from discopt.solvers import amp as amp_mod
 
-        # First two reads land before the deadline; every later read is past it,
-        # so the timeout path triggers regardless of how many clock samples
-        # solve_amp takes.
-        fake_clock = itertools.chain([0.0, 0.0], itertools.repeat(1.5))
+        # The timeout is driven by *state*, not by read ordinal: the clock is
+        # pre-deadline until an incumbent exists and past the deadline after.
+        # That is what "timed out after finding an incumbent" means, and it is
+        # immune to how many times anything reads the clock.
+        #
+        # The previous wiring here was ``chain([0.0, 0.0], repeat(1.5))`` --
+        # "the first two reads are before the deadline" -- which silently stopped
+        # reaching this path. ``monkeypatch.setattr(amp_mod.time, ...)`` replaces
+        # ``perf_counter`` on the *global* ``time`` module, so every clock read
+        # under the call draws from the sequence, not just ``amp``'s own; a burst
+        # of ~26 reads inside ``nonlinear_bound_tightening``'s budget polling
+        # consumed the pre-deadline values, the main loop saw a blown deadline
+        # before any incumbent was stored, and ``solve_amp`` returned through the
+        # "no feasible solution found" arm. The assertion below then described a
+        # path the test no longer executed -- so it failed for a reason that had
+        # nothing to do with the contract it names. Hence ``calls``: if the
+        # incumbent callback never fires, this test measured nothing and must not
+        # be able to pass (CLAUDE.md §6).
+        calls = {"n": 0}
+        state = {"incumbent_found": False}
 
-        monkeypatch.setattr(amp_mod.time, "perf_counter", lambda: next(fake_clock))
+        def fake_now():
+            # ``time_limit`` is 1.0 s and ``t_start`` is read before any incumbent
+            # exists, so the origin is 0.0 and the deadline is 1.0.
+            return 1.5 if state["incumbent_found"] else 0.0
+
+        def fake_best_nlp(*args, **kwargs):
+            calls["n"] += 1
+            state["incumbent_found"] = True
+            return np.array([2.0, 2.0], dtype=np.float64), 10.0
+
+        monkeypatch.setattr(amp_mod.time, "perf_counter", fake_now)
         monkeypatch.setattr(
             amp_mod,
             "_solve_milp_with_oa_recovery",
@@ -3521,11 +3546,7 @@ class TestCurrentCodeWeaknesses:
                 1,
             ),
         )
-        monkeypatch.setattr(
-            amp_mod,
-            "_solve_best_nlp_candidate",
-            lambda *args, **kwargs: (np.array([2.0, 2.0], dtype=np.float64), 10.0),
-        )
+        monkeypatch.setattr(amp_mod, "_solve_best_nlp_candidate", fake_best_nlp)
 
         result = amp_mod.solve_amp(
             _make_nlp1(),
@@ -3535,8 +3556,13 @@ class TestCurrentCodeWeaknesses:
             time_limit=1.0,
         )
 
+        assert calls["n"] == 1, (
+            "the incumbent callback never fired, so the timeout did not land "
+            "*after* an incumbent and this test measured nothing"
+        )
         assert result.status == "feasible"
         assert result.objective is not None
+        assert result.x is not None
         assert result.gap_certified is False
 
     @pytest.mark.xfail(


### PR DESCRIPTION
## Why

While assessing #927–#933 I checked what *would* have caught #927 (an unsound
`ex1252` dual bound, asserted by a test that lives in this repo). Nothing would
have. Following that thread found three CI lanes that had stopped signalling —
two red for weeks with no issue, one that never existed.

This PR repairs the instruments. It does not fix #927 itself; that is next, and
the nightly lane added here is what will hold it.

## 1. No lane ran `slow` + `correctness` — 153 tests

`python-correctness` runs `-m "correctness and not slow ..."`. Its comment said
the remainder was "the nightly `python-coverage` job's responsibility". Both
halves of that were false:

- `python-coverage` runs `-m "not slow and not correctness ..."` — it excludes
  the marker entirely.
- `ci.yml` had **no `schedule:` trigger**. There was no nightly.

So the 153 `slow`+`correctness` tests — the end-to-end known-optima and
certificate assertions, the ones that solve a real instance and check against
`minlplib.solu` — ran in **no lane at all**. #927's assertion is one of them.

Adds `python-correctness-nightly`: serial (same determinism argument as
`python-correctness`), `--timeout=900` (these tests pass real `time_limit=`
budgets to the solver — ex1252 uses 200 s — so a per-test timeout under the
budget would fail the harness instead of the assertion), `-v` + unbuffered so a
multi-hour job can be distinguished from a hung one (CLAUDE.md §10), 06:20 UTC.

`changes` now returns `code=false` on a `schedule` event, so the new trigger runs
only this lane rather than re-running the whole PR matrix nightly.

## 2. The weekly graduation gate had been exiting 2 before gating anything

```
# ERROR: unknown flag(s): ['node_reduce']; choices: ['all', 'lift_loose_products', ...]
##[error]Process completed with exit code 2.
```

The workflow passed a hardcoded `--flags root_fixpoint,node_reduce,psd_cost_gate,…`.
`node_reduce` was deprecated out of `GRADUATION_ARMS` in #581. Every scheduled
run since **2026-07-13** died on argument validation — four consecutive Mondays
in which the cert-neutrality regression guard proved nothing, while reporting as
a run that happened.

Fix: drop `--flags` entirely. The script's default is
`",".join(generality_sweep.GRADUATION_ARMS)`, so the gated set now *tracks* the
registry instead of being a copy that drifts. Verified both directions:

```
GRADUATION_ARMS = ('root_fixpoint', 'psd_cost_gate', 'lift_zero_spanning',
                   'lift_loose_products', 'lu_density_route',
                   'node_numerical_dual_bound', 'root_build_deadline')
unknown under the new (default) invocation: []
unknown under the OLD hardcoded list:       ['node_reduce']
CHECKS_EXECUTED=2  OK
```

Note the gated set goes 5 → 7 arms: the stale copy had also silently dropped
`lu_density_route`, and never picked up `node_numerical_dual_bound` (#517/#362)
or `root_build_deadline` (#832/#814). `timeout-minutes` 45 → 90 accordingly.

The workflow also gains a `pull_request` trigger on its own paths, so an edit to
the gate or the registry it reads is validated by the PR that makes it rather
than a week later by a cron nobody reads. **That trigger fires on this PR**, so
the gate itself is the check on this fix.

## 3. AMP integration: red on every push to main since 2026-07-27

40+ consecutive failures, no tracking issue, one test:
`test_amp_time_limit_with_incumbent_returns_feasible`, `assert 'time_limit' == 'feasible'`.

**The contract is intact. The test was the broken part.** It drove the timeout by
*read ordinal* — `chain([0.0, 0.0], repeat(1.5))`, commented "the first two reads
land before the deadline … so the timeout path triggers regardless of how many
clock samples solve_amp takes". That premise is false, and
`monkeypatch.setattr(amp_mod.time, "perf_counter", …)` is why: it replaces
`perf_counter` on the **global** `time` module, so every clock read under the
call draws from the sequence, not just AMP's own. Traced:

```
  read  4  1.5 (past deadline)   nonlinear_bound_tightening.py:2910 in _out_of_budget()
  read  6  1.5 (past deadline)   nonlinear_bound_tightening.py:221  in _iter_rows_until()
  …                              (~26 reads in NBT budget polling)
  read 30  1.5 (past deadline)   amp.py:2866 in _solve_amp_impl()
  read 31  1.5 (past deadline)   amp.py:3353 in _solve_amp_impl()
READS_EXECUTED=31
status='time_limit' objective=None
```

The pre-deadline values were consumed before the main loop ever read the clock,
so the deadline blew before any incumbent was stored and `solve_amp` exited
through the "no feasible solution found" arm. The assertion then described a path
the test no longer executed — and its failure message pointed at the solver.

Independent check that the contract holds, driving the timeout by **state**
(pre-deadline until `_solve_best_nlp_candidate` has returned an incumbent, past
the deadline after — which is what "timed out after finding an incumbent" means,
and is immune to read counts):

```
INCUMBENT_CALLBACKS_EXECUTED=1
status='feasible' objective=10.0 gap_certified=False x_is_none=False
```

The test now uses that wiring, and asserts `calls["n"] == 1` first, so it cannot
pass while measuring nothing (CLAUDE.md §6). Injection-tested: restoring the old
read-ordinal wiring makes it fail with

```
E  AssertionError: the incumbent callback never fired, so the timeout did not
   land *after* an incumbent and this test measured nothing
E  assert 0 == 1
```

— i.e. it now names the defect instead of implicating the solver.

## Failure routing

All three scheduled/main lanes gained a `report-failure` job that files, or
comments on, one open `ci-signal`-labelled issue. Each of the failures above
persisted for weeks; none of them reached anyone. Flagging in case you'd rather
not have the bot open issues — it's a self-contained job per workflow and easy to
drop.

## Verification

- `test_amp_time_limit_with_incumbent_returns_feasible`: **1 passed** (fails
  before the change with `assert 'time_limit' == 'feasible'`; fails under
  injection with the measured-nothing message).
- All 6 workflow files parse; `WORKFLOWS_PARSED=6`.
- Graduation-gate default flag set validates (above); the gate itself runs on
  this PR via the new trigger.
- `ruff check` / `ruff format --check` clean on the edited test.
- Full `slow`+`correctness` set running locally to size the new lane — result
  reported in a follow-up comment.

Contributes to #927 (adds the lane that will hold its regression test).
