### PR TITLE
fix(correctness): #971 the root-LP gate must model both ways a bound can differ

### DIFF
--- a/discopt_benchmarks/scripts/gen_claim_baseline.py
+++ b/discopt_benchmarks/scripts/gen_claim_baseline.py
@@ -11,6 +11,16 @@ differential gate (plan §3.2) compares every canonical-cutover PR against; sinc
 tolerance), so a bound drift requires deliberately regenerating this file in the
 PR that causes it.
 
+Since #971 the gate reads the recorded root LP in two ways, because the two are
+not equally reproducible: the recorded pair must *reproduce* on the bulk of the
+corpus (a handful of instances legitimately differ across arithmetic paths at an
+identical fingerprint — the certified bound is a Neumaier-Shcherbina bound read
+off a degenerate LP's non-unique dual), while the *properties* of the current
+result — the #961 status/bound contract, and a bound at or below the published
+optimum — are asserted hard on every host. So a row recorded here is a
+reproducibility reference, not a correctness oracle; the oracle is
+``docs/dev/data/cert-optima.json`` plus ``python/tests/data/known_optima.toml``.
+
 Usage (from the repo root, with the built extension importable)::
 
     JAX_PLATFORMS=cpu JAX_ENABLE_X64=1 \

--- a/discopt_benchmarks/scripts/issue971_root_lp_arithmetic_path.py
+++ b/discopt_benchmarks/scripts/issue971_root_lp_arithmetic_path.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python
+"""Issue #971 entry experiment: is the root LP bound a function of the matrix alone?
+
+``diff_root_lp`` excuses a root-LP difference only when the relaxation
+*fingerprint* differs too, on the reasoning that "a difference is only
+attributable when both sides solved the same LP". That rule assumes
+**same matrix bytes ⇒ same LP answer**. #971 reports CI failures on ``contvar``
+bucketed ``changed`` — i.e. the fingerprint MATCHED and the bound still moved by
+8.8% — which falsifies the assumption if reproducible.
+
+This probe holds the tree, the instance and the matrix fixed and varies only the
+*arithmetic path*, via OpenBLAS's runtime kernel dispatch (``OPENBLAS_CORETYPE``;
+the wheels ship ``DYNAMIC_ARCH``, so the same binary runs a Nehalem / Haswell /
+SkylakeX / Zen kernel on demand — the same knob a heterogeneous CI runner pool
+turns implicitly). For each core type it reports, from a **fresh process**, the
+relaxation fingerprint and the root LP ``(status, bound)``.
+
+Kill criterion: if every core type yields the same ``(status, bound)`` with the
+same fingerprint, the arithmetic path is NOT the mechanism and #971's premise
+needs another explanation. If any two agree on the fingerprint and disagree on
+the bound, ``diff_root_lp``'s attributability rule is provably incomplete.
+
+Discipline: asserts the tree under test by path (CLAUDE.md §8), never swallows an
+exception (§7), prints a completed-rep count and exits non-zero when it is zero
+(§6), and streams per-rep progress (§10).
+
+Usage (from the repo root, with the built extension importable)::
+
+    python -u discopt_benchmarks/scripts/issue971_root_lp_arithmetic_path.py \
+        [--instance contvar] [--coretypes Haswell,Nehalem,SkylakeX,Zen]
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+_REPO = Path(__file__).resolve().parents[2]
+_NL_DIR = _REPO / "python" / "tests" / "data" / "minlplib_nl"
+
+# Kernel families an x86-64 runner pool actually spans: pre-FMA (Nehalem),
+# FMA/AVX2 (Haswell), AVX-512 (SkylakeX), and AMD (Zen). OpenBLAS falls back to
+# a generic kernel for a core type the CPU cannot run, which is itself a
+# distinct arithmetic path, so an unsupported name is still a useful arm.
+_DEFAULT_CORETYPES = ("Haswell", "Nehalem", "SkylakeX", "Zen", "Prescott")
+
+_CHILD = r"""
+import json, os, sys
+sys.path.insert(0, {python_dir!r})
+import discopt
+assert discopt.__file__ == {expect_init!r}, (
+    "wrong tree under test: %s != %s" % (discopt.__file__, {expect_init!r})
+)
+sys.path.insert(0, {tests_dir!r})
+from support.claim_differential import current_root_lp, current_row
+
+row = current_row({name!r})
+status, bound = current_root_lp({name!r})
+print("RESULT " + json.dumps(
+    {{"coretype": os.environ.get("OPENBLAS_CORETYPE", ""),
+      "fingerprint": row["fingerprint"],
+      "n_rows": row["n_rows"], "n_cols": row["n_cols"],
+      "status": status, "bound": bound}}))
+"""
+
+
+def _run_one(name: str, coretype: str) -> dict:
+    """Build + solve ``name`` in a fresh process under ``coretype``.
+
+    No exception handling (CLAUDE.md §7): a crashing arm must surface as a
+    crash, not as a missing row that reads like agreement.
+    """
+    env = dict(os.environ)
+    env["OPENBLAS_CORETYPE"] = coretype
+    env["JAX_PLATFORMS"] = "cpu"
+    env["JAX_ENABLE_X64"] = "1"
+    src = _CHILD.format(
+        python_dir=str(_REPO / "python"),
+        tests_dir=str(_REPO / "python" / "tests"),
+        expect_init=str(_REPO / "python" / "discopt" / "__init__.py"),
+        name=name,
+    )
+    proc = subprocess.run(
+        [sys.executable, "-u", "-c", src], cwd=str(_REPO), env=env, capture_output=True, text=True
+    )
+    if proc.returncode != 0:
+        raise RuntimeError(f"{coretype} arm failed (rc={proc.returncode}):\n{proc.stderr[-4000:]}")
+    line = next((ln for ln in proc.stdout.splitlines() if ln.startswith("RESULT ")), None)
+    if line is None:
+        raise RuntimeError(f"{coretype} arm printed no RESULT:\n{proc.stdout[-2000:]}")
+    return json.loads(line[len("RESULT ") :])
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--instance", default="contvar")
+    ap.add_argument("--coretypes", default=",".join(_DEFAULT_CORETYPES))
+    args = ap.parse_args()
+
+    if not (_NL_DIR / f"{args.instance}.nl").exists():
+        raise SystemExit(f"no such instance: {args.instance}")
+
+    rows: list[dict] = []
+    for ct in [c for c in args.coretypes.split(",") if c]:
+        row = _run_one(args.instance, ct)
+        rows.append(row)
+        print(
+            f"  {ct:<10} fp={row['fingerprint'][:12]} status={row['status']} bound={row['bound']}",
+            flush=True,
+        )
+
+    print(f"\nREPS_COMPLETED={len(rows)}")
+    if not rows:
+        print("PROBE MEASURED NOTHING", file=sys.stderr)
+        return 2
+
+    fps = {r["fingerprint"] for r in rows}
+    answers = {(r["status"], r["bound"]) for r in rows}
+    print(f"distinct_fingerprints={len(fps)}  distinct_answers={len(answers)}")
+
+    # The falsifying observation: same matrix bytes, different answer.
+    same_bytes_diff_answer = False
+    for fp in fps:
+        arms = [r for r in rows if r["fingerprint"] == fp]
+        if len({(r["status"], r["bound"]) for r in arms}) > 1:
+            same_bytes_diff_answer = True
+            print(f"SAME_BYTES_DIFFERENT_ANSWER fingerprint={fp[:12]}:")
+            for r in arms:
+                print(f"    {r['coretype']:<10} -> ({r['status']}, {r['bound']})")
+    print(f"same_bytes_different_answer={same_bytes_diff_answer}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/python/tests/support/claim_differential.py
+++ b/python/tests/support/claim_differential.py
@@ -18,12 +18,16 @@ from __future__ import annotations
 
 import dataclasses
 import json
+import sys
+from functools import lru_cache
 from pathlib import Path
 from typing import Optional
 
 _REPO = Path(__file__).resolve().parents[3]
 _NL_DIR = _REPO / "python" / "tests" / "data" / "minlplib_nl"
 _BASELINE = _REPO / "docs" / "dev" / "data" / "claim-baseline.jsonl"
+_TESTS_DIR = _REPO / "python" / "tests"
+_CERT_OPTIMA = _REPO / "docs" / "dev" / "data" / "cert-optima.json"
 
 
 def baseline_path() -> Path:
@@ -78,31 +82,95 @@ def current_row(name: str) -> dict:
 @dataclasses.dataclass(frozen=True)
 class InstanceDiff:
     instance: str
-    status: str  # "unchanged" | "changed" | "error" | "missing"
+    # Shape gate: "unchanged" | "changed" | "fingerprint_drift" | "error" | "missing".
+    # Root-LP gate adds "unsound" (a host-independent property broken) and
+    # "unreproduced" (same matrix bytes, different answer — #971).
+    status: str
     detail: str = ""
+    # #971: whether this instance's certified root LP bound was actually checked
+    # against a reference optimum. Counted by the gate so the validity sweep can
+    # never quietly degrade to "no oracle, nothing compared" (CLAUDE.md §6).
+    oracle_checked: bool = False
 
 
-# Relative tolerance for the root-LP-bound gate (#961). Wide enough to absorb
-# cross-build/platform last-digit drift in the in-house simplex (the committed
-# history shows ~1e-12-relative noise on degenerate bases), narrow enough that
-# any real relaxation/bound change (the smallest genuine drift on record moved
-# the 3rd significant digit) fails the gate and forces a deliberate baseline
-# regeneration in the PR that caused it.
+# Relative tolerance for the root-LP-bound comparison (#961). Wide enough to
+# absorb cross-build/platform last-digit drift in the in-house simplex (the
+# committed history shows ~1e-12-relative noise on degenerate bases), narrow
+# enough that any real relaxation/bound change (the smallest genuine drift on
+# record moved the 3rd significant digit) is reported and forces a deliberate
+# baseline regeneration in the PR that caused it.
 ROOT_LP_REL_TOL = 1e-6
 
+# #971: how many instances may land in the ``unreproduced`` bucket — a root LP
+# whose (status, bound) differs from the committed row while the relaxation bytes
+# match, i.e. a difference the *arithmetic path*, not the matrix, produced. This
+# is an escape hatch, so it is bounded: raising it requires the same evidence any
+# other gate relaxation does. Measured basis: ``contvar`` is the only corpus
+# instance ever observed to do this — two ubuntu-x86-64 CI runners, identical
+# fingerprint, bounds 172170.3107274997 and 187283.4711213944 (#971), each
+# bit-stable on its own host — and the corpus sweep on the host that generated
+# this note put all 66 instances in ``unchanged``. The headroom of 3 covers that
+# class without letting a corpus-wide drift pass as "host noise". The bucket is
+# loud (printed per instance), and every instance in it has already passed the
+# host-independent soundness gate below — an unsound result is never excused as
+# host noise.
+MAX_UNREPRODUCED_ROOT_LP = 3
 
-def current_root_lp(name: str) -> tuple[str, float | None]:
-    """Solve ``name``'s root LP now; return ``(status, certified_bound_or_None)``.
+# Slack for the "certified root bound does not exceed the reference optimum"
+# check. Same absolute/relative convention as ``metrics.incorrect_count``, the
+# house-standard oracle comparison, so a violation here means the same thing it
+# means on a benchmark panel: a claim above the true optimum.
+OPTIMUM_ABS_TOL = 1e-4
+OPTIMUM_REL_TOL = 1e-3
+
+
+@lru_cache(maxsize=1)
+def reference_optima() -> dict[str, float]:
+    """Published global optima for corpus instances, keyed by instance name.
+
+    Union of the two committed registries: ``docs/dev/data/cert-optima.json``
+    (the corpus-wide oracle the benchmark panels' ``incorrect_count`` uses) and
+    ``python/tests/data/known_optima.toml`` (the curated per-instance registry),
+    with the curated file winning on the few names in both. These values are
+    published optima in the instance's **reported** objective sense.
+    """
+    optima: dict[str, float] = {}
+    if _CERT_OPTIMA.exists():
+        optima.update({k: float(v) for k, v in json.loads(_CERT_OPTIMA.read_text()).items()})
+    if str(_TESTS_DIR) not in sys.path:
+        sys.path.insert(0, str(_TESTS_DIR))
+    from _optima import optima_registry  # noqa: PLC0415 - tests dir must be on sys.path first
+
+    optima.update({k: float(v["optimum"]) for k, v in optima_registry().items()})
+    return optima
+
+
+@dataclasses.dataclass(frozen=True)
+class RootLpProbe:
+    """One root LP solve, with what is needed to judge it without a baseline."""
+
+    instance: str
+    status: str
+    bound: Optional[float]  # certified lower bound on the INTERNAL (minimize) objective
+    maximize: bool
+
+
+def current_root_lp_probe(name: str) -> RootLpProbe:
+    """Solve ``name``'s root LP now and report the result plus its objective sense.
 
     Mirrors ``gen_claim_baseline._root_lp``: the in-house engine at the declared
     root box, no exception handling (#961 / CLAUDE.md §7 — a crash must surface
-    as a crash, not read as "no bound").
+    as a crash, not read as "no bound"). ``bound`` is a lower bound on the
+    *internal* objective, which is the negated one for a MAXIMIZE model; the
+    sense travels with it so the validity check can compare against a published
+    optimum recorded in the reported sense.
     """
     import numpy as np
     from discopt._jax.mccormick_lp import MccormickLPRelaxer
-    from discopt.modeling.core import from_nl
+    from discopt.modeling.core import ObjectiveSense, from_nl
 
     model = from_nl(str(_NL_DIR / f"{name}.nl"))
+    maximize = model._objective is not None and model._objective.sense == ObjectiveSense.MAXIMIZE
     lbs, ubs = [], []
     for v in model._variables:
         lbs.append(np.asarray(v.lb, dtype=np.float64).ravel())
@@ -114,37 +182,104 @@ def current_root_lp(name: str) -> tuple[str, float | None]:
                 f"solve_at_node returned status='optimal' with "
                 f"lower_bound={res.lower_bound!r} (#961 contract violation)"
             )
-        return res.status, float(res.lower_bound)
-    return res.status, None
+        return RootLpProbe(name, res.status, float(res.lower_bound), maximize)
+    return RootLpProbe(name, res.status, None, maximize)
+
+
+def current_root_lp(name: str) -> tuple[str, float | None]:
+    """``(status, certified_bound_or_None)`` for ``name``'s root LP (see the probe)."""
+    probe = current_root_lp_probe(name)
+    return probe.status, probe.bound
+
+
+def root_lp_violations(probe: RootLpProbe) -> tuple[str, ...]:
+    """Host-independent properties this root LP result must satisfy (#971).
+
+    These are the things the engine *guarantees* on any machine, as opposed to the
+    exact float it happens to produce on one:
+
+    1. **The #961 status/bound contract.** ``optimal`` carries a finite bound and
+       nothing else carries one; a solved-but-uncertified node is ``uncertified``.
+    2. **Validity.** The certified bound is a rigorous lower bound on the root
+       relaxation, hence on the true global optimum, so it may not exceed a
+       published optimum (sense-corrected: for a MAXIMIZE model the internal
+       objective is the negated one, so the internal lower bound must not exceed
+       ``-optimum`` — the #759 framing, and the same convention as
+       ``benchmarks.metrics.dual_bound_crosses_optimum``). This is the
+       certificate invariant of CLAUDE.md §1, checked against the committed
+       oracles rather than against a remembered float.
+
+    Returns the violated properties (empty when the result is admissible).
+    """
+    import numpy as np
+
+    out: list[str] = []
+    if probe.status == "optimal":
+        if probe.bound is None or not np.isfinite(probe.bound):
+            out.append(f"status='optimal' with bound={probe.bound!r} (#961 contract)")
+    elif probe.bound is not None:
+        out.append(f"status={probe.status!r} carries bound={probe.bound!r} (#961 contract)")
+    optimum = reference_optima().get(probe.instance)
+    if optimum is not None and probe.bound is not None and np.isfinite(probe.bound):
+        internal_opt = -optimum if probe.maximize else optimum
+        slack = OPTIMUM_ABS_TOL + OPTIMUM_REL_TOL * abs(internal_opt)
+        if probe.bound > internal_opt + slack:
+            sense = "maximize" if probe.maximize else "minimize"
+            out.append(
+                f"root LP bound {probe.bound!r} exceeds the reference optimum "
+                f"{optimum!r} ({sense}; internal floor {internal_opt!r}, slack {slack:.3e})"
+            )
+    return tuple(out)
+
+
+def _oracle_checked(probe: RootLpProbe) -> bool:
+    """Whether ``root_lp_violations`` actually ran its validity comparison."""
+    return probe.bound is not None and probe.instance in reference_optima()
 
 
 def diff_root_lp(name: str, baseline: dict[str, dict]) -> InstanceDiff:
-    """Classify one instance's root LP ``(status, bound)`` vs the baseline (#961).
+    """Classify one instance's root LP result vs the baseline (#961, rules per #971).
 
-    The bound comparison is tolerance-based (``ROOT_LP_REL_TOL``): the exact
-    float is solver output and can carry cross-build last-digit noise, unlike the
-    integer shape columns. A baseline row that predates the ``root_lp_status``
-    field is classified ``changed`` (regenerate the baseline), NOT skipped —
-    an ungated recorded field is how 52 silent drifts accumulated.
+    Two different questions are asked of the same single solve:
 
-    A difference is only attributable when both sides solved the **same** LP.
-    ``diff_instance`` already records that the relaxation fingerprint is not
-    reproducible across Rust builds/platforms, naming ``contvar``/``tanksize``
-    as the known drifters; where those bytes differ, the matrix this root LP was
-    built from is not the matrix the baseline recorded, so a status/bound
-    difference says nothing about a claim change. Such an instance is bucketed
-    ``fingerprint_drift`` (reported, never silent) instead of ``changed``, for
-    the same reason and by the same rule the shape gate uses. The fingerprint is
-    only computed when a difference is seen, so the gating path is unaffected:
-    an instance whose bytes match is still compared exactly.
+    **Is the result admissible?** — ``root_lp_violations``: the #961 status/bound
+    contract, and the bound's validity against the committed reference optima.
+    These hold on every machine, so a violation is a hard finding (``unsound``)
+    no matter what the baseline says.
 
-    Measured (#961/#964): ``contvar``'s root LP certifies on the host that
-    generated the committed row, and declines (``uncertified``, no bound) on both
-    CI (ubuntu/x86-64) and a macOS/arm64 build — 5/5 deterministic per host — with
-    its fingerprint differing from the committed one on the declining build. Its
-    certification sits on the edge of the Neumaier–Shcherbina/conditioning guards,
-    so last-digit matrix differences flip it. That is a build boundary, not a
-    drift to gate on.
+    **Does the result reproduce the committed row?** — status compared exactly,
+    bound within ``ROOT_LP_REL_TOL``. A baseline row that predates the
+    ``root_lp_status`` field is classified ``changed`` (regenerate the baseline),
+    NOT skipped — an ungated recorded field is how 52 silent drifts accumulated.
+
+    A difference is attributable to the code under test only when the two sides
+    solved the same LP **by the same arithmetic**. Two ways that fails, both
+    bucketed informationally rather than as a claim change:
+
+    - ``fingerprint_drift`` — the relaxation bytes differ, so the matrix this root
+      LP was built from is not the matrix the baseline recorded (the in-house
+      FBBT/parse path is not byte-reproducible across Rust builds/platforms; see
+      ``diff_instance``).
+    - ``unreproduced`` (#971) — the bytes are identical and the answer still
+      differs. The certified bound is the Neumaier–Shcherbina safe bound built
+      from *the simplex's own dual vertex*; the optimal dual of a degenerate LP is
+      not unique, so an arithmetic-path difference that flips one tie-break
+      selects a different — equally valid — certificate, and the recorded float
+      moves by far more than a last digit. Measured on CI: ``contvar`` produced
+      ``172170.3107274997`` and ``187283.4711213944`` from an *identical*
+      fingerprint on two ubuntu-x86-64 runners, deterministic per host (#971).
+      ``issue971_root_lp_arithmetic_path.py`` reproduces the *mechanism* on
+      demand — holding the tree, the instance and the fingerprint fixed while
+      varying only the OpenBLAS kernel gives 5 kernels, 1 fingerprint, 3 distinct
+      bounds — though at that grain the spread is last-digit; the CI pair is the
+      evidence for the magnitude. Before #971 this case was bucketed ``changed``
+      and hard-failed the gate on whichever runners took the other path.
+
+    The escape is bounded and conditional, not a blanket skip: ``unreproduced`` is
+    capped at ``MAX_UNREPRODUCED_ROOT_LP`` by the calling gate, every instance in
+    it has already passed ``root_lp_violations``, and the fingerprint is computed
+    only when a difference is seen, so an instance whose bytes match is still
+    compared exactly.
     """
     base = baseline.get(name)
     if base is None:
@@ -156,9 +291,14 @@ def diff_root_lp(name: str, baseline: dict[str, dict]) -> InstanceDiff:
             name, "changed", "baseline lacks root_lp_bound/root_lp_status; regenerate it"
         )
     try:
-        cur_status, cur_bound = current_root_lp(name)
+        probe = current_root_lp_probe(name)
     except Exception as exc:  # noqa: BLE001 - report per-instance, do not abort the sweep
         return InstanceDiff(name, "error", repr(exc))
+    checked = _oracle_checked(probe)
+    violations = root_lp_violations(probe)
+    if violations:
+        return InstanceDiff(name, "unsound", "; ".join(violations), oracle_checked=checked)
+    cur_status, cur_bound = probe.status, probe.bound
     base_status, base_bound = base["root_lp_status"], base["root_lp_bound"]
     detail = ""
     if cur_status != base_status:
@@ -169,25 +309,35 @@ def diff_root_lp(name: str, baseline: dict[str, dict]) -> InstanceDiff:
     ):
         detail = f"root LP bound {base_bound} -> {cur_bound}"
     if not detail:
-        return InstanceDiff(name, "unchanged")
-    # A difference is only a claim change if both sides solved the same matrix.
+        return InstanceDiff(name, "unchanged", oracle_checked=checked)
+    # A difference is attributable only if both sides solved the same matrix...
     try:
         cur_fp = current_row(name)["fingerprint"]
     except Exception as exc:  # noqa: BLE001 - report per-instance, do not abort the sweep
         return InstanceDiff(name, "error", f"{detail}; fingerprint unavailable: {exc!r}")
     if cur_fp != base["fingerprint"]:
-        return InstanceDiff(name, "fingerprint_drift", f"{detail}; matrix bytes differ too")
-    return InstanceDiff(name, "changed", detail)
+        return InstanceDiff(
+            name, "fingerprint_drift", f"{detail}; matrix bytes differ too", oracle_checked=checked
+        )
+    # ...and by the same arithmetic, which the fingerprint does not record (#971).
+    return InstanceDiff(
+        name,
+        "unreproduced",
+        f"{detail}; identical matrix bytes, so the arithmetic path differs",
+        oracle_checked=checked,
+    )
 
 
 def partition_corpus_root_lp(
     baseline: Optional[dict[str, dict]] = None,
 ) -> dict[str, list[InstanceDiff]]:
-    """Classify every vendored instance's root LP vs the baseline (#961)."""
+    """Classify every vendored instance's root LP vs the baseline (#961/#971)."""
     baseline = baseline or load_baseline()
     buckets: dict[str, list[InstanceDiff]] = {
         "unchanged": [],
         "changed": [],
+        "unsound": [],
+        "unreproduced": [],
         "fingerprint_drift": [],
         "error": [],
         "missing": [],

--- a/python/tests/test_961_optimal_requires_bound.py
+++ b/python/tests/test_961_optimal_requires_bound.py
@@ -80,15 +80,15 @@ def test_certify_decline_reports_uncertified_not_optimal():
 
 
 @pytest.mark.claim_boundary
-def test_root_lp_gate_bites_when_the_matrix_bytes_are_identical():
-    """The build-boundary bucket must excuse only a *different* LP, never a drift.
+def test_root_lp_gate_separates_the_two_ways_a_difference_arises():
+    """Each non-reproducing bucket must be reached by its own cause, not one blanket.
 
-    ``diff_root_lp`` declines to call a root-LP difference a claim change when the
-    relaxation fingerprint differs too — the two sides did not solve the same
-    matrix (``contvar`` does this across builds; see the docstring there). That
-    escape must be conditional: with the recorded bytes matching what this build
-    produces, an altered status or bound is still ``changed``. Without this test,
-    widening the bucket to a blanket skip would look like a pass.
+    ``diff_root_lp`` excuses a root-LP difference from being a claim change in two
+    distinct situations, and the buckets must stay distinguishable: differing
+    relaxation bytes (``fingerprint_drift`` — the two sides did not solve the same
+    matrix) versus identical bytes with a different answer (``unreproduced`` — the
+    arithmetic path differs, #971). Without this test, collapsing either into a
+    blanket skip would look like a pass.
     """
     from support.claim_differential import current_row, diff_root_lp, load_baseline
 
@@ -105,7 +105,7 @@ def test_root_lp_gate_bites_when_the_matrix_bytes_are_identical():
 
     same_bytes = dict(row, root_lp_status="a-status-this-build-does-not-produce")
     d = diff_root_lp(name, {name: same_bytes})
-    assert d.status == "changed", f"gate did not bite on {name}: {d}"
+    assert d.status == "unreproduced", f"wrong bucket for a same-bytes difference on {name}: {d}"
 
     drifted = dict(same_bytes, fingerprint="0" * 64)
     d2 = diff_root_lp(name, {name: drifted})

--- a/python/tests/test_971_root_lp_arithmetic_path.py
+++ b/python/tests/test_971_root_lp_arithmetic_path.py
@@ -105,8 +105,25 @@ def test_same_bytes_different_bound_is_not_a_claim_change():
     must land in the bounded, informational ``unreproduced`` bucket instead.
     """
     baseline = load_baseline()
+    # Select on the fingerprint ITSELF, not on a "unchanged" verdict. Those are
+    # different conditions: ``diff_root_lp`` computes the fingerprint only once it
+    # has already seen a status/bound difference, so an instance whose root LP
+    # reproduces can still have drifted bytes -- and this test needs byte-identity,
+    # because that is the whole premise of the bucket under test. Measured on
+    # macOS/arm64 at this commit: the first ``unchanged`` instance is ``4stufen``
+    # and its fingerprint does NOT match the committed (linux/x86-64) baseline,
+    # while 64 of 66 instances are ``unchanged`` -- so selecting on ``unchanged``
+    # asserts byte-identity it did not establish and fails for a reason unrelated
+    # to the rule under test. This is the same predicate defect #973 removed from
+    # ``test_961_optimal_requires_bound.py``; it must not come back here.
     name = next(
-        (n for n in sorted(baseline) if diff_root_lp(n, baseline).status == "unchanged"),
+        (
+            n
+            for n in sorted(baseline)
+            if baseline[n].get("fingerprint") is not None
+            and current_row(n).get("fingerprint") == baseline[n]["fingerprint"]
+            and diff_root_lp(n, baseline).status == "unchanged"
+        ),
         None,
     )
     assert name is not None, "no exactly-reproduced instance to test the rule with"

--- a/python/tests/test_971_root_lp_arithmetic_path.py
+++ b/python/tests/test_971_root_lp_arithmetic_path.py
@@ -1,0 +1,129 @@
+"""Issue #971: the root-LP gate must model *both* ways a difference can arise.
+
+``diff_root_lp`` (#961) excused a root-LP difference from being a claim change
+only when the relaxation *fingerprint* differed too, reasoning that "a difference
+is only attributable when both sides solved the same LP". That rule assumes
+**same matrix bytes ⇒ same LP answer**, and CI falsified it: ``contvar`` was
+bucketed ``changed`` — the fingerprint MATCHED — with the root LP bound moving
+from ``172170.3107274997`` to ``187283.4711213944`` (8.8%) between two
+ubuntu-x86-64 runners, bit-identically on each. The gate hard-failed on ``main``
+and on PRs touching no solver code.
+
+The mechanism is not last-digit noise. The certified bound is the
+Neumaier-Shcherbina safe bound built from the simplex's own dual vertex, and a
+degenerate LP's optimal dual is not unique: an arithmetic-path difference that
+flips one ratio-test tie-break selects a different — equally valid — dual, and
+the bound it certifies moves discretely.
+``discopt_benchmarks/scripts/issue971_root_lp_arithmetic_path.py`` reproduces
+the mechanism on demand, holding tree/instance/fingerprint fixed while varying
+only the OpenBLAS kernel: 5 kernels, 1 fingerprint, 3 distinct bounds.
+
+The fix is not a tolerance bump (8.8% is not noise, and widening a correctness
+gate to turn a red green is what CLAUDE.md §3 forbids). It splits the gate into
+the part that holds on every host — the #961 status/bound contract and the
+bound's validity against the published optimum, asserted hard — and the part that
+does not, the exact float, which is reported and bounded.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+os.environ["JAX_PLATFORMS"] = "cpu"
+os.environ["JAX_ENABLE_X64"] = "1"
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import pytest
+from support.claim_differential import (
+    MAX_UNREPRODUCED_ROOT_LP,
+    RootLpProbe,
+    current_row,
+    diff_root_lp,
+    load_baseline,
+    reference_optima,
+    root_lp_violations,
+)
+
+pytestmark = [pytest.mark.claim_boundary]
+
+
+# ── the host-independent property predicate ────────────────────────────────────
+# Pure-function tests: no solve, so they run in the fast suite and prove the
+# predicate bites on every arm (CLAUDE.md §6 — an instrument that cannot fail is
+# not an instrument).
+
+
+def test_violations_flag_the_961_contract_in_both_directions():
+    assert root_lp_violations(RootLpProbe("x", "optimal", None, False))
+    assert root_lp_violations(RootLpProbe("x", "optimal", float("nan"), False))
+    assert root_lp_violations(RootLpProbe("x", "optimal", float("inf"), False))
+    # A non-optimal status may not carry a bound either.
+    assert root_lp_violations(RootLpProbe("x", "uncertified", 1.0, False))
+    # ...and the admissible pairs are admissible.
+    assert not root_lp_violations(RootLpProbe("x", "optimal", 1.0, False))
+    assert not root_lp_violations(RootLpProbe("x", "uncertified", None, False))
+
+
+def test_violations_flag_a_bound_above_the_reference_optimum():
+    name, optimum = next(iter(sorted(reference_optima().items())))
+    # A rigorous lower bound may sit anywhere below the optimum, however loose.
+    assert not root_lp_violations(RootLpProbe(name, "optimal", optimum - 1e6, False))
+    # It may not sit above it.
+    above = optimum + 1.0 + 1e-2 * abs(optimum)
+    assert root_lp_violations(RootLpProbe(name, "optimal", above, False)), (
+        f"a bound of {above} above {name}'s optimum {optimum} was not flagged"
+    )
+    # An unknown instance has no oracle, so validity is simply not asserted --
+    # which is exactly why the gate floors how many instances WERE checked.
+    assert not root_lp_violations(RootLpProbe("no-such-instance", "optimal", above, False))
+
+
+def test_violations_respect_the_objective_sense():
+    """For a MAXIMIZE model the internal objective is negated, so the internal
+    lower bound must not exceed ``-optimum``; comparing it to ``+optimum`` would
+    both miss real violations and manufacture false ones."""
+    name, optimum = next(iter(sorted(reference_optima().items())))
+    # Internal floor is -optimum: a bound just under it is admissible...
+    assert not root_lp_violations(RootLpProbe(name, "optimal", -optimum - 1.0, True))
+    # ...and one clearly above it is not.
+    assert root_lp_violations(
+        RootLpProbe(name, "optimal", -optimum + 1.0 + 1e-2 * abs(optimum), True)
+    )
+
+
+# ── the attributability rule ──────────────────────────────────────────────────
+
+
+@pytest.mark.slow
+def test_same_bytes_different_bound_is_not_a_claim_change():
+    """The #971 regression: identical fingerprint, different bound.
+
+    Before the fix this returned ``changed`` and hard-failed the gate — which is
+    exactly what CI did to ``contvar`` on runs that touched no solver code. It
+    must land in the bounded, informational ``unreproduced`` bucket instead.
+    """
+    baseline = load_baseline()
+    name = next(
+        (n for n in sorted(baseline) if diff_root_lp(n, baseline).status == "unchanged"),
+        None,
+    )
+    assert name is not None, "no exactly-reproduced instance to test the rule with"
+    row = dict(baseline[name])
+    assert row["fingerprint"] == current_row(name)["fingerprint"], "bytes must match to test this"
+
+    # Reproduce contvar's shape: same recorded bytes, a bound 8.8% away.
+    base_bound = row["root_lp_bound"]
+    moved = 187283.4711213944 if base_bound is None else base_bound * 1.088 + 1.0
+    doctored = dict(row, root_lp_status="optimal", root_lp_bound=moved)
+    d = diff_root_lp(name, {name: doctored})
+    assert d.status == "unreproduced", f"same-bytes bound difference misfiled on {name}: {d}"
+    assert "identical matrix bytes" in d.detail
+
+
+def test_the_escape_hatch_is_bounded():
+    """An excused bucket that can grow without limit is a gate that stopped
+    measuring. ``contvar`` is the only instance ever observed to do this, so the
+    cap stays within a couple of instances of that evidence."""
+    assert 1 <= MAX_UNREPRODUCED_ROOT_LP <= 3

--- a/python/tests/test_claim_baseline_neutral.py
+++ b/python/tests/test_claim_baseline_neutral.py
@@ -40,7 +40,12 @@ exact committed hash unachievable cross-build.
 from __future__ import annotations
 
 import pytest
-from support.claim_differential import load_baseline, partition_corpus, partition_corpus_root_lp
+from support.claim_differential import (
+    MAX_UNREPRODUCED_ROOT_LP,
+    load_baseline,
+    partition_corpus,
+    partition_corpus_root_lp,
+)
 
 # slow: rebuilds all 62 corpus relaxations in one test (~120s+), so it runs in the
 # serial claim-boundary CI job (generous timeout), not the parallel python-fast job.
@@ -72,6 +77,14 @@ def test_current_build_matches_committed_baseline_shape():
         )
 
 
+# Floor on the number of certified root bounds actually compared against a
+# published optimum. Measured: 43 of the 66 vendored instances both certify a
+# root bound and carry a reference optimum (ubuntu/x86-64, this build); the floor
+# sits under that so the validity sweep cannot quietly degrade into "no oracle,
+# nothing compared" and still read as a pass (CLAUDE.md §6).
+MIN_ORACLE_CHECKED_ROOT_LP = 40
+
+
 @pytest.mark.timeout(1800)
 def test_current_root_lp_matches_committed_baseline():
     """The recorded ``root_lp_bound``/``root_lp_status`` are gated, not ornamental.
@@ -79,27 +92,75 @@ def test_current_root_lp_matches_committed_baseline():
     Issue #961: the baseline spent effort computing a root LP bound per instance,
     committed it, and never asserted on it — 52 of 62 instances drifted silently,
     five of them hiding an ``optimal``/``lower_bound=None`` contract violation that
-    the generator's bare ``except`` recorded as a plausible "no bound". This gate
-    re-solves every root LP with the in-house engine and compares status exactly
-    and the bound within ``ROOT_LP_REL_TOL`` (cross-build last-digit noise is not
-    a claim change; anything larger is bound-changing per CLAUDE.md §5 and must
-    regenerate the baseline in the PR that causes it).
+    the generator's bare ``except`` recorded as a plausible "no bound".
+
+    Issue #971 split what this gate asserts, because the two halves are not
+    equally reproducible:
+
+    * **Hard, on every host** — the result must be *admissible*: the #961
+      status/bound contract, and a certified bound that does not exceed the
+      published optimum (``unsound``). Those hold on any machine, so they are
+      asserted unconditionally, on every instance, with a floor on how many were
+      actually oracle-checked.
+    * **Hard, but attributable only when the arithmetic matches** — the result
+      should *reproduce* the committed row. It does for the bulk of the corpus
+      (``unchanged >= 50``), and a difference is still a hard failure when the
+      baseline schema is stale (``changed``). Where the relaxation bytes match and
+      the answer still moved, the difference came from the arithmetic path, not
+      the code: the certified bound is a Neumaier–Shcherbina bound read off the
+      simplex's dual vertex, and a degenerate LP's optimal dual is not unique, so
+      one flipped tie-break yields a different valid certificate. ``contvar`` did
+      exactly this across two ubuntu-x86-64 runners at an identical fingerprint.
+      Such an instance is ``unreproduced``: reported, capped at
+      ``MAX_UNREPRODUCED_ROOT_LP``, and only ever reached after the soundness
+      assertions above have passed.
+
+    A bound change from the code under test still fails this gate: it moves the
+    corpus (dropping ``unchanged`` below its floor or overflowing the cap), and
+    must regenerate the baseline in the PR that causes it (CLAUDE.md §5).
     """
     baseline = load_baseline()
     assert baseline, "claim-baseline.jsonl is empty or missing"
     buckets = partition_corpus_root_lp(baseline)
+    unsound = buckets["unsound"]
     changed = buckets["changed"]
     errored = buckets["error"]
-    assert not changed, "root LP bound/status drifted vs committed baseline: " + "; ".join(
+    # Host-independent: a root LP result that breaks the #961 contract or claims a
+    # bound above the true optimum is wrong everywhere, whatever the baseline says.
+    assert not unsound, "root LP result violates a host-independent property: " + "; ".join(
+        f"{d.instance} ({d.detail})" for d in unsound
+    )
+    assert not changed, "root LP baseline schema is stale: " + "; ".join(
         f"{d.instance} ({d.detail})" for d in changed
     )
     assert not errored, "root LP solve crashed vs baseline: " + "; ".join(
         f"{d.instance} ({d.detail})" for d in errored
     )
     # Sanity (CLAUDE.md §6): the sweep actually compared the bulk of the corpus.
-    # This counts only exactly-compared instances, so the drift bucket below can
+    # This counts only exactly-compared instances, so the drift buckets below can
     # never grow into a way for the gate to stop measuring.
     assert len(buckets["unchanged"]) >= 50
+    # ...and the validity half of the gate really ran its oracle comparison,
+    # rather than finding no reference optimum and asserting nothing.
+    n_oracle = sum(1 for bucket in buckets.values() for d in bucket if d.oracle_checked)
+    assert n_oracle >= MIN_ORACLE_CHECKED_ROOT_LP, (
+        f"only {n_oracle} certified root bounds were checked against a reference "
+        f"optimum (floor {MIN_ORACLE_CHECKED_ROOT_LP}); the validity sweep is not measuring"
+    )
+    # Bounded escape hatch (#971): identical matrix bytes, different answer — the
+    # arithmetic path differs. Sound (asserted above) but not reproducible.
+    unreproduced = buckets["unreproduced"]
+    assert len(unreproduced) <= MAX_UNREPRODUCED_ROOT_LP, (
+        f"{len(unreproduced)} instances' root LP differs at an IDENTICAL relaxation "
+        f"fingerprint (cap {MAX_UNREPRODUCED_ROOT_LP}); that is a corpus-wide drift, "
+        "not host arithmetic: " + "; ".join(f"{d.instance} ({d.detail})" for d in unreproduced)
+    )
+    if unreproduced:
+        print(
+            f"\n[info] {len(unreproduced)} instance(s) whose root LP differs at an "
+            f"identical fingerprint (arithmetic-path difference, sound but not "
+            f"reproducible): " + "; ".join(f"{d.instance} ({d.detail})" for d in unreproduced)
+        )
     # Informational, mirroring the shape gate: an instance whose relaxation bytes
     # differ from the baseline's did not solve the same LP, so its root LP result
     # is not attributable (see diff_root_lp). Reported, never silent.


### PR DESCRIPTION
## Summary

The #961 root-LP gate excused a difference from being a claim change **only** when the relaxation *fingerprint* also differed — encoding the rule "a difference is only attributable when both sides solved the same LP", i.e. *same matrix bytes ⇒ same LP answer*. CI falsified that: `contvar` was bucketed `changed` — the fingerprint **matched** — with the root LP bound moving `172170.3107274997 → 187283.4711213944` (8.8%) between two `ubuntu-x86-64` runners, bit-stable on each. The gate hard-failed on `main` and on PRs touching no solver code (#970).

**Entry experiment** (`discopt_benchmarks/scripts/issue971_root_lp_arithmetic_path.py`, new): hold tree, instance and matrix fixed; vary only the arithmetic path via OpenBLAS kernel dispatch (`OPENBLAS_CORETYPE`, `DYNAMIC_ARCH` wheels). `contvar` over 5 kernels →

```
  Haswell    fp=8be8329b9f3d status=optimal bound=172170.31072749975
  Nehalem    fp=8be8329b9f3d status=optimal bound=172170.31072749972
  SkylakeX   fp=8be8329b9f3d status=optimal bound=172170.3107274997
  Zen        fp=8be8329b9f3d status=optimal bound=172170.31072749975
  Prescott   fp=8be8329b9f3d status=optimal bound=172170.31072749972
REPS_COMPLETED=5
distinct_fingerprints=1  distinct_answers=3
same_bytes_different_answer=True
```

1 fingerprint, 3 distinct bounds — the assumption is provably wrong. The spread *at that grain* is last-digit; the CI pair is the evidence for the magnitude. The amplification is structural, not noise: the certified bound is a Neumaier–Shcherbina bound read off the simplex's own dual vertex, and a degenerate LP's optimal dual is **not unique**, so one flipped ratio-test tie-break selects a different — equally valid — certificate and the bound moves discretely.

Explicitly **not** a tolerance bump (8.8% is not last-digit noise, and widening a correctness gate so a red turns green is what CLAUDE.md §3 forbids). Instead the gate now separates what holds on every host from what does not:

- **Hard, host-independent, on every instance** — new `root_lp_violations`: the #961 status/bound contract in *both* directions, plus **validity** of the certified bound against the committed oracles (`cert-optima.json` ∪ `known_optima.toml`, sense-corrected per #759 — for a MAXIMIZE model the internal lower bound must not exceed `-optimum`). Violations bucket `unsound` and fail whatever the baseline says. This is coverage the gate did not previously have.
- **Bounded and loud** — a difference at an *identical* fingerprint buckets `unreproduced` (was `changed`), capped at `MAX_UNREPRODUCED_ROOT_LP = 3` and reachable only after the soundness assertions pass. `unchanged >= 50` is retained, and a floor of 40 oracle-checked instances proves the validity sweep actually fired (measured 43 of 66).

Contributes to #971. Unblocks the gate that was failing #970 and `main`.

### Known trade-off

A genuine code-induced bound change confined to ≤ 3 instances *whose fingerprint does not move* now prints rather than fails, where it previously hard-failed. That hole already existed on the `fingerprint_drift` path. Cross-host bit-equality of a degenerate LP's dual is not a property the engine provides, so it is bounded and reported rather than asserted.

## Correctness

No solver math is touched — the change is entirely in the test-support gate (`python/tests/support/claim_differential.py`) and its tests, plus a new probe script and a docstring in the baseline generator. Net effect on certification is a **strengthening**: every corpus root LP bound is now checked against a published optimum on every host, which the gate never did before.

- [x] Cannot produce a false certificate (N/A — no solver-math change; the gate gains a soundness assertion)
- [x] No validation, fallback, or safety guard was weakened to make a check pass — the per-instance hard bound-equality assertion is replaced by a *stronger* host-independent soundness assertion plus a capped, loud, soundness-conditioned escape bucket; the retained `unchanged >= 50` floor and the new 40-instance oracle floor keep the sweep measuring

## Tests run (state the result — numbers, not adjectives)

- [x] `pytest -m smoke` → **917 passed, 19 skipped, 2 xpassed** (352 s)
- [x] `pytest -m slow python/tests/test_adversarial_recent_fixes.py` → **10 passed** (177 s). First run of that file showed one failure in `test_large_dense_jacobian_no_crash`; it passes in isolation (`1 passed`) and on a full re-run of the file. It is memory-heavy and CI runs it under `scripts/run_memory_capped_pytest.sh`; this PR touches no solver code.
- [x] `cargo test -p discopt-core` → N/A (no Rust touched)
- [x] `ruff check python/` / `ruff format --check python/` → clean (856 files)

Additionally, the claim-boundary trio (`test_claim_baseline_neutral.py`, `test_961_optimal_requires_bound.py`, `test_971_root_lp_arithmetic_path.py`) → **12 passed** (98 s), and a full corpus sweep on ubuntu/x86-64: **66/66 `unchanged`, 0 `unsound`, 43 oracle-checked**.

## Regression test

`python/tests/test_971_root_lp_arithmetic_path.py`:

- `test_same_bytes_different_bound_is_not_a_claim_change` — doctors the baseline for an exactly-reproduced instance to `contvar`'s shape (identical recorded fingerprint, bound moved 8.8%) and asserts the bucket is `unreproduced`. **Fail-before / pass-after confirmed** by running the pre-change `diff_root_lp` (loaded from `HEAD`) side by side with the new one on the same doctored row:

  ```
  OLD rule -> changed      | root LP status 'optimal' -> 'uncertified'
  NEW rule -> unreproduced | ... ; identical matrix bytes, so the arithmetic path differs
  ```

  `changed` is exactly the CI symptom this issue reports.
- `test_violations_flag_the_961_contract_in_both_directions`, `test_violations_flag_a_bound_above_the_reference_optimum`, `test_violations_respect_the_objective_sense` — pure-function tests proving the new soundness predicate bites on every arm (CLAUDE.md §6).
- `test_961_optimal_requires_bound.py::test_root_lp_gate_separates_the_two_ways_a_difference_arises` — updated from the old rule; keeps both non-reproducing buckets distinguishable so neither can collapse into a blanket skip.

- [x] Added a regression test that fails before / passes after

<!-- Bound-changing / performance section: N/A — no bound, cut, or relaxation changed. -->

---
_Generated by [Claude Code](https://claude.ai/code/session_01T3kki4Y6gXNxWHPaZiJHQF)_