### PR TITLE
fix(ci): reporters could not reach GitHub; drop the nightly schedule

### DIFF
--- a/.github/workflows/amp-integration.yml
+++ b/.github/workflows/amp-integration.yml
@@ -112,6 +112,12 @@ jobs:
       - name: Open or update the tracking issue
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # `gh` resolves the repo from the git remote, and these reporter jobs
+          # deliberately skip `actions/checkout` -- so every `gh` call died with
+          # "fatal: not a git repository" and the reporter that exists to make a
+          # failure visible failed silently itself. GH_REPO removes the git
+          # dependency without paying for a checkout.
+          GH_REPO: ${{ github.repository }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           TITLE: "CI signal down: AMP integration suite is failing on main"
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,11 +7,14 @@ on:
   pull_request:
     branches: [main, feature/mip-nlp-solver]
     types: [opened, synchronize, reopened, ready_for_review, labeled]
-  schedule:
-    # Nightly, 06:20 UTC. Only `python-correctness-nightly` runs on this trigger;
-    # every other job below is gated on `needs.changes`, which is `false` for a
-    # schedule event (no diff to inspect).
-    - cron: "20 6 * * *"
+
+# NO `schedule:` trigger. A nightly re-run of the slow correctness lane is a
+# ~2 h runner job every day against a SHA that has usually not moved, and the
+# CI-minute cost is not worth it — the same judgement `143bd1e9` made when it
+# removed the previous nightly ("duplicate work and the source of false-alarm
+# emails"), and re-adding it in `23fff2a6` was a mistake. `python-correctness-slow`
+# below is `workflow_dispatch`-only: run it deliberately, before a release or
+# when touching the certificate path.
 
 # Cancel superseded runs on the same PR/branch — saves CI minutes when
 # pushes land in quick succession.
@@ -39,16 +42,6 @@ jobs:
         shell: bash
         run: |
           set -uo pipefail
-          if [ "${{ github.event_name }}" = "schedule" ]; then
-            # The nightly trigger exists solely for `python-correctness-nightly`,
-            # which does NOT gate on this output. This is not the "uncertainty"
-            # case the rule below covers — there is no diff to be uncertain
-            # about, and re-running the whole PR matrix nightly would buy nothing
-            # that the last push already proved.
-            echo "code=false" >> "$GITHUB_OUTPUT"
-            echo "=> code=false (schedule: only the nightly correctness lane runs)"
-            exit 0
-          fi
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             # A manual run is a request to run EVERYTHING — that is the only
             # reason to press the button. There is also no base to diff against:
@@ -228,7 +221,9 @@ jobs:
           # --dist loadgroup keeps tests sharing a class on the same worker
           #   so xdist-incompatible fixtures stay serialized.
           # Coverage is intentionally dropped from the PR path — see the
-          # `python-coverage` job (nightly + label-triggered) for full coverage.
+          # `python-coverage` job (main pushes + the `coverage` label) instead.
+          # That parenthetical used to read "nightly + label-triggered";
+          # `python-coverage` has never had a schedule trigger.
           scripts/run_memory_capped_pytest.sh pytest python/tests/ \
             -q --tb=short --timeout=120 \
             -m "not slow and not correctness and not integration and not amp_benchmark and not requires_cyipopt and not memory_heavy" \
@@ -250,15 +245,13 @@ jobs:
     # #248's nvs16 garbage-bound guard regressed at the #632 uniform-relax cutover
     # and sat unnoticed for a full release cycle because no PR job ran the
     # `correctness` marker. This lane closes that gap. It runs only the cheap
-    # subset (`not slow`); the `slow` half is the `python-correctness-nightly`
-    # job below.
-    #
-    # That sentence used to read "remains the nightly `python-coverage` job's
-    # responsibility", and it was false in two ways at once: `python-coverage`
-    # runs `-m "not slow and not correctness ..."`, and this workflow had no
-    # `schedule:` trigger, so there was no nightly. The 153 `slow`+`correctness`
-    # tests ran in NO lane — including the one asserting that ex1252's dual bound
-    # under the #707/#721/#732 reform flags is sound, which is red (#927).
+    # subset (`not slow`); the `slow` half is `python-correctness-slow` below,
+    # which is manual-dispatch only — no automatic lane runs it, by design
+    # (see the `on:` block: a nightly costs more CI minutes than it is worth).
+    # Running it is therefore a deliberate act before a release or after a
+    # change to the certificate path, and its 153 `slow`+`correctness` tests
+    # have no continuous watch. That is a known, accepted gap; #927 (ex1252
+    # dual-bound soundness) is one of the things it would have caught.
     name: Python correctness (fast subset, 3.12, ubuntu)
     runs-on: ubuntu-latest
     needs: changes
@@ -330,12 +323,12 @@ jobs:
           JAX_ENABLE_X64: "1"
           PYTEST_MEMORY_LIMIT_MB: "32768"
 
-  python-correctness-nightly:
+  python-correctness-slow:
     # The other half of the correctness marker: the 153 tests that are `slow`
     # AND `correctness`. These are the end-to-end known-optima and soundness
     # assertions — the ones that solve a real instance and check the certificate
-    # against `minlplib.solu` — and until this job existed they ran in no lane at
-    # all. Nightly rather than per-PR because it is hours, not minutes; the
+    # against `minlplib.solu`. Manual dispatch only: hours rather than minutes,
+    # so it is neither a PR lane nor a nightly (see the `on:` block). The
     # `not slow` half stays on `python-correctness` for the PR-fast signal.
     #
     # Serial for the same reason as `python-correctness`: a soundness lane must
@@ -356,8 +349,8 @@ jobs:
     # 7 skipped, 1 failed — the failure being #927). `python-correctness` is
     # ~5 min locally and 23 min on a runner, so budget ~25 min here and leave
     # headroom for a slower runner rather than a hung solve.
-    name: Python correctness (slow, nightly, 3.12, ubuntu)
-    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    name: Python correctness (slow, on demand, 3.12, ubuntu)
+    if: github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     timeout-minutes: 120
     steps:
@@ -410,12 +403,16 @@ jobs:
           PYTHONUNBUFFERED: "1"
           PYTEST_MEMORY_LIMIT_MB: "32768"
 
-  # Same argument as the other two scheduled lanes: a nightly that fails into an
-  # empty room is not a signal.
-  report-nightly-failure:
+  # Same argument as the other two scheduled lanes: a lane that fails into an
+  # empty room is not a signal. This one is now dispatch-only, and a dispatched
+  # 2 h run is exactly the kind you walk away from, so the report still earns
+  # its place. It is NOT gated on `github.event_name` — the lane above has only
+  # one trigger left, and gating on a trigger that can no longer fire is how
+  # `23fff2a6` shipped three reporters that never reported.
+  report-slow-correctness-failure:
     name: File/refresh the CI-signal issue
-    needs: python-correctness-nightly
-    if: failure() && github.event_name == 'schedule'
+    needs: python-correctness-slow
+    if: failure()
     runs-on: ubuntu-latest
     permissions:
       issues: write
@@ -430,13 +427,13 @@ jobs:
           # dependency without paying for a checkout.
           GH_REPO: ${{ github.repository }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-          TITLE: "CI signal down: nightly slow-correctness lane is failing"
+          TITLE: "CI signal down: slow-correctness lane is failing"
         run: |
           set -euo pipefail
           gh label create ci-signal --force --color B60205 \
             --description "A CI lane that is supposed to be watching something has stopped watching"
           printf '%s\n' \
-            "The nightly \`slow\`+\`correctness\` lane failed." \
+            "The \`slow\`+\`correctness\` lane failed." \
             "" \
             "Run: ${RUN_URL}" \
             "" \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -423,6 +423,12 @@ jobs:
       - name: Open or update the tracking issue
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # `gh` resolves the repo from the git remote, and these reporter jobs
+          # deliberately skip `actions/checkout` -- so every `gh` call died with
+          # "fatal: not a git repository" and the reporter that exists to make a
+          # failure visible failed silently itself. GH_REPO removes the git
+          # dependency without paying for a checkout.
+          GH_REPO: ${{ github.repository }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           TITLE: "CI signal down: nightly slow-correctness lane is failing"
         run: |

--- a/.github/workflows/graduation-gate.yml
+++ b/.github/workflows/graduation-gate.yml
@@ -94,6 +94,12 @@ jobs:
       - name: Open or update the tracking issue
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # `gh` resolves the repo from the git remote, and these reporter jobs
+          # deliberately skip `actions/checkout` -- so every `gh` call died with
+          # "fatal: not a git repository" and the reporter that exists to make a
+          # failure visible failed silently itself. GH_REPO removes the git
+          # dependency without paying for a checkout.
+          GH_REPO: ${{ github.repository }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           TITLE: "CI signal down: flag-graduation gate (scheduled) is failing"
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -234,6 +234,27 @@ The release procedure that produces these entries is documented in
 
 ### Changed
 
+- **CI no longer runs a nightly, and the three failure reporters can now reach
+  GitHub** (`ci`). Two coupled corrections to `23fff2a6`:
+  1. **The nightly schedule is removed.** A daily ~2 h runner job against a SHA
+     that has usually not moved is not worth the CI minutes — the same judgement
+     `143bd1e9` made on 2026-05-28 when it deleted the previous nightly
+     ("duplicate work and the source of false-alarm emails"). The lane survives
+     as `python-correctness-slow`, `workflow_dispatch`-only. **Stated cost:** its
+     153 `slow`+`correctness` tests now have no continuous watch; running them is
+     a deliberate act before a release or after a change to the certificate path.
+     Two tests in `test_ci_changes_gate.py` pin the decision so a third re-add of
+     a `schedule:` trigger is a red check rather than a silent line.
+  2. **All three `report-failure` jobs died on their first `gh` call.** They skip
+     `actions/checkout` by design, so `gh` — which resolves the repo from the git
+     remote — exited `fatal: not a git repository`. The three reporters titled
+     "repair three signals that had stopped signalling" had therefore never
+     signalled: the `ci-signal` label does not exist and no issue was ever filed.
+     A real solver defect (#977) sat unrecorded for two days behind a red nightly
+     because of it. Fixed with `GH_REPO: ${{ github.repository }}`, which needs no
+     checkout. The `ci.yml` reporter also loses its now-unreachable
+     `github.event_name == 'schedule'` gate.
+
 - **The #843 QUBO/Ising local-search primal is now default-ON** (`perf`, #843,
   graduating the #846 seed; opt out with `DISCOPT_QUBO_PRIMAL=0`). An
   unconstrained all-binary quadratic model (the `chimera_k64ising` /Max-Cut

--- a/python/tests/test_ci_changes_gate.py
+++ b/python/tests/test_ci_changes_gate.py
@@ -227,8 +227,48 @@ def test_push_with_a_code_file_runs(tmp_path):
     assert _run_gate(repo, script) == "true"
 
 
-def test_schedule_still_skips_the_pr_matrix(tmp_path):
-    """The nightly lane does not gate on this output; the rest must not re-run."""
-    repo, _base, sha = _make_repo(tmp_path, ["python/discopt/solver.py"])
-    script = _render(_gate_script(), event="schedule", before="", sha=sha, base_ref="main")
-    assert _run_gate(repo, script) == "false"
+def test_ci_has_no_schedule_trigger():
+    """No nightly. This is a cost decision, and it has been reversed twice.
+
+    A daily run of the slow correctness lane is a ~2 h runner job against a SHA
+    that has usually not moved. ``143bd1e9`` removed the first nightly for that
+    reason; ``23fff2a6`` re-added one; the owner's call is that it should not
+    exist. This test is what makes the third re-add a red check instead of a
+    silent line in an ``on:`` block.
+
+    It replaces ``test_schedule_still_skips_the_pr_matrix``, which pinned the
+    gate's answer for a ``schedule`` event that can no longer occur.
+    """
+    wf = yaml.safe_load(_CI.read_text())
+    # PyYAML parses a bare `on:` key as the boolean True (YAML 1.1).
+    triggers = wf.get(True, wf.get("on"))
+    assert "schedule" not in triggers, (
+        "ci.yml grew a schedule trigger again. If a periodic run is genuinely "
+        "wanted, weigh the runner minutes first and delete this test "
+        "deliberately -- do not make it pass by narrowing what it checks."
+    )
+
+
+def test_slow_correctness_lane_and_its_reporter_stay_reachable():
+    """With the schedule gone, the lane's only trigger is a manual dispatch.
+
+    The reporter must NOT gate on ``github.event_name``: ``23fff2a6`` shipped
+    three reporters whose event gate could never be true, and they filed nothing
+    for two days while the lane was red (#977). A reporter that cannot fire is
+    the same as no reporter, but it reads as one.
+    """
+    wf = yaml.safe_load(_CI.read_text())
+    jobs = wf["jobs"]
+
+    lane = jobs["python-correctness-slow"]
+    assert lane["if"] == "github.event_name == 'workflow_dispatch'"
+
+    rep = jobs["report-slow-correctness-failure"]
+    assert rep["needs"] == "python-correctness-slow"
+    assert rep["if"] == "failure()", (
+        "the reporter must fire on any failure of the lane it watches; an "
+        f"event_name gate here is unreachable, got {rep['if']!r}"
+    )
+    # `gh` resolves the repo from the git remote and this job has no checkout.
+    env = rep["steps"][0]["env"]
+    assert env["GH_REPO"] == "${{ github.repository }}"


### PR DESCRIPTION
Two changes, one subject: the failure reporters added by `23fff2a6`.

## 1. The reporters cannot reach GitHub

`gh` resolves the target repository from the git remote. All three
`report-failure` jobs deliberately skip `actions/checkout` — they run no repo
code, only `gh` — so their working directory is not a git repository and the
**first** `gh` call dies:

```
failed to run git: fatal: not a git repository
##[error]Process completed with exit code 1
```

`GH_REPO: ${{ github.repository }}` gives `gh` the repository directly, with no
checkout to pay for.

This matters because `23fff2a6` is titled *"repair three signals that had
stopped signalling"* and the three reporters it introduced have **never once
signalled**: the `ci-signal` label does not exist in this repo, and
`gh issue list --label ci-signal` returns empty, because no reporter has ever
reached the API. The `ci.yml` one fired twice (the 08-09 and 08-10 nightlies)
and failed both times; those nightlies were red for a real solver defect (a GBD
master returning a point that violates its own Benders cut) that consequently
sat unrecorded for two days. It is now #977, found by hand rather than by the
mechanism built to find it. The other two reporters
(`amp-integration.yml`, `graduation-gate.yml`) have not fired yet and carry the
identical latent bug, so all three are fixed.

### Verification

A probe reproducing the CI condition exactly — `gh` invoked from a directory
that is not a git repository — run as an interleaved A/B:

```
OK   premise: cwd is not a git repository
OK   arm A: without GH_REPO -> 'not a git repository' (matches CI)
OK   arm B: with GH_REPO -> gh resolved the repo and succeeded
OK   arm C: reporter's issue lookup runs; existing issue number = '<none>'

EXECUTED_ASSERTIONS=4
FAILURES=0
PASS
```

Arm A is the vacuity control: without it, arm B passing would show only that
`gh` works, not that `GH_REPO` is what helps. The probe asserts its own premise
and exits non-zero on zero assertions. Arm C runs the reporter's own
`gh issue list … --jq` lookup; its empty result is the direct evidence that no
reporter has ever filed.

## 2. The nightly schedule is removed

**Retraction.** The first version of this PR description said:

> "It does not make the reporters *fire* — that needs a failing scheduled run,
> which the next nightly will supply while #977 is open. If the next nightly is
> red and still files nothing, this fix was insufficient and the job needs a
> closer look. That is the observable check."

That check is withdrawn, on both of its premises.

*The nightly was not the dependable fixture I treated it as.* `git log -S'  schedule:'`
gives the full history: added by `e2f1ca04` (2026-05-11), **deliberately removed
by `143bd1e9` (2026-05-28)** — *"Push CI already uploads coverage to Codecov on
every merge to main, so the nightly re-run against an unchanged SHA was
duplicate work and the source of false-alarm emails"* — and re-added by
`23fff2a6` (2026-08-08). It had run exactly twice in its current incarnation
when I called it "the next nightly."

*And the repo owner's call is that it should not exist*: a ~2 h runner job every
day, usually against an unmoved SHA, is not worth the CI minutes. So this PR
also removes the `schedule:` trigger, restoring `143bd1e9`'s judgement.

What that entails:

- `python-correctness-nightly` → **`python-correctness-slow`**, gated on
  `workflow_dispatch` only. The lane is kept, not deleted.
- **Stated cost:** its 153 `slow`+`correctness` tests now have **no continuous
  watch**. Running the lane is a deliberate act before a release or after a
  change to the certificate path. The comment in `ci.yml` says so plainly rather
  than implying coverage that does not exist — that implication is what
  `python-correctness`'s old comment got wrong, and it is how #927 went unseen.
- The `changes` filter's `schedule` branch is removed (it decided an output for
  an event that can no longer occur).
- `report-nightly-failure` → **`report-slow-correctness-failure`**, with its
  `github.event_name == 'schedule'` gate dropped. Left in place that condition
  would be permanently false — exactly the failure mode of the three reporters
  this PR is fixing. It now fires on any failure of the lane it watches, which
  still earns its place: a dispatched 2 h run is the kind you walk away from.
- The `python-coverage` cross-reference calling that job "nightly +
  label-triggered" is corrected; it runs on main pushes and the `coverage`
  label, and has never had a schedule trigger.
- The two **weekly** schedules (`amp-integration`, `graduation-gate`, both
  Mondays) are untouched. They are 1/7 the cadence and were not the cost
  complaint — say the word if they should go too.

## Verification of part 2

`ci.yml` parses as YAML; `on:` is now `[pull_request, push, workflow_dispatch]`
with no `schedule`; no job `needs:` dangles; `report-slow-correctness-failure`
resolves to the renamed lane and still carries `GH_REPO`. All three workflows
re-parse with `GH_REPO` in the intended job.

## What this does not do

It does not demonstrate a reporter firing end-to-end. With the nightly gone
there is no automatic trigger that would produce one, and I am not going to burn
a 2 h dispatch to prove it. The direct evidence is arm A/B/C above: the exact
`gh` invocation the reporter makes now succeeds where it previously died.

Relates to #977 (the defect this reporter should have surfaced) and to
`23fff2a6`. Leaves #977 open.
