### PR TITLE
perf(panel): #928/#966 coupled graduation panel FAILED — record the verdict

### DIFF
--- a/discopt_benchmarks/results/issue928_contvar_attribution.json
+++ b/discopt_benchmarks/results/issue928_contvar_attribution.json
@@ -1,0 +1,322 @@
+[
+  {
+    "rep": 1,
+    "instance": "contvar",
+    "arm": "base",
+    "flags": {
+      "DISCOPT_LP_WARM_DEADLINE": "0",
+      "DISCOPT_NODE_ROUND_BUDGET": "0",
+      "DISCOPT_HESS_COMPILE_GATE": "0"
+    },
+    "budget": 20.0,
+    "sense": "min",
+    "wall": 20.627214749983978,
+    "status": "time_limit",
+    "objective": null,
+    "bound": 183632.7659824633,
+    "gap": null,
+    "gap_certified": false,
+    "node_count": 7,
+    "incumbent_verification_failed": false
+  },
+  {
+    "rep": 1,
+    "instance": "contvar",
+    "arm": "warm",
+    "flags": {
+      "DISCOPT_LP_WARM_DEADLINE": "1",
+      "DISCOPT_NODE_ROUND_BUDGET": "0",
+      "DISCOPT_HESS_COMPILE_GATE": "0"
+    },
+    "budget": 20.0,
+    "sense": "min",
+    "wall": 21.096953250002116,
+    "status": "feasible",
+    "objective": 813745.1251099914,
+    "bound": 98924.53008646052,
+    "gap": 0.8784330289252557,
+    "gap_certified": false,
+    "node_count": 3,
+    "incumbent_verification_failed": false
+  },
+  {
+    "rep": 1,
+    "instance": "contvar",
+    "arm": "seam",
+    "flags": {
+      "DISCOPT_LP_WARM_DEADLINE": "0",
+      "DISCOPT_NODE_ROUND_BUDGET": "1",
+      "DISCOPT_HESS_COMPILE_GATE": "1"
+    },
+    "budget": 20.0,
+    "sense": "min",
+    "wall": 21.185290375025943,
+    "status": "time_limit",
+    "objective": null,
+    "bound": 183632.7659824633,
+    "gap": null,
+    "gap_certified": false,
+    "node_count": 7,
+    "incumbent_verification_failed": false
+  },
+  {
+    "rep": 1,
+    "instance": "contvar",
+    "arm": "cand",
+    "flags": {
+      "DISCOPT_LP_WARM_DEADLINE": "1",
+      "DISCOPT_NODE_ROUND_BUDGET": "1",
+      "DISCOPT_HESS_COMPILE_GATE": "1"
+    },
+    "budget": 20.0,
+    "sense": "min",
+    "wall": 21.46723395900335,
+    "status": "time_limit",
+    "objective": null,
+    "bound": null,
+    "gap": null,
+    "gap_certified": false,
+    "node_count": 287,
+    "incumbent_verification_failed": false
+  },
+  {
+    "rep": 1,
+    "instance": "casctanks",
+    "arm": "base",
+    "flags": {
+      "DISCOPT_LP_WARM_DEADLINE": "0",
+      "DISCOPT_NODE_ROUND_BUDGET": "0",
+      "DISCOPT_HESS_COMPILE_GATE": "0"
+    },
+    "budget": 20.0,
+    "sense": "min",
+    "wall": 20.978712959040422,
+    "status": "time_limit",
+    "objective": null,
+    "bound": 2.9097722176628698,
+    "gap": null,
+    "gap_certified": false,
+    "node_count": 31,
+    "incumbent_verification_failed": false
+  },
+  {
+    "rep": 1,
+    "instance": "casctanks",
+    "arm": "warm",
+    "flags": {
+      "DISCOPT_LP_WARM_DEADLINE": "1",
+      "DISCOPT_NODE_ROUND_BUDGET": "0",
+      "DISCOPT_HESS_COMPILE_GATE": "0"
+    },
+    "budget": 20.0,
+    "sense": "min",
+    "wall": 20.77560045896098,
+    "status": "time_limit",
+    "objective": null,
+    "bound": 2.459772217662872,
+    "gap": null,
+    "gap_certified": false,
+    "node_count": 31,
+    "incumbent_verification_failed": false
+  },
+  {
+    "rep": 1,
+    "instance": "casctanks",
+    "arm": "seam",
+    "flags": {
+      "DISCOPT_LP_WARM_DEADLINE": "0",
+      "DISCOPT_NODE_ROUND_BUDGET": "1",
+      "DISCOPT_HESS_COMPILE_GATE": "1"
+    },
+    "budget": 20.0,
+    "sense": "min",
+    "wall": 20.83302883396391,
+    "status": "time_limit",
+    "objective": null,
+    "bound": -56.50012254242376,
+    "gap": null,
+    "gap_certified": false,
+    "node_count": 63,
+    "incumbent_verification_failed": false
+  },
+  {
+    "rep": 1,
+    "instance": "casctanks",
+    "arm": "cand",
+    "flags": {
+      "DISCOPT_LP_WARM_DEADLINE": "1",
+      "DISCOPT_NODE_ROUND_BUDGET": "1",
+      "DISCOPT_HESS_COMPILE_GATE": "1"
+    },
+    "budget": 20.0,
+    "sense": "min",
+    "wall": 23.77358900004765,
+    "status": "time_limit",
+    "objective": null,
+    "bound": -57.23286411961264,
+    "gap": null,
+    "gap_certified": false,
+    "node_count": 95,
+    "incumbent_verification_failed": false
+  },
+  {
+    "rep": 2,
+    "instance": "contvar",
+    "arm": "base",
+    "flags": {
+      "DISCOPT_LP_WARM_DEADLINE": "0",
+      "DISCOPT_NODE_ROUND_BUDGET": "0",
+      "DISCOPT_HESS_COMPILE_GATE": "0"
+    },
+    "budget": 20.0,
+    "sense": "min",
+    "wall": 22.535775540978648,
+    "status": "time_limit",
+    "objective": null,
+    "bound": 183632.7659824633,
+    "gap": null,
+    "gap_certified": false,
+    "node_count": 7,
+    "incumbent_verification_failed": false
+  },
+  {
+    "rep": 2,
+    "instance": "contvar",
+    "arm": "warm",
+    "flags": {
+      "DISCOPT_LP_WARM_DEADLINE": "1",
+      "DISCOPT_NODE_ROUND_BUDGET": "0",
+      "DISCOPT_HESS_COMPILE_GATE": "0"
+    },
+    "budget": 20.0,
+    "sense": "min",
+    "wall": 20.98376458295388,
+    "status": "feasible",
+    "objective": 813745.1251099914,
+    "bound": 98924.53008646052,
+    "gap": 0.8784330289252557,
+    "gap_certified": false,
+    "node_count": 3,
+    "incumbent_verification_failed": false
+  },
+  {
+    "rep": 2,
+    "instance": "contvar",
+    "arm": "seam",
+    "flags": {
+      "DISCOPT_LP_WARM_DEADLINE": "0",
+      "DISCOPT_NODE_ROUND_BUDGET": "1",
+      "DISCOPT_HESS_COMPILE_GATE": "1"
+    },
+    "budget": 20.0,
+    "sense": "min",
+    "wall": 21.23168304102728,
+    "status": "time_limit",
+    "objective": null,
+    "bound": 183632.7659824633,
+    "gap": null,
+    "gap_certified": false,
+    "node_count": 7,
+    "incumbent_verification_failed": false
+  },
+  {
+    "rep": 2,
+    "instance": "contvar",
+    "arm": "cand",
+    "flags": {
+      "DISCOPT_LP_WARM_DEADLINE": "1",
+      "DISCOPT_NODE_ROUND_BUDGET": "1",
+      "DISCOPT_HESS_COMPILE_GATE": "1"
+    },
+    "budget": 20.0,
+    "sense": "min",
+    "wall": 21.446579541021492,
+    "status": "time_limit",
+    "objective": null,
+    "bound": null,
+    "gap": null,
+    "gap_certified": false,
+    "node_count": 287,
+    "incumbent_verification_failed": false
+  },
+  {
+    "rep": 2,
+    "instance": "casctanks",
+    "arm": "base",
+    "flags": {
+      "DISCOPT_LP_WARM_DEADLINE": "0",
+      "DISCOPT_NODE_ROUND_BUDGET": "0",
+      "DISCOPT_HESS_COMPILE_GATE": "0"
+    },
+    "budget": 20.0,
+    "sense": "min",
+    "wall": 20.986686040996574,
+    "status": "time_limit",
+    "objective": null,
+    "bound": 2.9097722176628698,
+    "gap": null,
+    "gap_certified": false,
+    "node_count": 31,
+    "incumbent_verification_failed": false
+  },
+  {
+    "rep": 2,
+    "instance": "casctanks",
+    "arm": "warm",
+    "flags": {
+      "DISCOPT_LP_WARM_DEADLINE": "1",
+      "DISCOPT_NODE_ROUND_BUDGET": "0",
+      "DISCOPT_HESS_COMPILE_GATE": "0"
+    },
+    "budget": 20.0,
+    "sense": "min",
+    "wall": 20.866780457959976,
+    "status": "time_limit",
+    "objective": null,
+    "bound": 2.459772217662872,
+    "gap": null,
+    "gap_certified": false,
+    "node_count": 31,
+    "incumbent_verification_failed": false
+  },
+  {
+    "rep": 2,
+    "instance": "casctanks",
+    "arm": "seam",
+    "flags": {
+      "DISCOPT_LP_WARM_DEADLINE": "0",
+      "DISCOPT_NODE_ROUND_BUDGET": "1",
+      "DISCOPT_HESS_COMPILE_GATE": "1"
+    },
+    "budget": 20.0,
+    "sense": "min",
+    "wall": 21.71995912498096,
+    "status": "time_limit",
+    "objective": null,
+    "bound": -56.50012254242376,
+    "gap": null,
+    "gap_certified": false,
+    "node_count": 63,
+    "incumbent_verification_failed": false
+  },
+  {
+    "rep": 2,
+    "instance": "casctanks",
+    "arm": "cand",
+    "flags": {
+      "DISCOPT_LP_WARM_DEADLINE": "1",
+      "DISCOPT_NODE_ROUND_BUDGET": "1",
+      "DISCOPT_HESS_COMPILE_GATE": "1"
+    },
+    "budget": 20.0,
+    "sense": "min",
+    "wall": 20.585538915998768,
+    "status": "time_limit",
+    "objective": null,
+    "bound": -60.74576346138068,
+    "gap": null,
+    "gap_certified": false,
+    "node_count": 63,
+    "incumbent_verification_failed": false
+  }
+]

--- a/discopt_benchmarks/results/issue966_coupled_binding20_rep1.json
+++ b/discopt_benchmarks/results/issue966_coupled_binding20_rep1.json
@@ -1,0 +1,1258 @@
+{
+  "summary": {
+    "instances": 19,
+    "budget": 20.0,
+    "arms": {
+      "base": "all OFF (today's default)",
+      "seam": "#966 ON, #928 OFF",
+      "cand": "all three ON"
+    },
+    "unsound": [],
+    "incumbent_verification_failed": [],
+    "pairs": [
+      {
+        "pair": "cand vs base",
+        "cells_over_budget": {
+          "base": 4,
+          "cand": 4
+        },
+        "total_overrun_s": {
+          "base": 22.2,
+          "cand": 19.6
+        },
+        "overrun_delta_s": -2.6,
+        "node_count_total": {
+          "base": 1329,
+          "cand": 1863
+        },
+        "cert_gains": [],
+        "cert_regressions": [],
+        "gained_incumbents": [],
+        "lost_incumbents": [],
+        "better_objective": [],
+        "worse_objective": [],
+        "tighter_bound": [
+          "beuster (19641.545373714685 -> 19641.605888231275)",
+          "tspn08 (267.8080239536436 -> 268.3529327885914)",
+          "tspn10 (166.12311826214523 -> 174.28500842155333)",
+          "tspn12 (198.54001195665876 -> 198.54006501145957)"
+        ],
+        "looser_bound": [
+          "casctanks (2.9097722176628698 -> -57.23286411961264)",
+          "nvs05 (4.099237735891656 -> 3.8053689247019755)",
+          "syn05hfsg (837.7324008980034 -> 837.7324095240308)",
+          "tls2 (1.2276411002856007 -> 1.1964300462250628)",
+          "tspn05 (191.25510622528546 -> 191.25507754309677)"
+        ],
+        "gained_bound": [],
+        "lost_bound": [
+          "contvar (183632.7659824633 -> None)"
+        ]
+      },
+      {
+        "pair": "cand vs seam",
+        "cells_over_budget": {
+          "seam": 5,
+          "cand": 4
+        },
+        "total_overrun_s": {
+          "seam": 16.3,
+          "cand": 19.6
+        },
+        "overrun_delta_s": 3.4,
+        "node_count_total": {
+          "seam": 1811,
+          "cand": 1863
+        },
+        "cert_gains": [],
+        "cert_regressions": [],
+        "gained_incumbents": [],
+        "lost_incumbents": [],
+        "better_objective": [],
+        "worse_objective": [],
+        "tighter_bound": [
+          "beuster (19641.5453739425 -> 19641.605888231275)",
+          "tspn08 (267.8080239536436 -> 268.3529327885914)",
+          "tspn10 (167.35910515007944 -> 174.28500842155333)",
+          "tspn12 (198.54001195665876 -> 198.54006501145957)"
+        ],
+        "looser_bound": [
+          "casctanks (-56.50012254242376 -> -57.23286411961264)",
+          "syn05hfsg (837.7324008980034 -> 837.7324095240308)",
+          "tls2 (1.3420196896557366 -> 1.1964300462250628)",
+          "tspn05 (191.25510622528546 -> 191.25507754309677)"
+        ],
+        "gained_bound": [],
+        "lost_bound": [
+          "contvar (183632.7659824633 -> None)"
+        ]
+      },
+      {
+        "pair": "seam vs base",
+        "cells_over_budget": {
+          "base": 4,
+          "seam": 5
+        },
+        "total_overrun_s": {
+          "base": 22.2,
+          "seam": 16.3
+        },
+        "overrun_delta_s": -6.0,
+        "node_count_total": {
+          "base": 1329,
+          "seam": 1811
+        },
+        "cert_gains": [],
+        "cert_regressions": [],
+        "gained_incumbents": [],
+        "lost_incumbents": [],
+        "better_objective": [],
+        "worse_objective": [],
+        "tighter_bound": [
+          "tls2 (1.2276411002856007 -> 1.3420196896557366)",
+          "tspn10 (166.12311826214523 -> 167.35910515007944)"
+        ],
+        "looser_bound": [
+          "casctanks (2.9097722176628698 -> -56.50012254242376)",
+          "nvs05 (4.099237735891656 -> 3.8053689247019755)"
+        ],
+        "gained_bound": [],
+        "lost_bound": []
+      }
+    ],
+    "panel_wall_s": 1136.9,
+    "loadavg_start": [
+      6.69,
+      5.86,
+      4.48
+    ],
+    "loadavg_end": [
+      3.71,
+      4.58,
+      4.78
+    ]
+  },
+  "cells": [
+    {
+      "instance": "4stufen",
+      "budget": 20.0,
+      "reference_optimum": null,
+      "base": {
+        "instance": "4stufen",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 20.441667791979853,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 20712.174649175664,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 7,
+        "incumbent_verification_failed": false
+      },
+      "seam": {
+        "instance": "4stufen",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 20.453620374959428,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 20712.174649175664,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 7,
+        "incumbent_verification_failed": false
+      },
+      "cand": {
+        "instance": "4stufen",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "1",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 20.48533337499248,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 20712.17464917334,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 7,
+        "incumbent_verification_failed": false
+      }
+    },
+    {
+      "instance": "bchoco06",
+      "budget": 20.0,
+      "reference_optimum": null,
+      "base": {
+        "instance": "bchoco06",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "max",
+        "wall": 20.54396808304591,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 1.0000000000126652,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 3,
+        "incumbent_verification_failed": false
+      },
+      "seam": {
+        "instance": "bchoco06",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "max",
+        "wall": 20.538999875017907,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 1.0000000000126652,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 3,
+        "incumbent_verification_failed": false
+      },
+      "cand": {
+        "instance": "bchoco06",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "1",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "max",
+        "wall": 20.55658166698413,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 1.0000000000001554,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 3,
+        "incumbent_verification_failed": false
+      }
+    },
+    {
+      "instance": "bchoco07",
+      "budget": 20.0,
+      "reference_optimum": null,
+      "base": {
+        "instance": "bchoco07",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "max",
+        "wall": 20.631007292016875,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 0.9999909483405423,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 15,
+        "incumbent_verification_failed": false
+      },
+      "seam": {
+        "instance": "bchoco07",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "max",
+        "wall": 20.466495874978136,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 0.9999909483405423,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 63,
+        "incumbent_verification_failed": false
+      },
+      "cand": {
+        "instance": "bchoco07",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "1",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "max",
+        "wall": 20.484140292042866,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 0.9999909483405423,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 63,
+        "incumbent_verification_failed": false
+      }
+    },
+    {
+      "instance": "bchoco08",
+      "budget": 20.0,
+      "reference_optimum": null,
+      "base": {
+        "instance": "bchoco08",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "max",
+        "wall": 20.96226174995536,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 1.0000000000038425,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 7,
+        "incumbent_verification_failed": false
+      },
+      "seam": {
+        "instance": "bchoco08",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "max",
+        "wall": 22.158700332976878,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 1.0000000000030296,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 15,
+        "incumbent_verification_failed": false
+      },
+      "cand": {
+        "instance": "bchoco08",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "1",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "max",
+        "wall": 20.51945662498474,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 1.0000000000005946,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 15,
+        "incumbent_verification_failed": false
+      }
+    },
+    {
+      "instance": "beuster",
+      "budget": 20.0,
+      "reference_optimum": null,
+      "base": {
+        "instance": "beuster",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 20.675709667033516,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 19641.545373714685,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 31,
+        "incumbent_verification_failed": false
+      },
+      "seam": {
+        "instance": "beuster",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 20.382557249977253,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 19641.5453739425,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 287,
+        "incumbent_verification_failed": false
+      },
+      "cand": {
+        "instance": "beuster",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "1",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 20.39440258400282,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 19641.605888231275,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 287,
+        "incumbent_verification_failed": false
+      }
+    },
+    {
+      "instance": "casctanks",
+      "budget": 20.0,
+      "reference_optimum": null,
+      "base": {
+        "instance": "casctanks",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 20.98886062495876,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 2.9097722176628698,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 31,
+        "incumbent_verification_failed": false
+      },
+      "seam": {
+        "instance": "casctanks",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 20.93146524997428,
+        "status": "time_limit",
+        "objective": null,
+        "bound": -56.50012254242376,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 63,
+        "incumbent_verification_failed": false
+      },
+      "cand": {
+        "instance": "casctanks",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "1",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 23.66690104198642,
+        "status": "time_limit",
+        "objective": null,
+        "bound": -57.23286411961264,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 95,
+        "incumbent_verification_failed": false
+      }
+    },
+    {
+      "instance": "clay0303hfsg",
+      "budget": 20.0,
+      "reference_optimum": 26669.10955143,
+      "base": {
+        "instance": "clay0303hfsg",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 20.674125709047075,
+        "status": "feasible",
+        "objective": 26669.109572842688,
+        "bound": 20947.586912205985,
+        "gap": 0.2145374462169132,
+        "gap_certified": false,
+        "node_count": 413,
+        "incumbent_verification_failed": false
+      },
+      "seam": {
+        "instance": "clay0303hfsg",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 20.500371125002857,
+        "status": "feasible",
+        "objective": 26669.109572842688,
+        "bound": 20947.586912205985,
+        "gap": 0.2145374462169132,
+        "gap_certified": false,
+        "node_count": 413,
+        "incumbent_verification_failed": false
+      },
+      "cand": {
+        "instance": "clay0303hfsg",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "1",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 20.67651099996874,
+        "status": "feasible",
+        "objective": 26669.109572842688,
+        "bound": 20947.586912205985,
+        "gap": 0.2145374462169132,
+        "gap_certified": false,
+        "node_count": 413,
+        "incumbent_verification_failed": false
+      }
+    },
+    {
+      "instance": "contvar",
+      "budget": 20.0,
+      "reference_optimum": null,
+      "base": {
+        "instance": "contvar",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 22.49741599999834,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 183632.7659824633,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 7,
+        "incumbent_verification_failed": false
+      },
+      "seam": {
+        "instance": "contvar",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 21.164642708026804,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 183632.7659824633,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 7,
+        "incumbent_verification_failed": false
+      },
+      "cand": {
+        "instance": "contvar",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "1",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 21.472301458998118,
+        "status": "time_limit",
+        "objective": null,
+        "bound": null,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 287,
+        "incumbent_verification_failed": false
+      }
+    },
+    {
+      "instance": "hda",
+      "budget": 20.0,
+      "reference_optimum": null,
+      "base": {
+        "instance": "hda",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 22.85106524999719,
+        "status": "time_limit",
+        "objective": null,
+        "bound": -64473.44240151017,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 3,
+        "incumbent_verification_failed": false
+      },
+      "seam": {
+        "instance": "hda",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 22.850456417014357,
+        "status": "time_limit",
+        "objective": null,
+        "bound": -64473.44240151017,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 3,
+        "incumbent_verification_failed": false
+      },
+      "cand": {
+        "instance": "hda",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "1",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 20.92067083303118,
+        "status": "time_limit",
+        "objective": null,
+        "bound": -64473.4424015326,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 3,
+        "incumbent_verification_failed": false
+      }
+    },
+    {
+      "instance": "heatexch_gen1",
+      "budget": 20.0,
+      "reference_optimum": null,
+      "base": {
+        "instance": "heatexch_gen1",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 21.629729042004328,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 38183.53174601794,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 3,
+        "incumbent_verification_failed": false
+      },
+      "seam": {
+        "instance": "heatexch_gen1",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 21.465249083994422,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 38183.53174601794,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 3,
+        "incumbent_verification_failed": false
+      },
+      "cand": {
+        "instance": "heatexch_gen1",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "1",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 24.387570874998346,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 38183.53174601911,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 3,
+        "incumbent_verification_failed": false
+      }
+    },
+    {
+      "instance": "heatexch_gen2",
+      "budget": 20.0,
+      "reference_optimum": null,
+      "base": {
+        "instance": "heatexch_gen2",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 20.596186082984786,
+        "status": "feasible",
+        "objective": 824551.3269251497,
+        "bound": 555767.7902857282,
+        "gap": 0.32597550675437925,
+        "gap_certified": false,
+        "node_count": 3,
+        "incumbent_verification_failed": false
+      },
+      "seam": {
+        "instance": "heatexch_gen2",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 20.59813550004037,
+        "status": "feasible",
+        "objective": 824551.3269251497,
+        "bound": 555767.7902857282,
+        "gap": 0.32597550675437925,
+        "gap_certified": false,
+        "node_count": 3,
+        "incumbent_verification_failed": false
+      },
+      "cand": {
+        "instance": "heatexch_gen2",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "1",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 20.62406862503849,
+        "status": "feasible",
+        "objective": 824551.3269251497,
+        "bound": 555767.7902857201,
+        "gap": 0.32597550675438897,
+        "gap_certified": false,
+        "node_count": 3,
+        "incumbent_verification_failed": false
+      }
+    },
+    {
+      "instance": "heatexch_gen3",
+      "budget": 20.0,
+      "reference_optimum": null,
+      "base": {
+        "instance": "heatexch_gen3",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 27.4498693330097,
+        "status": "time_limit",
+        "objective": null,
+        "bound": null,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 3,
+        "incumbent_verification_failed": false
+      },
+      "seam": {
+        "instance": "heatexch_gen3",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 22.543883500038646,
+        "status": "time_limit",
+        "objective": null,
+        "bound": null,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 95,
+        "incumbent_verification_failed": false
+      },
+      "cand": {
+        "instance": "heatexch_gen3",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "1",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 22.73786029202165,
+        "status": "time_limit",
+        "objective": null,
+        "bound": null,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 95,
+        "incumbent_verification_failed": false
+      }
+    },
+    {
+      "instance": "nvs05",
+      "budget": 20.0,
+      "reference_optimum": null,
+      "base": {
+        "instance": "nvs05",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 20.384551791998092,
+        "status": "feasible",
+        "objective": 8.731956986640789,
+        "bound": 4.099237735891656,
+        "gap": 0.530547649036388,
+        "gap_certified": false,
+        "node_count": 155,
+        "incumbent_verification_failed": false
+      },
+      "seam": {
+        "instance": "nvs05",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 20.376883457996882,
+        "status": "feasible",
+        "objective": 8.731956986640789,
+        "bound": 3.8053689247019755,
+        "gap": 0.564202053385754,
+        "gap_certified": false,
+        "node_count": 155,
+        "incumbent_verification_failed": false
+      },
+      "cand": {
+        "instance": "nvs05",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "1",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 20.369041833968367,
+        "status": "feasible",
+        "objective": 8.731956986640789,
+        "bound": 3.8053689247019755,
+        "gap": 0.564202053385754,
+        "gap_certified": false,
+        "node_count": 131,
+        "incumbent_verification_failed": false
+      }
+    },
+    {
+      "instance": "syn05hfsg",
+      "budget": 20.0,
+      "reference_optimum": null,
+      "base": {
+        "instance": "syn05hfsg",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "max",
+        "wall": 6.026838833000511,
+        "status": "optimal",
+        "objective": 837.7323012718434,
+        "bound": 837.7324008980034,
+        "gap": 2.8091518703525014e-14,
+        "gap_certified": true,
+        "node_count": 285,
+        "incumbent_verification_failed": false
+      },
+      "seam": {
+        "instance": "syn05hfsg",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "max",
+        "wall": 5.837811542034615,
+        "status": "optimal",
+        "objective": 837.7323012718434,
+        "bound": 837.7324008980034,
+        "gap": 2.8091518703525014e-14,
+        "gap_certified": true,
+        "node_count": 285,
+        "incumbent_verification_failed": false
+      },
+      "cand": {
+        "instance": "syn05hfsg",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "1",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "max",
+        "wall": 4.4395788750262,
+        "status": "optimal",
+        "objective": 837.7323012718434,
+        "bound": 837.7324095240308,
+        "gap": 0.0,
+        "gap_certified": true,
+        "node_count": 155,
+        "incumbent_verification_failed": false
+      }
+    },
+    {
+      "instance": "tls2",
+      "budget": 20.0,
+      "reference_optimum": null,
+      "base": {
+        "instance": "tls2",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 20.51369854202494,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 1.2276411002856007,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 159,
+        "incumbent_verification_failed": false
+      },
+      "seam": {
+        "instance": "tls2",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 20.433186541020405,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 1.3420196896557366,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 191,
+        "incumbent_verification_failed": false
+      },
+      "cand": {
+        "instance": "tls2",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "1",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 20.469841042009648,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 1.1964300462250628,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 127,
+        "incumbent_verification_failed": false
+      }
+    },
+    {
+      "instance": "tspn05",
+      "budget": 20.0,
+      "reference_optimum": null,
+      "base": {
+        "instance": "tspn05",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 9.445083750004414,
+        "status": "optimal",
+        "objective": 191.25520784466957,
+        "bound": 191.25510622528546,
+        "gap": 4.48930877429491e-07,
+        "gap_certified": true,
+        "node_count": 51,
+        "incumbent_verification_failed": false
+      },
+      "seam": {
+        "instance": "tspn05",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 9.449836125015281,
+        "status": "optimal",
+        "objective": 191.25520784466957,
+        "bound": 191.25510622528546,
+        "gap": 4.48930877429491e-07,
+        "gap_certified": true,
+        "node_count": 51,
+        "incumbent_verification_failed": false
+      },
+      "cand": {
+        "instance": "tspn05",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "1",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 7.084607291966677,
+        "status": "optimal",
+        "objective": 191.2552078446693,
+        "bound": 191.25507754309677,
+        "gap": 5.988990548450231e-07,
+        "gap_certified": true,
+        "node_count": 37,
+        "incumbent_verification_failed": false
+      }
+    },
+    {
+      "instance": "tspn08",
+      "budget": 20.0,
+      "reference_optimum": null,
+      "base": {
+        "instance": "tspn08",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 20.405042791971937,
+        "status": "feasible",
+        "objective": 290.566853967556,
+        "bound": 267.8080239536436,
+        "gap": 0.0783256235291504,
+        "gap_certified": false,
+        "node_count": 59,
+        "incumbent_verification_failed": false
+      },
+      "seam": {
+        "instance": "tspn08",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 20.408624625008088,
+        "status": "feasible",
+        "objective": 290.566853967556,
+        "bound": 267.8080239536436,
+        "gap": 0.0783256235291504,
+        "gap_certified": false,
+        "node_count": 59,
+        "incumbent_verification_failed": false
+      },
+      "cand": {
+        "instance": "tspn08",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "1",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 20.607874332985375,
+        "status": "feasible",
+        "objective": 290.56685396755563,
+        "bound": 268.3529327885914,
+        "gap": 0.07645029319636244,
+        "gap_certified": false,
+        "node_count": 53,
+        "incumbent_verification_failed": false
+      }
+    },
+    {
+      "instance": "tspn10",
+      "budget": 20.0,
+      "reference_optimum": null,
+      "base": {
+        "instance": "tspn10",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 20.409821999957785,
+        "status": "feasible",
+        "objective": 225.12607170016918,
+        "bound": 166.12311826214523,
+        "gap": 0.2620884955368748,
+        "gap_certified": false,
+        "node_count": 63,
+        "incumbent_verification_failed": false
+      },
+      "seam": {
+        "instance": "tspn10",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 20.41036995901959,
+        "status": "feasible",
+        "objective": 225.12607170016918,
+        "bound": 167.35910515007944,
+        "gap": 0.256598296740263,
+        "gap_certified": false,
+        "node_count": 63,
+        "incumbent_verification_failed": false
+      },
+      "cand": {
+        "instance": "tspn10",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "1",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 20.81741229101317,
+        "status": "feasible",
+        "objective": 225.12607170017012,
+        "bound": 174.28500842155333,
+        "gap": 0.22583374237670922,
+        "gap_certified": false,
+        "node_count": 55,
+        "incumbent_verification_failed": false
+      }
+    },
+    {
+      "instance": "tspn12",
+      "budget": 20.0,
+      "reference_optimum": null,
+      "base": {
+        "instance": "tspn12",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 20.571172291995026,
+        "status": "feasible",
+        "objective": 262.6473957963286,
+        "bound": 198.54001195665876,
+        "gap": 0.24408155140964083,
+        "gap_certified": false,
+        "node_count": 31,
+        "incumbent_verification_failed": false
+      },
+      "seam": {
+        "instance": "tspn12",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 20.56700370798353,
+        "status": "feasible",
+        "objective": 262.6473957963286,
+        "bound": 198.54001195665876,
+        "gap": 0.24408155140964083,
+        "gap_certified": false,
+        "node_count": 45,
+        "incumbent_verification_failed": false
+      },
+      "cand": {
+        "instance": "tspn12",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "1",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 20.418160417000763,
+        "status": "feasible",
+        "objective": 262.6473957963286,
+        "bound": 198.54006501145957,
+        "gap": 0.24408134940953854,
+        "gap_certified": false,
+        "node_count": 31,
+        "incumbent_verification_failed": false
+      }
+    }
+  ]
+}

--- a/discopt_benchmarks/results/issue966_coupled_binding20_rep2.json
+++ b/discopt_benchmarks/results/issue966_coupled_binding20_rep2.json
@@ -1,0 +1,1256 @@
+{
+  "summary": {
+    "instances": 19,
+    "budget": 20.0,
+    "arms": {
+      "base": "all OFF (today's default)",
+      "seam": "#966 ON, #928 OFF",
+      "cand": "all three ON"
+    },
+    "unsound": [],
+    "incumbent_verification_failed": [],
+    "pairs": [
+      {
+        "pair": "cand vs base",
+        "cells_over_budget": {
+          "base": 5,
+          "cand": 4
+        },
+        "total_overrun_s": {
+          "base": 21.5,
+          "cand": 18.8
+        },
+        "overrun_delta_s": -2.7,
+        "node_count_total": {
+          "base": 1201,
+          "cand": 1709
+        },
+        "cert_gains": [],
+        "cert_regressions": [],
+        "gained_incumbents": [],
+        "lost_incumbents": [],
+        "better_objective": [],
+        "worse_objective": [],
+        "tighter_bound": [
+          "beuster (19641.545373488752 -> 19641.605888231275)",
+          "tspn08 (267.8080239536436 -> 268.3529327885914)",
+          "tspn10 (167.35910515007944 -> 174.28500842155333)",
+          "tspn12 (198.54001195665876 -> 198.54006501145957)"
+        ],
+        "looser_bound": [
+          "casctanks (2.9097722176628698 -> -60.13056705942682)",
+          "nvs05 (4.099237735891656 -> 3.8053689247019755)",
+          "syn05hfsg (837.7324008980034 -> 837.7324095240308)",
+          "tls2 (0.8686135736142343 -> 0.7183065609201988)",
+          "tspn05 (191.25510622528546 -> 191.25507754309677)"
+        ],
+        "gained_bound": [],
+        "lost_bound": [
+          "contvar (183632.7659824633 -> None)"
+        ]
+      },
+      {
+        "pair": "cand vs seam",
+        "cells_over_budget": {
+          "seam": 5,
+          "cand": 4
+        },
+        "total_overrun_s": {
+          "seam": 17.9,
+          "cand": 18.8
+        },
+        "overrun_delta_s": 0.9,
+        "node_count_total": {
+          "seam": 1609,
+          "cand": 1709
+        },
+        "cert_gains": [],
+        "cert_regressions": [],
+        "gained_incumbents": [],
+        "lost_incumbents": [],
+        "better_objective": [],
+        "worse_objective": [],
+        "tighter_bound": [
+          "beuster (19641.54537395015 -> 19641.605888231275)",
+          "tspn08 (267.8080239536436 -> 268.3529327885914)",
+          "tspn10 (166.12311826214523 -> 174.28500842155333)",
+          "tspn12 (198.54001195665876 -> 198.54006501145957)"
+        ],
+        "looser_bound": [
+          "casctanks (-56.50012254242376 -> -60.13056705942682)",
+          "nvs05 (4.099237735891656 -> 3.8053689247019755)",
+          "syn05hfsg (837.7324008980034 -> 837.7324095240308)",
+          "tspn05 (191.25510622528546 -> 191.25507754309677)"
+        ],
+        "gained_bound": [],
+        "lost_bound": [
+          "contvar (183632.7659824633 -> None)"
+        ]
+      },
+      {
+        "pair": "seam vs base",
+        "cells_over_budget": {
+          "base": 5,
+          "seam": 5
+        },
+        "total_overrun_s": {
+          "base": 21.5,
+          "seam": 17.9
+        },
+        "overrun_delta_s": -3.6,
+        "node_count_total": {
+          "base": 1201,
+          "seam": 1609
+        },
+        "cert_gains": [],
+        "cert_regressions": [],
+        "gained_incumbents": [],
+        "lost_incumbents": [],
+        "better_objective": [],
+        "worse_objective": [],
+        "tighter_bound": [],
+        "looser_bound": [
+          "casctanks (2.9097722176628698 -> -56.50012254242376)",
+          "tls2 (0.8686135736142343 -> 0.7183065609201988)",
+          "tspn10 (167.35910515007944 -> 166.12311826214523)"
+        ],
+        "gained_bound": [],
+        "lost_bound": []
+      }
+    ],
+    "panel_wall_s": 1138.3,
+    "loadavg_start": [
+      4.82,
+      4.69,
+      4.8
+    ],
+    "loadavg_end": [
+      6.28,
+      5.52,
+      5.1
+    ]
+  },
+  "cells": [
+    {
+      "instance": "4stufen",
+      "budget": 20.0,
+      "reference_optimum": null,
+      "base": {
+        "instance": "4stufen",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 20.449201916984748,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 20712.174649175664,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 7,
+        "incumbent_verification_failed": false
+      },
+      "seam": {
+        "instance": "4stufen",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 20.451928666967433,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 20712.174649175664,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 7,
+        "incumbent_verification_failed": false
+      },
+      "cand": {
+        "instance": "4stufen",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "1",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 20.445171332976315,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 20712.17464917334,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 7,
+        "incumbent_verification_failed": false
+      }
+    },
+    {
+      "instance": "bchoco06",
+      "budget": 20.0,
+      "reference_optimum": null,
+      "base": {
+        "instance": "bchoco06",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "max",
+        "wall": 20.73396129201865,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 1.0000000000126652,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 3,
+        "incumbent_verification_failed": false
+      },
+      "seam": {
+        "instance": "bchoco06",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "max",
+        "wall": 20.592208458983805,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 1.0000000000126652,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 3,
+        "incumbent_verification_failed": false
+      },
+      "cand": {
+        "instance": "bchoco06",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "1",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "max",
+        "wall": 20.549059209006373,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 1.0000000000001554,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 3,
+        "incumbent_verification_failed": false
+      }
+    },
+    {
+      "instance": "bchoco07",
+      "budget": 20.0,
+      "reference_optimum": null,
+      "base": {
+        "instance": "bchoco07",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "max",
+        "wall": 20.65171000000555,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 0.9999909483405423,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 15,
+        "incumbent_verification_failed": false
+      },
+      "seam": {
+        "instance": "bchoco07",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "max",
+        "wall": 20.486913875036407,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 0.9999909483405423,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 63,
+        "incumbent_verification_failed": false
+      },
+      "cand": {
+        "instance": "bchoco07",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "1",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "max",
+        "wall": 20.416796708013862,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 0.9999909483405423,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 63,
+        "incumbent_verification_failed": false
+      }
+    },
+    {
+      "instance": "bchoco08",
+      "budget": 20.0,
+      "reference_optimum": null,
+      "base": {
+        "instance": "bchoco08",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "max",
+        "wall": 20.736070166982245,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 1.0000000000038425,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 7,
+        "incumbent_verification_failed": false
+      },
+      "seam": {
+        "instance": "bchoco08",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "max",
+        "wall": 22.17206549999537,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 1.0000000000030296,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 15,
+        "incumbent_verification_failed": false
+      },
+      "cand": {
+        "instance": "bchoco08",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "1",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "max",
+        "wall": 20.527384291985072,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 1.0000000000005946,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 15,
+        "incumbent_verification_failed": false
+      }
+    },
+    {
+      "instance": "beuster",
+      "budget": 20.0,
+      "reference_optimum": null,
+      "base": {
+        "instance": "beuster",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 20.664268040971365,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 19641.545373488752,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 31,
+        "incumbent_verification_failed": false
+      },
+      "seam": {
+        "instance": "beuster",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 20.483882041997276,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 19641.54537395015,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 287,
+        "incumbent_verification_failed": false
+      },
+      "cand": {
+        "instance": "beuster",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "1",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 20.41515212500235,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 19641.605888231275,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 287,
+        "incumbent_verification_failed": false
+      }
+    },
+    {
+      "instance": "casctanks",
+      "budget": 20.0,
+      "reference_optimum": null,
+      "base": {
+        "instance": "casctanks",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 21.11123395798495,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 2.9097722176628698,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 31,
+        "incumbent_verification_failed": false
+      },
+      "seam": {
+        "instance": "casctanks",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 20.77071908302605,
+        "status": "time_limit",
+        "objective": null,
+        "bound": -56.50012254242376,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 63,
+        "incumbent_verification_failed": false
+      },
+      "cand": {
+        "instance": "casctanks",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "1",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 23.11036241601687,
+        "status": "time_limit",
+        "objective": null,
+        "bound": -60.13056705942682,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 95,
+        "incumbent_verification_failed": false
+      }
+    },
+    {
+      "instance": "clay0303hfsg",
+      "budget": 20.0,
+      "reference_optimum": 26669.10955143,
+      "base": {
+        "instance": "clay0303hfsg",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 20.479750250000507,
+        "status": "feasible",
+        "objective": 26669.109572842688,
+        "bound": 20947.586912205985,
+        "gap": 0.2145374462169132,
+        "gap_certified": false,
+        "node_count": 413,
+        "incumbent_verification_failed": false
+      },
+      "seam": {
+        "instance": "clay0303hfsg",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 20.683019916992635,
+        "status": "feasible",
+        "objective": 26669.109572842688,
+        "bound": 20947.586912205985,
+        "gap": 0.2145374462169132,
+        "gap_certified": false,
+        "node_count": 413,
+        "incumbent_verification_failed": false
+      },
+      "cand": {
+        "instance": "clay0303hfsg",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "1",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 20.694508332991973,
+        "status": "feasible",
+        "objective": 26669.109572842688,
+        "bound": 20947.586912205985,
+        "gap": 0.2145374462169132,
+        "gap_certified": false,
+        "node_count": 413,
+        "incumbent_verification_failed": false
+      }
+    },
+    {
+      "instance": "contvar",
+      "budget": 20.0,
+      "reference_optimum": null,
+      "base": {
+        "instance": "contvar",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 22.372123375011142,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 183632.7659824633,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 7,
+        "incumbent_verification_failed": false
+      },
+      "seam": {
+        "instance": "contvar",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 21.31862362497486,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 183632.7659824633,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 7,
+        "incumbent_verification_failed": false
+      },
+      "cand": {
+        "instance": "contvar",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "1",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 21.816174416977447,
+        "status": "time_limit",
+        "objective": null,
+        "bound": null,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 255,
+        "incumbent_verification_failed": false
+      }
+    },
+    {
+      "instance": "hda",
+      "budget": 20.0,
+      "reference_optimum": null,
+      "base": {
+        "instance": "hda",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 22.966367957997136,
+        "status": "time_limit",
+        "objective": null,
+        "bound": -64473.44240151017,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 3,
+        "incumbent_verification_failed": false
+      },
+      "seam": {
+        "instance": "hda",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 22.887913790997118,
+        "status": "time_limit",
+        "objective": null,
+        "bound": -64473.44240151017,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 3,
+        "incumbent_verification_failed": false
+      },
+      "cand": {
+        "instance": "hda",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "1",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 20.764370209013578,
+        "status": "time_limit",
+        "objective": null,
+        "bound": -64473.4424015326,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 3,
+        "incumbent_verification_failed": false
+      }
+    },
+    {
+      "instance": "heatexch_gen1",
+      "budget": 20.0,
+      "reference_optimum": null,
+      "base": {
+        "instance": "heatexch_gen1",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 21.317493582959287,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 38183.53174601794,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 3,
+        "incumbent_verification_failed": false
+      },
+      "seam": {
+        "instance": "heatexch_gen1",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 21.885743874998298,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 38183.53174601794,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 3,
+        "incumbent_verification_failed": false
+      },
+      "cand": {
+        "instance": "heatexch_gen1",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "1",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 24.4885438340134,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 38183.53174601911,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 3,
+        "incumbent_verification_failed": false
+      }
+    },
+    {
+      "instance": "heatexch_gen2",
+      "budget": 20.0,
+      "reference_optimum": null,
+      "base": {
+        "instance": "heatexch_gen2",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 20.629221290990245,
+        "status": "feasible",
+        "objective": 824551.3269251497,
+        "bound": 555767.7902857282,
+        "gap": 0.32597550675437925,
+        "gap_certified": false,
+        "node_count": 3,
+        "incumbent_verification_failed": false
+      },
+      "seam": {
+        "instance": "heatexch_gen2",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 20.914991124998778,
+        "status": "feasible",
+        "objective": 824551.3269251497,
+        "bound": 555767.7902857282,
+        "gap": 0.32597550675437925,
+        "gap_certified": false,
+        "node_count": 3,
+        "incumbent_verification_failed": false
+      },
+      "cand": {
+        "instance": "heatexch_gen2",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "1",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 20.860921791987494,
+        "status": "feasible",
+        "objective": 824551.3269251497,
+        "bound": 555767.7902857201,
+        "gap": 0.32597550675438897,
+        "gap_certified": false,
+        "node_count": 3,
+        "incumbent_verification_failed": false
+      }
+    },
+    {
+      "instance": "heatexch_gen3",
+      "budget": 20.0,
+      "reference_optimum": null,
+      "base": {
+        "instance": "heatexch_gen3",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 27.44725050003035,
+        "status": "time_limit",
+        "objective": null,
+        "bound": null,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 3,
+        "incumbent_verification_failed": false
+      },
+      "seam": {
+        "instance": "heatexch_gen3",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 23.003986291994806,
+        "status": "time_limit",
+        "objective": null,
+        "bound": null,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 95,
+        "incumbent_verification_failed": false
+      },
+      "cand": {
+        "instance": "heatexch_gen3",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "1",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 22.020946458971594,
+        "status": "time_limit",
+        "objective": null,
+        "bound": null,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 95,
+        "incumbent_verification_failed": false
+      }
+    },
+    {
+      "instance": "nvs05",
+      "budget": 20.0,
+      "reference_optimum": null,
+      "base": {
+        "instance": "nvs05",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 20.334827375016175,
+        "status": "feasible",
+        "objective": 8.731956986640789,
+        "bound": 4.099237735891656,
+        "gap": 0.530547649036388,
+        "gap_certified": false,
+        "node_count": 155,
+        "incumbent_verification_failed": false
+      },
+      "seam": {
+        "instance": "nvs05",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 20.295323791971896,
+        "status": "feasible",
+        "objective": 8.731956986640789,
+        "bound": 4.099237735891656,
+        "gap": 0.530547649036388,
+        "gap_certified": false,
+        "node_count": 155,
+        "incumbent_verification_failed": false
+      },
+      "cand": {
+        "instance": "nvs05",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "1",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 20.326225582975894,
+        "status": "feasible",
+        "objective": 8.731956986640789,
+        "bound": 3.8053689247019755,
+        "gap": 0.564202053385754,
+        "gap_certified": false,
+        "node_count": 131,
+        "incumbent_verification_failed": false
+      }
+    },
+    {
+      "instance": "syn05hfsg",
+      "budget": 20.0,
+      "reference_optimum": null,
+      "base": {
+        "instance": "syn05hfsg",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "max",
+        "wall": 5.784996500005946,
+        "status": "optimal",
+        "objective": 837.7323012718434,
+        "bound": 837.7324008980034,
+        "gap": 2.8091518703525014e-14,
+        "gap_certified": true,
+        "node_count": 285,
+        "incumbent_verification_failed": false
+      },
+      "seam": {
+        "instance": "syn05hfsg",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "max",
+        "wall": 5.969141167006455,
+        "status": "optimal",
+        "objective": 837.7323012718434,
+        "bound": 837.7324008980034,
+        "gap": 2.8091518703525014e-14,
+        "gap_certified": true,
+        "node_count": 285,
+        "incumbent_verification_failed": false
+      },
+      "cand": {
+        "instance": "syn05hfsg",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "1",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "max",
+        "wall": 4.889475042000413,
+        "status": "optimal",
+        "objective": 837.7323012718434,
+        "bound": 837.7324095240308,
+        "gap": 0.0,
+        "gap_certified": true,
+        "node_count": 155,
+        "incumbent_verification_failed": false
+      }
+    },
+    {
+      "instance": "tls2",
+      "budget": 20.0,
+      "reference_optimum": null,
+      "base": {
+        "instance": "tls2",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 20.37080562498886,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 0.8686135736142343,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 31,
+        "incumbent_verification_failed": false
+      },
+      "seam": {
+        "instance": "tls2",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 20.64590741705615,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 0.7183065609201988,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 3,
+        "incumbent_verification_failed": false
+      },
+      "cand": {
+        "instance": "tls2",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "1",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 20.439654832996894,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 0.7183065609201988,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 3,
+        "incumbent_verification_failed": false
+      }
+    },
+    {
+      "instance": "tspn05",
+      "budget": 20.0,
+      "reference_optimum": null,
+      "base": {
+        "instance": "tspn05",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 9.584854250017088,
+        "status": "optimal",
+        "objective": 191.25520784466957,
+        "bound": 191.25510622528546,
+        "gap": 4.48930877429491e-07,
+        "gap_certified": true,
+        "node_count": 51,
+        "incumbent_verification_failed": false
+      },
+      "seam": {
+        "instance": "tspn05",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 9.56331570801558,
+        "status": "optimal",
+        "objective": 191.25520784466957,
+        "bound": 191.25510622528546,
+        "gap": 4.48930877429491e-07,
+        "gap_certified": true,
+        "node_count": 51,
+        "incumbent_verification_failed": false
+      },
+      "cand": {
+        "instance": "tspn05",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "1",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 7.131062625034247,
+        "status": "optimal",
+        "objective": 191.2552078446693,
+        "bound": 191.25507754309677,
+        "gap": 5.988990548450231e-07,
+        "gap_certified": true,
+        "node_count": 37,
+        "incumbent_verification_failed": false
+      }
+    },
+    {
+      "instance": "tspn08",
+      "budget": 20.0,
+      "reference_optimum": null,
+      "base": {
+        "instance": "tspn08",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 20.448589667037595,
+        "status": "feasible",
+        "objective": 290.566853967556,
+        "bound": 267.8080239536436,
+        "gap": 0.0783256235291504,
+        "gap_certified": false,
+        "node_count": 59,
+        "incumbent_verification_failed": false
+      },
+      "seam": {
+        "instance": "tspn08",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 20.416926875011995,
+        "status": "feasible",
+        "objective": 290.566853967556,
+        "bound": 267.8080239536436,
+        "gap": 0.0783256235291504,
+        "gap_certified": false,
+        "node_count": 61,
+        "incumbent_verification_failed": false
+      },
+      "cand": {
+        "instance": "tspn08",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "1",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 20.647928041988052,
+        "status": "feasible",
+        "objective": 290.56685396755563,
+        "bound": 268.3529327885914,
+        "gap": 0.07645029319636244,
+        "gap_certified": false,
+        "node_count": 55,
+        "incumbent_verification_failed": false
+      }
+    },
+    {
+      "instance": "tspn10",
+      "budget": 20.0,
+      "reference_optimum": null,
+      "base": {
+        "instance": "tspn10",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 20.416947334015276,
+        "status": "feasible",
+        "objective": 225.12607170016918,
+        "bound": 167.35910515007944,
+        "gap": 0.256598296740263,
+        "gap_certified": false,
+        "node_count": 63,
+        "incumbent_verification_failed": false
+      },
+      "seam": {
+        "instance": "tspn10",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 20.59966979199089,
+        "status": "feasible",
+        "objective": 225.12607170016918,
+        "bound": 166.12311826214523,
+        "gap": 0.2620884955368748,
+        "gap_certified": false,
+        "node_count": 61,
+        "incumbent_verification_failed": false
+      },
+      "cand": {
+        "instance": "tspn10",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "1",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 20.919516500027385,
+        "status": "feasible",
+        "objective": 225.12607170017012,
+        "bound": 174.28500842155333,
+        "gap": 0.22583374237670922,
+        "gap_certified": false,
+        "node_count": 55,
+        "incumbent_verification_failed": false
+      }
+    },
+    {
+      "instance": "tspn12",
+      "budget": 20.0,
+      "reference_optimum": null,
+      "base": {
+        "instance": "tspn12",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 20.382850042020436,
+        "status": "feasible",
+        "objective": 262.6473957963286,
+        "bound": 198.54001195665876,
+        "gap": 0.24408155140964083,
+        "gap_certified": false,
+        "node_count": 31,
+        "incumbent_verification_failed": false
+      },
+      "seam": {
+        "instance": "tspn12",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 20.335275625053328,
+        "status": "feasible",
+        "objective": 262.6473957963286,
+        "bound": 198.54001195665876,
+        "gap": 0.24408155140964083,
+        "gap_certified": false,
+        "node_count": 31,
+        "incumbent_verification_failed": false
+      },
+      "cand": {
+        "instance": "tspn12",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "1",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 20.37008008302655,
+        "status": "feasible",
+        "objective": 262.6473957963286,
+        "bound": 198.54006501145957,
+        "gap": 0.24408134940953854,
+        "gap_certified": false,
+        "node_count": 31,
+        "incumbent_verification_failed": false
+      }
+    }
+  ]
+}

--- a/discopt_benchmarks/results/issue966_coupled_binding20_rep3.json
+++ b/discopt_benchmarks/results/issue966_coupled_binding20_rep3.json
@@ -1,0 +1,1262 @@
+{
+  "summary": {
+    "instances": 19,
+    "budget": 20.0,
+    "arms": {
+      "base": "all OFF (today's default)",
+      "seam": "#966 ON, #928 OFF",
+      "cand": "all three ON"
+    },
+    "unsound": [],
+    "incumbent_verification_failed": [],
+    "pairs": [
+      {
+        "pair": "cand vs base",
+        "cells_over_budget": {
+          "base": 5,
+          "cand": 4
+        },
+        "total_overrun_s": {
+          "base": 21.4,
+          "cand": 18.8
+        },
+        "overrun_delta_s": -2.7,
+        "node_count_total": {
+          "base": 1445,
+          "cand": 2053
+        },
+        "cert_gains": [],
+        "cert_regressions": [],
+        "gained_incumbents": [
+          "tls2"
+        ],
+        "lost_incumbents": [],
+        "better_objective": [],
+        "worse_objective": [],
+        "tighter_bound": [
+          "beuster (19231.01306785854 -> 19641.60588823138)",
+          "tls2 (2.003761171751076 -> 2.0999999901667694)",
+          "tspn08 (267.8080239536436 -> 268.3529327885914)",
+          "tspn10 (167.35910515007944 -> 174.28500842155333)",
+          "tspn12 (198.54001195665876 -> 198.54006501145957)"
+        ],
+        "looser_bound": [
+          "casctanks (2.9097722176628698 -> -60.13056705942682)",
+          "nvs05 (4.099237735891656 -> 3.8053689247019755)",
+          "syn05hfsg (837.7324008980034 -> 837.7324095240308)",
+          "tspn05 (191.25510622528546 -> 191.25507754309677)"
+        ],
+        "gained_bound": [],
+        "lost_bound": [
+          "contvar (183632.7659824633 -> None)"
+        ]
+      },
+      {
+        "pair": "cand vs seam",
+        "cells_over_budget": {
+          "seam": 5,
+          "cand": 4
+        },
+        "total_overrun_s": {
+          "seam": 16.2,
+          "cand": 18.8
+        },
+        "overrun_delta_s": 2.6,
+        "node_count_total": {
+          "seam": 1637,
+          "cand": 2053
+        },
+        "cert_gains": [],
+        "cert_regressions": [],
+        "gained_incumbents": [
+          "tls2"
+        ],
+        "lost_incumbents": [],
+        "better_objective": [],
+        "worse_objective": [],
+        "tighter_bound": [
+          "beuster (19233.282305948764 -> 19641.60588823138)",
+          "tls2 (1.1964300462250628 -> 2.0999999901667694)",
+          "tspn08 (267.8080239536436 -> 268.3529327885914)",
+          "tspn10 (167.35910515007944 -> 174.28500842155333)",
+          "tspn12 (198.54001195665876 -> 198.54006501145957)"
+        ],
+        "looser_bound": [
+          "casctanks (-56.50012254242376 -> -60.13056705942682)",
+          "nvs05 (4.099237735891656 -> 3.8053689247019755)",
+          "syn05hfsg (837.7324008980034 -> 837.7324095240308)",
+          "tspn05 (191.25510622528546 -> 191.25507754309677)"
+        ],
+        "gained_bound": [],
+        "lost_bound": [
+          "contvar (183632.7659824633 -> None)"
+        ]
+      },
+      {
+        "pair": "seam vs base",
+        "cells_over_budget": {
+          "base": 5,
+          "seam": 5
+        },
+        "total_overrun_s": {
+          "base": 21.4,
+          "seam": 16.2
+        },
+        "overrun_delta_s": -5.2,
+        "node_count_total": {
+          "base": 1445,
+          "seam": 1637
+        },
+        "cert_gains": [],
+        "cert_regressions": [],
+        "gained_incumbents": [],
+        "lost_incumbents": [],
+        "better_objective": [],
+        "worse_objective": [],
+        "tighter_bound": [
+          "beuster (19231.01306785854 -> 19233.282305948764)"
+        ],
+        "looser_bound": [
+          "casctanks (2.9097722176628698 -> -56.50012254242376)",
+          "tls2 (2.003761171751076 -> 1.1964300462250628)"
+        ],
+        "gained_bound": [],
+        "lost_bound": []
+      }
+    ],
+    "panel_wall_s": 1135.4,
+    "loadavg_start": [
+      6.28,
+      5.52,
+      5.1
+    ],
+    "loadavg_end": [
+      3.26,
+      4.04,
+      4.7
+    ]
+  },
+  "cells": [
+    {
+      "instance": "4stufen",
+      "budget": 20.0,
+      "reference_optimum": null,
+      "base": {
+        "instance": "4stufen",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 20.5193327080342,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 20712.174649175664,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 7,
+        "incumbent_verification_failed": false
+      },
+      "seam": {
+        "instance": "4stufen",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 20.337959374999627,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 20712.174649175664,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 3,
+        "incumbent_verification_failed": false
+      },
+      "cand": {
+        "instance": "4stufen",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "1",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 20.42088704102207,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 20712.17464917334,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 7,
+        "incumbent_verification_failed": false
+      }
+    },
+    {
+      "instance": "bchoco06",
+      "budget": 20.0,
+      "reference_optimum": null,
+      "base": {
+        "instance": "bchoco06",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "max",
+        "wall": 20.39602083299542,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 1.0000000000126652,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 3,
+        "incumbent_verification_failed": false
+      },
+      "seam": {
+        "instance": "bchoco06",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "max",
+        "wall": 20.301084291015286,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 1.0000000000126652,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 3,
+        "incumbent_verification_failed": false
+      },
+      "cand": {
+        "instance": "bchoco06",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "1",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "max",
+        "wall": 20.41697362496052,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 1.0000000000001554,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 3,
+        "incumbent_verification_failed": false
+      }
+    },
+    {
+      "instance": "bchoco07",
+      "budget": 20.0,
+      "reference_optimum": null,
+      "base": {
+        "instance": "bchoco07",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "max",
+        "wall": 20.5717690839665,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 0.9999909483405423,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 15,
+        "incumbent_verification_failed": false
+      },
+      "seam": {
+        "instance": "bchoco07",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "max",
+        "wall": 20.676268042006996,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 0.9999909483405423,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 3,
+        "incumbent_verification_failed": false
+      },
+      "cand": {
+        "instance": "bchoco07",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "1",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "max",
+        "wall": 20.36623587500071,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 0.9999909483405423,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 63,
+        "incumbent_verification_failed": false
+      }
+    },
+    {
+      "instance": "bchoco08",
+      "budget": 20.0,
+      "reference_optimum": null,
+      "base": {
+        "instance": "bchoco08",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "max",
+        "wall": 21.024423084047157,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 1.0000000000038425,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 7,
+        "incumbent_verification_failed": false
+      },
+      "seam": {
+        "instance": "bchoco08",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "max",
+        "wall": 22.22955120797269,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 1.0000000000030296,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 15,
+        "incumbent_verification_failed": false
+      },
+      "cand": {
+        "instance": "bchoco08",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "1",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "max",
+        "wall": 20.39345333300298,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 1.0000000000005946,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 15,
+        "incumbent_verification_failed": false
+      }
+    },
+    {
+      "instance": "beuster",
+      "budget": 20.0,
+      "reference_optimum": null,
+      "base": {
+        "instance": "beuster",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 20.62986116699176,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 19231.01306785854,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 31,
+        "incumbent_verification_failed": false
+      },
+      "seam": {
+        "instance": "beuster",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 20.389122665976174,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 19233.282305948764,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 255,
+        "incumbent_verification_failed": false
+      },
+      "cand": {
+        "instance": "beuster",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "1",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 20.413141458993778,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 19641.60588823138,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 287,
+        "incumbent_verification_failed": false
+      }
+    },
+    {
+      "instance": "casctanks",
+      "budget": 20.0,
+      "reference_optimum": null,
+      "base": {
+        "instance": "casctanks",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 21.86239079205552,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 2.9097722176628698,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 31,
+        "incumbent_verification_failed": false
+      },
+      "seam": {
+        "instance": "casctanks",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 21.045145707961638,
+        "status": "time_limit",
+        "objective": null,
+        "bound": -56.50012254242376,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 63,
+        "incumbent_verification_failed": false
+      },
+      "cand": {
+        "instance": "casctanks",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "1",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 23.07252950000111,
+        "status": "time_limit",
+        "objective": null,
+        "bound": -60.13056705942682,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 95,
+        "incumbent_verification_failed": false
+      }
+    },
+    {
+      "instance": "clay0303hfsg",
+      "budget": 20.0,
+      "reference_optimum": 26669.10955143,
+      "base": {
+        "instance": "clay0303hfsg",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 20.439303958031815,
+        "status": "feasible",
+        "objective": 26669.109572842688,
+        "bound": 20947.586912205985,
+        "gap": 0.2145374462169132,
+        "gap_certified": false,
+        "node_count": 401,
+        "incumbent_verification_failed": false
+      },
+      "seam": {
+        "instance": "clay0303hfsg",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 20.910583916993346,
+        "status": "feasible",
+        "objective": 26669.109572842688,
+        "bound": 20947.586912205985,
+        "gap": 0.2145374462169132,
+        "gap_certified": false,
+        "node_count": 413,
+        "incumbent_verification_failed": false
+      },
+      "cand": {
+        "instance": "clay0303hfsg",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "1",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 20.712600958009716,
+        "status": "feasible",
+        "objective": 26669.109572842688,
+        "bound": 20947.586912205985,
+        "gap": 0.2145374462169132,
+        "gap_certified": false,
+        "node_count": 413,
+        "incumbent_verification_failed": false
+      }
+    },
+    {
+      "instance": "contvar",
+      "budget": 20.0,
+      "reference_optimum": null,
+      "base": {
+        "instance": "contvar",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 22.532154707994778,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 183632.7659824633,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 7,
+        "incumbent_verification_failed": false
+      },
+      "seam": {
+        "instance": "contvar",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 21.26433175004786,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 183632.7659824633,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 7,
+        "incumbent_verification_failed": false
+      },
+      "cand": {
+        "instance": "contvar",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "1",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 21.438077124999836,
+        "status": "time_limit",
+        "objective": null,
+        "bound": null,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 287,
+        "incumbent_verification_failed": false
+      }
+    },
+    {
+      "instance": "hda",
+      "budget": 20.0,
+      "reference_optimum": null,
+      "base": {
+        "instance": "hda",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 22.797861083003227,
+        "status": "time_limit",
+        "objective": null,
+        "bound": -64473.44240151017,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 3,
+        "incumbent_verification_failed": false
+      },
+      "seam": {
+        "instance": "hda",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 22.79997979098698,
+        "status": "time_limit",
+        "objective": null,
+        "bound": -64473.44240151017,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 3,
+        "incumbent_verification_failed": false
+      },
+      "cand": {
+        "instance": "hda",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "1",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 20.906653625017498,
+        "status": "time_limit",
+        "objective": null,
+        "bound": -64473.4424015326,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 3,
+        "incumbent_verification_failed": false
+      }
+    },
+    {
+      "instance": "heatexch_gen1",
+      "budget": 20.0,
+      "reference_optimum": null,
+      "base": {
+        "instance": "heatexch_gen1",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 20.764657208987046,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 38183.53174601794,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 3,
+        "incumbent_verification_failed": false
+      },
+      "seam": {
+        "instance": "heatexch_gen1",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 20.85171958396677,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 38183.53174601794,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 3,
+        "incumbent_verification_failed": false
+      },
+      "cand": {
+        "instance": "heatexch_gen1",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "1",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 24.8247505420004,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 38183.53174601911,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 3,
+        "incumbent_verification_failed": false
+      }
+    },
+    {
+      "instance": "heatexch_gen2",
+      "budget": 20.0,
+      "reference_optimum": null,
+      "base": {
+        "instance": "heatexch_gen2",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 20.605213915987406,
+        "status": "feasible",
+        "objective": 824551.3269251497,
+        "bound": 555767.7902857282,
+        "gap": 0.32597550675437925,
+        "gap_certified": false,
+        "node_count": 3,
+        "incumbent_verification_failed": false
+      },
+      "seam": {
+        "instance": "heatexch_gen2",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 20.61002445803024,
+        "status": "feasible",
+        "objective": 824551.3269251497,
+        "bound": 555767.7902857282,
+        "gap": 0.32597550675437925,
+        "gap_certified": false,
+        "node_count": 3,
+        "incumbent_verification_failed": false
+      },
+      "cand": {
+        "instance": "heatexch_gen2",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "1",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 20.605484915955458,
+        "status": "feasible",
+        "objective": 824551.3269251497,
+        "bound": 555767.7902857201,
+        "gap": 0.32597550675438897,
+        "gap_certified": false,
+        "node_count": 3,
+        "incumbent_verification_failed": false
+      }
+    },
+    {
+      "instance": "heatexch_gen3",
+      "budget": 20.0,
+      "reference_optimum": null,
+      "base": {
+        "instance": "heatexch_gen3",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 26.9893228749861,
+        "status": "time_limit",
+        "objective": null,
+        "bound": null,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 3,
+        "incumbent_verification_failed": false
+      },
+      "seam": {
+        "instance": "heatexch_gen3",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 22.807397999975365,
+        "status": "time_limit",
+        "objective": null,
+        "bound": null,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 95,
+        "incumbent_verification_failed": false
+      },
+      "cand": {
+        "instance": "heatexch_gen3",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "1",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 22.563898541033268,
+        "status": "time_limit",
+        "objective": null,
+        "bound": null,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 95,
+        "incumbent_verification_failed": false
+      }
+    },
+    {
+      "instance": "nvs05",
+      "budget": 20.0,
+      "reference_optimum": null,
+      "base": {
+        "instance": "nvs05",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 20.416086541023105,
+        "status": "feasible",
+        "objective": 8.731956986640789,
+        "bound": 4.099237735891656,
+        "gap": 0.530547649036388,
+        "gap_certified": false,
+        "node_count": 155,
+        "incumbent_verification_failed": false
+      },
+      "seam": {
+        "instance": "nvs05",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 20.376214666990563,
+        "status": "feasible",
+        "objective": 8.731956986640789,
+        "bound": 4.099237735891656,
+        "gap": 0.530547649036388,
+        "gap_certified": false,
+        "node_count": 155,
+        "incumbent_verification_failed": false
+      },
+      "cand": {
+        "instance": "nvs05",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "1",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 20.37258595804451,
+        "status": "feasible",
+        "objective": 8.731956986640789,
+        "bound": 3.8053689247019755,
+        "gap": 0.564202053385754,
+        "gap_certified": false,
+        "node_count": 131,
+        "incumbent_verification_failed": false
+      }
+    },
+    {
+      "instance": "syn05hfsg",
+      "budget": 20.0,
+      "reference_optimum": null,
+      "base": {
+        "instance": "syn05hfsg",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "max",
+        "wall": 5.794720750011038,
+        "status": "optimal",
+        "objective": 837.7323012718434,
+        "bound": 837.7324008980034,
+        "gap": 2.8091518703525014e-14,
+        "gap_certified": true,
+        "node_count": 285,
+        "incumbent_verification_failed": false
+      },
+      "seam": {
+        "instance": "syn05hfsg",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "max",
+        "wall": 5.93532133300323,
+        "status": "optimal",
+        "objective": 837.7323012718434,
+        "bound": 837.7324008980034,
+        "gap": 2.8091518703525014e-14,
+        "gap_certified": true,
+        "node_count": 285,
+        "incumbent_verification_failed": false
+      },
+      "cand": {
+        "instance": "syn05hfsg",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "1",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "max",
+        "wall": 4.637114750046749,
+        "status": "optimal",
+        "objective": 837.7323012718434,
+        "bound": 837.7324095240308,
+        "gap": 0.0,
+        "gap_certified": true,
+        "node_count": 155,
+        "incumbent_verification_failed": false
+      }
+    },
+    {
+      "instance": "tls2",
+      "budget": 20.0,
+      "reference_optimum": null,
+      "base": {
+        "instance": "tls2",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 20.407439165981486,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 2.003761171751076,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 287,
+        "incumbent_verification_failed": false
+      },
+      "seam": {
+        "instance": "tls2",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 20.391924208030105,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 1.1964300462250628,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 127,
+        "incumbent_verification_failed": false
+      },
+      "cand": {
+        "instance": "tls2",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "1",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 20.475887915992644,
+        "status": "feasible",
+        "objective": 11.299999999980916,
+        "bound": 2.0999999901667694,
+        "gap": 0.8141592929052819,
+        "gap_certified": false,
+        "node_count": 317,
+        "incumbent_verification_failed": false
+      }
+    },
+    {
+      "instance": "tspn05",
+      "budget": 20.0,
+      "reference_optimum": null,
+      "base": {
+        "instance": "tspn05",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 9.573034000000916,
+        "status": "optimal",
+        "objective": 191.25520784466957,
+        "bound": 191.25510622528546,
+        "gap": 4.48930877429491e-07,
+        "gap_certified": true,
+        "node_count": 51,
+        "incumbent_verification_failed": false
+      },
+      "seam": {
+        "instance": "tspn05",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 9.51818087499123,
+        "status": "optimal",
+        "objective": 191.25520784466957,
+        "bound": 191.25510622528546,
+        "gap": 4.48930877429491e-07,
+        "gap_certified": true,
+        "node_count": 51,
+        "incumbent_verification_failed": false
+      },
+      "cand": {
+        "instance": "tspn05",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "1",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 7.129135749943089,
+        "status": "optimal",
+        "objective": 191.2552078446693,
+        "bound": 191.25507754309677,
+        "gap": 5.988990548450231e-07,
+        "gap_certified": true,
+        "node_count": 37,
+        "incumbent_verification_failed": false
+      }
+    },
+    {
+      "instance": "tspn08",
+      "budget": 20.0,
+      "reference_optimum": null,
+      "base": {
+        "instance": "tspn08",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 20.43245229200693,
+        "status": "feasible",
+        "objective": 290.566853967556,
+        "bound": 267.8080239536436,
+        "gap": 0.0783256235291504,
+        "gap_certified": false,
+        "node_count": 59,
+        "incumbent_verification_failed": false
+      },
+      "seam": {
+        "instance": "tspn08",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 20.432969707995653,
+        "status": "feasible",
+        "objective": 290.566853967556,
+        "bound": 267.8080239536436,
+        "gap": 0.0783256235291504,
+        "gap_certified": false,
+        "node_count": 59,
+        "incumbent_verification_failed": false
+      },
+      "cand": {
+        "instance": "tspn08",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "1",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 20.57685745798517,
+        "status": "feasible",
+        "objective": 290.56685396755563,
+        "bound": 268.3529327885914,
+        "gap": 0.07645029319636244,
+        "gap_certified": false,
+        "node_count": 53,
+        "incumbent_verification_failed": false
+      }
+    },
+    {
+      "instance": "tspn10",
+      "budget": 20.0,
+      "reference_optimum": null,
+      "base": {
+        "instance": "tspn10",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 20.41070437495364,
+        "status": "feasible",
+        "objective": 225.12607170016918,
+        "bound": 167.35910515007944,
+        "gap": 0.256598296740263,
+        "gap_certified": false,
+        "node_count": 63,
+        "incumbent_verification_failed": false
+      },
+      "seam": {
+        "instance": "tspn10",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 20.41641858301591,
+        "status": "feasible",
+        "objective": 225.12607170016918,
+        "bound": 167.35910515007944,
+        "gap": 0.256598296740263,
+        "gap_certified": false,
+        "node_count": 63,
+        "incumbent_verification_failed": false
+      },
+      "cand": {
+        "instance": "tspn10",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "1",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 20.808616333990358,
+        "status": "feasible",
+        "objective": 225.12607170017012,
+        "bound": 174.28500842155333,
+        "gap": 0.22583374237670922,
+        "gap_certified": false,
+        "node_count": 55,
+        "incumbent_verification_failed": false
+      }
+    },
+    {
+      "instance": "tspn12",
+      "budget": 20.0,
+      "reference_optimum": null,
+      "base": {
+        "instance": "tspn12",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 20.644517375039868,
+        "status": "feasible",
+        "objective": 262.6473957963286,
+        "bound": 198.54001195665876,
+        "gap": 0.24408155140964083,
+        "gap_certified": false,
+        "node_count": 31,
+        "incumbent_verification_failed": false
+      },
+      "seam": {
+        "instance": "tspn12",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 20.368555292021483,
+        "status": "feasible",
+        "objective": 262.6473957963286,
+        "bound": 198.54001195665876,
+        "gap": 0.24408155140964083,
+        "gap_certified": false,
+        "node_count": 31,
+        "incumbent_verification_failed": false
+      },
+      "cand": {
+        "instance": "tspn12",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "1",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 20.3934089159593,
+        "status": "feasible",
+        "objective": 262.6473957963286,
+        "bound": 198.54006501145957,
+        "gap": 0.24408134940953854,
+        "gap_certified": false,
+        "node_count": 31,
+        "incumbent_verification_failed": false
+      }
+    }
+  ]
+}

--- a/discopt_benchmarks/scripts/issue928_contvar_attribution_probe.py
+++ b/discopt_benchmarks/scripts/issue928_contvar_attribution_probe.py
@@ -1,0 +1,72 @@
+"""Attribution probe: is contvar's lost bound #928 alone, or the #928x#966 pair?
+
+The 3-arm graduation panel has no arm with DISCOPT_LP_WARM_DEADLINE=1 and the
+#966 seam flags OFF, so "the cand arm loses the bound and the seam arm keeps it"
+attributes the loss to #928 *given* the seam, not to #928 by itself. This adds
+that fourth arm on the two instances that moved, and reports every cell.
+
+Prints an executed-comparison count and exits non-zero if it compared nothing
+(CLAUDE.md §6). Worker exceptions propagate (§7).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+CORPUS = ROOT / "python/tests/data/minlplib_nl"
+WORKER = Path(__file__).with_name("issue966_coupled_worker.py")
+WARM, ROUND, HESS = (
+    "DISCOPT_LP_WARM_DEADLINE",
+    "DISCOPT_NODE_ROUND_BUDGET",
+    "DISCOPT_HESS_COMPILE_GATE",
+)
+
+ARMS = (
+    ("base", {WARM: "0", ROUND: "0", HESS: "0"}),
+    ("warm", {WARM: "1", ROUND: "0", HESS: "0"}),  # <- the missing arm: #928 alone
+    ("seam", {WARM: "0", ROUND: "1", HESS: "1"}),
+    ("cand", {WARM: "1", ROUND: "1", HESS: "1"}),
+)
+
+INSTANCES = sys.argv[1].split(",")
+BUDGET = float(sys.argv[2])
+REPS = int(sys.argv[3])
+
+fired = 0
+print(f"loadavg_start={[round(x, 2) for x in os.getloadavg()]}", flush=True)
+rows = []
+for rep in range(1, REPS + 1):
+    for name in INSTANCES:
+        for key, env in ARMS:  # interleaved within instance (§9)
+            t = time.perf_counter()
+            proc = subprocess.run(
+                [sys.executable, "-u", str(WORKER), str(CORPUS / f"{name}.nl"), str(BUDGET)],
+                capture_output=True,
+                text=True,
+                env={**os.environ, **env},
+                timeout=40 * BUDGET + 900,
+            )
+            if proc.returncode != 0:
+                sys.stderr.write(proc.stdout[-2000:] + "\n" + proc.stderr[-4000:] + "\n")
+                raise SystemExit(f"worker failed: {name} {key}")
+            r = json.loads(proc.stdout.strip().splitlines()[-1])
+            fired += 1
+            rows.append({"rep": rep, "instance": name, "arm": key, **r})
+            print(
+                f"rep{rep} {name:12s} {key:5s} wall={r['wall']:5.1f} nodes={r['node_count']:4d} "
+                f"status={r['status']:12s} bound={r['bound']} obj={r['objective']} "
+                f"cert={int(bool(r['gap_certified']))}  [{time.perf_counter() - t:.0f}s]",
+                flush=True,
+            )
+print(f"loadavg_end={[round(x, 2) for x in os.getloadavg()]}")
+print(f"CELLS_EXECUTED={fired}")
+Path(ROOT / "discopt_benchmarks/results/issue928_contvar_attribution.json").write_text(
+    json.dumps(rows, indent=2)
+)
+raise SystemExit(0 if fired else 1)

--- a/discopt_benchmarks/scripts/issue966_coupled_graduation_panel.py
+++ b/discopt_benchmarks/scripts/issue966_coupled_graduation_panel.py
@@ -1,0 +1,276 @@
+"""Coupled §5 graduation panel for the three budget flags (#928 + #966 item 3).
+
+``DISCOPT_LP_WARM_DEADLINE`` (#917/#928) failed the net-positive bar for one
+*measured* reason: the LP layer honours its grant, but the enclosing
+separated-relaxation round does not, so the budget-honouring LPs simply let the
+loop fit more (unclamped) rounds and the ON arm's wall went UP at a 20 s budget
+(ON-OFF +325.4 / +68.5 / +12.7 s over three reps). #966 fixed that seam behind
+``DISCOPT_NODE_ROUND_BUDGET`` and ``DISCOPT_HESS_COMPILE_GATE``. The three are
+therefore ONE change for graduation purposes, and this panel scores them as one.
+
+Three arms, run back-to-back per instance (interleaved, CLAUDE.md §9) in isolated
+subprocesses, every flag set explicitly on every arm:
+
+    A  base       all three OFF  -- today's default, the control
+    B  seam       #966 ON, #928 OFF -- isolates the round/compile budget fix
+    C  candidate  all three ON   -- what graduation would make the default
+
+C vs A is the graduation question. C vs B isolates #928's marginal effect now
+that the seam is closed, and B vs A isolates #966's own effect, so a failure can
+be attributed instead of guessed at.
+
+Ends with an executed-comparison count; exits non-zero if it compared nothing
+(§6). Every arm's raw record is written to ``--out`` for re-analysis.
+
+    python -u discopt_benchmarks/scripts/issue966_coupled_graduation_panel.py \
+        --budget 20 --instances 4stufen,bchoco06,... \
+        --out discopt_benchmarks/results/issue966_coupled_binding20_rep1.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+CORPUS = ROOT / "python/tests/data/minlplib_nl"
+WORKER = Path(__file__).with_name("issue966_coupled_worker.py")
+TOL = 1e-6
+
+WARM = "DISCOPT_LP_WARM_DEADLINE"
+ROUND = "DISCOPT_NODE_ROUND_BUDGET"
+HESS = "DISCOPT_HESS_COMPILE_GATE"
+
+# (key, label, env). Every flag is named in every arm: an arm must never inherit.
+ARMS = (
+    ("base", "all OFF (today's default)", {WARM: "0", ROUND: "0", HESS: "0"}),
+    ("seam", "#966 ON, #928 OFF", {WARM: "0", ROUND: "1", HESS: "1"}),
+    ("cand", "all three ON", {WARM: "1", ROUND: "1", HESS: "1"}),
+)
+
+
+def loadavg() -> list[float]:
+    """1/5/15-minute load, recorded into the artifact at panel start and end.
+
+    CLAUDE.md §9 makes a load gate part of any timing claim; recording it beside
+    the numbers keeps the gate auditable instead of a sentence in a PR body. The
+    arms are interleaved per instance precisely so a load excursion hits all
+    three within seconds of each other rather than biasing one.
+    """
+    return list(os.getloadavg())
+
+
+def reference_optimum(name: str):
+    sys.path.insert(0, str(ROOT / "python/tests"))
+    try:
+        from _optima import known_optimum  # type: ignore
+
+        return known_optimum(name)
+    except Exception:
+        return None
+
+
+def run_one(nl: Path, budget: float, env: dict) -> dict:
+    proc = subprocess.run(
+        [sys.executable, "-u", str(WORKER), str(nl), str(budget)],
+        capture_output=True,
+        text=True,
+        env={**os.environ, **env},
+        timeout=40 * budget + 900,
+    )
+    if proc.returncode != 0:
+        sys.stderr.write(proc.stdout[-3000:] + "\n" + proc.stderr[-6000:] + "\n")
+        raise SystemExit(f"worker failed on {nl.stem} env={env}")
+    return json.loads(proc.stdout.strip().splitlines()[-1])
+
+
+def soundness(cells: list[dict]) -> dict:
+    """Per-arm soundness scoring: a bound past the oracle or across the incumbent,
+    or an incumbent that failed verification, is disqualifying on its own."""
+    unsound, verification_failed = [], []
+    for c in cells:
+        ref = c["reference_optimum"]
+        for key, _label, _env in ARMS:
+            rec = c[key]
+            sense = rec["sense"]
+            if rec["incumbent_verification_failed"]:
+                verification_failed.append(f"{c['instance']}:{key}")
+            if rec["bound"] is not None and rec["objective"] is not None:
+                bad = (
+                    rec["bound"] < rec["objective"] - 1e-4
+                    if sense == "max"
+                    else rec["bound"] > rec["objective"] + 1e-4
+                )
+                if bad:
+                    unsound.append(f"{c['instance']}:{key}:bound-crosses-incumbent")
+            if rec["bound"] is not None and ref is not None:
+                bad = (
+                    rec["bound"] < float(ref) - 1e-4
+                    if sense == "max"
+                    else rec["bound"] > float(ref) + 1e-4
+                )
+                if bad:
+                    unsound.append(f"{c['instance']}:{key}:bound-past-oracle")
+    return {"unsound": unsound, "incumbent_verification_failed": verification_failed}
+
+
+def compare(cells: list[dict], a_key: str, b_key: str) -> dict:
+    """Score arm ``b`` against arm ``a`` with the #917 panel's metric set."""
+    cert_gains, cert_regressions = [], []
+    lost_incumbents, gained_incumbents = [], []
+    worse_obj, better_obj = [], []
+    looser_bound, tighter_bound = [], []
+    lost_bound, gained_bound = [], []
+    over_a = over_b = 0
+    overrun_a = overrun_b = 0.0
+    nodes_a = nodes_b = 0
+
+    for c in cells:
+        a, b, name, budget = c[a_key], c[b_key], c["instance"], c["budget"]
+        sense = a["sense"]
+        for rec, is_a in ((a, True), (b, False)):
+            if rec["wall"] > budget * 1.05:
+                if is_a:
+                    over_a += 1
+                else:
+                    over_b += 1
+            ov = max(0.0, rec["wall"] - budget)
+            if is_a:
+                overrun_a += ov
+                nodes_a += rec["node_count"]
+            else:
+                overrun_b += ov
+                nodes_b += rec["node_count"]
+
+        if bool(b["gap_certified"]) and not bool(a["gap_certified"]):
+            cert_gains.append(name)
+        if bool(a["gap_certified"]) and not bool(b["gap_certified"]):
+            cert_regressions.append(name)
+        if a["objective"] is not None and b["objective"] is None:
+            lost_incumbents.append(name)
+        if a["objective"] is None and b["objective"] is not None:
+            gained_incumbents.append(name)
+
+        ab, bb = a["bound"], b["bound"]
+        # A finite bound going to None is the most severe bound outcome there is --
+        # the solve stops claiming anything at all -- and comparing only cells where
+        # BOTH arms are finite silently skips it (the #917 panel's original bug).
+        if ab is not None and bb is None:
+            lost_bound.append(f"{name} ({ab} -> None)")
+        if ab is None and bb is not None:
+            gained_bound.append(f"{name} (None -> {bb})")
+        if ab is not None and bb is not None and abs(bb - ab) / max(1.0, abs(ab)) > 1e-9:
+            if (bb < ab) if sense == "min" else (bb > ab):
+                looser_bound.append(f"{name} ({ab} -> {bb})")
+            else:
+                tighter_bound.append(f"{name} ({ab} -> {bb})")
+
+        ao, bo = a["objective"], b["objective"]
+        if ao is not None and bo is not None and abs(bo - ao) > TOL * max(1.0, abs(ao)):
+            if (bo > ao) if sense == "min" else (bo < ao):
+                worse_obj.append(f"{name} ({ao} -> {bo})")
+            else:
+                better_obj.append(f"{name} ({ao} -> {bo})")
+
+    return {
+        "pair": f"{b_key} vs {a_key}",
+        "cells_over_budget": {a_key: over_a, b_key: over_b},
+        "total_overrun_s": {a_key: round(overrun_a, 1), b_key: round(overrun_b, 1)},
+        "overrun_delta_s": round(overrun_b - overrun_a, 1),
+        "node_count_total": {a_key: nodes_a, b_key: nodes_b},
+        "cert_gains": cert_gains,
+        "cert_regressions": cert_regressions,
+        "gained_incumbents": gained_incumbents,
+        "lost_incumbents": lost_incumbents,
+        "better_objective": better_obj,
+        "worse_objective": worse_obj,
+        "tighter_bound": tighter_bound,
+        "looser_bound": looser_bound,
+        "gained_bound": gained_bound,
+        "lost_bound": lost_bound,
+    }
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--budget", type=float, default=20.0)
+    ap.add_argument("--instances", default=None)
+    ap.add_argument("--out", default=None)
+    args = ap.parse_args()
+
+    names = (
+        [s for s in args.instances.split(",") if s]
+        if args.instances
+        else sorted(p.stem for p in CORPUS.glob("*.nl"))
+    )
+    budget = args.budget
+
+    cells, compared = [], 0
+    t_panel = time.perf_counter()
+    load_start = loadavg()
+    for idx, name in enumerate(names, 1):
+        nl = CORPUS / f"{name}.nl"
+        cell = {"instance": name, "budget": budget, "reference_optimum": reference_optimum(name)}
+        for key, _label, env in ARMS:
+            cell[key] = run_one(nl, budget, env)
+        cells.append(cell)
+        compared += 1
+        parts = " | ".join(
+            f"{key} wall={cell[key]['wall']:6.1f} ({cell[key]['wall'] / budget:4.2f}x) "
+            f"cert={int(bool(cell[key]['gap_certified']))} bound={cell[key]['bound']}"
+            for key, _l, _e in ARMS
+        )
+        print(f"[{idx}/{len(names)}] {name:22s} {parts}", flush=True)
+
+    snd = soundness(cells)
+    pairs = [
+        compare(cells, "base", "cand"),
+        compare(cells, "seam", "cand"),
+        compare(cells, "base", "seam"),
+    ]
+    grad = pairs[0]
+    cert_clean = not (
+        snd["unsound"]
+        or snd["incumbent_verification_failed"]
+        or grad["cert_regressions"]
+        or grad["lost_incumbents"]
+        or grad["lost_bound"]
+    )
+    summary = {
+        "instances": len(cells),
+        "budget": budget,
+        "arms": {k: lbl for k, lbl, _e in ARMS},
+        **snd,
+        "pairs": pairs,
+        "panel_wall_s": round(time.perf_counter() - t_panel, 1),
+        "loadavg_start": [round(x, 2) for x in load_start],
+        "loadavg_end": [round(x, 2) for x in loadavg()],
+    }
+
+    print()
+    print(json.dumps(summary, indent=2))
+    print(f"\nCERT_CLEAN={cert_clean}  (graduation pair: cand vs base)")
+    print(f"OVERRUN_DELTA_S_CAND_VS_BASE={grad['overrun_delta_s']}")
+    print(f"COMPARISONS_EXECUTED={compared}")
+
+    if args.out:
+        out = Path(args.out)
+        if not out.is_absolute():
+            out = ROOT / out
+        out.parent.mkdir(parents=True, exist_ok=True)
+        out.write_text(json.dumps({"summary": summary, "cells": cells}, indent=2))
+        print(f"wrote {out}")
+
+    if compared == 0:
+        print("PANEL FIRED NOTHING", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/discopt_benchmarks/scripts/issue966_coupled_worker.py
+++ b/discopt_benchmarks/scripts/issue966_coupled_worker.py
@@ -1,0 +1,67 @@
+"""#966/#928 coupled panel worker: one instance, one budget, one process.
+
+Reads the three coupled flags from the environment (the panel sets all three
+explicitly on every arm, so an inherited value can never leak into a cell) and
+reports the full result record as JSON on stdout. Exceptions propagate: a broken
+arm must fail the panel, never read as a clean run (CLAUDE.md §7).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import time
+
+os.environ.setdefault("JAX_PLATFORMS", "cpu")
+os.environ.setdefault("JAX_ENABLE_X64", "1")
+
+import discopt  # noqa: E402
+from discopt import solver as _solver  # noqa: E402
+from discopt._jax import mccormick_lp as _mc  # noqa: E402
+from discopt.modeling.core import ObjectiveSense, from_nl  # noqa: E402
+from discopt.solvers import milp_simplex as _ms  # noqa: E402
+
+# CLAUDE.md §8: prove which tree is under test before measuring anything with it.
+# One marker per merged PR whose behaviour this panel is scoring; a run against a
+# tree missing any of them is not the experiment and must die, not report.
+assert "/python/discopt/" in discopt.__file__, discopt.__file__
+assert hasattr(_solver, "_extend_budget_for_incumbent"), "#917 marker absent"
+assert hasattr(_ms, "_dual_start_slack_basis"), "#928 marker '_dual_start_slack_basis' absent"
+assert "round_deadline" in _mc.MccormickLPRelaxer.solve_at_node.__code__.co_varnames, (
+    "#966 marker 'round_deadline' absent from solve_at_node"
+)
+
+FLAGS = ("DISCOPT_LP_WARM_DEADLINE", "DISCOPT_NODE_ROUND_BUDGET", "DISCOPT_HESS_COMPILE_GATE")
+for _f in FLAGS:
+    assert _f in os.environ, f"{_f} not set by the panel — an arm must never inherit a default"
+
+path, budget = sys.argv[1], float(sys.argv[2])
+
+m = from_nl(path)
+sense = "max" if m._objective.sense == ObjectiveSense.MAXIMIZE else "min"
+
+t0 = time.perf_counter()
+r = m.solve(time_limit=budget)
+wall = time.perf_counter() - t0
+
+print(
+    json.dumps(
+        {
+            "instance": path.split("/")[-1].removesuffix(".nl"),
+            "flags": {f: os.environ[f] for f in FLAGS},
+            "budget": budget,
+            "sense": sense,
+            "wall": wall,
+            "status": r.status,
+            "objective": r.objective,
+            "bound": r.bound,
+            "gap": r.gap,
+            "gap_certified": bool(r.gap_certified),
+            "node_count": int(r.node_count or 0),
+            "incumbent_verification_failed": bool(
+                getattr(r, "incumbent_verification_failed", False)
+            ),
+        }
+    )
+)

--- a/docs/dev/performance-plan.md
+++ b/docs/dev/performance-plan.md
@@ -1735,3 +1735,81 @@ Stage-1 validation patch (route `diving` through a per-model evaluator cache):
 > amplification §14b measured needs the #928 branch's banked dual floor, so
 > the corpus-wide differential panel for these two flags is coupled to the
 > #928 graduation panel re-run (issue #966 item 3).
+
+### 14b. #928 + #966 coupled graduation panel: FAILED, and the loss is an *interaction* (2026-08-09)
+
+> §14a left `DISCOPT_LP_WARM_DEADLINE` cert-clean but not net-positive, with a named
+> next step: "a load-gated, multi-rep panel over the instances where the deadline
+> actually binds." That panel has now run, and it grew a second question first.
+>
+> **Why the three flags were scored as one change.** #928's net-positive failure had a
+> *measured* cause, not a mysterious one: the LP layer honours its grant, but the
+> enclosing separated-relaxation round did not, so budget-honouring LPs merely let the
+> loop fit more unclamped rounds and the ON arm's wall went **up** (ON−OFF +325.4 /
+> +68.5 / +12.7 s at a 20 s budget). #966 closed that seam behind
+> `DISCOPT_NODE_ROUND_BUDGET` (a `round_deadline` threaded into `solve_at_node`, min-
+> combined with the build deadline) and `DISCOPT_HESS_COMPILE_GATE` (refuse to *start*
+> a per-node NLP whose first-time sparse-Hessian XLA compile — measured 124 s on
+> heatexch_gen3 against a 20 s budget — cannot fit; a compile is uninterruptible, so
+> entry refusal is the whole treatment). Graduating #928 without #966 re-creates the
+> known regression, so the panel has three arms rather than two:
+> `base` (all OFF) / `seam` (#966 only) / `cand` (all three), interleaved per instance,
+> every flag named explicitly in every arm so no cell can inherit a default.
+>
+> **Panel**: 19 binding instances, 20 s budget, 3 reps, `wtpanel` built from
+> `origin/main` and gated by four §8 markers per cell (`discopt.__file__`,
+> `_extend_budget_for_incumbent`, `_dual_start_slack_basis`, `round_deadline` in
+> `solve_at_node.__code__.co_varnames`). `COMPARISONS_EXECUTED=19` each rep;
+> `loadavg` recorded into every artifact.
+> Raw: `discopt_benchmarks/results/issue966_coupled_binding20_rep{1,2,3}.json`.
+>
+> **The wall regression is gone.** The entry question passes cleanly and reproducibly:
+>
+> | pair | rep1 | rep2 | rep3 | mean ± sd |
+> |---|---|---|---|---|
+> | cand − base overrun | −2.6 s | −2.7 s | −2.7 s | **−2.7 ± 0.0 s** |
+> | seam − base overrun | −6.0 s | −3.6 s | −5.2 s | **−4.9 ± 1.0 s** |
+>
+> The sign flip is attributable to #966; #928 gives back ~2.3 s of #966's gain.
+>
+> **`CERT_CLEAN=False` in 3/3 reps, on exactly one item**: contvar's bound goes
+> `183632.766 → None` in the `cand` arm — not looser, *absent*. Nothing is unsound
+> (`unsound=[]`, `incumbent_verification_failed=[]`, no cert regressions, no lost
+> incumbents in any rep), so this is a claim-quality failure, not a soundness one.
+> **Neither flag set graduates.**
+>
+> **The 3-arm panel could not attribute it, so a 4th arm was run.** `cand` loses the
+> bound and `seam` keeps it, which attributes the loss to #928 *given the seam* — not
+> to #928 by itself. The panel has no `warm`-only arm, so one was added
+> (`discopt_benchmarks/scripts/issue928_contvar_attribution_probe.py`, 2 reps,
+> `CELLS_EXECUTED=16`, bit-identical across reps):
+>
+> | contvar @20 s | nodes | status | bound | incumbent |
+> |---|---|---|---|---|
+> | base | 7 | time_limit | 183632.766 | none |
+> | warm (#928 alone) | 3 | **feasible** | 98924.530 (looser, sound) | **813745.125** |
+> | seam (#966 alone) | 7 | time_limit | 183632.766 | none |
+> | cand (all three) | **287** | time_limit | **none** | none |
+>
+> **#928 alone does not destroy the bound — it trades bound quality for an incumbent**
+> (the 98924.53 figure is exactly the one §14a reported). The destruction is an
+> **interaction**: with the round budget also clamping, the node count explodes 7 → 287
+> and no node ever certifies anything, so the tree spends the whole budget on cheap
+> uncertified nodes. The suspect is the pair "LP yields on its deadline" ×  "round
+> yields on *its* deadline" compounding into a node result that carries no adoptable
+> bound at all; that is the thing to fix before either flag is re-panelled.
+>
+> **A second cost, from #966 alone, not surfaced in PR #968**: casctanks
+> `2.9098 → −56.5001` in the `seam` arm, identical in all three reps and in both probe
+> reps (and −57.2/−60.1/−60.7 with all three on). Sound (looser) and therefore
+> invisible to `cert_clean`, but a dual bound crossing from +2.9 to −56.5 is a
+> collapse, not a drift — the round budget is declining the rounds that were producing
+> casctanks' bound. #928 alone costs it only 2.9098 → 2.4598.
+>
+> **Verdict.** `seam` (#966 alone) *is* cert-clean in 3/3 reps and is the only arm that
+> buys wall time (−4.9 ± 1.0 s), but it fails the net-positive bar on the other half of
+> the metric set: its bound ledger over three reps is 4 looser (casctanks every rep,
+> tls2 ×2, nvs05, tspn10) against 3 tiny non-reproducible tighter entries, and node
+> counts rise (1329 → 1811). This is the `DISCOPT_CUT_INHERIT` shape again — sound, and
+> genuinely better on the metric it was built for, while paying for it in the metric
+> the solver's product actually is. **All three flags stay default-OFF.**


### PR DESCRIPTION
## What this is

The §5 graduation gate for the three coupled budget flags, run to a verdict, plus the record required by §4/§11. **No solver behaviour changes** — panel scripts, raw artifacts, and one plan-doc section (`§14b`). All three flags stay default-OFF.

## Why the three flags were panelled as one change

`DISCOPT_LP_WARM_DEADLINE` (#928) failed the net-positive bar for a *measured* reason, not a mysterious one: the LP layer honours its grant, but the enclosing separated-relaxation round did not, so budget-honouring LPs merely let the loop fit more unclamped rounds and the ON arm's wall went **up** (ON−OFF +325.4 / +68.5 / +12.7 s at a 20 s budget). #966 closed that seam behind `DISCOPT_NODE_ROUND_BUDGET` and `DISCOPT_HESS_COMPILE_GATE`. Graduating #928 without #966 re-creates the known regression, so the panel has three arms — `base` (all OFF) / `seam` (#966 only) / `cand` (all three) — interleaved per instance, with every flag named explicitly in every arm so no cell can inherit a default.

## Method

19 binding instances, 20 s budget, 3 reps. The tree under test was built fresh from `origin/main` in a scratch worktree and gated per cell by four §8 markers (`discopt.__file__`, `_extend_budget_for_incumbent`, `_dual_start_slack_basis`, `round_deadline` in `solve_at_node.__code__.co_varnames`) — a run against a tree missing any of them dies rather than reporting. `COMPARISONS_EXECUTED=19` each rep; `loadavg` start/end recorded into every artifact rather than asserted in prose.

## Result: the wall regression is gone

| pair | rep1 | rep2 | rep3 | mean ± sd |
|---|---|---|---|---|
| cand − base overrun | −2.6 s | −2.7 s | −2.7 s | **−2.7 ± 0.0 s** |
| seam − base overrun | −6.0 s | −3.6 s | −5.2 s | **−4.9 ± 1.0 s** |

The sign flip is attributable to #966. #928 gives ~2.3 s of that gain back.

## Result: `CERT_CLEAN=False` in 3/3 reps

One item, every rep: contvar `183632.766 → None` in the `cand` arm — not looser, *absent*. Nothing is unsound anywhere (`unsound=[]`, no verification failures, no cert regressions, no lost incumbents in any arm), so this is a claim-quality failure rather than a soundness one.

The 3-arm panel could not attribute it — `cand` loses the bound and `seam` keeps it, which blames #928 *given the seam*, not #928 by itself. So a 4th arm was run (2 reps, `CELLS_EXECUTED=16`, bit-identical across reps):

| contvar @20 s | nodes | status | bound | incumbent |
|---|---|---|---|---|
| base | 7 | time_limit | 183632.766 | none |
| warm (#928 alone) | 3 | **feasible** | 98924.530 (looser, sound) | **813745.125** |
| seam (#966 alone) | 7 | time_limit | 183632.766 | none |
| cand (all three) | **287** | time_limit | **none** | none |

**#928 alone does not destroy the bound** — it trades bound quality for an incumbent (98924.53 is exactly the figure §14a reported). The destruction is an **interaction**: with the round budget also clamping, the node count explodes 7 → 287 and no node ever certifies anything, so the tree spends the whole budget on cheap uncertified nodes. That compounding — "LP yields on its deadline" × "round yields on its deadline" producing a node result carrying no adoptable bound — is the thing to fix before either flag is re-panelled.

## A second cost, from #966 alone, not surfaced in PR #968

casctanks `2.9098 → −56.5001` in the `seam` arm, identical in all three panel reps and both probe reps (−57.2 / −60.1 / −60.7 with all three on). Sound (looser) and therefore invisible to `cert_clean`, but a dual bound crossing from +2.9 to −56.5 is a collapse, not a drift: the round budget is declining the rounds that were producing casctanks' bound. #928 alone costs it only 2.9098 → 2.4598.

## Verdict

**No flag graduates.** `seam` (#966 alone) *is* cert-clean in 3/3 reps and is the only arm that buys wall time, but it fails net-positive on the other half of the metric set: its bound ledger over three reps is 4 looser (casctanks every rep, tls2 ×2, nvs05, tspn10) against 3 tiny non-reproducible tighter entries, and node counts rise (1329 → 1811). This is the `DISCOPT_CUT_INHERIT` shape again — sound, genuinely better on the metric it was built for, paying for it in the metric the solver's product actually is.

## Verification

- `ruff check` + `ruff format --check` clean on the three new scripts (the rest of `discopt_benchmarks/scripts/` carries pre-existing findings and is not linted by CI).
- The one lint fix inside `compare()` was a nested-`if` collapse, so the post-edit scorer was re-run over all three saved rep artifacts and asserted to reproduce the recorded summaries exactly — `RESCORE_ASSERTIONS_EXECUTED=15`.
- No source under `python/` or `crates/` is touched, so there is nothing for the solver suites to regress; CI runs as the gate.

Contributes to #928 and #966. Neither is finished by this PR — both flags remain open with the interaction above as the next thing to fix.
