### PR TITLE
fix(correctness): #927 an undecided node LP is not a proof of emptiness

### DIFF
--- a/crates/discopt-core/src/bnb/spatial_tree.rs
+++ b/crates/discopt-core/src/bnb/spatial_tree.rs
@@ -55,6 +55,36 @@ impl Ord for QNode {
     }
 }
 
+/// What a node LP's terminal status licenses the tree to conclude about the region
+/// the node covers.
+///
+/// #927: this mapping is the soundness hinge of the whole search. Only a
+/// Farkas-certified [`LpStatus::Infeasible`] proves a region is empty; every other
+/// non-optimal status is the LP declining to decide, and pruning on it fabricates
+/// an emptiness proof the solver never had. The `match` is exhaustive on purpose —
+/// a new `LpStatus` variant must make an explicit choice here rather than silently
+/// inheriting "prune it".
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum NodeVerdict {
+    /// The LP solved: its safe bound is a valid lower bound for the region.
+    Bound,
+    /// The region is PROVEN empty (certified infeasible) — it contributes nothing.
+    EmptyRegion,
+    /// The LP decided nothing. The region may well contain the optimum, so it must
+    /// be branched (or closed with its inherited bound), never pruned.
+    Undecided,
+}
+
+fn verdict_for(status: LpStatus) -> NodeVerdict {
+    match status {
+        LpStatus::Optimal => NodeVerdict::Bound,
+        // `Infeasible` is returned only after the simplex verifies a Farkas dual
+        // ray (see `lp::simplex`), so it is a proof.
+        LpStatus::Infeasible => NodeVerdict::EmptyRegion,
+        LpStatus::Unbounded | LpStatus::IterLimit | LpStatus::Numerical => NodeVerdict::Undecided,
+    }
+}
+
 /// Termination status of the tree solve.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum TreeStatus {
@@ -171,6 +201,12 @@ pub struct SpatialTreeResult {
     /// subtree of them freezes the frontier — the diagnostic for a bound plateau
     /// caused by certification failure rather than relaxation looseness.
     pub n_uncertified: usize,
+    /// #927: nodes whose LP came back with a status that DECIDES NOTHING
+    /// (`Numerical` / `IterLimit` / `Unbounded`). These are branched rather than
+    /// fathomed — a nonzero count means the search hit ill-conditioned node LPs and
+    /// paid for them in extra nodes, which is exactly the trade that keeps the
+    /// certificate honest. Reported so "the fallback fired" is observable.
+    pub n_undecided: usize,
     /// #917: seconds of the caller's withheld reserve this search actually reclaimed
     /// (0.0 when it never did). Reported so "the extension fired" is directly
     /// observable instead of inferred from a wall-clock reading — a panel that can
@@ -264,6 +300,7 @@ pub fn solve_spatial_tree(
     let mut node_count = 0usize;
     let mut n_lp_solves = 0usize;
     let mut n_uncertified = 0usize;
+    let mut n_undecided = 0usize;
 
     // Global lower bound = min, over every region that leaves the tree WITHOUT being
     // subdivided (pruned / infeasible / feasible-leaf / width-exhausted), of a valid
@@ -313,6 +350,7 @@ pub fn solve_spatial_tree(
                 node_count,
                 n_lp_solves,
                 n_uncertified,
+                n_undecided,
                 incumbent_extension_s: extension_s,
             };
         }
@@ -338,6 +376,7 @@ pub fn solve_spatial_tree(
                 node_count,
                 n_lp_solves,
                 n_uncertified,
+                n_undecided,
                 incumbent_extension_s: extension_s,
             };
         }
@@ -371,8 +410,47 @@ pub fn solve_spatial_tree(
             n_uncertified += 1;
         }
 
-        // Infeasible node: empty region, contributes +inf (nothing).
-        if node.status != LpStatus::Optimal {
+        let verdict = verdict_for(node.status);
+        if verdict != NodeVerdict::Bound {
+            // Certified-infeasible node: empty region, contributes +inf (nothing).
+            if verdict == NodeVerdict::EmptyRegion {
+                continue;
+            }
+            // #927: every OTHER non-Optimal status (`Numerical`, `IterLimit`,
+            // `Unbounded`) is the LP *failing to decide*, NOT a proof that the
+            // region is empty — and the simplex contract is explicit that an
+            // unproven verdict may "force a fallback, never an unsound fathom".
+            // Treating them as empty is a false emptiness proof: on ex1252 under
+            // `DISCOPT_INTEGER_MULTILINEAR_REFORM` + `DISCOPT_MULTILINEAR_COUPLING_RLT`
+            // the reformulation lifts x^3 of a variable near 2950, so the envelope
+            // rows carry magnitudes near 1e11 and the node LP on a tight box came
+            // back `Numerical`. The region it covered held the true optimum
+            // (128893.74); fathoming it produced a certified `optimal` at
+            // 216826.52 — a false certificate.
+            //
+            // An undecided LP is a reason to BRANCH, not to prune: the children
+            // are better conditioned (narrower boxes → smaller envelope
+            // coefficients) and each carries `parent_bound`, which is a valid lower
+            // bound for this region because the parent's region contains it. When
+            // no branchable column is left, the region closes with that same honest
+            // bound rather than with `+inf`.
+            n_undecided += 1;
+            let split = widest_original_col(spec, &lo, &hi, &root_w, config.min_box_width);
+            match split {
+                Some(j) => {
+                    let at = clamp_interior(0.5 * (lo[j] + hi[j]), lo[j], hi[j]);
+                    push_children(
+                        &mut heap,
+                        &lo,
+                        &hi,
+                        j,
+                        at,
+                        parent_bound,
+                        spec.integrality[j],
+                    );
+                }
+                None => global_lb_closed = global_lb_closed.min(parent_bound),
+            }
             continue;
         }
         // Rigorous safe lower bound for this region, inheriting the parent's bound as
@@ -479,17 +557,8 @@ pub fn solve_spatial_tree(
         // closed with its honest rigorous `bound` (surfaced as `Exhausted` if that
         // leaves the gap open — never silently upgraded to `Optimal`).
         let fallback = || -> Option<(usize, f64)> {
-            let mut best: Option<(f64, usize)> = None;
-            for j in 0..spec.n_orig {
-                let wj = hi[j] - lo[j];
-                if wj > config.min_box_width.max(1e-9) {
-                    let rw = wj / root_w[j];
-                    if best.map(|(bw, _)| rw > bw).unwrap_or(true) {
-                        best = Some((rw, j));
-                    }
-                }
-            }
-            best.map(|(_, j)| (j, clamp_interior(x[j], lo[j], hi[j])))
+            widest_original_col(spec, &lo, &hi, &root_w, config.min_box_width)
+                .map(|j| (j, clamp_interior(x[j], lo[j], hi[j])))
         };
         let pick = if let Some(j) = frac_int {
             Some((j, x[j].floor() + 0.5)) // integer branch: <= floor, >= ceil
@@ -506,45 +575,15 @@ pub fn solve_spatial_tree(
         };
 
         // Two covering children.
-        if spec.integrality[split_col] {
-            // integer: child1 x<=floor, child2 x>=ceil
-            let f = (split_at - 0.5).floor();
-            let lo1 = lo.clone();
-            let mut hi1 = hi.clone();
-            hi1[split_col] = f;
-            let mut lo2 = lo.clone();
-            let hi2 = hi.clone();
-            lo2[split_col] = f + 1.0;
-            if hi1[split_col] >= lo1[split_col] - 1e-12 {
-                heap.push(QNode {
-                    pb: bound,
-                    lo: lo1,
-                    hi: hi1,
-                });
-            }
-            if hi2[split_col] >= lo2[split_col] - 1e-12 {
-                heap.push(QNode {
-                    pb: bound,
-                    lo: lo2,
-                    hi: hi2,
-                });
-            }
-        } else {
-            let mut hi1 = hi.clone();
-            hi1[split_col] = split_at;
-            let mut lo2 = lo.clone();
-            lo2[split_col] = split_at;
-            heap.push(QNode {
-                pb: bound,
-                lo: lo.clone(),
-                hi: hi1,
-            });
-            heap.push(QNode {
-                pb: bound,
-                lo: lo2,
-                hi: hi.clone(),
-            });
-        }
+        push_children(
+            &mut heap,
+            &lo,
+            &hi,
+            split_col,
+            split_at,
+            bound,
+            spec.integrality[split_col],
+        );
     }
 
     // Worklist empty: every region was explored or fathomed. The reported bound is
@@ -570,6 +609,7 @@ pub fn solve_spatial_tree(
                 node_count,
                 n_lp_solves,
                 n_uncertified,
+                n_undecided,
                 incumbent_extension_s: extension_s,
             }
         }
@@ -581,8 +621,85 @@ pub fn solve_spatial_tree(
             node_count,
             n_lp_solves,
             n_uncertified,
+            n_undecided,
             incumbent_extension_s: extension_s,
         },
+    }
+}
+
+/// Widest ORIGINAL column relative to its root width, or `None` when every one is
+/// already at or below `min_box_width` (nothing left to branch on).
+fn widest_original_col(
+    spec: &SpatialKernelSpec,
+    lo: &[f64],
+    hi: &[f64],
+    root_w: &[f64],
+    min_box_width: f64,
+) -> Option<usize> {
+    let mut best: Option<(f64, usize)> = None;
+    for j in 0..spec.n_orig {
+        let wj = hi[j] - lo[j];
+        if wj > min_box_width.max(1e-9) {
+            let rw = wj / root_w[j];
+            if best.map(|(bw, _)| rw > bw).unwrap_or(true) {
+                best = Some((rw, j));
+            }
+        }
+    }
+    best.map(|(_, j)| j)
+}
+
+/// Push the two covering children of `[lo, hi]` split on `split_col` at `split_at`,
+/// each inheriting `pb` as its (valid) region lower bound. The two children cover
+/// the parent box exactly, so no feasible point is lost.
+#[allow(clippy::too_many_arguments)]
+fn push_children(
+    heap: &mut BinaryHeap<QNode>,
+    lo: &[f64],
+    hi: &[f64],
+    split_col: usize,
+    split_at: f64,
+    pb: f64,
+    is_int: bool,
+) {
+    if is_int {
+        // integer: child1 x<=floor, child2 x>=ceil
+        let f = (split_at - 0.5).floor();
+        let lo1 = lo.to_vec();
+        let mut hi1 = hi.to_vec();
+        hi1[split_col] = f;
+        let mut lo2 = lo.to_vec();
+        let hi2 = hi.to_vec();
+        lo2[split_col] = f + 1.0;
+        if hi1[split_col] >= lo1[split_col] - 1e-12 {
+            heap.push(QNode {
+                pb,
+                lo: lo1,
+                hi: hi1,
+            });
+        }
+        if hi2[split_col] >= lo2[split_col] - 1e-12 {
+            heap.push(QNode {
+                pb,
+                lo: lo2,
+                hi: hi2,
+            });
+        }
+    } else {
+        let mut hi1 = hi.to_vec();
+        hi1[split_col] = split_at;
+        let mut lo2 = lo.to_vec();
+        lo2[split_col] = split_at;
+        heap.push(QNode {
+            pb,
+            lo: lo.to_vec(),
+            hi: hi1,
+        });
+        heap.push(QNode {
+            pb,
+            lo: lo2,
+            hi: hi.to_vec(),
+        });
     }
 }
 
@@ -813,5 +930,39 @@ mod tests {
         assert_eq!(res.status, TreeStatus::TimeLimit);
         assert_eq!(res.node_count, 0);
         assert_eq!(res.bound, f64::NEG_INFINITY);
+    }
+
+    /// #927 regression: ONLY a certified `Infeasible` licenses the tree to treat a
+    /// region as empty.
+    ///
+    /// The false certificate on ex1252 (a certified `optimal` 216826.52 against a
+    /// true optimum of 128893.74, under `DISCOPT_INTEGER_MULTILINEAR_REFORM` +
+    /// `DISCOPT_MULTILINEAR_COUPLING_RLT`) came from exactly one line: the tree
+    /// fathomed on `status != Optimal`, and the node LP had returned `Numerical`.
+    /// That reformulation lifts `x^3` for an `x` near 2950, so the cubic's tangent
+    /// envelope rows carry coefficients near `3*2950^2 = 2.6e7` and right-hand sides
+    /// near `7.7e10` formed by a cancelling subtraction; at the box corner `x = ui`
+    /// the row and the auxiliary column's own upper bound `ui^3` are two different
+    /// roundings of the same number, leaving an absolute residual near 1e-5 that no
+    /// LP feasibility tolerance can absorb. The simplex said so honestly
+    /// (`Numerical`, not `Infeasible`) and was overruled.
+    ///
+    /// Pinning the mapping is what keeps that from coming back: a region is empty
+    /// only when something PROVED it empty.
+    #[test]
+    fn only_certified_infeasible_proves_a_region_empty() {
+        assert_eq!(verdict_for(LpStatus::Optimal), NodeVerdict::Bound);
+        assert_eq!(verdict_for(LpStatus::Infeasible), NodeVerdict::EmptyRegion);
+        for undecided in [
+            LpStatus::Numerical,
+            LpStatus::IterLimit,
+            LpStatus::Unbounded,
+        ] {
+            assert_eq!(
+                verdict_for(undecided),
+                NodeVerdict::Undecided,
+                "{undecided:?} is not a proof of emptiness and must not fathom"
+            );
+        }
     }
 }

--- a/crates/discopt-python/src/spatial_bindings.rs
+++ b/crates/discopt-python/src/spatial_bindings.rs
@@ -313,6 +313,7 @@ pub fn solve_spatial_tree_py<'py>(
     out.set_item("node_count", res.node_count)?;
     out.set_item("n_lp_solves", res.n_lp_solves)?;
     out.set_item("n_uncertified", res.n_uncertified)?;
+    out.set_item("n_undecided", res.n_undecided)?;
     // #917: seconds of the caller's withheld reserve the tree actually reclaimed.
     out.set_item("incumbent_extension_s", res.incumbent_extension_s)?;
     Ok(out)


### PR DESCRIPTION
Closes #927.

## The defect

`ex1252` under `DISCOPT_INTEGER_MULTILINEAR_REFORM=1` + `DISCOPT_MULTILINEAR_COUPLING_RLT=1`
returned a **certified** `optimal` at `216826.5179` against a true optimum of
`128893.74`. A false certificate — the failure mode CLAUDE.md §1 treats as a
full-stop regression.

## Root cause

The node LP was returning `LpStatus::Numerical` — the simplex honestly reporting
that it could not solve that LP reliably — and the spatial tree discarded the
region anyway:

```rust
if node.status != LpStatus::Optimal { continue; }
```

`continue` here means *this region is empty, nothing in it can beat the incumbent*.
That is only true for a **Farkas-certified** `Infeasible`. For `Numerical`,
`IterLimit`, and `Unbounded` the LP has declined to decide, and pruning on it
fabricates an emptiness proof the solver never had. On `ex1252` the region pruned
this way was the one containing the true optimum.

Confirmed directly, not inferred: a temporary `eprintln!` behind
`DISCOPT_DEBUG_NODE_STATUS` printed `[node-status] fathomed as empty with status Numerical`.

The `LpSolve` doc contract already states this rule — that an unproven verdict must
*"force a fallback, never an unsound fathom"* — and `convex_kernel.rs:1431` already
implements it (`if r.status != LpStatus::Infeasible { uncertified_drop = true; }`,
commented "A PROVEN-infeasible node is a legitimate fathom … Unbounded / numerical /
iteration-limit is NOT"). The spatial tree was the one place that did not.

## The fix

Separate *proof* from *failure to decide*, as an explicit exhaustive mapping so a
future `LpStatus` variant cannot silently inherit "prune it":

```rust
fn verdict_for(status: LpStatus) -> NodeVerdict {
    match status {
        LpStatus::Optimal    => NodeVerdict::Bound,
        LpStatus::Infeasible => NodeVerdict::EmptyRegion,
        LpStatus::Unbounded | LpStatus::IterLimit | LpStatus::Numerical => NodeVerdict::Undecided,
    }
}
```

`EmptyRegion` fathoms as before. `Undecided` **branches** the node on its widest
original column, carrying the (valid) inherited `parent_bound`; when no branchable
column remains the node closes against that honest bound. Termination is preserved
— an undecided node either shrinks or closes — and the bound it contributes is one
the solver actually proved.

`SpatialTreeResult` gains `n_undecided`, exposed through the Python bindings, so the
rate of undecided node LPs is observable rather than invisible. It is the natural
net-positive metric for #956.

## Class-level audit

Per CLAUDE.md §2 this was fixed as a class, not an instance. Every `!= LpStatus::Optimal`
site outside `lp/` was checked: `convex_kernel.rs:1431` already draws this exact
distinction; `convex_kernel.rs:580` returns a sound sentinel; `milp_driver.rs:490` is a
cut-loop `break`, not a fathom; `convex_kernel.rs:2107` is a W2 A/B probe;
`convex_kernel.rs:1884` returns `None` from a dive. The spatial tree was the sole gap.
No instance-keyed special case was added.

## Verification

* `python/tests/test_integer_multilinear_reform.py::test_ex1252_multilinear_reform_sound_and_lifts_bound`
  — **1 passed in 200.53s**. Fails before this commit (bound `216826.52` > optimum
  `128893.74`), passes after. Requires `-m slow`.
* Full solve, both arms, 200 s (`ARMS_EXECUTED=2` asserted so the probe cannot
  silently measure nothing):

  | arm | status | objective | bound | nodes | sound |
  |---|---|---|---|---|---|
  | reform+RLT (the #927 configuration) | `time_limit` | – | 20520.45 | 30338 | ✅ |
  | no flags (control) | `feasible` | 134263.59 | 100509.01 | 607 | ✅ |

  The #927 configuration is now honest-but-weak where it was previously a false
  certified `optimal`. On the propagated box alone the fix reaches
  `bound = 128893.7408` against the true optimum `128893.7409` — tight and below it.
* `cargo test -p discopt-core` — **584 passed, 0 failed**. Clippy clean on the touched
  file; `cargo fmt` via pre-commit.
* New unit test `only_certified_infeasible_proves_a_region_empty` pins the mapping.
  An earlier synthetic reproducer was **discarded because it passed with and without
  the fix** (diagnostic: `status=Optimal … undecided=0` — the spec never triggered
  `Numerical`). Per CLAUDE.md §6 a test that cannot fail is not a test.
* `pytest -m smoke` and `pytest -m slow python/tests/test_adversarial_recent_fixes.py`
  — to be reported in a comment; deliberately not run yet, because they would load the
  machine while the differential panel below is measuring (CLAUDE.md §9).
* Differential panel over the 81 in-repo `python/tests/data/minlplib` instances,
  baseline (`8bfce1f1`) vs fix, interleaved-arm CSV — **in flight, posted as a comment
  when complete.** Criteria: instances with `n_undecided == 0` must be exactly
  unchanged (status, nodes, objective, bound — bound-neutral regime, CLAUDE.md §5);
  instances with `n_undecided > 0` are where the fix bites and are checked for
  soundness against `minlplib.solu`. Instances that hit the time limit in either arm
  are compared for soundness only, since their node counts are wall-clock dependent
  and not a bound-neutrality signal.

## Scope explicitly NOT in this PR

The conditioning defect that *produces* the undecided LPs — McCormick envelope rows
built by cancellation at magnitude ~1e11 that cut off the exactly-feasible point
`(ui, ui³)`, confirmed independently by HiGHS — is filed as **#956**. It is
bound-changing across every relaxation in the solver and needs its own corpus-wide
differential panel under CLAUDE.md §5; conflating it with a soundness fix would make
neither reviewable. #957 covers a separate denormal issue found on the way.

This PR makes the search sound. #956 makes it fast again.
