### PR TITLE
fix(deps): pin why pyyaml is in the dev extra, and test it

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,10 +70,15 @@ dev = [
     "pytest",
     "pytest-timeout",
     "pytest-cov",
-    # test_ci_changes_gate.py parses .github/workflows/ci.yml to run the real
-    # `changes` gate script. Declared here rather than relied on transitively:
-    # without it that file is a collection ERROR, not a skip — red for the wrong
-    # reason. (Also in the `gams` extra, for gamsconfig.yaml merging.)
+    # test_gams_link.py opens with "None of this requires a GAMS installation"
+    # and three of its tests `import yaml` unguarded, so PyYAML is a hard test
+    # dependency and not a `[gams]`-only one. Declared here rather than relied
+    # on transitively: without it those tests are collection ERRORS, not skips —
+    # red for the wrong reason, and only in a `pip install -e ".[dev]"` tree,
+    # since four CI jobs pip-install pyyaml separately and would stay green.
+    # test_dev_extra_declares_test_deps.py pins this; it named
+    # test_ci_changes_gate.py until 2026-08-09, a file that no longer exists.
+    # (Also in the `gams` extra, for gamsconfig.yaml merging.)
     "pyyaml>=6",
     "pytest-xdist",
     # Pin the lint/typecheck toolchain to the exact versions in

--- a/python/tests/test_dev_extra_declares_test_deps.py
+++ b/python/tests/test_dev_extra_declares_test_deps.py
@@ -1,0 +1,104 @@
+"""The ``[dev]`` extra must provide what the GAMS-link tests import.
+
+``python/tests/test_gams_link.py`` opens with "None of this requires a GAMS
+installation" and is written to run in a plain developer environment -- yet three
+of its tests do a bare ``import yaml`` with no ``importorskip`` guard, so they
+*error* rather than skip when PyYAML is absent. PyYAML was declared only in the
+``[gams]`` extra, which that file deliberately does not require.
+
+CI never noticed because four of its jobs ``pip install`` pyyaml explicitly on
+top of the extras, so the only environment that broke was the documented one:
+``pip install -e ".[dev]"``, the command in CLAUDE.md.
+
+This test derives the requirement from the test file itself rather than
+hardcoding "pyyaml", so the next unguarded third-party import added to that file
+is caught the same way.
+"""
+
+from __future__ import annotations
+
+import ast
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_PYPROJECT = _REPO_ROOT / "pyproject.toml"
+_TARGET = Path(__file__).parent / "test_gams_link.py"
+
+# Import name -> distribution name, for the cases where they differ.
+_DIST_FOR_MODULE = {
+    "yaml": "pyyaml",
+    "sklearn": "scikit-learn",
+    "PIL": "pillow",
+}
+
+_FIRST_PARTY = {"discopt", "support"}
+
+
+def _unguarded_third_party_imports(path: Path) -> set[str]:
+    """Top-level modules imported outside any ``try``/``except``.
+
+    A ``try``-wrapped import is a deliberate optional dependency; a bare one is a
+    hard requirement of the file.
+    """
+    tree = ast.parse(path.read_text())
+    guarded: list[tuple[int, int]] = [
+        (n.lineno, max(getattr(c, "end_lineno", n.lineno) for c in ast.walk(n)))
+        for n in ast.walk(tree)
+        if isinstance(n, ast.Try)
+    ]
+    found: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            names = [a.name.split(".")[0] for a in node.names]
+        elif isinstance(node, ast.ImportFrom) and node.level == 0 and node.module:
+            names = [node.module.split(".")[0]]
+        else:
+            continue
+        if any(lo <= node.lineno <= hi for lo, hi in guarded):
+            continue
+        for name in names:
+            if name in sys.stdlib_module_names or name in _FIRST_PARTY or name.startswith("_"):
+                continue
+            found.add(name)
+    return found
+
+
+def _declared_distributions() -> set[str]:
+    """Distributions a ``pip install -e ".[dev]"`` resolves: core deps + ``[dev]``."""
+    tomllib = pytest.importorskip(
+        "tomllib", reason="tomllib is stdlib from 3.11; this is a packaging-metadata check"
+    )
+    cfg = tomllib.loads(_PYPROJECT.read_text())["project"]
+    specs = list(cfg.get("dependencies", [])) + list(
+        cfg.get("optional-dependencies", {}).get("dev", [])
+    )
+    out = set()
+    for spec in specs:
+        # Strip version/marker/extras decoration: "ruff==0.14.6", "pounce[x]>=1".
+        name = spec.split(";")[0].strip()
+        for sep in ("==", ">=", "<=", "~=", "!=", ">", "<", "["):
+            name = name.split(sep)[0]
+        out.add(name.strip().lower().replace("_", "-"))
+    return out
+
+
+def test_gams_link_tests_are_runnable_from_the_dev_extra_alone():
+    imported = _unguarded_third_party_imports(_TARGET)
+    assert imported, f"scanned {_TARGET.name} and found no third-party imports -- probe is dead"
+
+    declared = _declared_distributions()
+    missing = {
+        mod: _DIST_FOR_MODULE.get(mod, mod)
+        for mod in imported
+        if _DIST_FOR_MODULE.get(mod, mod).lower().replace("_", "-") not in declared
+    }
+    assert not missing, (
+        f"{_TARGET.name} imports {sorted(missing)} unguarded, but the dev extra does not "
+        f"declare {sorted(missing.values())}. Either declare it in [project."
+        f"optional-dependencies].dev or guard the import -- do not rely on CI installing it."
+    )
+    # Prove the check compared something (CLAUDE.md §6).
+    assert len(imported) >= 2, f"only {len(imported)} imports examined: {sorted(imported)}"


### PR DESCRIPTION
## The defect

The `dev` extra already declares `pyyaml`, so nothing is broken today. What is broken is the **reason** it gives:

```toml
# test_ci_changes_gate.py parses .github/workflows/ci.yml to run the real
# `changes` gate script. ...
"pyyaml>=6",
```

`python/tests/test_ci_changes_gate.py` does not exist in the tree. The declaration is still correct, for a different file: `test_gams_link.py` opens with *"None of this requires a GAMS installation"* and three of its tests do a bare `import yaml` with no `importorskip`, so PyYAML is a hard test dependency and not a `[gams]`-only one.

That leaves the dependency one stale-comment-driven cleanup away from deletion — and **the deletion would be invisible to CI**. Four CI jobs `pip install` pyyaml on top of the extras (`ci.yml:163,243,304,374`), so CI stays green either way. The only environment that breaks is the documented one, `pip install -e ".[dev]"` — the command in CLAUDE.md — where those three tests become collection *errors*, not skips.

## The fix

1. The comment now cites the file that actually needs it, and records that it named a non-existent file until today.
2. `python/tests/test_dev_extra_declares_test_deps.py` pins the invariant.

The test derives the requirement rather than restating it: it walks `test_gams_link.py`'s AST for imports that are outside any `try`/`except` and are neither stdlib nor first-party, maps import name → distribution name for the cases where they differ, and asserts each resolves from `[project].dependencies` ∪ `[dev]`. **No package name is hardcoded**, so the next unguarded third-party import added to that file is caught the same way.

Per §6 it also refuses to pass while measuring nothing: it asserts the scan found imports at all, and that it examined at least two.

## Verification

- Passes as committed.
- **Negative control**: with `"pyyaml>=6"` removed from the `dev` block the test fails (`1 failed`) — run programmatically, file restored afterward, so the test is proven to bite rather than assumed to.
- `ruff check` + `ruff format --check` clean.
- `test_dev_extra_declares_test_deps.py` + `test_gams_link.py` → **53 passed**.

## Note on scope

I checked whether to generalize this across all of `python/tests/`. A scan of 520 test files finds unguarded-looking imports of `cyipopt`, `gamspy`, `highspy`, `onnx`, `scs`, `sklearn`, `sympy`, `torch` and more — but the scan cannot see module-level `pytest.importorskip`, so most of those are false positives. A tree-wide version needs importorskip modelling to avoid being a noise generator, which is a larger job than this fix. Scoped to the file with the demonstrated gap.
