### PR TITLE
fix(bench): a suite ran every local instance instead of the ones it declares

### DIFF
--- a/discopt_benchmarks/run_benchmarks.py
+++ b/discopt_benchmarks/run_benchmarks.py
@@ -513,6 +513,20 @@ def _run_benchmark(args):
     else:
         instances, known_optima = _load_minlplib_instances(suite_config)
 
+    # A suite that resolves to nothing must not report metrics. Every rate in
+    # the gate table (incorrect_count, geomean ratios, root-gap coverage) is
+    # computed over the rows that ran, so an empty panel produces a full set of
+    # vacuously-passing numbers -- a green gate that measured nothing. Refuse.
+    if not instances:
+        print(
+            f"ERROR: suite {args.suite!r} resolved to 0 instances. Its declared "
+            "instance_list is missing or matches nothing in the local corpus "
+            "(see the WARN above). Not running: an empty panel would report "
+            "gate metrics that passed by not being evaluated.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
     # Subprocess-isolated, resumable path (recommended for full MINLPLib).
     if args.subprocess:
         _run_scaled(args, suite_config or {}, instances, known_optima)
@@ -681,6 +695,26 @@ def _read_instance_list(path: str | Path | None) -> set[str] | None:
     return names
 
 
+def _load_cert_optima() -> dict[str, float]:
+    """The vendored BARON optima for the certification panel.
+
+    ``docs/dev/data/cert-optima.json`` is the panel's oracle (global50 + the
+    perf panel). Returns ``{}`` if it is absent -- a missing oracle must not
+    take the runner down, but it must also not be mistaken for "everything was
+    verified": every caller merges this on top of its own map and instances
+    with no entry keep ``best_known_objective=None``, which the metrics layer
+    already reports as unverified rather than correct.
+    """
+    p = Path(__file__).parent.parent / "docs" / "dev" / "data" / "cert-optima.json"
+    if not p.exists():
+        print(f"WARN: cert optima {p} not found; panel instances will have no oracle",
+              file=sys.stderr)
+        return {}
+    with open(p) as f:
+        raw = json.load(f)
+    return {str(k): float(v) for k, v in raw.items()}
+
+
 def _instance_list_order(path: str | Path | None) -> list[str]:
     """Same as _read_instance_list but preserves file order."""
     if not path:
@@ -728,10 +762,25 @@ def _load_minlplib_instances(
 
     Returns (instances, known_optima) where instances is a list of InstanceInfo
     and known_optima maps instance name to expected objective.
+
+    This is the DEFAULT path (no --fetch/--use-cache). It must apply the same
+    suite filters as ``_load_minlplib_from_cache``: until it did, a suite whose
+    membership is a list *file* (``instance_list``) silently ran every ``.nl``
+    in the local corpus instead. ``--suite global50`` ran 119 instances, not 50,
+    and reported them under the panel's name.
     """
     from benchmarks.metrics import InstanceInfo
 
-    # Known optima from MINLPLib (verified by BARON/ANTIGONE/SCIP)
+    # Known optima from MINLPLib (verified by BARON/ANTIGONE/SCIP).
+    #
+    # This literal covers 21 of the 50 global50 names, so on the panel it left
+    # ~85 of the instances it was asked about with no oracle at all. An instance
+    # with `best_known_objective=None` cannot be counted incorrect, which makes
+    # `incorrect_count` -- the zero-slack gate -- read 0 by not being evaluated.
+    # `docs/dev/data/cert-optima.json` is the vendored BARON panel and covers 48
+    # of the 50. The two are merged below rather than one replacing the other:
+    # where both carry a value they agree to within 1e-6 (measured), so this
+    # widens coverage without re-baselining any existing verdict.
     known_optima_map = {
         "ex1221": 7.66718007,
         "ex1225": 31.0,
@@ -767,6 +816,7 @@ def _load_minlplib_instances(
         "meanvar": 5.24339907,
         "alan": 2.9250,
     }
+    known_optima_map.update(_load_cert_optima())
 
     # Load instance classifications
     instance_classes = _load_instance_classes()
@@ -792,14 +842,19 @@ def _load_minlplib_instances(
     max_instances = suite_config.get("max_instances", 10000) if suite_config else 10000
     problem_class_filter = suite_config.get("problem_class") if suite_config else None
     instance_list_inline = suite_config.get("instance_list_inline") if suite_config else None
+    list_file = suite_config.get("instance_list") if suite_config else None
 
-    # If inline instance list specified, only use those
+    # Membership can be declared inline (`instance_list_inline`) or as a list
+    # FILE (`instance_list`). Both must be honoured, and both fail closed:
+    # `_read_instance_list` returns an empty set for a missing file, so a typo
+    # in a suite table filters to nothing loudly instead of running the whole
+    # corpus under the suite's name. Reading only the inline form is what let
+    # `--suite global50` report 119 instances as the 50-instance panel.
+    allowed = _read_instance_list(list_file)
     if instance_list_inline:
-        filtered = {}
-        for name in instance_list_inline:
-            if name in found_instances:
-                filtered[name] = found_instances[name]
-        found_instances = filtered
+        allowed = (allowed or set()) | set(instance_list_inline)
+    if allowed is not None:
+        found_instances = {n: p for n, p in found_instances.items() if n in allowed}
 
     instances = []
     for name, nl_path in sorted(found_instances.items()):

--- a/discopt_benchmarks/tests/test_suite_membership.py
+++ b/discopt_benchmarks/tests/test_suite_membership.py
@@ -1,0 +1,140 @@
+"""A suite must run the instances it declares, and know their optima.
+
+Both halves of this file are about a benchmark that reports a number for the
+wrong thing:
+
+* ``--suite global50`` ran **119** instances -- every ``.nl`` in the local
+  corpus -- and labelled the result with the panel's name. The default loader
+  (``_load_minlplib_instances``, used whenever ``--fetch``/``--use-cache`` is
+  not passed) read only ``instance_list_inline`` and ignored ``instance_list``,
+  the list *file* form that every ``[gates.cert*]`` panel is defined with.
+  ``_load_minlplib_from_cache`` honoured both, so which loader ran silently
+  decided what the suite meant.
+* On that same path the oracle was a 34-entry literal covering **21 of the 50**
+  panel names. An instance with ``best_known_objective=None`` can never be
+  counted incorrect, so ``incorrect_count`` -- the gate CLAUDE.md gives zero
+  slack -- read 0 largely by not being evaluated.
+
+These tests exercise the real loader against the real config; they are not a
+transcription of it.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+import tomllib
+
+_BENCH = Path(__file__).resolve().parents[1]
+if str(_BENCH) not in sys.path:
+    sys.path.insert(0, str(_BENCH))
+
+import run_benchmarks as rb  # noqa: E402
+
+_CONFIG = _BENCH / "config" / "benchmarks.toml"
+_PANEL_LIST = _BENCH / "config" / "baron_global50.txt"
+
+pytestmark = pytest.mark.skipif(
+    not _CONFIG.exists() or not _PANEL_LIST.exists(),
+    reason="needs the benchmark config and the global50 instance list",
+)
+
+
+def _suite(name: str) -> dict:
+    with open(_CONFIG, "rb") as f:
+        return tomllib.load(f)["suites"][name]
+
+
+def _panel_names() -> list[str]:
+    return [
+        ln.strip()
+        for ln in _PANEL_LIST.read_text().splitlines()
+        if ln.strip() and not ln.startswith("#")
+    ]
+
+
+def test_global50_resolves_to_the_panel_not_the_whole_corpus():
+    """The bug, stated as a number: 50 declared, 119 run.
+
+    Asserted as a bound rather than an exact count because how many of the 50
+    have a local ``.nl`` is a property of the vendored corpus, not of the
+    selection logic. The corpus is larger than the panel, so "no more than the
+    panel" is what distinguishes a working filter from an absent one.
+    """
+    declared = _panel_names()
+    assert len(declared) == 50, "the panel list itself changed; update this test"
+
+    instances, _ = rb._load_minlplib_instances(_suite("global50"))
+    got = {i.name for i in instances}
+
+    assert got, "the panel resolved to nothing -- fail-closed fired unexpectedly"
+    assert got <= set(declared), (
+        f"loader returned {len(got - set(declared))} instances that are NOT in "
+        f"the panel list, e.g. {sorted(got - set(declared))[:5]}"
+    )
+    assert len(got) >= 40, (
+        f"only {len(got)} of 50 panel instances resolved locally; the corpus or the list moved"
+    )
+
+
+def test_a_missing_list_file_filters_to_nothing_rather_than_everything():
+    """Fail closed. A typo in a suite table must not silently run the corpus.
+
+    This is the property that makes the assertion above trustworthy: without
+    it, "filter applied" and "filter file unreadable" look identical from the
+    outside, and the unreadable case is the dangerous one.
+    """
+    instances, _ = rb._load_minlplib_instances({"instance_list": "config/does-not-exist.txt"})
+    assert instances == []
+
+
+def test_no_suite_config_still_loads_the_whole_corpus():
+    """The other direction: absence of a list means "no filter", not "nothing".
+
+    ``_read_instance_list(None)`` returns None (no filter) while a missing file
+    returns an empty set. Conflating them would either break the unfiltered
+    suites or resurrect the bug.
+    """
+    instances, _ = rb._load_minlplib_instances(None)
+    assert len(instances) > 50
+
+
+def test_the_panel_has_an_oracle_for_nearly_every_instance():
+    """A correctness gate over instances with no known optimum is vacuous.
+
+    Two panel instances (casctanks, tspn05) have no vendored optimum; that is a
+    real gap and the bound below admits exactly it. What it rejects is the prior
+    state, where 29 of the 50 had none.
+    """
+    instances, optima = rb._load_minlplib_instances(_suite("global50"))
+    assert instances, "no instances -- the assertion below would be vacuous"
+
+    with_oracle = [i for i in instances if optima.get(i.name) is not None]
+    ratio = len(with_oracle) / len(instances)
+    assert ratio >= 0.90, (
+        f"only {len(with_oracle)}/{len(instances)} panel instances have a known "
+        f"optimum ({ratio:.0%}); incorrect_count cannot fire on the rest"
+    )
+
+
+def test_vendored_optima_agree_with_the_hardcoded_map():
+    """Merging the two oracles must widen coverage, not re-baseline verdicts.
+
+    If these ever disagree, one of them is wrong and a correctness verdict
+    silently changes meaning depending on which loader ran -- exactly the class
+    of thing this file exists to catch.
+    """
+    cert = rb._load_cert_optima()
+    assert cert, "cert-optima.json did not load; the comparison would be vacuous"
+
+    _, merged = rb._load_minlplib_instances(_suite("global50"))
+    compared = 0
+    for name, value in cert.items():
+        if name in merged:
+            compared += 1
+            assert merged[name] == pytest.approx(value, abs=1e-6, rel=1e-6), (
+                f"{name}: vendored optimum {value} disagrees with the merged map's {merged[name]}"
+            )
+    assert compared >= 40, f"only {compared} optima compared; expected the panel's ~48"


### PR DESCRIPTION
Found while trying to run the global50 panel on #922: the run reported
**"Instances: 119"** for a 50-instance suite.

## The bug

There are two MINLPLib loaders in `run_benchmarks.py`:

| loader | when | `instance_list_inline` | `instance_list` (file) |
| --- | --- | --- | --- |
| `_load_minlplib_from_cache` | `--fetch` / `--use-cache` | honoured | honoured |
| `_load_minlplib_instances` | **default** | honoured | **ignored** |

Every panel in `benchmarks.toml` declares membership with the *file* form, so on
the default path the filter was dropped and the runner used every `.nl` in
`python/tests/data/minlplib/` + `minlplib_nl/` — 119 — under the suite's name.
Which loader ran silently decided what the suite meant, with no diagnostic
either way.

## The part that matters more

On that same path the oracle is a hardcoded literal covering **21 of the 50**
panel names, so ~85 of the 119 rows carried `best_known_objective=None`. An
instance with no known optimum can never be counted incorrect — so
`incorrect_count`, the gate CLAUDE.md gives zero slack, read 0 largely *by not
being evaluated*. That is a green correctness panel whose assertion mostly never
fired.

`docs/dev/data/cert-optima.json` is the vendored BARON panel and covers 48 of
the 50. It is merged on top of the literal rather than replacing it; where both
carry a value they agree to within 1e-6 (measured over the panel: **0
disagreements**), so this widens coverage without re-baselining any verdict.

## Fail-closed, and what it exposed

Selection now fails closed like the cache path: a missing list file yields an
empty set, not "no filter". That immediately surfaced a third, pre-existing
problem — `[suites.comparison]` names `config/comparison_instances.txt`, which
**has never existed in this repo's history**, while six phase2/3/4 gate criteria
reference `suite = "comparison"`. It resolved to 119 before and resolves to 0
now.

An empty panel would report a full set of vacuously-passing rates, so the runner
refuses: 0 instances prints what happened and exits 1.

```
WARN: instance_list .../config/comparison_instances.txt not found
ERROR: suite 'comparison' resolved to 0 instances. ... Not running: an empty
panel would report gate metrics that passed by not being evaluated.
exit code = 1
```

Creating that curated list is a judgement about what the comparison panel should
contain, so I left it to you — it is now loud instead of silent.

## Measured

Default path, per suite:

```
global50   ->  50 instances,  48 with a known optimum   (was 119 / 34)
comparison ->   0 instances  -> refuses, exit 1         (was 119)
smoke      ->  10 instances,   8 with a known optimum   (unchanged)
no suite   -> 119 instances                             (unchanged)
```

## Verification

`tests/test_suite_membership.py`, A/B'd against both loader versions with a
marker confirming which file was loaded:

```
ARM A: origin/main's run_benchmarks.py  (_load_cert_optima refs: 0) -> 4 failed
ARM B: this fix                         (_load_cert_optima refs: 2) -> 5 passed
```

The fifth test (`test_no_suite_config_still_loads_the_whole_corpus`) passes in
**both** arms by design — it is the guard that this change does not break the
unfiltered suites, so it must not discriminate. Arm A is the vacuity control for
the other four.

21 tests pass across `test_suite_membership.py` + `test_cert_instrumentation.py`.

## Scope

`run_benchmarks.py` carries 3 pre-existing ruff findings and is not
ruff-format-clean on `main`; `discopt_benchmarks/` sits outside the pre-commit
`files: ^python/` scope. I left both alone — reformatting the file would bury
this diff. The new test file is ruff-clean.

This is a harness defect, not a solver one; nothing on the solve path changes.
