### PR TITLE
feat(implicit): #75 lower an implicit block to full space instead of hiding it

### DIFF
--- a/python/discopt/modeling/__init__.py
+++ b/python/discopt/modeling/__init__.py
@@ -89,6 +89,7 @@ from discopt.modeling.core import (
 )
 from discopt.modeling.implicit import (
     implicit,
+    implicit_full_space,
 )
 from discopt.modeling.indexed import (
     IndexedConstraint,
@@ -133,6 +134,7 @@ __all__ = [
     "udf",
     "custom",
     "implicit",
+    "implicit_full_space",
     "CustomCall",
     "sum",
     "prod",

--- a/python/discopt/modeling/core.py
+++ b/python/discopt/modeling/core.py
@@ -3060,6 +3060,8 @@ class Model:
         tol: float = 1e-10,
         max_iter: int = 50,
         name: str = "implicit",
+        formulation: str = "custom_root",
+        bounds=None,
     ) -> Expression:
         """Define a vector ``v`` implicitly by ``residual(u, v) = 0`` (issue #379).
 
@@ -3071,6 +3073,18 @@ class Model:
         rejected. ``u_inputs`` are the model expressions the block depends on
         (the DAG edges into the solve); they are required, not inferred.
 
+        ``formulation="full_space"`` is the alternative lowering: ``v`` becomes a
+        real vector variable and the residuals become real ``== 0`` constraints,
+        so the block is ordinary algebra. That keeps JAX off the solve path (the
+        tape refuses a ``CustomCall``) and keeps a global certificate reachable
+        (a relaxation needs the equations), at the cost of the reduced-space size
+        win. In that mode ``residual`` receives **discopt expressions** and must
+        be written in discopt operators rather than ``jnp.*``. There is no inner
+        Newton solve, so ``x0`` / ``tol`` / ``max_iter`` are *refused* rather
+        than silently dropped -- select a root with ``bounds`` and warm-start
+        through ``solve(initial_solution=...)``.
+        See :func:`discopt.modeling.implicit_full_space`.
+
         See :func:`discopt.modeling.implicit` for parameter details.
 
         Examples
@@ -3079,6 +3093,35 @@ class Model:
         >>> v = m.implicit(lambda U, V: [V[0] ** 2 - U[0]], [u], n_unknowns=1)
         >>> m.minimize((v[0] - 3.0) ** 2)   # v = sqrt(u); optimum at u = 9
         """
+        if formulation == "full_space":
+            from discopt.modeling.implicit import implicit_full_space as _full
+
+            # There is no inner Newton solve in this arm, so these two control
+            # nothing.  Accepting them silently would let a caller tune a knob
+            # that is not connected to anything (CLAUDE.md §3: no dead flags).
+            for _k, _v, _default in (("tol", tol, 1e-10), ("max_iter", max_iter, 50)):
+                if _v != _default:
+                    raise ValueError(
+                        f"{_k}= does not apply with formulation='full_space': the "
+                        "residuals become ordinary equality constraints and are "
+                        "solved by the outer solver, not by an inner Newton "
+                        "iteration. Use solve() tolerances instead."
+                    )
+            return _full(self, residual, u_inputs, n_unknowns, x0, bounds=bounds, name=name)
+        if formulation != "custom_root":
+            raise ValueError(
+                f"formulation must be 'custom_root' or 'full_space', got {formulation!r}"
+            )
+        if bounds is not None:
+            # Not a silent no-op: the opaque node has no column to put a box on,
+            # so honouring `bounds` here would mean emitting inequality
+            # constraints on the node output -- a different model than the caller
+            # asked for.  Refuse rather than guess (CLAUDE.md §3).
+            raise ValueError(
+                "bounds= is only supported with formulation='full_space'; the "
+                "custom_root node has no variable to bound. Add explicit "
+                "constraints on the returned node if you need them."
+            )
         from discopt.modeling.implicit import implicit as _implicit
 
         return _implicit(residual, u_inputs, n_unknowns, x0, tol=tol, max_iter=max_iter, name=name)

--- a/python/discopt/modeling/implicit.py
+++ b/python/discopt/modeling/implicit.py
@@ -21,9 +21,11 @@ Prototype for #379 -- API and scope may still change.
 
 from __future__ import annotations
 
-from typing import Callable, Sequence
+from typing import Callable, Sequence, Union
 
-from discopt.modeling.core import Expression, custom
+import numpy as np
+
+from discopt.modeling.core import Expression, Model, Variable, custom
 
 
 def _implicit_solver(
@@ -83,6 +85,181 @@ def _implicit_solver(
         return jax.lax.custom_root(f, x0_arr, solve, tangent_solve)
 
     return phi
+
+
+def _flatten_u_inputs(u_inputs: Sequence) -> list:
+    """Flatten ``u_inputs`` to a list of SCALAR expressions.
+
+    The ``custom_root`` arm passes ``residual`` a flat ``u`` array built by
+    ``concatenate([atleast_1d(x).ravel() for x in u_vals])`` (see
+    :func:`implicit`'s ``solve_fn``).  The full-space arm must index ``u``
+    identically or the same residual callable would mean two different things
+    depending on the formulation, so this reproduces that flattening on the
+    symbolic side: element order within an input, inputs in argument order.
+    """
+    flat: list = []
+    for expr in u_inputs:
+        shape = tuple(getattr(expr, "shape", ()) or ())
+        size = int(np.prod(shape)) if shape else 1
+        if not shape:
+            flat.append(expr)
+            continue
+        if len(shape) != 1:
+            raise ValueError(
+                f"implicit(formulation='full_space') supports scalar and 1-D inputs; "
+                f"got an input with shape {shape}"
+            )
+        flat.extend(expr[i] for i in range(size))
+    return flat
+
+
+def _unique_name(model: Model, base: str) -> str:
+    """``base``, suffixed if the model already has a variable of that name.
+
+    Variable names must be unique in a model, and a lowered block is often
+    created in a loop (one per cyclic block), so a fixed default name would
+    collide on the second block.
+    """
+    taken = {v.name for v in model._variables}
+    if base not in taken:
+        return base
+    k = 2
+    while f"{base}_{k}" in taken:
+        k += 1
+    return f"{base}_{k}"
+
+
+def implicit_full_space(
+    model: Model,
+    residual: Callable,
+    u_inputs: Sequence,
+    n_unknowns: int,
+    x0=None,
+    *,
+    bounds=None,
+    name: str = "implicit",
+) -> Variable:
+    """Lower ``residual(u, v) = 0`` into the model as variables + equations.
+
+    The alternative to :func:`implicit`'s opaque ``custom_root`` node: instead of
+    hiding the block behind a ``CustomCall``, ``v`` becomes a real vector
+    :class:`~discopt.modeling.core.Variable` and each residual becomes a real
+    ``== 0`` constraint.  ``residual`` is therefore called with **discopt
+    expressions**, not JAX arrays, and must be written in discopt's own operators
+    (``+ - * / **``, ``dm.exp``, ``dm.log``, ``dm.sin``, ...) -- not ``jnp.*``.
+
+    Why this exists (#379, #75).  The ``custom_root`` node has two costs that are
+    both consequences of the equations being invisible to everything downstream:
+
+    1. **It pins JAX to the solve path.** The tape refuses a ``CustomCall``
+       outright (``_nl_expr_compiler``: "CustomCall (dm.custom) has no tape
+       equivalent"), so any model containing one falls back to the JAX evaluator.
+       Lowered, the block is ordinary algebra and the Rust tape handles it.
+    2. **It forecloses a certificate.** A convex relaxation of an implicitly
+       defined ``v`` needs the defining equations; with only ``v = phi(u)`` there
+       is nothing to relax, so ``_custom_call_reduced_admissible`` refuses the
+       global path and the solve is local-only (``gap_certified=False``).
+       Measured on ``v**2 - u == 0, v <= 1.4, min -u`` over ``u in [1,2]``: the
+       opaque node returns ``-1.96`` from ``x0=+1`` and ``-2.0`` from ``x0=-1``
+       -- same box, same equations, different answer, because which root Newton
+       lands in *is* the definition.  Lowered, both roots are in the box and the
+       spatial B&B certifies the real optimum.
+
+    What you give up is the reduced-space size win that motivated #379: ``v``
+    stays in the model rather than being eliminated.  That is the trade, and it
+    is the caller's to make -- hence a separate entry point rather than a
+    silently different lowering of the same one.
+
+    Parameters
+    ----------
+    model : Model
+        The model to add the unknowns and defining equations to.
+    residual : callable
+        ``residual(u, v) -> sequence`` of length ``n_unknowns``, where ``u`` is a
+        flat list of scalar expressions (the flattened ``u_inputs``) and ``v`` is
+        the unknown vector variable.  Indexing matches the ``custom_root`` arm,
+        so a residual written in plain arithmetic works unchanged in both.
+    u_inputs : sequence of Expression
+        The expressions the block depends on.  Unlike the opaque node these are
+        not DAG edges into a hidden solve -- they simply appear in the emitted
+        equations -- but they are still required, so the two arms take the same
+        arguments.
+    n_unknowns : int
+        Length of ``v``.
+    x0 : array-like, optional
+        **Refused.**  Accepted in the signature only so that switching
+        ``formulation`` gives a pointed error instead of a bare ``TypeError``.
+        There is no inner Newton solve to start here, and discopt has no
+        per-variable start slot, so a recorded ``x0`` would be read by nothing --
+        a silent no-op.  Pass a starting point through
+        ``solve(initial_solution={v: x0})`` instead, and select a root with
+        ``bounds`` rather than with a starting point.
+    bounds : tuple of (array-like, array-like), optional
+        ``(lb, ub)`` for ``v``.  Default is the model-wide default box.  Pass the
+        real bounds when you have them: an unbounded ``v`` has no finite
+        McCormick relaxation, which forfeits the certificate this lowering exists
+        to make possible.
+    name : str
+        Base name for the unknown vector; suffixed if already taken.
+
+    Returns
+    -------
+    Variable
+        The vector variable ``v``, indexable as ``v[i]`` exactly like the opaque
+        node's return value.
+
+    Raises
+    ------
+    ValueError
+        If ``n_unknowns < 1``, ``bounds`` has the wrong length, ``x0`` is given,
+        or ``residual`` does not return exactly ``n_unknowns`` entries.
+    """
+    if n_unknowns < 1:
+        raise ValueError(f"n_unknowns must be >= 1, got {n_unknowns}")
+
+    if x0 is not None:
+        # Refuse rather than record-and-ignore.  ``v`` is an ordinary model
+        # variable; nothing in discopt reads a per-variable start value, so
+        # stashing x0 on it would look like a warm start and be read by nothing.
+        raise ValueError(
+            "x0= is not supported with formulation='full_space': there is no "
+            "inner Newton solve to start, and a lowered v is an ordinary model "
+            "variable. Pass the starting point to the solve instead -- "
+            "solve(initial_solution={v: x0}) -- and use bounds= to select which "
+            "root you want, which unlike x0 is visible to the relaxation."
+        )
+
+    lb: Union[float, np.ndarray]
+    ub: Union[float, np.ndarray]
+    if bounds is None:
+        lb = -9.999e19
+        ub = 9.999e19
+    else:
+        lb_a, ub_a = bounds
+        lb = np.broadcast_to(np.asarray(lb_a, dtype=float), (n_unknowns,)).copy()
+        ub = np.broadcast_to(np.asarray(ub_a, dtype=float), (n_unknowns,)).copy()
+
+    v = model.continuous(_unique_name(model, name), shape=(n_unknowns,), lb=lb, ub=ub)
+
+    u_flat = _flatten_u_inputs(u_inputs)
+    rows = residual(u_flat, v)
+    try:
+        n_rows = len(rows)
+    except TypeError as e:  # not a sequence -- a common mistake for n_unknowns=1
+        raise ValueError(
+            f"residual must return a sequence of {n_unknowns} expressions, "
+            f"got {type(rows).__name__}"
+        ) from e
+    if n_rows != n_unknowns:
+        raise ValueError(f"residual must return {n_unknowns} entries, got {n_rows}")
+
+    # The square defining system.  These are ordinary equality constraints: the
+    # tape compiles them, FBBT propagates through them, and the spatial B&B
+    # relaxes them -- all of which the opaque node blocks.
+    for row in rows:
+        model.subject_to(row == 0.0)
+
+    return v
 
 
 def implicit(

--- a/python/tests/test_implicit_full_space.py
+++ b/python/tests/test_implicit_full_space.py
@@ -1,0 +1,288 @@
+"""``m.implicit(formulation="full_space")`` -- lower a block instead of hiding it (#379, #75).
+
+The ``custom_root`` node hides ``g(u, v) = 0`` behind a ``CustomCall``. Two
+consequences follow from the equations being invisible, and these tests pin both
+*and* their repair:
+
+1. **JAX is pinned to the solve path.** ``_nl_expr_compiler`` raises
+   ``UnsupportedForTape("CustomCall (dm.custom) has no tape equivalent")``, so a
+   model containing the node falls back to the JAX evaluator. Lowered, the block
+   is ordinary algebra and the tape takes it.
+2. **No certificate is reachable.** A relaxation of an implicitly defined ``v``
+   needs the defining equations; with only ``v = phi(u)`` there is nothing to
+   relax, so ``_custom_call_reduced_admissible`` refuses the global path.
+
+The sharpest statement of (2) is that the opaque node's *answer depends on the
+Newton starting point* -- same box, same equations, different optimum -- because
+which root Newton lands in is the only definition ``v`` has.
+``test_opaque_node_answer_depends_on_x0_but_full_space_does_not`` pins that
+falsification directly, so the motivation cannot silently rot.
+
+Each subprocess driver prints a JAX module count; the paired opaque arm asserting
+a NON-zero count is the vacuity control -- without it, "0 jax modules" could mean
+the driver never solved anything.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import textwrap
+
+import discopt.modeling as dm
+import numpy as np
+import pytest
+
+# min -u  s.t.  v = sqrt(u), v <= 1.4, u in [1, 2]  ->  u = 1.96, obj = -1.96.
+# The residual v**2 - u = 0 also admits v = -sqrt(u), for which v <= 1.4 is slack
+# for every u, giving -2.0. Restricting v to a POSITIVE box picks the intended
+# branch declaratively -- which is the whole point: the box is visible, an x0 is
+# not.
+_SQRT_BLOCK = """
+import discopt.modeling as dm
+m = dm.Model("sq")
+u = m.continuous("u", lb=1.0, ub=2.0)
+"""
+
+_FULL_SPACE_TAIL = """
+v = m.implicit(
+    lambda U, V: [V[0] * V[0] - U[0]], [u], 1,
+    formulation="full_space", bounds=(0.1, 3.0),
+)
+m.subject_to(v[0] <= 1.4)
+m.minimize(-u)
+"""
+
+_OPAQUE_TAIL = """
+v = m.implicit(lambda U, V: [V[0] * V[0] - U[0]], [u], 1, x0=[{x0}])
+m.subject_to(v <= 1.4)
+m.minimize(-u)
+"""
+
+_REPORT = """
+r = m.solve(time_limit=120)
+import sys
+print("STATUS:" + str(r.status))
+print("OBJ:" + repr(r.objective))
+print("CERTIFIED:" + str(getattr(r, "gap_certified", None)))
+print("JAXMODS:" + str(sum(1 for k in sys.modules if k == "jax" or k.startswith("jax."))))
+"""
+
+
+def _run_raw(src: str) -> dict:
+    import os
+
+    out = subprocess.run(
+        [sys.executable, "-c", textwrap.dedent(src)],
+        capture_output=True,
+        text=True,
+        env=dict(os.environ),
+        timeout=600,
+    )
+    assert out.returncode == 0, f"driver failed\nstdout={out.stdout}\nstderr={out.stderr[-3000:]}"
+    parsed = {}
+    for line in out.stdout.splitlines():
+        if ":" in line:
+            k, _, v = line.partition(":")
+            parsed[k] = v
+    return parsed
+
+
+@pytest.mark.correctness
+def test_full_space_lowering_solves_without_jax():
+    """The lowered block solves on the tape: 0 jax modules, correct optimum."""
+    res = _run_raw(_SQRT_BLOCK + _FULL_SPACE_TAIL + _REPORT)
+    assert res["STATUS"] == "optimal", res
+    assert res["JAXMODS"] == "0", f"full-space lowering still imported JAX: {res}"
+    assert float(res["OBJ"]) == pytest.approx(-1.96, abs=1e-5), res
+
+    # Vacuity control: the SAME problem through the opaque node must import JAX,
+    # or "0" above is measuring an environment without JAX rather than the change.
+    opaque = _run_raw(_SQRT_BLOCK + _OPAQUE_TAIL.format(x0=1.0) + _REPORT)
+    assert opaque["STATUS"] == "optimal", opaque
+    assert int(opaque["JAXMODS"]) > 0, (
+        f"control did not import JAX, so the test is vacuous: {opaque}"
+    )
+
+
+@pytest.mark.correctness
+def test_full_space_lowering_certifies_where_the_opaque_node_cannot():
+    """Lowering restores the global certificate the CustomCall forfeits."""
+    full = _run_raw(_SQRT_BLOCK + _FULL_SPACE_TAIL + _REPORT)
+    opaque = _run_raw(_SQRT_BLOCK + _OPAQUE_TAIL.format(x0=1.0) + _REPORT)
+
+    assert full["CERTIFIED"] == "True", f"lowered block did not certify: {full}"
+    assert opaque["CERTIFIED"] == "False", (
+        "the opaque node reported a certificate; if CustomCall models became "
+        f"globally certifiable this test's premise needs revisiting: {opaque}"
+    )
+
+
+@pytest.mark.correctness
+def test_opaque_node_answer_depends_on_x0_but_full_space_does_not():
+    """The falsification that motivates the lowering, pinned.
+
+    Same box, same equations: the opaque node returns a different optimum for a
+    different Newton start, because ``x0`` silently selects the branch. The
+    lowered model has both roots in the box and does not depend on ``x0`` at all.
+    """
+    pos = _run_raw(_SQRT_BLOCK + _OPAQUE_TAIL.format(x0=1.0) + _REPORT)
+    neg = _run_raw(_SQRT_BLOCK + _OPAQUE_TAIL.format(x0=-1.0) + _REPORT)
+    assert float(pos["OBJ"]) == pytest.approx(-1.96, abs=1e-5), pos
+    assert float(neg["OBJ"]) == pytest.approx(-2.0, abs=1e-5), neg
+    assert abs(float(pos["OBJ"]) - float(neg["OBJ"])) > 1e-3, (
+        "the opaque node no longer depends on x0; this test's premise is stale"
+    )
+
+    # The lowered model has no x0 to depend on -- the branch is stated as a BOX,
+    # which is visible to the relaxation where a starting point is not. Selecting
+    # the OTHER root is then a declarative edit, and it moves the answer the way
+    # the equations say it should.
+    def _boxed(lo, hi):
+        return (
+            _SQRT_BLOCK
+            + f"""
+v = m.implicit(
+    lambda U, V: [V[0] * V[0] - U[0]], [u], 1,
+    formulation="full_space", bounds=({lo}, {hi}),
+)
+m.subject_to(v[0] <= 1.4)
+m.minimize(-u)
+"""
+            + _REPORT
+        )
+
+    pos_box = _run_raw(_boxed(0.1, 3.0))  # v = +sqrt(u); v <= 1.4 binds at u = 1.96
+    neg_box = _run_raw(_boxed(-3.0, -0.1))  # v = -sqrt(u); v <= 1.4 always slack
+    assert float(pos_box["OBJ"]) == pytest.approx(-1.96, abs=1e-5), pos_box
+    assert float(neg_box["OBJ"]) == pytest.approx(-2.0, abs=1e-5), neg_box
+    assert pos_box["CERTIFIED"] == "True" and neg_box["CERTIFIED"] == "True", (pos_box, neg_box)
+
+
+@pytest.mark.correctness
+def test_nonlinear_multi_equation_block_solves_without_jax():
+    """A 2x2 nonlinear block, not just the 1x1 square-root case."""
+    src = """
+import discopt.modeling as dm
+m = dm.Model("cyc")
+u = m.continuous("u", lb=0.5, ub=1.5)
+v = m.implicit(
+    lambda U, V: [
+        V[0] - (0.3 * V[1] + 0.5 * U[0]),
+        V[1] - (0.2 * V[0] * V[0] + 1.0),
+    ],
+    [u], 2, formulation="full_space", bounds=([-3.0, -3.0], [3.0, 3.0]),
+)
+m.minimize(v[0] + v[1] - u)
+"""
+    res = _run_raw(src + _REPORT)
+    assert res["STATUS"] == "optimal", res
+    assert res["JAXMODS"] == "0", f"2x2 nonlinear block still imported JAX: {res}"
+
+
+@pytest.mark.smoke
+def test_lowering_emits_one_variable_and_one_equation_per_unknown():
+    m = dm.Model("shape")
+    u = m.continuous("u", lb=0.0, ub=1.0)
+    n_vars_before, n_cons_before = len(m._variables), len(m._constraints)
+    v = m.implicit(
+        lambda U, V: [V[0] - U[0], V[1] - V[0], V[2] - V[1] * V[1]],
+        [u],
+        3,
+        formulation="full_space",
+        bounds=(-5.0, 5.0),
+    )
+    assert len(m._variables) == n_vars_before + 1  # one VECTOR variable
+    assert v.shape == (3,)
+    assert len(m._constraints) == n_cons_before + 3  # one equation per unknown
+    assert np.allclose(v.lb, -5.0) and np.allclose(v.ub, 5.0)
+
+
+@pytest.mark.smoke
+def test_residual_indexing_matches_the_custom_root_arm():
+    """``u`` is flattened the same way in both arms, so one residual serves both.
+
+    The ``custom_root`` arm hands ``residual`` a flat concatenation of the
+    *raveled* inputs. A vector input plus a scalar input is the case that would
+    catch a mismatch -- with only scalars every flattening looks alike.
+    """
+    m = dm.Model("flat")
+    a = m.continuous("a", shape=(2,), lb=1.0, ub=2.0)
+    b = m.continuous("b", lb=3.0, ub=4.0)
+    seen = {}
+
+    def residual(U, V):
+        seen["n"] = len(U)
+        # v0 = a0 + a1 + b : exercises every flattened slot, so a wrong order or
+        # a dropped element changes the emitted equation.
+        return [V[0] - (U[0] + U[1] + U[2])]
+
+    v = m.implicit(residual, [a, b], 1, formulation="full_space", bounds=(0.0, 20.0))
+    assert seen["n"] == 3, "u was not flattened to 3 scalar slots"
+
+    m.minimize(v[0])
+    r = m.solve(time_limit=60)
+    # min over a in [1,2]^2, b in [3,4]  ->  1 + 1 + 3 = 5
+    assert r.objective == pytest.approx(5.0, abs=1e-5), r.objective
+
+
+@pytest.mark.smoke
+def test_second_block_gets_a_distinct_name():
+    """Two blocks in one model must not collide on the default variable name."""
+    m = dm.Model("two")
+    u = m.continuous("u", lb=0.0, ub=1.0)
+    v1 = m.implicit(lambda U, V: [V[0] - U[0]], [u], 1, formulation="full_space")
+    v2 = m.implicit(lambda U, V: [V[0] - 2.0 * U[0]], [u], 1, formulation="full_space")
+    assert v1.name != v2.name
+    assert len({v.name for v in m._variables}) == len(m._variables)
+
+
+@pytest.mark.smoke
+def test_full_space_rejects_a_residual_of_the_wrong_length():
+    m = dm.Model("bad")
+    u = m.continuous("u", lb=0.0, ub=1.0)
+    with pytest.raises(ValueError, match="must return 2 entries, got 1"):
+        m.implicit(lambda U, V: [V[0] - U[0]], [u], 2, formulation="full_space")
+
+
+@pytest.mark.smoke
+def test_full_space_rejects_a_non_sequence_residual():
+    m = dm.Model("bad2")
+    u = m.continuous("u", lb=0.0, ub=1.0)
+    with pytest.raises(ValueError, match="sequence of 1 expressions"):
+        m.implicit(lambda U, V: V[0] - U[0], [u], 1, formulation="full_space")
+
+
+@pytest.mark.smoke
+def test_inner_newton_knobs_are_refused_not_silently_dropped():
+    """``x0`` / ``tol`` / ``max_iter`` steer an inner Newton solve this arm has not.
+
+    Accepting them would be the worst outcome: the caller tunes a knob, nothing
+    changes, and nothing says so. discopt has no per-variable start slot either,
+    so a "recorded" ``x0`` would be read by nothing.
+    """
+    m = dm.Model("x0")
+    u = m.continuous("u", lb=0.0, ub=1.0)
+    with pytest.raises(ValueError, match="x0= is not supported"):
+        m.implicit(lambda U, V: [V[0] - U[0]], [u], 1, x0=[0.5], formulation="full_space")
+    with pytest.raises(ValueError, match="tol= does not apply"):
+        m.implicit(lambda U, V: [V[0] - U[0]], [u], 1, tol=1e-6, formulation="full_space")
+    with pytest.raises(ValueError, match="max_iter= does not apply"):
+        m.implicit(lambda U, V: [V[0] - U[0]], [u], 1, max_iter=5, formulation="full_space")
+
+    # The defaults must NOT trip the guard -- otherwise the arm is unusable.
+    v = m.implicit(lambda U, V: [V[0] - U[0]], [u], 1, formulation="full_space")
+    assert v.shape == (1,)
+
+
+@pytest.mark.smoke
+def test_unknown_formulation_and_misplaced_bounds_are_refused():
+    m = dm.Model("refuse")
+    u = m.continuous("u", lb=0.0, ub=1.0)
+    with pytest.raises(ValueError, match="must be 'custom_root' or 'full_space'"):
+        m.implicit(lambda U, V: [V[0] - U[0]], [u], 1, formulation="reduced")
+    # bounds= on the opaque arm has no variable to apply to. Refuse rather than
+    # silently drop it (the node would then be unbounded and the caller would not
+    # know).
+    with pytest.raises(ValueError, match="only supported with formulation='full_space'"):
+        m.implicit(lambda U, V: [V[0] - U[0]], [u], 1, bounds=(0.0, 1.0))


### PR DESCRIPTION
## What

Adds `formulation="full_space"` to `Model.implicit` (and the standalone
`dm.implicit_full_space`): instead of hiding `g(u, v) = 0` behind a `CustomCall`,
the unknowns `v` become a real vector `Variable` and each residual becomes a real
`== 0` constraint. The residual callable is handed **discopt expressions**, so it
is written in discopt operators, not `jnp.*`.

The existing `custom_root` arm is untouched and remains the default.

## Why

`implicit()` is the last modeling feature that pins JAX to the solve path, and it
does so for a reason that also costs the certificate. Both costs are the same
fact — the defining equations are invisible to everything downstream:

1. **JAX stays on the solve path.** `_nl_expr_compiler` raises
   `UnsupportedForTape("CustomCall (dm.custom) has no tape equivalent")`, so any
   model containing the node falls back to the JAX evaluator.
2. **No certificate is reachable.** A relaxation of an implicitly defined `v`
   needs the defining equations; with only `v = phi(u)` there is nothing to
   relax, so `_custom_call_reduced_admissible` refuses the global path.

(2) is not a theoretical worry. Measured on `v**2 - u == 0`, `v <= 1.4`,
`min -u` over `u in [1, 2]`, the opaque node returns a **different optimum for a
different Newton start** — `-1.96` from `x0=+1`, `-2.0` from `x0=-1` — same box,
same equations, because which root Newton lands in *is* the only definition `v`
has. Both report `gap_certified=False`, so nothing false is certified, but the
answer is selected by a starting point rather than by the model.

Lowered, both roots are in the box, the branch is selected declaratively by
`bounds=`, the tape compiles the block (0 JAX modules), and the spatial B&B
certifies. The trade is the reduced-space size win that motivated #379: `v` stays
in the model instead of being eliminated. That is the caller's call to make,
which is why this is an explicit `formulation=` rather than a silently different
lowering of the same entry point.

## Refusals rather than silent no-ops

`x0`, `tol`, and `max_iter` steer an inner Newton solve this arm does not have.
They are **refused** with a message pointing at the replacement
(`bounds=` to select a root, `solve(initial_solution={v: x0})` to warm-start)
rather than accepted and ignored. discopt has no per-variable start slot, so
"recording" `x0` on the returned variable would have been an attribute nothing
reads. Likewise `bounds=` on the `custom_root` arm is refused — that node has no
column to put a box on.

## Verification

New file `python/tests/test_implicit_full_space.py`, 11 tests:
**11 fail at the base commit (`a1d73e6e`), 11 pass on this change.**

Each subprocess driver prints a JAX module count, and the JAX-freedom tests carry
a **paired opaque-node control asserting a NON-zero count** — without it, "0 jax
modules" could be measuring an environment without JAX rather than the change.

Runs on this branch:

| suite | result |
| --- | --- |
| `python/tests/test_implicit_node.py` + `test_implicit_full_space.py` | 22 passed |
| `pytest -m smoke` | 938 passed, 1 skipped, 2 xpassed |
| `pytest -m slow python/tests/test_adversarial_recent_fixes.py` | 10 passed |
| `pytest python/tests/ -m "not slow"` | 8351 passed, 36 skipped, 9 xfailed, 2 xpassed, **0 failures** (723s) |
| `ruff check` / `ruff format --check` | clean |

The existing 11 `test_implicit_node.py` tests (the `custom_root` arm) pass
unchanged — the default path is not touched.

Measured on the sqrt block: `status=optimal obj=-1.96 certified=True JAXMODS=0`
against the opaque node's `JAXMODS=211 certified=False`.

## Branch dependency

**This PR is stacked on #922** (base `refactor/remove-jax-from-solve-path`, not
`main`). The JAX-freedom claim cannot be reproduced on `main`:
`python/discopt/_tape_nlp_evaluator.py` does not exist there, so a lowered block
on `main` still routes to the JAX evaluator. Merge #922 first.

## Follow-on outside this repo

`discopt-aggregation` (`~/Dropbox/projects/discopt-plugins/discopt-aggregation`)
manufactures its own JAX dependency: its `ImplicitBlock.equations` are already
discopt `Expression`s, and `eliminate_implicit` converts them to `jnp` through a
~70-line `_jax_eval_expr` interpreter purely to satisfy the `custom_root`
callable signature. With this arm available that interpreter can be deleted and
the expressions passed straight through. That change belongs in that repo and is
not part of this PR.

Part of the JAX-removal workstream tracked by #922 (the "75" in
`test_75_jax_free_solve_path.py` is a workstream label, not a GitHub issue —
GitHub #75 is an unrelated merged convexification PR, so this body deliberately
does not link it). Relates to #379, which introduced the `custom_root` node and
is already closed; this leaves it closed.
