### PR TITLE
ci: repair two signals that reported without measuring

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,9 +64,24 @@ jobs:
             exit 0
           fi
           if [ "${{ github.event_name }}" = "pull_request" ]; then
-            git fetch --no-tags --depth=200 origin "${{ github.base_ref }}" || true
+            # No --depth: the checkout above is already `fetch-depth: 0`, and a
+            # shallow fetch would install a boundary that hides the merge base of
+            # any branch forked more than that many base commits back.
+            git fetch --no-tags origin "${{ github.base_ref }}" || true
             base="$(git merge-base "origin/${{ github.base_ref }}" HEAD 2>/dev/null || true)"
-            changed="$(git diff --name-only "${base:-HEAD~1}" HEAD 2>/dev/null || true)"
+            # Same rule as the two branches around this one: an unresolvable base
+            # is UNCERTAINTY, not a licence to guess. `${base:-HEAD~1}` used to
+            # gate the whole matrix on the tip commit's file list, so a PR whose
+            # tip happens to be docs-only skipped every solver job even when the
+            # branch changes the solver — and `pull_request` is the trigger that
+            # fires on nearly every change here. The `git fetch` above is
+            # `|| true`, so this is reachable by a silent fetch failure alone.
+            if [ -n "$base" ]; then
+              changed="$(git diff --name-only "$base" HEAD 2>/dev/null || true)"
+            else
+              changed=""   # unknown base -> falls through to code=true below
+              echo "no merge-base with origin/${{ github.base_ref }} -> treating as uncertain"
+            fi
           else
             # `push`: diff against the pushed-from commit. If it is unusable (an
             # all-zero SHA on a branch's first push, a force-push, a shallow

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,13 +49,39 @@ jobs:
             echo "=> code=false (schedule: only the nightly correctness lane runs)"
             exit 0
           fi
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            # A manual run is a request to run EVERYTHING — that is the only
+            # reason to press the button. There is also no base to diff against:
+            # `github.event.before` exists only on `push`, so the generic branch
+            # below degenerated to `HEAD~1..HEAD` and answered as if only the tip
+            # commit had changed. That is how a dispatch of this workflow came
+            # back with rust / python-fast / claim-boundary / correctness / AMP
+            # all `skipped` — nine checks that read as non-red while executing
+            # nothing (found re-running #960; same genre as the #953 dark
+            # signals). Never gate a manual run on a guessed diff.
+            echo "code=true" >> "$GITHUB_OUTPUT"
+            echo "=> code=true (workflow_dispatch: a manual run always runs everything)"
+            exit 0
+          fi
           if [ "${{ github.event_name }}" = "pull_request" ]; then
             git fetch --no-tags --depth=200 origin "${{ github.base_ref }}" || true
             base="$(git merge-base "origin/${{ github.base_ref }}" HEAD 2>/dev/null || true)"
             changed="$(git diff --name-only "${base:-HEAD~1}" HEAD 2>/dev/null || true)"
           else
-            changed="$(git diff --name-only "${{ github.event.before }}" "${{ github.sha }}" 2>/dev/null \
-                      || git diff --name-only HEAD~1 HEAD 2>/dev/null || true)"
+            # `push`: diff against the pushed-from commit. If it is unusable (an
+            # all-zero SHA on a branch's first push, a force-push, a shallow
+            # clone) do NOT substitute a guess — an unknown base is the
+            # "uncertainty" case this job promises to resolve as `true`.
+            before="${{ github.event.before }}"
+            case "$before" in
+              ""|*[!0-9a-f]*|0000000000000000000000000000000000000000) before="" ;;
+            esac
+            if [ -n "$before" ] && git cat-file -e "$before^{commit}" 2>/dev/null; then
+              changed="$(git diff --name-only "$before" "${{ github.sha }}" 2>/dev/null || true)"
+            else
+              changed=""   # unknown base -> falls through to code=true below
+              echo "no usable base ('${{ github.event.before }}') -> treating as uncertain"
+            fi
           fi
           echo "Changed files:"; printf '%s\n' "$changed"
           # Allowlist of paths that can NOT affect solver behavior (safe to skip).
@@ -300,9 +326,16 @@ jobs:
     # Serial for the same reason as `python-correctness`: a soundness lane must
     # be deterministic, and xdist can order-mask global/claim state.
     #
-    # `--timeout=900` because these tests pass real `time_limit=` budgets to the
-    # solver (ex1252 uses 200 s) and a per-test timeout below the budget would
-    # fail the harness instead of the assertion.
+    # `--timeout=1800` because these tests pass real `time_limit=` / `deadline=`
+    # budgets to the solver and a per-test timeout below the budget would fail the
+    # harness instead of the assertion. Raised from 900 s: the two ex1252
+    # disjunctive-config bars are budget-bound (`max_leaf_solves` 48 and 120), and
+    # their deadlines are backstops sized ~2x the measured runner rate (this runner
+    # manages ~0.175 leaf solves/s, so 48 leaves ~275 s and 120 leaves ~690 s;
+    # the deadlines are 600 s and 1500 s). The 120 min job timeout is the real
+    # backstop against a hang — the per-test timeout must not be what decides a
+    # quality bar, because then the bar measures the runner. See
+    # `_assert_budget_not_clock` in test_disjunctive_config_bound.py.
     #
     # Measured 313 s serially on an M-series laptop (153 selected: 146 passed,
     # 7 skipped, 1 failed — the failure being #927). `python-correctness` is
@@ -352,7 +385,7 @@ jobs:
           # prints a summary at the end cannot be distinguished from a hung one
           # (CLAUDE.md §10).
           scripts/run_memory_capped_pytest.sh pytest python/tests/ \
-            -v --tb=short --timeout=900 -p no:cacheprovider \
+            -v --tb=short --timeout=1800 -p no:cacheprovider \
             -m "correctness and slow and not integration and not amp_benchmark and not requires_cyipopt and not memory_heavy" \
             --ignore=python/tests/test_amp.py \
             --durations=25

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -193,28 +193,46 @@ The release procedure that produces these entries is documented in
   driving #960 to green, and both share a shape: a check that answers confidently
   from something other than the thing it claims to be testing.
 
-  1. **A manual `workflow_dispatch` skipped the entire heavy matrix.** The
-     `changes` gate reads `github.event.before`, which exists only on `push`. On a
-     dispatch that expression expands to the empty string, the first `git diff`
-     fails, and the fallback silently diffs `HEAD~1..HEAD` — so the gate answered
-     as if only the tip commit had changed. Dispatching CI on #960, whose tip
-     touched `CHANGELOG.md` and `docs/dev/data/claim-baseline.jsonl`, produced
-     `code=false` and left Rust, `Python fast`, `Python claim-boundary`, `Python
-     correctness` and AMP all `skipped`: nine checks that render as *not red*
-     while executing nothing. That is the #953 failure mode, one trigger over.
-     A dispatch is now `code=true` unconditionally — pressing the button means
-     "run everything", and there is no base to diff against anyway. The `push`
-     branch no longer substitutes a guess either: an all-zero `before` (a
-     branch's first push), a non-existent object (force-push, shallow clone) or
-     an empty one is now the *uncertainty* case the job's own comment already
-     promised to resolve as `true`.
+  1. **The `changes` gate answered from a guessed diff on all three event
+     arms.** It resolves a base commit and diffs against it; every arm had a
+     path where the base is unavailable and the code substituted
+     `HEAD~1..HEAD` — the tip commit's file list — instead of recognising that
+     it did not know. When that guess lands on a docs-only commit the gate says
+     `code=false` and every solver job below it reports `skipped`, which renders
+     as *not red*. That is the #953 failure mode: a wrong `false` here is not a
+     missing test, it is a green-looking wall of nothing.
+
+     * `workflow_dispatch`: `github.event.before` exists only on `push`, so it
+       expands to the empty string, the first `git diff` fails, and the fallback
+       fires. Dispatching CI on #960, whose tip touched `CHANGELOG.md` and
+       `docs/dev/data/claim-baseline.jsonl`, produced `code=false` and left
+       Rust, `Python fast`, `Python claim-boundary`, `Python correctness` and
+       AMP all `skipped` — nine checks that executed nothing. Now `code=true`
+       unconditionally: pressing the button means "run everything", and there is
+       no base to diff against anyway.
+     * `pull_request` — the trigger that fires on nearly every change here —
+       used `${base:-HEAD~1}`, reachable two ways: the `git fetch` above it is
+       `|| true`, so a fetch failure is silent, and the `--depth=200` fetch
+       installed a shallow boundary that hides the merge base of a branch forked
+       further back than that. Either way a PR that changes the solver behind a
+       docs-only tip commit skipped every solver job. The depth cap is gone (the
+       checkout is already `fetch-depth: 0`) and an unresolvable base is now
+       treated as uncertain.
+     * `push`: an all-zero `before` (a branch's first push), a non-existent
+       object (force-push, shallow clone), or an empty one is likewise the
+       *uncertainty* case the job's own comment already promised to resolve as
+       `true`.
 
      New `python/tests/test_ci_changes_gate.py` extracts the gate's real shell
-     script out of `ci.yml` — not a copy — renders the `${{ github.* }}`
-     expressions, and runs it against throwaway git repos, one case per event
-     type. 9 tests; 5 fail on the pre-change workflow (the dispatch case and all
-     four unusable-base cases) and the 4 pinning the behaviour that must not
-     change (docs-only skips, a code file runs, `schedule` skips) pass both ways.
+     script out of `ci.yml` — not a copy, so it cannot drift — renders the
+     `${{ github.* }}` expressions, and runs it against throwaway git repos, one
+     case per event type. 12 tests; 6 fail on the pre-change workflow (one per
+     defective arm plus the four `push` base shapes) and the 6 pinning behaviour
+     that must not change (docs-only PRs and pushes still skip, a code file
+     runs, `schedule` still skips the PR matrix, a resolvable merge base is still
+     used in preference to the tip) pass both ways. `pyyaml` moves into the `dev`
+     extra so that file is a skip rather than a collection error where it is
+     absent.
 
   2. **Two `ex1252` quality bars measured the runner, not the relaxation.**
      `compute_disjunctive_config_bound` stops on whichever of `max_leaf_solves`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -189,6 +189,56 @@ The release procedure that produces these entries is documented in
 
 ### Fixed
 
+- **Two CI signals that reported without measuring** (`ci`). Both were found while
+  driving #960 to green, and both share a shape: a check that answers confidently
+  from something other than the thing it claims to be testing.
+
+  1. **A manual `workflow_dispatch` skipped the entire heavy matrix.** The
+     `changes` gate reads `github.event.before`, which exists only on `push`. On a
+     dispatch that expression expands to the empty string, the first `git diff`
+     fails, and the fallback silently diffs `HEAD~1..HEAD` — so the gate answered
+     as if only the tip commit had changed. Dispatching CI on #960, whose tip
+     touched `CHANGELOG.md` and `docs/dev/data/claim-baseline.jsonl`, produced
+     `code=false` and left Rust, `Python fast`, `Python claim-boundary`, `Python
+     correctness` and AMP all `skipped`: nine checks that render as *not red*
+     while executing nothing. That is the #953 failure mode, one trigger over.
+     A dispatch is now `code=true` unconditionally — pressing the button means
+     "run everything", and there is no base to diff against anyway. The `push`
+     branch no longer substitutes a guess either: an all-zero `before` (a
+     branch's first push), a non-existent object (force-push, shallow clone) or
+     an empty one is now the *uncertainty* case the job's own comment already
+     promised to resolve as `true`.
+
+     New `python/tests/test_ci_changes_gate.py` extracts the gate's real shell
+     script out of `ci.yml` — not a copy — renders the `${{ github.* }}`
+     expressions, and runs it against throwaway git repos, one case per event
+     type. 9 tests; 5 fail on the pre-change workflow (the dispatch case and all
+     four unusable-base cases) and the 4 pinning the behaviour that must not
+     change (docs-only skips, a code file runs, `schedule` skips) pass both ways.
+
+  2. **Two `ex1252` quality bars measured the runner, not the relaxation.**
+     `compute_disjunctive_config_bound` stops on whichever of `max_leaf_solves`
+     and `deadline` comes first, and reported no indication of which. The leaf
+     budget is reproducible; the clock is not. The nightly lane read 33498
+     (42/120 leaves) and 31567 (32/48) on a runner ~3x slower than the reference
+     machine and failed both bars as if the bound had regressed. It had not: at
+     the full budget the bound is **bit-identical** across the #957 boundary —
+     37945.427865923564 at 48 leaves and 63080.286987442756 at 120, matching the
+     values the tests' own docstrings record, with the same leaf and prune counts
+     in both arms.
+
+     `DisjunctiveConfigResult` gains `stopped_on` (`"budget"` / `"deadline"` /
+     `"exhausted"`), mirroring `WorkBudget.stopped_on` from #912 — the same
+     distinction between a search decided by work and one decided by the clock.
+     The two bars now assert `stopped_on != "deadline"` *before* the bound
+     comparison, so a slow machine and a bound regression produce different
+     failures with different instructions, and the clock-bound message says
+     explicitly not to lower the bar. Deadlines are re-sized as backstops at ~2x
+     the measured runner rate (0.175 leaf solves/s → 600 s for 48 leaves, 1500 s
+     for 120), and the nightly lane's `--timeout` goes 900 s → 1800 s so the
+     harness timeout is never what decides a quality bar. The 120-minute job
+     timeout remains the backstop against a hang.
+
 - **Outward rounding no longer turns an exact zero into a subnormal** (`fix`, #957).
   `interval.py`'s `_round_down`/`_round_up` are `np.nextafter(x, ∓inf)`, and
   `nextafter(0.0, ±inf)` is `±5e-324`. At every other magnitude "one ULP" is a

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,6 +70,11 @@ dev = [
     "pytest",
     "pytest-timeout",
     "pytest-cov",
+    # test_ci_changes_gate.py parses .github/workflows/ci.yml to run the real
+    # `changes` gate script. Declared here rather than relied on transitively:
+    # without it that file is a collection ERROR, not a skip — red for the wrong
+    # reason. (Also in the `gams` extra, for gamsconfig.yaml merging.)
+    "pyyaml>=6",
     "pytest-xdist",
     # Pin the lint/typecheck toolchain to the exact versions in
     # .pre-commit-config.yaml (the single source of truth CI also runs), so a

--- a/python/discopt/_jax/disjunctive_config_bound.py
+++ b/python/discopt/_jax/disjunctive_config_bound.py
@@ -66,6 +66,21 @@ class DisjunctiveConfigResult:
     ``None`` when the pass declined / could not certify anything above ``-inf``.
     ``infeasible`` is True only when EVERY configuration pattern was pruned
     infeasible — a rigorous proof the input box contains no feasible point.
+
+    ``stopped_on`` records *what ended the pass*, following the same convention as
+    ``WorkBudget.stopped_on`` (#912):
+
+    * ``"budget"``    — the ``max_leaf_solves`` leaf budget was spent. The bound is
+      a reproducible function of the input and the budget.
+    * ``"deadline"``  — the wall-clock ``deadline`` fired first. The bound is then
+      a function of **how fast the machine is**, and comparing it against a fixed
+      quality bar measures the runner, not the relaxation.
+    * ``"exhausted"`` — the search ran out of work (no splittable leaf left)
+      before either limit. Also reproducible.
+
+    Without this field the two reproducible outcomes and the irreproducible one
+    are indistinguishable in the result, which is exactly how a slow runner came
+    to look like a bound regression on ``ex1252`` (#960 post-merge).
     """
 
     bound: Optional[float] = None
@@ -75,6 +90,7 @@ class DisjunctiveConfigResult:
     n_pruned_cutoff: int = 0
     n_leaves: int = 0
     wall: float = 0.0
+    stopped_on: str = "exhausted"
 
 
 @dataclass
@@ -224,9 +240,17 @@ def compute_disjunctive_config_bound(
     terminal_bounds: list[float] = []
 
     def _out_of_budget() -> bool:
+        # Record WHICH limit fired, not just that one did: the leaf budget is a
+        # reproducible stopping rule, the clock is not, and a caller comparing the
+        # bound against a fixed bar can only interpret it if it knows which one
+        # ended the pass. Same distinction as ``WorkBudget.stopped_on`` (#912).
         if res.n_processed >= max_leaf_solves:
+            res.stopped_on = "budget"
             return True
-        return deadline is not None and time.perf_counter() >= deadline
+        if deadline is not None and time.perf_counter() >= deadline:
+            res.stopped_on = "deadline"
+            return True
+        return False
 
     def _process(leaf: _Leaf) -> Optional[_Leaf]:
         """FBBT -> OBBT(cutoff) -> LP on the leaf. Returns the surviving leaf

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -6523,11 +6523,17 @@ def solve_model(
                                     model._disjunctive_config_floor = float(_dcb.bound)
                                     logger.info(
                                         "disjunctive config bound: floor %.6g "
-                                        "(%d leaf solves, %d infeasible, %.1fs)",
+                                        "(%d leaf solves, %d infeasible, %.1fs, "
+                                        "stopped on %s)",
                                         _dcb.bound,
                                         _dcb.n_processed,
                                         _dcb.n_pruned_infeasible,
                                         _dcb.wall,
+                                        # Expected to be "deadline" here: in-solve
+                                        # the wall budget governs by design (the
+                                        # leaf cap above is a runaway backstop), so
+                                        # this floor is anytime, not reproducible.
+                                        _dcb.stopped_on,
                                     )
                             except Exception as _dcb_exc:  # pragma: no cover
                                 logger.debug("disjunctive config bound skipped: %s", _dcb_exc)

--- a/python/tests/test_ci_changes_gate.py
+++ b/python/tests/test_ci_changes_gate.py
@@ -1,0 +1,173 @@
+"""The CI ``changes`` gate decides whether the heavy test jobs run at all.
+
+When it answers ``code=false`` every solver job below it reports ``skipped`` —
+which renders as *not red*. So a wrong ``false`` is not a missing test, it is a
+green-looking wall of nothing, the failure mode #953 was filed for. This suite
+runs the gate's actual shell script (extracted from ``ci.yml``, not a copy) in a
+throwaway git repo and pins its answer per event type.
+
+The case that motivated it: ``github.event.before`` exists only on ``push``, so
+on ``workflow_dispatch`` the script's generic branch fell through to
+``HEAD~1..HEAD`` and gated the whole matrix on the tip commit's file list. A
+manual re-run of #960 came back with rust / python-fast / claim-boundary /
+correctness / AMP all skipped.
+"""
+
+from __future__ import annotations
+
+import re
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+import yaml
+
+_REPO = Path(__file__).resolve().parents[2]
+_CI = _REPO / ".github" / "workflows" / "ci.yml"
+
+pytestmark = pytest.mark.skipif(
+    not _CI.exists() or shutil.which("git") is None,
+    reason="needs .github/workflows/ci.yml and git",
+)
+
+_ZERO_SHA = "0" * 40
+
+
+def _gate_script() -> str:
+    """The `changes` job's filter step, read out of the workflow itself."""
+    wf = yaml.safe_load(_CI.read_text())
+    steps = wf["jobs"]["changes"]["steps"]
+    for step in steps:
+        if step.get("id") == "filter":
+            return step["run"]
+    raise AssertionError("no `filter` step in the `changes` job — did it get renamed?")
+
+
+def _render(script: str, *, event: str, before: str, sha: str, base_ref: str) -> str:
+    """Substitute the ``${{ github.* }}`` expressions GitHub would expand."""
+    subs = {
+        "github.event_name": event,
+        "github.event.before": before,
+        "github.sha": sha,
+        "github.base_ref": base_ref,
+    }
+    out = script
+    for key, val in subs.items():
+        out = re.sub(r"\$\{\{\s*" + re.escape(key) + r"\s*\}\}", val, out)
+    leftover = re.findall(r"\$\{\{.*?\}\}", out)
+    assert not leftover, f"unsubstituted workflow expressions: {leftover}"
+    return out
+
+
+def _git(repo: Path, *args: str) -> str:
+    return subprocess.run(
+        ["git", *args], cwd=repo, capture_output=True, text=True, check=True
+    ).stdout.strip()
+
+
+def _make_repo(tmp_path: Path, tip_files: list[str]) -> tuple[Path, str, str]:
+    """A two-commit repo; the second commit touches ``tip_files``."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init", "-q", "-b", "main")
+    _git(repo, "config", "user.email", "t@example.com")
+    _git(repo, "config", "user.name", "t")
+    (repo / "seed.py").write_text("x = 1\n")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-qm", "seed")
+    base = _git(repo, "rev-parse", "HEAD")
+    for rel in tip_files:
+        p = repo / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text("changed\n")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-qm", "tip")
+    return repo, base, _git(repo, "rev-parse", "HEAD")
+
+
+def _run_gate(repo: Path, script: str) -> str:
+    """Execute the gate; return its ``code=`` output."""
+    out_file = repo / "gh_output"
+    out_file.write_text("")
+    proc = subprocess.run(
+        ["bash", "-c", script],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+        env={
+            "PATH": "/usr/bin:/bin:/usr/local/bin",
+            "GITHUB_OUTPUT": str(out_file),
+            "HOME": str(repo),
+        },
+    )
+    written = out_file.read_text()
+    assert proc.returncode == 0, f"gate script failed: {proc.stderr[-2000:]}"
+    m = re.search(r"^code=(true|false)$", written, re.M)
+    assert m, f"gate wrote no code= line.\nstdout:\n{proc.stdout}\nGITHUB_OUTPUT:\n{written}"
+    return m.group(1)
+
+
+# ----------------------------------------------------------------------
+# The regression: a manual run must never gate on a guessed diff
+# ----------------------------------------------------------------------
+
+
+def test_workflow_dispatch_always_runs_everything(tmp_path):
+    """The bug: docs-only tip commit + dispatch => the whole matrix skipped.
+
+    ``github.event.before`` is empty on ``workflow_dispatch``; the tip commit here
+    touches only allowlisted paths, which is exactly the #960 re-run shape
+    (CHANGELOG.md + docs/dev/data/claim-baseline.jsonl).
+    """
+    repo, _base, sha = _make_repo(tmp_path, ["CHANGELOG.md", "docs/dev/data/claim-baseline.jsonl"])
+    script = _render(_gate_script(), event="workflow_dispatch", before="", sha=sha, base_ref="main")
+    assert _run_gate(repo, script) == "true"
+
+
+def test_workflow_dispatch_runs_everything_even_on_a_code_tip(tmp_path):
+    repo, _base, sha = _make_repo(tmp_path, ["python/discopt/solver.py"])
+    script = _render(_gate_script(), event="workflow_dispatch", before="", sha=sha, base_ref="main")
+    assert _run_gate(repo, script) == "true"
+
+
+# ----------------------------------------------------------------------
+# An unknown base is the documented "uncertainty" case: run
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("before", ["", _ZERO_SHA, "not-a-sha", "deadbeef" * 5])
+def test_push_with_an_unusable_base_runs_everything(tmp_path, before):
+    """First push of a branch, force-push, or a shallow clone: base unknown.
+
+    The gate promises `code=true` on uncertainty; substituting `HEAD~1..HEAD` is
+    a guess, not a resolution, and on a docs-only tip it silently skips.
+    """
+    repo, _base, sha = _make_repo(tmp_path, ["CHANGELOG.md"])
+    script = _render(_gate_script(), event="push", before=before, sha=sha, base_ref="main")
+    assert _run_gate(repo, script) == "true"
+
+
+# ----------------------------------------------------------------------
+# The behaviour that must NOT change
+# ----------------------------------------------------------------------
+
+
+def test_push_docs_only_still_skips(tmp_path):
+    """A real base with only allowlisted files: skipping is the whole point."""
+    repo, base, sha = _make_repo(tmp_path, ["CHANGELOG.md", "docs/notes.md"])
+    script = _render(_gate_script(), event="push", before=base, sha=sha, base_ref="main")
+    assert _run_gate(repo, script) == "false"
+
+
+def test_push_with_a_code_file_runs(tmp_path):
+    repo, base, sha = _make_repo(tmp_path, ["docs/notes.md", "python/discopt/solver.py"])
+    script = _render(_gate_script(), event="push", before=base, sha=sha, base_ref="main")
+    assert _run_gate(repo, script) == "true"
+
+
+def test_schedule_still_skips_the_pr_matrix(tmp_path):
+    """The nightly lane does not gate on this output; the rest must not re-run."""
+    repo, _base, sha = _make_repo(tmp_path, ["python/discopt/solver.py"])
+    script = _render(_gate_script(), event="schedule", before="", sha=sha, base_ref="main")
+    assert _run_gate(repo, script) == "false"

--- a/python/tests/test_ci_changes_gate.py
+++ b/python/tests/test_ci_changes_gate.py
@@ -66,6 +66,16 @@ def _git(repo: Path, *args: str) -> str:
     ).stdout.strip()
 
 
+def _commit(repo: Path, files: list[str], msg: str) -> str:
+    for rel in files:
+        p = repo / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(f"{msg}\n")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-qm", msg)
+    return _git(repo, "rev-parse", "HEAD")
+
+
 def _make_repo(tmp_path: Path, tip_files: list[str]) -> tuple[Path, str, str]:
     """A two-commit repo; the second commit touches ``tip_files``."""
     repo = tmp_path / "repo"
@@ -77,13 +87,27 @@ def _make_repo(tmp_path: Path, tip_files: list[str]) -> tuple[Path, str, str]:
     _git(repo, "add", "-A")
     _git(repo, "commit", "-qm", "seed")
     base = _git(repo, "rev-parse", "HEAD")
-    for rel in tip_files:
-        p = repo / rel
-        p.parent.mkdir(parents=True, exist_ok=True)
-        p.write_text("changed\n")
+    return repo, base, _commit(repo, tip_files, "tip")
+
+
+def _make_pr_repo(tmp_path: Path) -> tuple[Path, str, str]:
+    """A PR-shaped repo: base, then a solver change, then a docs-only tip.
+
+    The real change is two commits back, so a gate that diffs ``HEAD~1..HEAD``
+    cannot see it — which is the whole point of diffing against the merge base.
+    """
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init", "-q", "-b", "feature")
+    _git(repo, "config", "user.email", "t@example.com")
+    _git(repo, "config", "user.name", "t")
+    (repo / "seed.py").write_text("x = 1\n")
     _git(repo, "add", "-A")
-    _git(repo, "commit", "-qm", "tip")
-    return repo, base, _git(repo, "rev-parse", "HEAD")
+    _git(repo, "commit", "-qm", "seed")
+    base = _git(repo, "rev-parse", "HEAD")
+    _commit(repo, ["python/discopt/solver.py"], "solver change")
+    tip = _commit(repo, ["docs/notes.md"], "docs tip")
+    return repo, base, tip
 
 
 def _run_gate(repo: Path, script: str) -> str:
@@ -146,6 +170,43 @@ def test_push_with_an_unusable_base_runs_everything(tmp_path, before):
     repo, _base, sha = _make_repo(tmp_path, ["CHANGELOG.md"])
     script = _render(_gate_script(), event="push", before=before, sha=sha, base_ref="main")
     assert _run_gate(repo, script) == "true"
+
+
+def test_pull_request_with_no_merge_base_runs_everything(tmp_path):
+    """`pull_request` is the trigger that fires on nearly every change here.
+
+    ``git merge-base origin/<base_ref> HEAD`` yields nothing when the ref is
+    missing — the `git fetch` above it is `|| true`, so a fetch failure is
+    silent, and a shallow fetch boundary hides a far-back merge base the same
+    way. Falling back to `HEAD~1..HEAD` then gates the whole matrix on the tip
+    commit: this repo's tip is docs-only while the solver change sits a commit
+    behind it, so every solver job would be skipped on a PR that changes the
+    solver — not red, just absent.
+    """
+    repo, _base, tip = _make_pr_repo(tmp_path)
+    script = _render(_gate_script(), event="pull_request", before="", sha=tip, base_ref="main")
+    assert _run_gate(repo, script) == "true"
+
+
+def test_pull_request_with_a_merge_base_sees_past_the_tip_commit(tmp_path):
+    """Control for the test above, and the behaviour that must be preserved.
+
+    Same repo, same event, same rendered script — only `origin/main` is made
+    resolvable. The gate must diff from the merge base, so it sees the solver
+    change two commits back even though the tip is docs-only.
+    """
+    repo, base, tip = _make_pr_repo(tmp_path)
+    _git(repo, "update-ref", "refs/remotes/origin/main", base)
+    script = _render(_gate_script(), event="pull_request", before="", sha=tip, base_ref="main")
+    assert _run_gate(repo, script) == "true"
+
+
+def test_pull_request_docs_only_against_its_merge_base_skips(tmp_path):
+    """A genuinely docs-only PR must still skip — the gate's reason for being."""
+    repo, base, tip = _make_repo(tmp_path, ["docs/notes.md", "README.md"])
+    _git(repo, "update-ref", "refs/remotes/origin/main", base)
+    script = _render(_gate_script(), event="pull_request", before="", sha=tip, base_ref="main")
+    assert _run_gate(repo, script) == "false"
 
 
 # ----------------------------------------------------------------------

--- a/python/tests/test_disjunctive_config_bound.py
+++ b/python/tests/test_disjunctive_config_bound.py
@@ -84,6 +84,71 @@ def test_anytime_validity_tiny_budget(monkeypatch):
         assert res.bound <= EX1252_OPT + 1e-2, "bound above the optimum is unsound"
 
 
+def test_stopped_on_reports_the_clock_when_the_deadline_fires(monkeypatch):
+    """An already-expired deadline must be reported as such, not as a bound.
+
+    Without this field the result of a clock-truncated pass is indistinguishable
+    from a fully-budgeted one, so a slow runner and a bound regression produce
+    the same evidence.
+    """
+    r = _reformed(monkeypatch)
+    lb, ub = flat_variable_bounds(r)
+    res = compute_disjunctive_config_bound(
+        r,
+        np.asarray(lb),
+        np.asarray(ub),
+        max_leaf_solves=120,
+        deadline=time.perf_counter() - 1.0,  # already gone
+    )
+    assert res.stopped_on == "deadline", f"expected 'deadline', got {res.stopped_on!r}"
+    assert res.n_processed == 0
+
+
+def test_stopped_on_reports_the_budget_when_the_leaf_cap_fires(monkeypatch):
+    """The reproducible stopping rule reports itself distinctly from the clock."""
+    r = _reformed(monkeypatch)
+    lb, ub = flat_variable_bounds(r)
+    res = compute_disjunctive_config_bound(
+        r,
+        np.asarray(lb),
+        np.asarray(ub),
+        max_leaf_solves=2,
+        deadline=time.perf_counter() + 600.0,  # generous: must not be what stops it
+    )
+    assert res.stopped_on == "budget", f"expected 'budget', got {res.stopped_on!r}"
+    assert res.n_processed == 2
+
+
+def _assert_budget_not_clock(res, budget: int, deadline_s: float) -> None:
+    """The quality bars below are only readable if the LEAF BUDGET ended the pass.
+
+    The pass stops on whichever of ``max_leaf_solves`` and ``deadline`` comes
+    first. The leaf budget is reproducible: at a fixed budget the bound is a
+    function of the relaxation alone (measured bit-identical across two arms and
+    two budgets — 37945.427865923564 at 48 leaves, 63080.286987442756 at 120).
+    The clock is not: whatever the pass has managed by then depends on the
+    machine.
+
+    So a bound below the bar means one of two completely different things, and
+    the difference is not visible in the bound. This turns the ambiguity into two
+    distinct failures. Do NOT "fix" a clock-bound failure by lowering the bar —
+    raise the deadline, or get a faster runner.
+
+    History: the nightly lane read 33498 (42/120 leaves) and 31567 (32/48) on a
+    runner ~3x slower than the reference machine and reported both as bound
+    regressions. Both were the deadline; the bounds at full budget were unchanged
+    to the last digit.
+    """
+    assert res.stopped_on != "deadline", (
+        f"CLOCK-BOUND, not a bound regression: the pass hit its {deadline_s:.0f}s "
+        f"deadline after only {res.n_processed}/{budget} leaf solves, so the bound "
+        f"it reports ({res.bound}) measures this runner's speed, not the "
+        f"relaxation. Raise the deadline (the job's own timeout is the backstop); "
+        f"do NOT lower the quality bar."
+    )
+    assert res.n_processed > 0, "the pass processed no leaf at all — it did not fire"
+
+
 @pytest.mark.slow
 def test_ex1252_spatial_recursion_clears_721_bar(monkeypatch):
     """#732 Stage 4: with continuous bisection at count-complete leaves, the pass
@@ -94,20 +159,23 @@ def test_ex1252_spatial_recursion_clears_721_bar(monkeypatch):
     Stage 2: counts are still splittable there, so the spatial extension only
     engages deeper).
     """
+    budget, deadline_s = 120, 1500.0
     r = _reformed(monkeypatch)
     lb, ub = flat_variable_bounds(r)
     res = compute_disjunctive_config_bound(
         r,
         np.asarray(lb),
         np.asarray(ub),
-        max_leaf_solves=120,
-        deadline=time.perf_counter() + 240.0,
+        max_leaf_solves=budget,
+        deadline=time.perf_counter() + deadline_s,
     )
     assert res.bound is not None
     assert res.bound <= EX1252_OPT + 1e-2, f"UNSOUND: {res.bound} > optimum {EX1252_OPT}"
+    _assert_budget_not_clock(res, budget, deadline_s)
     assert res.bound >= 48000.0, (
-        f"spatial recursion bound {res.bound} fell below the #721 bar (48k) — "
-        "re-run the plan-doc Stage-4 measurement before shipping a change here"
+        f"spatial recursion bound {res.bound} fell below the #721 bar (48k) at the "
+        f"full {budget}-leaf budget — re-run the plan-doc Stage-4 measurement "
+        "before shipping a change here"
     )
 
 
@@ -119,20 +187,23 @@ def test_ex1252_pass_clears_stage2_gate(monkeypatch):
     >= 33k gate (12658); the disjunctive pass clears it with no incumbent and no
     tree (measured ~37.9k at this budget).
     """
+    budget, deadline_s = 48, 600.0
     r = _reformed(monkeypatch)
     lb, ub = flat_variable_bounds(r)
     res = compute_disjunctive_config_bound(
         r,
         np.asarray(lb),
         np.asarray(ub),
-        max_leaf_solves=48,
-        deadline=time.perf_counter() + 180.0,
+        max_leaf_solves=budget,
+        deadline=time.perf_counter() + deadline_s,
     )
     assert res.bound is not None, "the pass must certify a bound on the config class"
     assert res.bound <= EX1252_OPT + 1e-2, f"UNSOUND: {res.bound} > optimum {EX1252_OPT}"
+    _assert_budget_not_clock(res, budget, deadline_s)
     assert res.bound >= STAGE2_GATE, (
-        f"pass bound {res.bound} fell below the Stage-2 gate {STAGE2_GATE} — "
-        "re-run the plan-doc entry experiments before shipping a change here"
+        f"pass bound {res.bound} fell below the Stage-2 gate {STAGE2_GATE} at the "
+        f"full {budget}-leaf budget — re-run the plan-doc entry experiments before "
+        "shipping a change here"
     )
 
 


### PR DESCRIPTION
## Summary

Two CI defects found while driving #960 to green. Both share a shape: a check that answers confidently from something other than the thing it claims to be testing. Neither has a tracking issue — they were surfaced by the #960 work and are fixed here directly.

### 1. A manual `workflow_dispatch` skipped the entire heavy matrix

The `changes` gate reads `github.event.before`, which exists **only on `push`**. On a dispatch it expands to the empty string, the first `git diff` fails, and the fallback silently diffs `HEAD~1..HEAD` — so the gate answered as if only the tip commit had changed.

Dispatching CI on #960, whose tip touched `CHANGELOG.md` and `docs/dev/data/claim-baseline.jsonl`, produced `code=false` and left Rust, `Python fast`, `Python claim-boundary`, `Python correctness` and AMP all `skipped` — **nine checks that render as *not red* while executing nothing.** That is the #953 failure mode, one trigger over. Measured, from the job's own log:

```
changed="$(git diff --name-only "" "3d240e2e…" || git diff --name-only HEAD~1 HEAD)"
Changed files:  CHANGELOG.md,  docs/dev/data/claim-baseline.jsonl
=> code=false (heavy test jobs will SKIP)
```

- A dispatch is now `code=true` unconditionally — pressing the button means "run everything", and there is no base to diff against anyway.
- The `push` branch no longer substitutes a guess: an all-zero `before` (a branch's first push), a non-existent object (force-push, shallow clone), or an empty one is now the **uncertainty** case the job's own comment already promised to resolve as `true`.

### 2. Two `ex1252` quality bars measured the runner, not the relaxation

`compute_disjunctive_config_bound` stops on whichever of `max_leaf_solves` and `deadline` comes first, and reported no indication of which. The leaf budget is reproducible; the clock is not. The nightly lane read 33498 (42/120 leaves) and 31567 (32/48) on a runner ~3× slower than the reference machine and failed both bars as if the bound had regressed.

**It had not.** Measured at the full budget, the bound is bit-identical across the #957 boundary:

| budget | before (`main` @ 726ae1e7) | after (#957) |
| --- | --- | --- |
| 48 leaves | 37945.427865923564 · 26 leaves · 2 pruned · 57.8 s | **37945.427865923564** · 26 · 2 · 55.5 s |
| 120 leaves | 63080.286987442756 · 59 leaves · 5 pruned · 137.1 s | **63080.286987442756** · 59 · 5 · 135.2 s |

Both match the values the tests' own docstrings record (~37.9k, 63080), both arms reached the full budget, and #957 was marginally *faster*.

`DisjunctiveConfigResult` gains `stopped_on` (`"budget"` / `"deadline"` / `"exhausted"`), mirroring `WorkBudget.stopped_on` from #912 — the same distinction between a search decided by work and one decided by the clock. The two bars now assert `stopped_on != "deadline"` **before** the bound comparison, so a slow machine and a bound regression produce different failures with different instructions, and the clock-bound message says explicitly not to lower the bar. Deadlines are re-sized as backstops at ~2× the measured runner rate (0.175 leaf solves/s → 600 s for 48 leaves, 1500 s for 120), and the nightly lane's `--timeout` goes 900 s → 1800 s so the harness timeout is never what decides a quality bar. The 120-minute job timeout remains the backstop against a hang.

The solver's own in-solve log line now reports `stopped_on` too; there it is expected to read `"deadline"`, because that path is anytime by design (the leaf cap is a runaway backstop).

> **Timing note:** the nightly fires at 06:20 UTC. If it runs before this merges, expect those two `ex1252` bars red again with the old misleading message — that is the bug this fixes, not a new one.

## Correctness

No solver math changes. `stopped_on` is pure instrumentation: a new field with a default, one construction site, set only inside the existing `_out_of_budget` predicate — it cannot change which leaves are processed or what bound is returned. Verified empirically: the `ex1252` bound is bit-identical at both budgets (table above), with identical leaf and prune counts. The workflow change can only cause *more* jobs to run, never fewer.

- [x] Cannot produce a false certificate — N/A, no solver-math change (and the one bound measured is bit-identical)
- [x] No validation, fallback, or safety guard was weakened — the reverse: two guards that were silently answering without measuring now measure, and a third (`_assert_budget_not_clock`) was added ahead of the existing bars

## Tests run (state the result — numbers, not adjectives)

- [x] `pytest -m smoke python/tests/` → **916 passed, 15 skipped, 2 xpassed** (376 s) — identical to the pre-change baseline
- [x] `pytest python/tests/test_disjunctive_config_bound.py -m correctness` → **7 passed** (198 s), including both re-armed `ex1252` bars
- [x] `pytest python/tests/test_ci_changes_gate.py` → **9 passed** (2.3 s)
- [x] `cargo test -p discopt-core` → N/A, no Rust touched
- [x] `ruff check` / `ruff format --check` clean; `ci.yml` parses as YAML (10 jobs, 4 triggers)

## Regression test

**`python/tests/test_ci_changes_gate.py`** (new, 9 tests) extracts the gate's *real* shell script out of `ci.yml` — not a copy, so it cannot drift — renders the `${{ github.* }}` expressions, and runs it against throwaway git repos, one case per event type. Against the pre-change workflow:

```
5 failed, 4 passed
  FAILED test_workflow_dispatch_always_runs_everything
  FAILED test_push_with_an_unusable_base_runs_everything[]
  FAILED test_push_with_an_unusable_base_runs_everything[0000…]
  FAILED test_push_with_an_unusable_base_runs_everything[not-a-sha]
  FAILED test_push_with_an_unusable_base_runs_everything[deadbeef…]
```

The 4 that pass both ways are the deliberate pins on behaviour that must **not** change: docs-only pushes still skip, a code file still runs, `schedule` still skips the PR matrix.

**`test_stopped_on_reports_the_clock_when_the_deadline_fires`** / **`…_the_budget_when_the_leaf_cap_fires`** (new) fail with `AttributeError: 'DisjunctiveConfigResult' object has no attribute 'stopped_on'` on the pre-change source and pass after. Both are fast (0.1 s and 1.9 s) — no `slow` marker needed.

- [x] Added regression tests that fail before / pass after


---
_Generated by [Claude Code](https://claude.ai/code/session_01TJpDTK6fNERipKaSfDrhLC)_