### PR TITLE
fix(bench): the layer profile could not report a measured zero

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,34 @@ The release procedure that produces these entries is documented in
 
 ### Fixed
 
+- **The benchmark layer profile could not report a measured zero** (`fix`). Both
+  producers of the Rust/JAX/Python time fractions —
+  `benchmarks/runner.py` and `benchmarks/_subprocess_worker.py` — computed the
+  share as `x / wall if x else None`, so a layer measured at exactly `0.0`
+  became `None`. `layer_profiling_summary` filters `None` out, so
+  `mean_jax_fraction` then came back `nan`, which reads as *"this was never
+  instrumented"*.
+
+  This inverted the instrument on the one case it exists for. On the `global50`
+  panel `jax_time_fraction` was `None` on **50 of 50** instances — not because
+  the profile failed, but because JAX genuinely no longer runs on the solve path
+  — and `rust_time_fraction` on 7 of 50 fast instances for the same reason. The
+  field would have read identically if JAX had been running throughout.
+
+  Fractions are now computed by a shared `metrics.time_fraction()` that branches
+  on `is None`, so a measured `0.0` records as `0.0` and `None` is reserved for a
+  solver that does not report the field at all. Verified end-to-end: on `main`
+  the smoke suite now reports a JAX fraction up to 0.93, on the JAX-removal
+  branch it reports 0.0 — two states the old encoding could not tell apart.
+
+  Also adds the missing **`pounce_time_fraction`**. POUNCE is where the NLP cost
+  went once it left JAX (78% of a `tspn08` solve per `discopt._timing`), and the
+  benchmark record had no field for it, so the dominant layer was invisible. It
+  reads `None` until the `_timing`/`pounce_time` work merges, then populates.
+  `layer_profiling_summary` gains `n_profiled` so callers can distinguish
+  "0.0 across 50 runs" from "0 runs reported it", and the generated report
+  renders an unreported layer as `not reported` rather than `nan%`.
+
 - **The POUNCE-native NLP path now requires — and verifies — a cross-thread-safe
   `NlProblem`** (`fix`, #932). #932 reported the pyo3 panic
   `_pounce::nl_problem::PyNlProblem is unsendable, but sent to another thread`

--- a/discopt_benchmarks/benchmarks/_subprocess_worker.py
+++ b/discopt_benchmarks/benchmarks/_subprocess_worker.py
@@ -44,7 +44,7 @@ def _solve(
     options: dict,
 ) -> dict:
     """Run model.solve and return a SolveResult-shaped dict."""
-    from benchmarks.metrics import SolveResult, SolveStatus
+    from benchmarks.metrics import SolveResult, SolveStatus, time_fraction
     import discopt.modeling as dm
 
     start = time.monotonic()
@@ -88,10 +88,14 @@ def _solve(
     }
     bench_status = status_map.get(getattr(result, "status", "unknown"), SolveStatus.UNKNOWN)
 
+    # `time_fraction` rather than truthiness: a measured 0.0 must survive as 0.0.
+    # See its docstring -- this worker had the same collapse as the in-process
+    # runner, so the defect reproduced under --subprocess too.
     wt = result.wall_time if getattr(result, "wall_time", 0) > 0 else 1e-10
-    rust_frac = (result.rust_time / wt) if getattr(result, "rust_time", None) else None
-    jax_frac = (result.jax_time / wt) if getattr(result, "jax_time", None) else None
-    py_frac = (result.python_time / wt) if getattr(result, "python_time", None) else None
+    rust_frac = time_fraction(getattr(result, "rust_time", None), wt)
+    jax_frac = time_fraction(getattr(result, "jax_time", None), wt)
+    py_frac = time_fraction(getattr(result, "python_time", None), wt)
+    pounce_frac = time_fraction(getattr(result, "pounce_time", None), wt)
 
     return SolveResult(
         instance=instance,
@@ -104,6 +108,7 @@ def _solve(
         rust_time_fraction=rust_frac,
         jax_time_fraction=jax_frac,
         python_time_fraction=py_frac,
+        pounce_time_fraction=pounce_frac,
     ).to_dict()
 
 

--- a/discopt_benchmarks/benchmarks/metrics.py
+++ b/discopt_benchmarks/benchmarks/metrics.py
@@ -35,6 +35,24 @@ class SolveStatus(Enum):
     UNKNOWN = "unknown"
 
 
+def time_fraction(seconds: Optional[float], wall: float) -> Optional[float]:
+    """A layer's share of the wall clock, or None if the layer was not measured.
+
+    The distinction this exists to preserve: **a measured 0.0 is data, not a
+    missing value.** Both call sites used to write ``x / wt if x else None``,
+    which collapses "this layer took no time" into "this layer was never
+    instrumented". That is the wrong way round for the case that matters --
+    ``jax_time`` is exactly 0.0 across the whole global50 panel now, and that
+    zero is the measurement, not its absence.
+
+    None is reserved for a solver that genuinely does not report the field at
+    all (every non-discopt solver, whose adapters leave these unset).
+    """
+    if seconds is None:
+        return None
+    return float(seconds) / wall
+
+
 @dataclass
 class SolveResult:
     """Result from a single solver run on a single instance."""
@@ -55,10 +73,19 @@ class SolveResult:
     # objective (None until the first incumbent is found).
     trajectory: Optional[list[list[float]]] = None
 
-    # Layer profiling (discopt-specific)
+    # Layer profiling (discopt-specific). These are NOT four peers that sum to
+    # 1.0 -- see discopt.modeling.core.SolveResult and discopt._timing:
+    #   rust + python  partition the wall clock (disjoint)
+    #   jax    <= python   (JAX cost is ~96% interpreted Python, not XLA)
+    #   pounce <= rust     (POUNCE is native)
+    # Summing them double-counts; the pre-#921 model did exactly that.
     rust_time_fraction: Optional[float] = None
     jax_time_fraction: Optional[float] = None
     python_time_fraction: Optional[float] = None
+    # POUNCE's share. Absent before: after the NLP work moved off JAX this is
+    # where it went, so the benchmark could not see its dominant cost -- 11.69 s
+    # of a 15 s tspn08 solve (78%) had no field to land in.
+    pounce_time_fraction: Optional[float] = None
     batch_sizes: Optional[list[int]] = None  # Node batch sizes during solve
 
     # NLP/LP subsolver stats
@@ -555,20 +582,32 @@ def node_count_reduction(
 
 def layer_profiling_summary(results: list[SolveResult]) -> dict[str, float]:
     """
-    Aggregate Rust/JAX/Python time fractions across runs.
+    Aggregate Rust/JAX/POUNCE/Python time fractions across runs.
 
     This is discopt-specific: measures where time is spent
     across the hybrid architecture layers.
+
+    ``nan`` here means **no run reported that layer** and nothing else. A layer
+    measured at 0.0 must aggregate to 0.0, not vanish -- ``mean_jax_fraction``
+    returning ``nan`` while JAX provably never ran is the instrument failing to
+    report its own strongest result. ``n_profiled`` is emitted so a caller can
+    tell "0.0 across 50 runs" from "0 runs had the field", which the fractions
+    alone cannot express.
     """
-    rust_fracs = [r.rust_time_fraction for r in results if r.rust_time_fraction is not None]
-    jax_fracs = [r.jax_time_fraction for r in results if r.jax_time_fraction is not None]
+    def _mean(attr: str) -> float:
+        vals = [getattr(r, attr) for r in results]
+        vals = [v for v in vals if v is not None]
+        return float(np.mean(vals)) if vals else float("nan")
+
     py_fracs = [r.python_time_fraction for r in results if r.python_time_fraction is not None]
 
     return {
-        "mean_rust_fraction": float(np.mean(rust_fracs)) if rust_fracs else float("nan"),
-        "mean_jax_fraction": float(np.mean(jax_fracs)) if jax_fracs else float("nan"),
-        "mean_python_fraction": float(np.mean(py_fracs)) if py_fracs else float("nan"),
+        "mean_rust_fraction": _mean("rust_time_fraction"),
+        "mean_jax_fraction": _mean("jax_time_fraction"),
+        "mean_pounce_fraction": _mean("pounce_time_fraction"),
+        "mean_python_fraction": _mean("python_time_fraction"),
         "max_python_fraction": float(np.max(py_fracs)) if py_fracs else float("nan"),
+        "n_profiled": float(len(py_fracs)),
     }
 
 

--- a/discopt_benchmarks/benchmarks/runner.py
+++ b/discopt_benchmarks/benchmarks/runner.py
@@ -19,6 +19,7 @@ from benchmarks.metrics import (
     InstanceInfo,
     SolveResult,
     SolveStatus,
+    time_fraction,
 )
 
 
@@ -340,11 +341,21 @@ class BenchmarkRunner:
             }
             bench_status = status_map.get(result.status, SolveStatus.UNKNOWN)
 
-            # Compute layer profiling fractions
+            # Compute layer profiling fractions.
+            #
+            # `is not None`, NOT truthiness. A measured 0.0 is a RESULT -- on the
+            # global50 panel `jax_time` is exactly 0.0 on all 50 instances because
+            # JAX no longer runs on the solve path, which is the single most
+            # useful thing this profile can say. Truthiness mapped that to None,
+            # `layer_profiling_summary` then filtered the Nones out, and
+            # `mean_jax_fraction` came back `nan` -- indistinguishable from "this
+            # was never instrumented". The instrument reported nothing precisely
+            # when it had the strongest thing to report.
             wt = result.wall_time if result.wall_time > 0 else 1e-10
-            rust_frac = result.rust_time / wt if result.rust_time else None
-            jax_frac = result.jax_time / wt if result.jax_time else None
-            py_frac = result.python_time / wt if result.python_time else None
+            rust_frac = time_fraction(getattr(result, "rust_time", None), wt)
+            jax_frac = time_fraction(getattr(result, "jax_time", None), wt)
+            py_frac = time_fraction(getattr(result, "python_time", None), wt)
+            pounce_frac = time_fraction(getattr(result, "pounce_time", None), wt)
 
             traj = (
                 _downsample_trajectory(
@@ -368,6 +379,7 @@ class BenchmarkRunner:
                 rust_time_fraction=rust_frac,
                 jax_time_fraction=jax_frac,
                 python_time_fraction=py_frac,
+                pounce_time_fraction=pounce_frac,
             )
         except Exception as e:
             elapsed = time.monotonic() - start_time

--- a/discopt_benchmarks/tests/test_layer_profile.py
+++ b/discopt_benchmarks/tests/test_layer_profile.py
@@ -1,0 +1,110 @@
+"""A measured zero is a result; the profile must be able to say it.
+
+The layer profile answers "where did the wall clock go". After the NLP work
+moved off JAX, the most valuable thing it can report is ``jax_time_fraction ==
+0.0`` -- and that is exactly the value it could not express. Both producers
+wrote ``x / wt if x else None``, so a measured 0.0 became ``None``;
+``layer_profiling_summary`` filters ``None`` out; ``mean_jax_fraction`` came
+back ``nan``, which reads as "never instrumented".
+
+Measured on the global50 panel before this fix: ``jax_time_fraction`` was
+``None`` on 50 of 50 instances, and ``rust_time_fraction`` on 7 of 50 (the fast
+instances where Rust time rounded to zero). The field would have read exactly
+the same if JAX had been running the whole time.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_BENCH = Path(__file__).resolve().parents[1]
+if str(_BENCH) not in sys.path:
+    sys.path.insert(0, str(_BENCH))
+
+from benchmarks.metrics import (  # noqa: E402
+    SolveResult,
+    SolveStatus,
+    layer_profiling_summary,
+    time_fraction,
+)
+
+
+def test_a_measured_zero_stays_zero():
+    """The bug in one line: 0.0 in, 0.0 out -- not None."""
+    assert time_fraction(0.0, 10.0) == 0.0
+
+
+def test_an_unreported_layer_is_still_none():
+    """The other direction. None must remain reserved for "no such measurement",
+    which is the honest answer for every non-discopt solver adapter."""
+    assert time_fraction(None, 10.0) is None
+
+
+def test_ordinary_fractions_are_unchanged():
+    assert time_fraction(2.5, 10.0) == pytest.approx(0.25)
+
+
+def _result(**kw) -> SolveResult:
+    base = {"instance": "i", "solver": "discopt", "status": SolveStatus.OPTIMAL}
+    base.update(kw)
+    return SolveResult(**base)
+
+
+def test_all_zero_jax_aggregates_to_zero_not_nan():
+    """The global50 case. Fifty runs that provably never touched JAX must
+    summarise as 0.0; ``nan`` there is the instrument declining to report its
+    own strongest result."""
+    runs = [
+        _result(jax_time_fraction=0.0, python_time_fraction=0.9, rust_time_fraction=0.1)
+        for _ in range(50)
+    ]
+    summary = layer_profiling_summary(runs)
+
+    assert summary["mean_jax_fraction"] == 0.0, (
+        f"50 runs measured at exactly 0.0 summarised as {summary['mean_jax_fraction']}"
+    )
+    assert summary["n_profiled"] == 50.0
+
+
+def test_nan_still_means_no_data():
+    """``nan`` must keep its one honest meaning, or the assertion above is
+    satisfiable by a summary that reports 0.0 for everything."""
+    summary = layer_profiling_summary([_result()])
+    assert summary["mean_jax_fraction"] != summary["mean_jax_fraction"]  # nan
+    assert summary["n_profiled"] == 0.0
+
+
+def test_pounce_has_a_bucket_in_the_summary():
+    """POUNCE is where the NLP cost went after JAX left the solve path -- 78% of
+    a tspn08 solve per ``discopt._timing``. Before this change the benchmark
+    record had no field for it, so the dominant layer was invisible."""
+    runs = [_result(pounce_time_fraction=0.78, python_time_fraction=0.2)]
+    assert layer_profiling_summary(runs)["mean_pounce_fraction"] == pytest.approx(0.78)
+
+
+def test_the_four_layers_are_not_peers():
+    """A guard on the documented invariant, so nobody later "fixes" the profile
+    by making the buckets sum to 1.0. jax <= python and pounce <= rust; summing
+    all four double-counts, which is the pre-#921 defect this schema replaced.
+    """
+    r = _result(
+        rust_time_fraction=0.6,
+        python_time_fraction=0.4,
+        pounce_time_fraction=0.55,
+        jax_time_fraction=0.3,
+    )
+    assert r.jax_time_fraction <= r.python_time_fraction
+    assert r.pounce_time_fraction <= r.rust_time_fraction
+    assert r.rust_time_fraction + r.python_time_fraction == pytest.approx(1.0)
+    total = sum(
+        (
+            r.rust_time_fraction,
+            r.python_time_fraction,
+            r.pounce_time_fraction,
+            r.jax_time_fraction,
+        )
+    )
+    assert total > 1.0, "if the four ever sum to 1.0 they have been made peers again"

--- a/discopt_benchmarks/utils/reporting.py
+++ b/discopt_benchmarks/utils/reporting.py
@@ -219,12 +219,26 @@ def generate_report(
         if not np.isnan(profile["mean_rust_fraction"]):
             lines.append("## Layer Profiling (discopt)")
             lines.append("")
+            # `nan` must not render as "nan%", which reads like a measured
+            # value. It means the layer was not reported at all -- a distinct
+            # statement from a measured 0.0%, and the two must stay legible
+            # apart in the report as well as in the data.
+            def _pct(key: str) -> str:
+                v = profile[key]
+                return "not reported" if np.isnan(v) else f"{v:.1%}"
+
+            n = int(profile.get("n_profiled", 0))
+            lines.append(f"Layers measured on {n} run(s). `rust` + `python` partition the ")
+            lines.append("wall clock; `JAX` is a subset of Python and `POUNCE` a subset of Rust, ")
+            lines.append("so the rows do not sum to 100%.")
+            lines.append("")
             lines.append("| Layer | Mean Time Fraction | Target |")
             lines.append("|-------|-------------------|--------|")
-            lines.append(f"| Rust (tree, LP, sparse LA) | {profile['mean_rust_fraction']:.1%} | — |")
-            lines.append(f"| JAX (relaxations, autodiff, NLP) | {profile['mean_jax_fraction']:.1%} | — |")
-            lines.append(f"| Python orchestration | {profile['mean_python_fraction']:.1%} | <5% |")
-            lines.append(f"| Max Python overhead | {profile['max_python_fraction']:.1%} | <10% |")
+            lines.append(f"| Rust (tree, LP, sparse LA) | {_pct('mean_rust_fraction')} | — |")
+            lines.append(f"| ↳ POUNCE (NLP/LP/QP subsolves) | {_pct('mean_pounce_fraction')} | — |")
+            lines.append(f"| Python orchestration | {_pct('mean_python_fraction')} | <5% |")
+            lines.append(f"| ↳ JAX (relaxations, autodiff) | {_pct('mean_jax_fraction')} | — |")
+            lines.append(f"| Max Python overhead | {_pct('max_python_fraction')} | <10% |")
             lines.append("")
 
     # ── GPU vs CPU ──


### PR DESCRIPTION
## The defect

Both producers of the layer time fractions — `benchmarks/runner.py` and
`benchmarks/_subprocess_worker.py` — computed a layer's share as:

    x / wall if x else None

Truthiness, not `is None`. A layer measured at exactly `0.0` therefore became
`None`. `layer_profiling_summary` filters `None` out, so `mean_jax_fraction`
came back `nan`, which reads as *"this was never instrumented"*.

This inverts the instrument on the one case it exists for.

## The measurement

On the global50 panel (50 instances, run against the JAX-removal branch):

| field | non-None |
|---|---|
| `rust_time_fraction` | 43/50 |
| `jax_time_fraction` | **0/50** |
| `python_time_fraction` | 50/50 |

`jax_time_fraction` was `None` everywhere not because the profile failed, but
because JAX genuinely no longer runs on the solve path — the single most useful
thing this profile can say, and the one value it could not express. The 7
missing Rust entries are fast instances whose Rust time rounded to zero.

Direct A/B on the expression itself:

    producer:   main -> None   fixed -> 0.0
    aggregate:  main -> nan    fixed -> 0.0

## The fix

- New shared `metrics.time_fraction()` branching on `is None`. A measured `0.0`
  records as `0.0`; `None` stays reserved for a solver that does not report the
  field at all (every non-discopt adapter).
- Both call sites use it, so the defect is fixed under `--subprocess` too — the
  worker had the same collapse.
- Adds the missing **`pounce_time_fraction`**. POUNCE is where the NLP cost went
  once it left JAX — 78% of a `tspn08` solve per `discopt._timing` — and the
  benchmark record had no field for it, so the dominant layer was invisible. It
  reads `None` on `main` (where `pounce_time` does not exist yet) and populates
  once the `_timing` work merges.
- `layer_profiling_summary` gains `n_profiled`, so a caller can distinguish
  "0.0 across 50 runs" from "0 runs reported it" — the fractions alone cannot.
- The generated report renders an unreported layer as `not reported` instead of
  `nan%`, and labels the rows as non-peers (`rust`+`python` partition the wall;
  `jax ⊆ python`, `pounce ⊆ rust`) so nobody sums them.

## Verification

- New `discopt_benchmarks/tests/test_layer_profile.py` — 7 tests. Fails before
  (`ImportError` on `main`; the behavioural claim additionally demonstrated by
  the direct A/B above), passes after.
- Guard tests in both directions: `nan` must keep meaning "no data", and a test
  asserts the four fractions sum to **more** than 1.0, so a later "fix" that
  makes them peers fails loudly — that peer model is the pre-#921 defect.
- End-to-end on real solves: all four fields populate. On `main` the smoke suite
  now reports a JAX fraction up to **0.93**; on the JAX-removal branch it reports
  **0.0**. The old encoding rendered both as `None`/`nan`.
- Full benchmark suite (`-m "not slow"`): **5 failures on this branch, the same
  5 on `main`** (`test_ellipsoidal_regression`, `test_superposition_regression`).
  Pre-existing, unrelated, not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GZrQpYYd9tbLnFEH8gZokP
