### PR TITLE
fix(panel): #966 panel's oracle was a bare-except no-op; retract the claim it made

### DIFF
--- a/discopt_benchmarks/scripts/issue966_coupled_graduation_panel.py
+++ b/discopt_benchmarks/scripts/issue966_coupled_graduation_panel.py
@@ -66,13 +66,43 @@ def loadavg() -> list[float]:
 
 
 def reference_optimum(name: str):
-    sys.path.insert(0, str(ROOT / "python/tests"))
-    try:
-        from _optima import known_optimum  # type: ignore
+    """The largest value a valid dual bound may take, or ``None`` if unknown.
 
+    This used to read ``python/tests/_optima.py`` behind a bare ``except``, which
+    is CLAUDE.md §7's failure exactly: the module covers 27 curated instances, so
+    for the other 18 of this panel's 19 the lookup returned ``None`` and the arm
+    was skipped -- and the panel still printed ``unsound: []``, which reads as a
+    soundness result over 19 instances and was one comparison. The oracle is now
+    ``minlplib.solu``, which covers the library; ``_optima`` remains the fallback
+    for anything the .solu file does not name, and a missing/unreadable .solu is
+    reported rather than swallowed (the caller counts coverage, see
+    ``soundness``).
+    """
+    ceiling = _solu_ceiling(name)
+    if ceiling is not None:
+        return ceiling
+    sys.path.insert(0, str(ROOT / "python/tests"))
+    from _optima import known_optimum  # type: ignore
+
+    try:
         return known_optimum(name)
-    except Exception:
+    except KeyError:
+        # The one genuine "no oracle" outcome, and the only one that may be
+        # swallowed: everything else (missing .solu, bad import) must crash.
         return None
+
+
+def _solu_ceiling(name: str):
+    sys.path.insert(0, str(Path(__file__).parent))
+    from minlplib_solu import load, primal_ceiling  # type: ignore
+
+    global _SOLU
+    if _SOLU is None:
+        _SOLU = load()
+    return primal_ceiling(name, _SOLU)
+
+
+_SOLU: dict | None = None
 
 
 def run_one(nl: Path, budget: float, env: dict) -> dict:
@@ -91,10 +121,18 @@ def run_one(nl: Path, budget: float, env: dict) -> dict:
 
 def soundness(cells: list[dict]) -> dict:
     """Per-arm soundness scoring: a bound past the oracle or across the incumbent,
-    or an incumbent that failed verification, is disqualifying on its own."""
-    unsound, verification_failed = [], []
+    or an incumbent that failed verification, is disqualifying on its own.
+
+    Returns the number of oracle comparisons actually executed and the instances
+    with no oracle at all (§6). ``unsound: []`` over zero comparisons is not a
+    soundness result, and the caller must be able to tell the two apart.
+    """
+    unsound, verification_failed, uncovered = [], [], []
+    oracle_cmps = 0
     for c in cells:
         ref = c["reference_optimum"]
+        if ref is None:
+            uncovered.append(c["instance"])
         for key, _label, _env in ARMS:
             rec = c[key]
             sense = rec["sense"]
@@ -109,6 +147,7 @@ def soundness(cells: list[dict]) -> dict:
                 if bad:
                     unsound.append(f"{c['instance']}:{key}:bound-crosses-incumbent")
             if rec["bound"] is not None and ref is not None:
+                oracle_cmps += 1
                 bad = (
                     rec["bound"] < float(ref) - 1e-4
                     if sense == "max"
@@ -116,7 +155,12 @@ def soundness(cells: list[dict]) -> dict:
                 )
                 if bad:
                     unsound.append(f"{c['instance']}:{key}:bound-past-oracle")
-    return {"unsound": unsound, "incumbent_verification_failed": verification_failed}
+    return {
+        "unsound": unsound,
+        "incumbent_verification_failed": verification_failed,
+        "oracle_comparisons_executed": oracle_cmps,
+        "instances_without_oracle": sorted(set(uncovered)),
+    }
 
 
 def compare(cells: list[dict], a_key: str, b_key: str) -> dict:
@@ -201,7 +245,23 @@ def main() -> int:
     ap.add_argument("--budget", type=float, default=20.0)
     ap.add_argument("--instances", default=None)
     ap.add_argument("--out", default=None)
+    ap.add_argument(
+        "--rescore",
+        default=None,
+        help="Re-run soundness() over a saved artifact's cells instead of solving. "
+        "The cells already carry every arm's bound, so a panel whose oracle was "
+        "broken can be re-scored without spending the wall time again.",
+    )
     args = ap.parse_args()
+
+    if args.rescore:
+        saved = json.loads(Path(args.rescore).read_text())["cells"]
+        for c in saved:
+            c["reference_optimum"] = reference_optimum(c["instance"])
+        snd = soundness(saved)
+        print(json.dumps(snd, indent=2))
+        print(f"ORACLE_COMPARISONS_EXECUTED={snd['oracle_comparisons_executed']}")
+        return 0 if snd["oracle_comparisons_executed"] else 1
 
     names = (
         [s for s in args.instances.split(",") if s]
@@ -257,6 +317,8 @@ def main() -> int:
     print(f"\nCERT_CLEAN={cert_clean}  (graduation pair: cand vs base)")
     print(f"OVERRUN_DELTA_S_CAND_VS_BASE={grad['overrun_delta_s']}")
     print(f"COMPARISONS_EXECUTED={compared}")
+    print(f"ORACLE_COMPARISONS_EXECUTED={snd['oracle_comparisons_executed']}")
+    print(f"INSTANCES_WITHOUT_ORACLE={snd['instances_without_oracle']}")
 
     if args.out:
         out = Path(args.out)
@@ -268,6 +330,11 @@ def main() -> int:
 
     if compared == 0:
         print("PANEL FIRED NOTHING", file=sys.stderr)
+        return 1
+    if snd["oracle_comparisons_executed"] == 0:
+        # A panel that never reached an oracle cannot report on soundness, and
+        # ``unsound: []`` from it is a formatting artifact, not a measurement.
+        print("PANEL MADE NO ORACLE COMPARISONS", file=sys.stderr)
         return 1
     return 0
 

--- a/discopt_benchmarks/scripts/issue966_rescore_against_solu.py
+++ b/discopt_benchmarks/scripts/issue966_rescore_against_solu.py
@@ -1,0 +1,78 @@
+"""Re-score the saved #966 panel artifacts against the FULL MINLPLib oracle.
+
+The panel's own soundness check used ``python/tests/_optima.py``, which covers
+1 of its 19 instances, and swallowed the lookup failure in a bare ``except``
+(CLAUDE.md §7). This re-reads the saved cells -- no re-run needed -- and scores
+every arm's bound against ``minlplib.solu``.
+
+Prints the number of bound-vs-oracle comparisons actually executed and exits
+non-zero if that is zero (§6). Uncovered instances are reported, never counted
+as clean.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+from minlplib_solu import load, primal_ceiling  # noqa: E402
+
+TOL = 1e-4
+ARMS = ("base", "seam", "cand")
+
+table = load()
+compared = 0
+violations, uncovered, closest = [], set(), []
+
+for rep in (1, 2, 3):
+    art = Path(f"discopt_benchmarks/results/issue966_coupled_binding20_rep{rep}.json")
+    cells = json.loads(art.read_text())["cells"]
+    for c in cells:
+        name = c["instance"]
+        ceil_ = primal_ceiling(name, table)
+        if ceil_ is None:
+            uncovered.add(name)
+            continue
+        for arm in ARMS:
+            rec = c[arm]
+            b = rec["bound"]
+            if b is None:
+                continue
+            compared += 1
+            sense = rec["sense"]
+            # For min: a valid dual bound is <= the optimum <= the best primal.
+            slack = (ceil_ - b) if sense == "min" else (b - ceil_)
+            closest.append((slack, f"rep{rep}:{name}:{arm}", b, ceil_))
+            if slack < -TOL * max(1.0, abs(ceil_)):
+                violations.append(
+                    {
+                        "rep": rep,
+                        "instance": name,
+                        "arm": arm,
+                        "sense": sense,
+                        "bound": b,
+                        "oracle_ceiling": ceil_,
+                        "excess": -slack,
+                    }
+                )
+
+closest.sort(key=lambda t: t[0])
+print(
+    json.dumps(
+        {
+            "bound_vs_oracle_comparisons": compared,
+            "instances_uncovered_by_solu": sorted(uncovered),
+            "violations": violations,
+            "tightest_5_margins": [
+                {"cell": c[1], "bound": c[2], "oracle_ceiling": c[3], "margin": c[0]}
+                for c in closest[:5]
+            ],
+        },
+        indent=2,
+    )
+)
+print(f"ORACLE_COMPARISONS_EXECUTED={compared}")
+print(f"ORACLE_VIOLATIONS={len(violations)}")
+raise SystemExit(0 if compared else 1)

--- a/discopt_benchmarks/scripts/minlplib_solu.py
+++ b/discopt_benchmarks/scripts/minlplib_solu.py
@@ -1,0 +1,67 @@
+"""MINLPLib ``minlplib.solu`` oracle reader.
+
+``python/tests/_optima.py`` records optima for 27 curated instances. Scoring a
+corpus panel against it silently degrades to "no oracle" for everything else --
+the #966 coupled panel had oracle coverage on **1 of 19** instances and still
+printed ``unsound: []``, which reads as a soundness result and was not one.
+
+``minlplib.solu`` (from the benchmark snapshot named in CLAUDE.md) covers the
+whole library. Entries:
+
+    =opt=      name  v   proven optimum
+    =best=     name  v   best known primal  (>= optimum for min)
+    =bestdual= name  v   best known dual    (<= optimum for min)
+    =inf=      name      proven infeasible
+    =unkn=     name      nothing known
+
+For a MINIMIZATION instance a valid dual bound must satisfy ``bound <= optimum``,
+and ``optimum <= best``, so ``bound > best`` is unsound. ``=opt=`` is used when
+present, ``=best=`` otherwise; instances with neither yield ``None`` and MUST be
+reported as uncovered rather than counted as clean.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+_DEFAULT = Path(
+    os.environ.get(
+        "DISCOPT_MINLPLIB_SOLU",
+        Path.home() / "Dropbox/projects/discopt-minlp-benchmark/minlplib.solu",
+    )
+)
+
+
+def load(path: Path | None = None) -> dict[str, dict[str, float | str]]:
+    """Parse the .solu file into ``{name: {tag: value}}``. Raises if unreadable."""
+    p = Path(path) if path is not None else _DEFAULT
+    if not p.exists():
+        raise FileNotFoundError(
+            f"minlplib.solu not found at {p}; set DISCOPT_MINLPLIB_SOLU to override"
+        )
+    out: dict[str, dict[str, float | str]] = {}
+    for line in p.read_text().splitlines():
+        parts = line.split()
+        if len(parts) < 2 or not parts[0].startswith("="):
+            continue
+        tag, name = parts[0].strip("="), parts[1]
+        rec = out.setdefault(name, {})
+        rec[tag] = float(parts[2]) if len(parts) >= 3 else True
+    return out
+
+
+def primal_ceiling(name: str, table: dict) -> float | None:
+    """Largest value a valid MIN dual bound may take, or ``None`` if unknown.
+
+    ``=opt=`` when proven; otherwise ``=best=``, the best known primal, which is
+    an upper bound on the true optimum and therefore still a valid ceiling.
+    """
+    rec = table.get(name)
+    if not rec:
+        return None
+    for tag in ("opt", "best"):
+        v = rec.get(tag)
+        if isinstance(v, float):
+            return v
+    return None

--- a/docs/dev/performance-plan.md
+++ b/docs/dev/performance-plan.md
@@ -1813,3 +1813,46 @@ Stage-1 validation patch (route `diving` through a per-model evaluator cache):
 > counts rise (1329 → 1811). This is the `DISCOPT_CUT_INHERIT` shape again — sound, and
 > genuinely better on the metric it was built for, while paying for it in the metric
 > the solver's product actually is. **All three flags stay default-OFF.**
+
+### 14b-qual. Retraction of §14b's soundness evidence — the oracle was 1/19 (2026-08-09)
+
+> CLAUDE.md §11: a measurement that contradicts a claim I already published gets
+> retracted in writing before anything else proceeds. This qualifies §14b above.
+>
+> §14b asserts "**Nothing is unsound** (`unsound=[]`, `incumbent_verification_failed=[]`,
+> …)". The `unsound=[]` half of that was **not** a measurement over 19 instances. The
+> panel's `reference_optimum()` read `python/tests/_optima.py` behind a bare
+> `except Exception: return None` — §7's exact failure mode — and that module records
+> 27 curated instances. A counted control over the panel's own 19 names
+> (`old_oracle_covered`) returns **one**: `clay0303hfsg`. Every other instance's oracle
+> arm was skipped, and the panel printed `unsound: []` regardless. The other soundness
+> checks in the same function *did* fire on all 19 (bound-crosses-incumbent,
+> incumbent verification), so §14b's soundness conclusion was never empty — but its
+> bound-vs-oracle component rested on one instance's three arms per rep (9 comparisons
+> over the three reps, counted) and was reported as though it covered all 19.
+>
+> **The claim survives re-measurement, and is now stated at its real strength.** The
+> three saved artifacts were re-scored against `minlplib.solu` — the library-wide
+> oracle — without re-running anything, since the cells already carry every arm's
+> bound (`--rescore`, and the standalone
+> `discopt_benchmarks/scripts/issue966_rescore_against_solu.py`):
+>
+> | | merged §14b | re-scored |
+> |---|---|---|
+> | instances with an oracle | 1 / 19 | **16 / 19** |
+> | bound-vs-oracle comparisons | 3 per rep, 9 total | **44 per rep, 132 over 3 reps** |
+> | violations | 0 | **0** |
+>
+> Tightest margin over all 132: `syn05hfsg`, −1.99e-09 — inside the 1e-4 relative
+> tolerance and attributable to LP arithmetic, not a crossed bound. `bchoco06`,
+> `bchoco07` and `bchoco08` are named in neither oracle and remain **uncovered**; they
+> are reported, never counted as clean. §14b's verdict (all three flags default-OFF)
+> is unchanged — that verdict turned on `cert_clean` and the bound ledger, not on this
+> line.
+>
+> **Instrument fixed, not just the sentence.** `reference_optimum()` now consults
+> `minlplib.solu` first and falls back to `_optima`; only `KeyError` (the one genuine
+> "no oracle" outcome) is swallowed, so a missing `.solu` or a bad import crashes.
+> `soundness()` returns `oracle_comparisons_executed` and `instances_without_oracle`,
+> both printed, and the panel **exits non-zero** when it made zero oracle comparisons
+> (§6) — the state that produced this retraction can no longer report success.


### PR DESCRIPTION
## What this fixes

The `#966` coupled graduation panel (merged in #969) scored soundness with:

```python
def reference_optimum(name):
    try:
        from _optima import known_optimum
        return known_optimum(name)
    except Exception:
        return None
```

That is CLAUDE.md §7's failure mode exactly. `python/tests/_optima.py` records 27 curated instances; a counted control over the panel's own 19 names finds **one** of them (`clay0303hfsg`). For the other 18 the lookup returned `None`, the bound-vs-oracle arm was skipped, and the panel printed `unsound: []` regardless.

So `docs/dev/performance-plan.md` §14b's "Nothing is unsound" rested on **9** bound-vs-oracle comparisons across three reps while reading as a result over 19 instances. (The other soundness checks in the same function — bound-crosses-incumbent, incumbent verification — *did* fire on all 19, so the conclusion was never empty, just far weaker than stated.)

## The claim survives re-measurement

The saved cells already carry every arm's bound, so no re-run was needed. Re-scored against `minlplib.solu`, the library-wide oracle:

| | merged §14b | re-scored |
|---|---|---|
| instances with an oracle | 1 / 19 | **16 / 19** |
| bound-vs-oracle comparisons | 3 per rep, **9** total | **44 per rep, 132** total |
| violations | 0 | **0** |

Tightest margin over all 132: `syn05hfsg`, −1.99e-09 — inside the 1e-4 relative tolerance and attributable to LP arithmetic, not a crossed bound. `bchoco06`, `bchoco07`, `bchoco08` are named in neither oracle and are reported as **uncovered**, never counted as clean.

§14b's verdict (all three flags stay default-OFF) is unchanged: it turned on `cert_clean` and the bound ledger, not on this line.

## Changes

- **new** `discopt_benchmarks/scripts/minlplib_solu.py` — reader for `minlplib.solu` (`=opt=` / `=best=` / `=bestdual=` / `=inf=` / `=unkn=`) with `primal_ceiling()`, the largest value a valid dual bound may take. Raises if the file is unreadable.
- `reference_optimum()` consults `.solu` first, falls back to `_optima`. Only `KeyError` — the one genuine "no oracle" outcome — is swallowed; a missing `.solu` or a bad import crashes.
- `soundness()` returns `oracle_comparisons_executed` and `instances_without_oracle`; both are printed, and the panel **exits non-zero** when it made zero oracle comparisons (§6). The state that produced this retraction can no longer report success.
- `--rescore <artifact>` re-runs `soundness()` over saved cells without re-solving; standalone `issue966_rescore_against_solu.py` does the same independently.
- `docs/dev/performance-plan.md` gains **§14b-qual**, the written retraction required by §11.

## Verification

Scripts-only + docs; no solver code is touched, so no bound can move.

- `--rescore` over each of the three saved artifacts: `ORACLE_COMPARISONS_EXECUTED=44`, `unsound: []`, `instances_without_oracle: [bchoco06, bchoco07, bchoco08]` — identical in all three reps (3 × 44 = 132, matching the independent `issue966_rescore_against_solu.py`).
- Counted negative control on the coverage claim: `INSTANCES_INSPECTED=19`, `old_oracle_covered=["clay0303hfsg"]`, new coverage 16, `still_uncovered=[bchoco06, bchoco07, bchoco08]`.
- Counted control on the old comparison total: `OLD_ORACLE_COMPARISONS_TOTAL=9` (3 per rep).
- `ruff check` + `ruff format --check` clean on the three changed/added scripts. (The rest of `discopt_benchmarks/scripts/` carries pre-existing lint debt this PR does not touch.)

Contributes to #966

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GZrQpYYd9tbLnFEH8gZokP
