### PR TITLE
fix(correctness): #954 verify the NLP-BB incumbent against every declared row and bound

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -189,6 +189,47 @@ The release procedure that produces these entries is documented in
 
 ### Fixed
 
+- **The NLP-BB incumbent is verified against every declared row and bound before
+  it is returned** (`fix`, #954). `_solve_nlp_bb` was the last of the five solve
+  exit paths with nothing checking the point it returns (#779/#789 closed
+  `solve_model` and `_try_native_spatial_kernel`; #952 closed `_solve_milp_bb` and
+  `_solve_miqp_bb`). Its exit was the same three steps those two had — snap the
+  integers, unpack, return — with no verification of the point whose objective is
+  reported as `objective` and, on `optimal`, as the dual `bound` too.
+
+  Two things kept this from being "apply the #952 gate here". Its rows are
+  nonlinear, so the arbiter cannot be `_matrix_solution_feasible`; the new
+  `_nonlinear_point_excess` applies the repo's nonlinear convention instead
+  (`viol <= tol + rtol*term_scale` at `abs=1e-6`, `rtol=1e-9` — the same test
+  `_jax.primal_heuristics._check_constraint_feasibility` applies whenever a primal
+  heuristic accepts an incumbent), and returns the excess it measured so the
+  refusal names a magnitude and the reported number cannot drift from the decision.
+  And the terminal refine re-solve can *replace* the reported point after every
+  gate the search ran, so the check is the last thing before the return. The rows
+  judged are the ones the model declares — root cuts (#781) are appended to the
+  model before the evaluator is compiled and are excluded — and the box is the
+  declared one, captured before FBBT overwrites it.
+
+  The rounding guard at this call site (#954 item 3) ran at
+  `_round_incumbent_integers`'s default `feas_tol=1e-4`, 100x the declared
+  `abs=1e-6`. It now takes the exit's own arbiter, so a snap can no longer be
+  admitted at 1e-4 and then refused by the exit at 1e-6; a rejected snap keeps the
+  unrounded incumbent, which is C-3's documented fallback.
+
+  Entry experiment before the gate was written (CLAUDE.md §4), over a 106-item
+  panel — a 40-seed convex-MINLP family plus every in-repo `minlplib_nl` instance
+  driven through this path with `nlp_bb=True`: 100 entered `_solve_nlp_bb`, 69
+  returned a point, 2638 comparisons; worst raw violation 9.36e-11 (`tls2`), worst
+  tolerance that would be needed to admit any returned point 3.93e-14, and **0**
+  instances a 1e-6 gate would newly refuse. As with #952 this was never a live
+  false certificate — the defect is that nothing bounded the excursion, whose size
+  was set by whatever the NLP backend converged to, and the exit would equally
+  have returned 1e-2. Bound-neutral per CLAUDE.md §5: the gated arm reproduces the
+  baseline's `node_count`, `objective`, status and `gap_certified` on every
+  self-terminating instance; the 7 apparent drifts in the contended panel run were
+  all on wall-truncated (`gap_certified=False`) searches and vanished on
+  uncontended reruns of both arms.
+
 - **Three CI signals that had stopped signalling** (`ci`). An audit of why #927
   (an unsound `ex1252` dual bound, asserted by a test in the tree) could sit open
   found that the lanes meant to catch it were all dark:

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -2231,6 +2231,132 @@ def _check_constraint_feasibility(evaluator, x, cl_list, cu_list, tol=1e-4):
     return max_viol <= tol
 
 
+# The absolute tolerance the NLP-BB exit gate (#954) holds a returned incumbent
+# to: the repo's declared ``abs=1e-6`` (CLAUDE.md "Key Constraints"), the same
+# figure ``_matrix_solution_feasible`` enforces on the matrix paths (#952) and
+# ``_jax.primal_heuristics._check_constraint_feasibility`` enforces when a primal
+# heuristic accepts an incumbent. Deliberately NOT the 1e-4 that this module's
+# local ``_check_constraint_feasibility`` defaults to; see the gate's call site.
+_NLPBB_EXIT_ABS_TOL = 1e-6
+# Term-magnitude forgiveness, identical to the two arbiters above: a row built
+# from terms of size ~1e5 carries ~1e-6 of pure cancellation noise, so an
+# absolute-only test at 1e-6 rejects genuinely optimal points (the prob07 lesson
+# recorded in ``primal_heuristics._check_constraint_feasibility``). Kept extremely
+# tight so only noise proportional to the row's own terms is forgiven.
+_NLPBB_EXIT_RTOL = 1e-9
+
+
+def _nonlinear_point_excess(
+    evaluator,
+    x,
+    cl_list,
+    cu_list,
+    n_rows=None,
+    box=None,
+    tol=_NLPBB_EXIT_ABS_TOL,
+    rtol=_NLPBB_EXIT_RTOL,
+):
+    """How far ``x`` sits outside nonlinear rows + a box, net of term-scaled noise.
+
+    The nonlinear counterpart of :func:`_matrix_solution_feasible` /
+    :func:`_matrix_solution_violations`, and deliberately ONE function rather than
+    an arbiter plus a separate reporter: the decision and the reported magnitude
+    come from the same number, so they cannot drift out of agreement (#952 kept
+    them apart by giving the reporter no tolerance at all; here the reporter *is*
+    the arbiter's own quantity).
+
+    Returns ``(excess, where, n_compared)``:
+
+    * ``excess`` — ``max(viol_i - rtol*scale_i)`` over the checked rows and box
+      entries, where ``scale_i = sum_j |J_ij| |x_j|`` is the row's additive-term
+      magnitude (from the Jacobian, never from the possibly-``1e20`` bound
+      sentinels) and ``|x_i|`` for a box entry. The point is feasible at absolute
+      tolerance ``tol`` exactly when ``excess <= tol``. When the raw violation
+      already clears ``tol`` the Jacobian is not evaluated and the raw maximum is
+      returned instead — an upper bound on the excess, and exact whenever the
+      returned value exceeds ``tol``, which is the only regime a caller acts on.
+    * ``where`` — which row or variable carried the maximum, for the message.
+    * ``n_compared`` — executed comparisons (CLAUDE.md §6), so a caller can prove
+      the check looked at something rather than short-circuiting on empty inputs.
+
+    ``n_rows`` limits the check to the FIRST ``n_rows`` evaluator rows. The NLP-BB
+    path appends root cuts (#781) to the model before compiling the evaluator;
+    those rows are valid for integer-feasible points but deliberately tight, and
+    they are not rows the user declared, so a gate must not judge a returned point
+    by them.
+    """
+    x = np.asarray(x, dtype=np.float64)
+    excess = -np.inf
+    where = "nothing checked"
+    n_compared = 0
+
+    if not np.all(np.isfinite(x)):
+        bad = int(np.argmax(~np.isfinite(x)))
+        return np.inf, f"x[{bad}] is not finite", int(x.size)
+
+    n = 0
+    viol = np.zeros(0, dtype=np.float64)
+    if cl_list is not None and len(cl_list) and getattr(evaluator, "n_constraints", 0):
+        cl = np.asarray(cl_list, dtype=np.float64)
+        cu = np.asarray(cu_list, dtype=np.float64)
+        g = np.asarray(evaluator.evaluate_constraints(x), dtype=np.float64)
+        n = min(len(g), len(cl))
+        if n_rows is not None:
+            n = min(n, int(n_rows))
+        if n > 0:
+            viol = np.maximum(np.maximum(cl[:n] - g[:n], g[:n] - cu[:n]), 0.0)
+            n_compared += 2 * n
+            excess = max(excess, float(viol.max()))
+            where = f"constraint row {int(viol.argmax())}"
+
+    box_viol = np.zeros(0, dtype=np.float64)
+    if box is not None:
+        box_arr = np.asarray(box, dtype=np.float64)
+        if box_arr.size:
+            k = min(x.shape[0], box_arr.shape[0])
+            box_viol = np.maximum(np.maximum(box_arr[:k, 0] - x[:k], x[:k] - box_arr[:k, 1]), 0.0)
+            n_compared += 2 * k
+            if k and float(box_viol.max()) > excess:
+                excess = float(box_viol.max())
+                where = f"bound on x[{int(box_viol.argmax())}]"
+
+    if excess == -np.inf:
+        return 0.0, "nothing checked", n_compared
+    if excess <= tol:
+        # Cheap path: the raw violation already clears the tolerance, so the
+        # term-scaled forgiveness cannot change the verdict. Skips the Jacobian.
+        return float(excess), where, n_compared
+
+    # Some block exceeds the absolute tolerance: net out the term-scaled noise
+    # before deciding, exactly as the two sibling arbiters do.
+    excess = -np.inf
+    where = "nothing checked"
+    if n > 0:
+        try:
+            jac = np.asarray(evaluator.evaluate_jacobian(x), dtype=np.float64)
+            # ``np.asarray`` on a sparse matrix silently yields a 0-d object array
+            # (CLAUDE.md "Key Constraints"), which would feed garbage into the
+            # scale. ``evaluate_jacobian`` documents a dense (m, n) return; verify
+            # it rather than trust it, and fall back to the strict path if not.
+            if jac.ndim != 2 or jac.shape[0] < n:
+                raise TypeError(f"expected a dense (m, n) Jacobian, got shape {jac.shape}")
+            scale = np.asarray(np.abs(jac[:n]) @ np.abs(x), dtype=np.float64).ravel()[:n]
+        except Exception as exc:
+            # An unevaluable Jacobian is not a licence to forgive: fall back to
+            # the raw (stricter) violation rather than silently passing a point.
+            logger.debug("#954 gate: Jacobian unavailable, using raw residuals: %s", exc)
+            scale = np.zeros(n, dtype=np.float64)
+        net = viol - rtol * scale
+        excess = float(net.max())
+        where = f"constraint row {int(net.argmax())}"
+    if box_viol.size:
+        net_box = box_viol - rtol * np.abs(x[: box_viol.size])
+        if float(net_box.max()) > excess:
+            excess = float(net_box.max())
+            where = f"bound on x[{int(net_box.argmax())}]"
+    return float(excess), where, n_compared
+
+
 def _is_integer_feasible_solution(x, int_offsets, int_sizes, tol=1e-5):
     """Return True if all discrete variables are integral within tolerance."""
     for off, sz in zip(int_offsets, int_sizes):
@@ -12870,6 +12996,15 @@ def _solve_nlp_bb(
 
     # --- Extract variable info and create tree ---
     n_vars, lb, ub, int_offsets, int_sizes = _extract_variable_info(model)
+    # #954: the exit gate below verifies the returned incumbent against the box
+    # the *model* declares, captured here before FBBT overwrites ``lb``/``ub``.
+    # FBBT bounds are derived, so checking against them would let a wrong
+    # inference manufacture a refusal on a point genuinely feasible for the model
+    # as written (the same reasoning as the #952 gates on the matrix paths).
+    _declared_box = np.stack([lb.copy(), ub.copy()], axis=1)
+    # ... and against the rows the model declares, counted here so the root-cut
+    # stage below (#781) cannot smuggle its appended cut rows into the gate.
+    _declared_ncons = sum(1 for _c in model._constraints if isinstance(_c, Constraint))
 
     # --- Root presolve: FBBT + integer-bound rounding before tree creation ---
     t_rust_start = time.perf_counter()
@@ -12991,6 +13126,18 @@ def _solve_nlp_bb(
     # --- Infer constraint bounds ---
     cl_list, cu_list = _infer_constraint_bounds(model, evaluator)
     constraint_bounds = list(zip(cl_list, cu_list)) if cl_list else None
+
+    # #954: how many evaluator rows the DECLARED constraints occupy. Rows follow
+    # constraint order (``_infer_constraint_bounds``) and the root-cut stage
+    # appends its cuts last, so the declared rows are the leading block. Summed
+    # from the evaluator's own per-constraint flat sizes rather than assumed
+    # 1-row-per-constraint, because a vector-valued body (DAE collocation
+    # residuals) contributes many rows.
+    _declared_rows = len(cl_list)
+    _flat_sizes = getattr(evaluator, "_constraint_flat_sizes", None)
+    if _flat_sizes is not None and len(_flat_sizes) >= _declared_ncons:
+        _declared_rows = int(np.sum(np.asarray(_flat_sizes)[:_declared_ncons]))
+    _declared_rows = max(0, min(_declared_rows, len(cl_list)))
 
     opts: dict = {}
     opts.setdefault("print_level", 0)
@@ -13835,11 +13982,42 @@ def _solve_nlp_bb(
         # C-3: snap near-integral discrete coordinates to exact integers before
         # reporting; the dual-recovery re-solve below is best-effort and does
         # not guarantee the reported primal is rounded (see helper docstring).
-        _rounded_inc, _rounded_feas = _round_incumbent_integers(
-            sol_flat, int_offsets, int_sizes, evaluator, cl_list, cu_list
-        )
-        if _rounded_feas:
+        #
+        # #954 item 3 — the helper's ``feas_tol`` at this call site. It used to run
+        # at the helper default ``1e-4``, 100x the declared ``abs=1e-6``, which is
+        # not a tolerance this path can justify now that the exit below refuses at
+        # 1e-6: a rounding accepted at 1e-4 and rejected by the exit would turn a
+        # solve that had a perfectly good unrounded point into a crash. So the
+        # acceptance decision is taken with the SAME arbiter the exit uses — one
+        # test, so the guard cannot admit what the gate refuses — and the helper is
+        # called in snap-only mode. Its own ``feasible`` flag is deliberately not
+        # consulted here (it would be a second, looser opinion of the same
+        # question); it stays for the call sites that have no exit arbiter.
+        _rounded_inc, _ = _round_incumbent_integers(sol_flat, int_offsets, int_sizes)
+        if np.array_equal(_rounded_inc, sol_flat):
+            # Nothing was snapped: there is no acceptance decision to take, and
+            # re-judging the unchanged point here would only pre-empt the exit
+            # gate below with a confusing "snap rejected" message.
             sol_flat = _rounded_inc
+        else:
+            _round_excess, _, _round_cmp = _nonlinear_point_excess(
+                evaluator,
+                _rounded_inc,
+                cl_list,
+                cu_list,
+                n_rows=_declared_rows,
+                box=_declared_box,
+            )
+            if _round_excess <= _NLPBB_EXIT_ABS_TOL:
+                sol_flat = _rounded_inc
+            else:
+                logger.debug(
+                    "NLP-BB: integer snap rejected (excess %.3e > %.0e over %d comparisons); "
+                    "reporting the unrounded incumbent (C-3).",
+                    _round_excess,
+                    _NLPBB_EXIT_ABS_TOL,
+                    _round_cmp,
+                )
         x_dict = _unpack_solution(model, sol_flat)
 
         # Refine the incumbent's continuous variables, then recover relaxation
@@ -13938,6 +14116,45 @@ def _solve_nlp_bb(
                 # of a deliberately relaxed box (see the two-solve note above).
         except Exception as _exc:
             logger.debug("NLP-BB dual recovery failed: %s", _exc)
+
+        # --- #954: exit gate ---
+        # The last of the five solve exit paths with no verification of the point
+        # it returns. Its exit was the same three steps the MILP/MIQP paths had
+        # before #952 — snap, unpack, return — with nothing checking the point
+        # whose objective is reported as ``objective`` and, on ``optimal``, as the
+        # dual ``bound`` too. The search's own acceptance gates run at the local
+        # ``_check_constraint_feasibility`` default of 1e-4, and the terminal
+        # refine re-solve above can REPLACE the point after every one of them, so
+        # this is placed last: it judges the vector that actually leaves.
+        #
+        # This path's rows are nonlinear, so the arbiter is the nonlinear
+        # convention (``viol <= tol + rtol*term_scale``) rather than #952's
+        # ``_matrix_solution_feasible`` — same 1e-6 absolute tolerance, same 1e-9
+        # relative forgiveness as ``primal_heuristics._check_constraint_feasibility``,
+        # which is what every primal heuristic here already holds an incumbent to.
+        # Judged against the DECLARED rows (root cuts excluded, ``_declared_rows``)
+        # and the DECLARED box (captured pre-FBBT), so neither a derived bound nor
+        # an appended cut can manufacture a refusal.
+        #
+        # Refusal, not repair or a quiet downgrade (CLAUDE.md §3): a point outside
+        # the declared feasible set has no honest status here — reporting it as
+        # ``feasible`` would still publish its objective, and on this path that
+        # same number is also the dual bound.
+        _exit_excess, _exit_where, _exit_cmp = _nonlinear_point_excess(
+            evaluator,
+            sol_flat,
+            cl_list,
+            cu_list,
+            n_rows=_declared_rows,
+            box=_declared_box,
+        )
+        if _exit_excess > _NLPBB_EXIT_ABS_TOL:
+            raise RuntimeError(
+                "NLP-BB returned an infeasible point labeled feasible/optimal: "
+                f"{_exit_where} violated by {_exit_excess:.6e} beyond the "
+                f"term-scaled tolerance (declared abs tol {_NLPBB_EXIT_ABS_TOL:.0e}, "
+                f"{_exit_cmp} comparisons over {_declared_rows} declared rows)"
+            )
 
         assert model._objective is not None
         if model._objective.sense == ObjectiveSense.MAXIMIZE:

--- a/python/tests/test_954_nlpbb_incumbent_feasibility.py
+++ b/python/tests/test_954_nlpbb_incumbent_feasibility.py
@@ -1,0 +1,370 @@
+"""Issue #954: the NLP-BB path must verify the incumbent it returns.
+
+Background
+----------
+``_solve_nlp_bb`` was the last of the five solve exit paths with no verification
+of the point it returns (#952 closed ``_solve_miqp_bb`` and ``_solve_milp_bb``;
+``solve_model`` and ``_try_native_spatial_kernel`` were closed by #779/#789). Its
+exit was the same three steps those two had — snap the integers, unpack, return —
+with nothing checking the point whose objective is reported as ``objective`` and,
+on ``optimal``, as the dual ``bound`` too.
+
+Two things separate this path from #952's:
+
+* its rows are nonlinear, so the arbiter cannot be ``_matrix_solution_feasible``.
+  The gate uses the repo's nonlinear convention instead — ``viol <= tol +
+  rtol*term_scale``, ``tol=1e-6``, ``rtol=1e-9`` — the same one
+  ``_jax.primal_heuristics._check_constraint_feasibility`` applies whenever a
+  primal heuristic accepts an incumbent.
+* the terminal refine re-solve can REPLACE the reported point after every gate
+  the search ran, so the check has to be the last thing before the return.
+
+Entry experiment (CLAUDE.md §4), run before the gate was written, over a 106-item
+panel — the 40-seed family below plus every in-repo ``minlplib_nl`` instance,
+driven through this path with ``nlp_bb=True`` because the in-repo corpus is mostly
+nonconvex and would otherwise dispatch elsewhere. 100 entered ``_solve_nlp_bb``,
+69 returned a point, 2638 comparisons against the declared rows and bounds::
+
+    worst raw violation = 9.36e-11  (tls2, row 16)
+    worst tolerance that would be needed to admit any returned point = 3.93e-14
+    instances a 1e-6 gate would newly refuse = 0
+
+So there was no live false primal, and the gate this adds refuses nothing that
+was being returned — four orders of headroom. The defect is that nothing bounded
+the excursion: its size was set by whatever the NLP backend converged to, and the
+exit would equally have returned 1e-2.
+
+What is pinned here
+-------------------
+1. :func:`test_returned_incumbent_is_within_declared_tolerance` — the standing
+   watch, measured independently of the solver's own helpers, with an
+   executed-comparison count (CLAUDE.md §6).
+2. :func:`test_exit_gate_refuses_an_off_row_incumbent` — the gate FIRES. Fails
+   before the change (the point came back as ``optimal``).
+3. :func:`test_baseline_solve_is_unaffected` — its control: the same model with
+   the same refine failure returns normally when the incumbent is not perturbed.
+4. :func:`test_snap_acceptance_uses_the_exit_arbiter` — #954 item 3: the integer
+   snap at this call site is accepted by the exit's own arbiter, not by the
+   helper default ``feas_tol=1e-4`` (100x the declared ``abs=1e-6``), so the guard
+   can no longer admit a rounding that the exit then refuses.
+5. :func:`test_gate_judges_declared_rows_only` — an appended root cut (#781) is
+   not a declared row and must not be able to manufacture a refusal.
+6. :func:`test_arbiter_agrees_with_the_authoritative_nonlinear_check` — parity
+   with ``primal_heuristics._check_constraint_feasibility`` so the new arbiter
+   cannot drift away from the repo's existing one.
+"""
+
+import discopt.modeling as dm
+import numpy as np
+import pytest
+from discopt import solver as S
+
+# The repo's declared absolute feasibility tolerance (CLAUDE.md "Key
+# Constraints"); the gate is held to this, not to the helper's legacy 1e-4.
+DECLARED_ABS_TOL = 1e-6
+
+
+def _panel_model(seed: int) -> dm.Model:
+    """A genuinely nonlinear convex MINLP — the dispatch routes it to NLP-BB.
+
+    ``min Σ exp(0.4 xⱼ) + Σ cᵢyᵢ`` s.t. ``Σ log(1+xⱼ) >= tgt`` (a concave ``>=``
+    row, so the feasible set is convex), ``xⱼ <= 4 y_{j mod 2}``, ``y`` binary,
+    ``x ∈ [0,4]³``. The log row is active at every optimum, which is what makes an
+    excursion off it observable.
+    """
+    rng = np.random.default_rng(1000 + seed)
+    m = dm.Model(f"nlp954_{seed}")
+    y = m.binary("y", shape=(2,))
+    x = m.continuous("x", shape=(3,), lb=0.0, ub=4.0)
+    c = rng.uniform(1.0, 3.0, 2)
+    tgt = rng.uniform(0.8, 2.2)
+    m.minimize(
+        sum(dm.exp(0.4 * x[j]) for j in range(3)) + sum(float(c[i]) * y[i] for i in range(2))
+    )
+    m.subject_to(sum(dm.log(1.0 + x[j]) for j in range(3)) >= tgt)
+    for j in range(3):
+        m.subject_to(x[j] <= 4 * y[j % 2])
+    return m
+
+
+def _worst_violation(model: dm.Model, x_dict: dict) -> tuple[float, int]:
+    """Max violation of the returned point over every declared row AND bound.
+
+    Measured through ``NLPEvaluator.evaluate_constraints`` against the model as
+    declared — deliberately not through the solver's own helpers, so this test
+    cannot inherit the defect it checks for. Returns ``(worst, n_compared)``;
+    ``n_compared`` is the executed-comparison count (CLAUDE.md §6).
+    """
+    from discopt._jax.nlp_evaluator import NLPEvaluator
+
+    x = np.concatenate(
+        [np.asarray(x_dict[v.name], dtype=np.float64).ravel() for v in model._variables]
+    )
+    ev = NLPEvaluator(model)
+    cl, cu = (np.asarray(b, dtype=np.float64) for b in S._infer_constraint_bounds(model, ev))
+    g = np.asarray(ev.evaluate_constraints(x), dtype=np.float64)
+    n = min(len(g), len(cl))
+    assert n > 0, "no constraint rows evaluated: this probe would measure nothing"
+    lo, hi = (np.asarray(b, dtype=np.float64) for b in ev.variable_bounds)
+    viols = np.concatenate([g[:n] - cu[:n], cl[:n] - g[:n], x - hi, lo - x])
+    return float(np.max(viols)), int(2 * n + 2 * len(x))
+
+
+@pytest.mark.correctness
+@pytest.mark.slow
+def test_returned_incumbent_is_within_declared_tolerance():
+    """The standing watch: no NLP-BB incumbent leaves outside a declared row/bound.
+
+    This passed before the fix too — the measured excursions are ~1e-15 — because
+    the point was never to catch a live false certificate but to bound something
+    nothing bounded. :func:`test_exit_gate_refuses_an_off_row_incumbent` is the
+    one that fails without the gate.
+    """
+    seeds = 12
+    compared = 0
+    checks = 0
+    worst = (-np.inf, -1)
+
+    for seed in range(seeds):
+        m = _panel_model(seed)
+        r = m.solve(time_limit=60)
+        assert r.status == "optimal", f"seed {seed}: status {r.status}, panel assumes optimal"
+        assert r.nlp_bb, f"seed {seed} did not dispatch to NLP-BB; this panel tests that path"
+        assert r.x is not None
+        viol, n_checked = _worst_violation(m, r.x)
+        compared += 1
+        checks += n_checked
+        if viol > worst[0]:
+            worst = (viol, seed)
+
+    # §6: prove the probe fired rather than skipping every seed.
+    assert compared == seeds, f"only {compared}/{seeds} seeds compared"
+    assert checks == seeds * (2 * 4 + 2 * 5), f"unexpected comparison count {checks}"
+    assert worst[0] <= DECLARED_ABS_TOL, (
+        f"seed {worst[1]} returned a point {worst[0]:.6e} outside a declared row/bound, "
+        f"beyond the declared abs tolerance {DECLARED_ABS_TOL:.0e}"
+    )
+
+
+def _patch_offrow_tree(monkeypatch, cont_slice, shift):
+    """Make the tree hand back an incumbent nudged off the active log row.
+
+    Proxies ``PyTreeManager`` and perturbs only the vector returned by
+    ``incumbent()``, so the search itself is untouched and the exit gate is the
+    only thing under test. Returns a dict whose ``applied`` flag lets the caller
+    prove the perturbation actually happened (CLAUDE.md §6) — without it a passing
+    ``pytest.raises`` could be pinning some unrelated error.
+    """
+    real_tree_cls = S.PyTreeManager
+    state = {"applied": False}
+
+    class _OffRowTree:
+        def __init__(self, *args, **kwargs):
+            self._inner = real_tree_cls(*args, **kwargs)
+
+        def __getattr__(self, name):
+            return getattr(self._inner, name)
+
+        def incumbent(self):
+            inc = self._inner.incumbent()
+            if inc is None:
+                return None
+            sol, obj = inc
+            sol = np.asarray(sol, dtype=np.float64).copy()
+            block = sol[cont_slice]
+            if np.all(np.isfinite(block)) and float(np.max(block)) > 1e-2:
+                sol[cont_slice.start + int(np.argmax(block))] += shift
+                state["applied"] = True
+            return sol, obj
+
+    monkeypatch.setattr(S, "PyTreeManager", _OffRowTree)
+    return state
+
+
+def _disable_terminal_refine(monkeypatch):
+    """Make the terminal refine/dual-recovery re-solve unavailable.
+
+    That re-solve is best-effort and guarded (``except Exception`` -> debug log),
+    and when it runs it would re-converge a perturbed point back onto the row —
+    repairing the very excursion under test. Its failure is the regime the gate
+    exists for: with it unavailable, nothing but the gate stands between an
+    off-row point and a certified return. Returns a counter proving it fired.
+    """
+    calls = {"n": 0}
+
+    def _boom(*args, **kwargs):
+        calls["n"] += 1
+        raise RuntimeError("refine disabled for test")
+
+    monkeypatch.setattr(S, "_solve_node_nlp_kkt", _boom)
+    return calls
+
+
+@pytest.mark.correctness
+def test_exit_gate_refuses_an_off_row_incumbent(monkeypatch):
+    """The gate fires: an incumbent off a declared row is refused, not returned.
+
+    ``Σ log(1+xⱼ) >= tgt`` is active at the optimum, so pushing the largest ``x``
+    coordinate down by 1e-2 puts the incumbent well outside that row while leaving
+    it inside every variable bound and leaving the binaries integral. Before the
+    fix this came back as ``optimal`` with that point as both ``objective`` and
+    ``bound``; now it raises.
+    """
+    # Variable order is y (2 binaries) then x (3 continuous).
+    state = _patch_offrow_tree(monkeypatch, slice(2, 5), -1e-2)
+    refine = _disable_terminal_refine(monkeypatch)
+
+    m = _panel_model(0)
+    with pytest.raises(RuntimeError, match="NLP-BB returned an infeasible point labeled"):
+        m.solve(time_limit=60)
+
+    assert state["applied"], "the incumbent was never perturbed; the test proved nothing"
+    assert refine["n"] > 0, "the refine stub never ran; the perturbation may have been repaired"
+
+
+@pytest.mark.correctness
+def test_baseline_solve_is_unaffected(monkeypatch):
+    """Control for the test above: same model, same disabled refine, no perturbation.
+
+    Without this, a passing ``pytest.raises`` above could be pinning a gate that
+    fires on everything.
+    """
+    refine = _disable_terminal_refine(monkeypatch)
+
+    m = _panel_model(0)
+    r = m.solve(time_limit=60)
+
+    assert refine["n"] > 0, "the refine stub never ran; this control is not comparable"
+    assert r.status == "optimal", f"unperturbed solve returned {r.status}"
+    assert r.x is not None
+    worst, n_checked = _worst_violation(m, r.x)
+    assert n_checked > 0
+    assert worst <= DECLARED_ABS_TOL, f"unperturbed incumbent already {worst:.3e} off a row"
+
+
+def _tight_row_fixture():
+    """A model, evaluator and near-integral point whose integer snap breaks a row.
+
+    ``10*y - x == 0`` with ``y`` integer and ``x`` continuous. The point sits
+    exactly on that row at ``y = 3 - 5e-6``, which is inside the 1e-5 integrality
+    window, so the snap applies and moves ``y`` by 5e-6 — a 5e-5 equality
+    residual. That lands deliberately between the two tolerances under test:
+    inside the retired ``feas_tol=1e-4`` and outside the declared ``abs=1e-6``.
+    """
+    from discopt._jax.nlp_evaluator import NLPEvaluator
+
+    m = dm.Model("snap954")
+    y = m.integer("y", lb=0, ub=5)
+    x = m.continuous("x", lb=0.0, ub=100.0)
+    m.minimize(x)
+    m.subject_to(10.0 * y - x == 0.0)
+    ev = NLPEvaluator(m)
+    cl, cu = (np.asarray(b, dtype=np.float64) for b in S._infer_constraint_bounds(m, ev))
+    # y is 5e-6 shy of 3 (inside the 1e-5 snap window); x sits exactly on the row.
+    y_val = 3.0 - 5e-6
+    point = np.array([y_val, 10.0 * y_val], dtype=np.float64)
+    return m, ev, cl, cu, point
+
+
+@pytest.mark.correctness
+def test_snap_acceptance_uses_the_exit_arbiter():
+    """#954 item 3: the snap is judged at 1e-6, not at the helper's legacy 1e-4.
+
+    The retired call passed ``feas_tol`` at its default 1e-4 — 100x the declared
+    ``abs=1e-6``. On the fixture the snap moves an equality row by 5e-5: inside
+    1e-4 (so the old guard adopted the snapped point) and outside 1e-6 (so the
+    exit gate this issue adds would then have refused the very point the guard
+    installed). The call site now takes the exit's own arbiter, so the two can no
+    longer disagree.
+    """
+    m, ev, cl, cu, point = _tight_row_fixture()
+    int_offsets, int_sizes = [0], [1]
+
+    rounded, _ = S._round_incumbent_integers(point, int_offsets, int_sizes)
+    assert rounded[0] == 3.0, "the fixture point was not inside the 1e-5 snap window"
+    assert rounded[1] == point[1], "only the integer coordinate may be snapped"
+
+    residual = float(np.abs(ev.evaluate_constraints(rounded))[0])
+    assert 1e-6 < residual < 1e-4, f"fixture residual {residual:.3e} does not separate the two"
+
+    # The retired verdict: the helper's default admitted this snap.
+    assert S._check_constraint_feasibility(ev, rounded, cl, cu, tol=1e-4), (
+        "fixture no longer reproduces the 1e-4 acceptance this item is about"
+    )
+
+    # The verdict the call site now takes — the same arbiter the exit enforces.
+    box = np.stack([np.array([0.0, 0.0]), np.array([5.0, 100.0])], axis=1)
+    excess, where, n_cmp = S._nonlinear_point_excess(ev, rounded, cl, cu, box=box)
+    assert n_cmp > 0, "the arbiter compared nothing"
+    assert excess > S._NLPBB_EXIT_ABS_TOL, f"{where}: excess {excess:.3e} should exceed the gate"
+
+    # And the unsnapped point — the one the call site keeps instead — is clean.
+    excess0, _, n_cmp0 = S._nonlinear_point_excess(ev, point, cl, cu, box=box)
+    assert n_cmp0 > 0
+    assert excess0 <= S._NLPBB_EXIT_ABS_TOL
+
+
+@pytest.mark.correctness
+def test_gate_judges_declared_rows_only():
+    """An appended root cut (#781) must not be able to manufacture a refusal.
+
+    The NLP-BB path appends cut rows to the model *before* compiling the
+    evaluator. Those rows are valid for integer-feasible points but deliberately
+    tight, and they are not rows the user declared, so the gate is limited to the
+    leading declared block.
+    """
+    from discopt._jax.nlp_evaluator import NLPEvaluator
+
+    m = dm.Model("cutrows954")
+    x = m.continuous("x", lb=0.0, ub=10.0)
+    m.minimize(x)
+    m.subject_to(x >= 1.0)  # declared row, satisfied at x = 2
+    m.subject_to(x <= 1.5)  # stands in for an appended cut: violated at x = 2
+    ev = NLPEvaluator(m)
+    cl, cu = (np.asarray(b, dtype=np.float64) for b in S._infer_constraint_bounds(m, ev))
+    point = np.array([2.0])
+
+    all_rows, _, n_all = S._nonlinear_point_excess(ev, point, cl, cu)
+    assert n_all == 4, f"expected 2 comparisons per row over 2 rows, got {n_all}"
+    assert all_rows > S._NLPBB_EXIT_ABS_TOL, "fixture must violate the trailing row"
+
+    declared_only, _, n_decl = S._nonlinear_point_excess(ev, point, cl, cu, n_rows=1)
+    assert n_decl == 2, f"expected 2 comparisons over 1 declared row, got {n_decl}"
+    assert declared_only <= S._NLPBB_EXIT_ABS_TOL, "the trailing row leaked into the verdict"
+
+
+@pytest.mark.correctness
+def test_arbiter_agrees_with_the_authoritative_nonlinear_check():
+    """Parity with ``primal_heuristics._check_constraint_feasibility``.
+
+    That function is what every primal heuristic on this path already holds an
+    incumbent to. The gate must not be a second, differently-tuned opinion of the
+    same question, so accept/reject is pinned to agree over a sweep that straddles
+    the tolerance — including the term-scaled regime, where a large-magnitude row
+    forgives noise an absolute-only test would reject (the prob07 lesson).
+    """
+    from discopt._jax.nlp_evaluator import NLPEvaluator
+    from discopt._jax.primal_heuristics import _check_constraint_feasibility as authoritative
+
+    compared = 0
+    for scale in (1.0, 1e3, 1e5):
+        m = dm.Model(f"parity954_{scale:g}")
+        x = m.continuous("x", lb=0.0, ub=10.0 * scale)
+        m.minimize(x)
+        m.subject_to(x * x - float(scale) * x >= 0.0)
+        m.subject_to(x <= float(scale))
+        ev = NLPEvaluator(m)
+        cl, cu = (np.asarray(b, dtype=np.float64) for b in S._infer_constraint_bounds(m, ev))
+        for delta in (0.0, 1e-9, 1e-7, 1e-6, 1e-5, 1e-3):
+            point = np.array([float(scale) + delta])
+            mine, _, n_cmp = S._nonlinear_point_excess(ev, point, cl, cu)
+            assert n_cmp > 0
+            theirs = bool(authoritative(ev, point))
+            assert (mine <= S._NLPBB_EXIT_ABS_TOL) == theirs, (
+                f"scale {scale:g} delta {delta:g}: gate says "
+                f"{mine <= S._NLPBB_EXIT_ABS_TOL} (excess {mine:.3e}), authoritative "
+                f"check says {theirs}"
+            )
+            compared += 1
+
+    assert compared == 18, f"parity sweep ran {compared} comparisons, expected 18"


### PR DESCRIPTION
## Summary

`_solve_nlp_bb` was the last of the five solve exit paths with no verification of the point it returns (#779/#789 closed `solve_model` and the native spatial kernel; #952 closed `_solve_milp_bb`/`_solve_miqp_bb`). Its exit was the same three steps those two had — snap the integers, unpack, return — with nothing checking the point whose objective is reported as `objective` and, on `optimal`, as the dual `bound` too.

Two things kept this from being "apply the #952 gate here":

* **The rows are nonlinear**, so `_matrix_solution_feasible` is the wrong arbiter. The new `_nonlinear_point_excess` applies the repo's nonlinear convention instead (`viol <= tol + rtol*term_scale`, `abs=1e-6`, `rtol=1e-9`) — the same test `_jax.primal_heuristics._check_constraint_feasibility` already applies whenever a primal heuristic accepts an incumbent. It returns the excess it measured, so the refusal message and the accept/reject decision are the *same number* and cannot drift apart (#952 kept arbiter and reporter separate by giving the reporter no tolerance at all; here the reporter is the arbiter's own quantity).
* **The terminal refine re-solve can replace the reported point** after every gate the search ran, so the check is placed last: it judges the vector that actually leaves. It judges the **declared** rows (root cuts, #781, are appended to the model before the evaluator is compiled and are excluded via `_declared_rows`) against the **declared** box (captured before FBBT overwrites `lb`/`ub`), so neither a derived bound nor an appended cut can manufacture a refusal. Refusal, not repair or a quiet downgrade (CLAUDE.md §3).

**#954 item 3 — the rounding guard's `feas_tol`: changed, not justified.** The `_round_incumbent_integers` call site ran at the helper default `1e-4`, 100x the declared `abs=1e-6`. It now takes the exit's own arbiter, so a snap can no longer be admitted at 1e-4 and then refused by the exit at 1e-6 (which would turn a solve with a perfectly good unrounded point into a crash). A rejected snap keeps the unrounded incumbent — C-3's documented fallback. The helper's own `feas_tol` default is untouched for the call sites that have no exit arbiter.

Closes #954.

### Entry experiment (CLAUDE.md §4), run before the gate was written

The `~/Dropbox/projects/discopt-minlp-benchmark/` corpus is not present in this environment and minlplib.org is unreachable through the proxy, so the panel is the in-repo corpus driven through this path with `nlp_bb=True` (the in-repo instances are mostly nonconvex and would otherwise dispatch elsewhere — the issue's own panel only reached the path on a handful) plus a 40-seed convex-MINLP family that dispatches here naturally. 106 items, 45 s budget, 90 s hard cap per instance:

```
entered _solve_nlp_bb        : 100
POINTS_MEASURED              : 69
COMPARISONS                  : 2638
worst raw violation          : 9.36e-11   (tls2, row 16)
worst tolerance needed       : 3.93e-14   (fac2)
instances a 1e-6 gate refuses: 0
```

Measured against a pristine re-read of each instance through `NLPEvaluator.evaluate_constraints` plus declared variable bounds — deliberately not through the solver's own helpers. So, as with #952, there was no live false primal: the defect is that *nothing bounded* the excursion — its size was set by whatever the NLP backend converged to, and the exit would equally have returned 1e-2. The gate has four orders of headroom over anything this corpus produces, so there is no newly-refused instance to characterize.

## Correctness

Tightens an acceptance gate; it does not change a relaxation, a bound, or a cut. It can only turn a returned point into a loud refusal, never the reverse. A refusal inside a RENS/local-branching sub-solve is contained by that heuristic's existing `except Exception` (the heuristic produces nothing; the parent search is unaffected).

- [x] Cannot produce a false certificate (or: N/A — no solver-math change)
- [x] No validation, fallback, or safety guard was weakened to make a check pass

**Bound-neutral verification (CLAUDE.md §5).** Gated vs baseline arms over the same 106-item panel: `node_count`, `objective`, status and `gap_certified` identical on every self-terminating instance. Seven apparent drifts appeared in the contended panel run (`casctanks`, `clay0303hfsg`, `heatexch_gen1`, `heatexch_gen2`, `tspn12`); all were on wall-truncated `gap_certified=False` searches or in the last ulp, and all vanished on uncontended serial reruns of both arms — e.g. `tspn12` (the only `gap_certified=True` drift) returns objective `262.64739579632845`, bound `262.64738262947174`, `node_count=1` identically, 3/3 reps on each arm, and `casctanks`/`heatexch_gen1`/`heatexch_gen2` return 95/95/31 nodes on both arms. That is the timing artifact the issue's verification-regime note warned about, so status was not used as the self-termination key.

## Tests run (state the result — numbers, not adjectives)

- [x] `pytest -m smoke` → 916 passed, 15 skipped, 2 xpassed (384 s)
- [x] `pytest -m slow python/tests/test_adversarial_recent_fixes.py` → 10 passed (174 s)
- [x] `cargo test -p discopt-core` → N/A, no Rust touched
- [x] `ruff check` / `ruff format --check` clean
- [x] `pytest python/tests/test_954_nlpbb_incumbent_feasibility.py -m correctness` → 6 passed (7.5 s)

One flake worth naming: the *first* adversarial run failed `test_large_dense_jacobian_no_crash`, whose assertion is a wall-clock deadline. Two subsequent runs (isolated, then the full file) pass, and a direct probe of that model shows the gate is never reached on it — `gate_calls=0`, because the solve hits its budget with no incumbent — so the failure was that test's deadline under load, not this change.

## Regression test

`python/tests/test_954_nlpbb_incumbent_feasibility.py`, six tests, each with an executed-comparison count (CLAUDE.md §6):

1. `test_returned_incumbent_is_within_declared_tolerance` — the standing watch, measured independently of the solver's helpers.
2. `test_exit_gate_refuses_an_off_row_incumbent` — **the one that fails before the change**: a `PyTreeManager` proxy nudges the incumbent 1e-2 off the active `Σ log(1+xⱼ) >= tgt` row with the (best-effort, guarded) refine re-solve made unavailable, which is the regime the gate exists for. Before: `Failed: DID NOT RAISE RuntimeError` — the point came back as `optimal`. After: raises.
3. `test_baseline_solve_is_unaffected` — its control, so a passing `pytest.raises` cannot be pinning a gate that fires on everything.
4. `test_snap_acceptance_uses_the_exit_arbiter` — item 3, on a fixture whose snap lands deliberately between the two tolerances (5e-5 residual: inside the retired 1e-4, outside the declared 1e-6).
5. `test_gate_judges_declared_rows_only` — an appended cut row cannot manufacture a refusal.
6. `test_arbiter_agrees_with_the_authoritative_nonlinear_check` — accept/reject parity with `primal_heuristics._check_constraint_feasibility` over a sweep straddling the tolerance at three data scales, so the new arbiter cannot drift from the existing one.

- [x] Added a regression test that fails before / passes after


---
_Generated by [Claude Code](https://claude.ai/code/session_0131ExU9jk2ohNFyCAGPRUTg)_