### PR TITLE
fix(relax): #928 a round cut short must return the floor it holds

### DIFF
--- a/discopt_benchmarks/results/issue928_round_floor_binding20.json
+++ b/discopt_benchmarks/results/issue928_round_floor_binding20.json
@@ -1,0 +1,3916 @@
+{
+  "summary": {
+    "budget": 20.0,
+    "reps": 3,
+    "instances": [
+      "4stufen",
+      "bchoco06",
+      "bchoco07",
+      "bchoco08",
+      "beuster",
+      "casctanks",
+      "clay0303hfsg",
+      "contvar",
+      "hda",
+      "heatexch_gen1",
+      "heatexch_gen2",
+      "heatexch_gen3",
+      "nvs05",
+      "syn05hfsg",
+      "tls2",
+      "tspn05",
+      "tspn08",
+      "tspn10",
+      "tspn12"
+    ],
+    "oracle": "known_optima.toml + cross-arm primal ceiling (minlplib.solu unreachable)",
+    "cand_vs_base_overrun_deltas_s": [
+      -94.4,
+      -313.5,
+      -16.7
+    ],
+    "seam_vs_base_overrun_deltas_s": [
+      -118.7,
+      -311.4,
+      -5.6
+    ],
+    "cert_clean_all_reps": false,
+    "ceiling_comparisons_executed": 63,
+    "loadavg_start": [
+      0.41,
+      0.6,
+      0.55
+    ],
+    "loadavg_end": [
+      1.19,
+      1.28,
+      1.24
+    ],
+    "panel_wall_s": 4536.1
+  },
+  "reps": [
+    {
+      "rep": 1,
+      "unsound": [],
+      "incumbent_verification_failed": [],
+      "oracle_comparisons_executed": 2,
+      "instances_without_oracle": [
+        "4stufen",
+        "bchoco06",
+        "bchoco07",
+        "bchoco08",
+        "beuster",
+        "casctanks",
+        "contvar",
+        "hda",
+        "heatexch_gen1",
+        "heatexch_gen2",
+        "heatexch_gen3",
+        "nvs05",
+        "syn05hfsg",
+        "tls2",
+        "tspn05",
+        "tspn08",
+        "tspn10",
+        "tspn12"
+      ],
+      "ceiling_comparisons_executed": 21,
+      "ceiling_violations": [],
+      "pairs": {
+        "cand_vs_base": {
+          "pair": "cand vs base",
+          "cells_over_budget": {
+            "base": 16,
+            "cand": 13
+          },
+          "total_overrun_s": {
+            "base": 169.4,
+            "cand": 75.0
+          },
+          "overrun_delta_s": -94.4,
+          "node_count_total": {
+            "base": 501,
+            "cand": 823
+          },
+          "cert_gains": [],
+          "cert_regressions": [],
+          "gained_incumbents": [
+            "tspn08"
+          ],
+          "lost_incumbents": [],
+          "better_objective": [
+            "tspn10 (232.16969389157208 -> 225.1260717001723)"
+          ],
+          "worse_objective": [],
+          "tighter_bound": [
+            "4stufen (19713.03606420082 -> 20282.050738742604)",
+            "bchoco08 (1.0000000093277979 -> 0.9999999999999977)",
+            "beuster (6352.061283279524 -> 17698.956442695056)",
+            "casctanks (-90.17863668805973 -> -90.17863067603525)",
+            "hda (-20747118223745.168 -> -124296.87906625487)",
+            "heatexch_gen2 (555767.7902849488 -> 578091.8643598154)",
+            "tspn10 (161.16079717285405 -> 161.16083653483406)",
+            "tspn12 (183.3259927436284 -> 192.92305137670508)"
+          ],
+          "looser_bound": [
+            "tspn05 (178.1165439208231 -> 177.89283170577465)"
+          ],
+          "gained_bound": [
+            "clay0303hfsg (None -> -1.230904907067064e-05)"
+          ],
+          "lost_bound": []
+        },
+        "cand_vs_seam": {
+          "pair": "cand vs seam",
+          "cells_over_budget": {
+            "seam": 16,
+            "cand": 13
+          },
+          "total_overrun_s": {
+            "seam": 50.7,
+            "cand": 75.0
+          },
+          "overrun_delta_s": 24.3,
+          "node_count_total": {
+            "seam": 857,
+            "cand": 823
+          },
+          "cert_gains": [],
+          "cert_regressions": [],
+          "gained_incumbents": [
+            "tspn08"
+          ],
+          "lost_incumbents": [],
+          "better_objective": [],
+          "worse_objective": [],
+          "tighter_bound": [
+            "bchoco08 (1.0000000093277979 -> 0.9999999999999977)",
+            "casctanks (-90.17863668805973 -> -90.17863067603525)",
+            "hda (-20747118223745.168 -> -124296.87906625487)",
+            "heatexch_gen2 (576818.7162116509 -> 578091.8643598154)",
+            "tspn10 (161.16079717285405 -> 161.16083653483406)",
+            "tspn12 (192.92291097809897 -> 192.92305137670508)"
+          ],
+          "looser_bound": [
+            "4stufen (20365.63091728957 -> 20282.050738742604)",
+            "tspn05 (178.1165439208231 -> 177.89283170577465)"
+          ],
+          "gained_bound": [],
+          "lost_bound": []
+        },
+        "seam_vs_base": {
+          "pair": "seam vs base",
+          "cells_over_budget": {
+            "base": 16,
+            "seam": 16
+          },
+          "total_overrun_s": {
+            "base": 169.4,
+            "seam": 50.7
+          },
+          "overrun_delta_s": -118.7,
+          "node_count_total": {
+            "base": 501,
+            "seam": 857
+          },
+          "cert_gains": [],
+          "cert_regressions": [],
+          "gained_incumbents": [],
+          "lost_incumbents": [],
+          "better_objective": [
+            "tspn10 (232.16969389157208 -> 225.1260717001723)"
+          ],
+          "worse_objective": [],
+          "tighter_bound": [
+            "4stufen (19713.03606420082 -> 20365.63091728957)",
+            "beuster (6352.061283279524 -> 17698.956442695056)",
+            "heatexch_gen2 (555767.7902849488 -> 576818.7162116509)",
+            "tspn12 (183.3259927436284 -> 192.92291097809897)"
+          ],
+          "looser_bound": [],
+          "gained_bound": [
+            "clay0303hfsg (None -> -1.230904907067064e-05)"
+          ],
+          "lost_bound": []
+        }
+      },
+      "cert_clean": true
+    },
+    {
+      "rep": 2,
+      "unsound": [],
+      "incumbent_verification_failed": [],
+      "oracle_comparisons_executed": 3,
+      "instances_without_oracle": [
+        "4stufen",
+        "bchoco06",
+        "bchoco07",
+        "bchoco08",
+        "beuster",
+        "casctanks",
+        "contvar",
+        "hda",
+        "heatexch_gen1",
+        "heatexch_gen2",
+        "heatexch_gen3",
+        "nvs05",
+        "syn05hfsg",
+        "tls2",
+        "tspn05",
+        "tspn08",
+        "tspn10",
+        "tspn12"
+      ],
+      "ceiling_comparisons_executed": 21,
+      "ceiling_violations": [],
+      "pairs": {
+        "cand_vs_base": {
+          "pair": "cand vs base",
+          "cells_over_budget": {
+            "base": 17,
+            "cand": 16
+          },
+          "total_overrun_s": {
+            "base": 367.4,
+            "cand": 53.9
+          },
+          "overrun_delta_s": -313.5,
+          "node_count_total": {
+            "base": 615,
+            "cand": 877
+          },
+          "cert_gains": [],
+          "cert_regressions": [],
+          "gained_incumbents": [],
+          "lost_incumbents": [
+            "tspn12"
+          ],
+          "better_objective": [],
+          "worse_objective": [
+            "tls2 (10.299999999983916 -> 11.299999999980916)"
+          ],
+          "tighter_bound": [
+            "4stufen (19713.03606420082 -> 20282.050738742604)",
+            "beuster (6352.061283279524 -> 17698.956442695056)",
+            "casctanks (-90.17863668805973 -> -90.17863067603525)",
+            "hda (-20747118223745.168 -> -119286.31279576839)",
+            "heatexch_gen2 (555767.7902849488 -> 576818.7162116928)",
+            "tspn10 (161.16079717285405 -> 161.16083653483406)",
+            "tspn12 (183.3259927436284 -> 192.92305137670508)"
+          ],
+          "looser_bound": [
+            "tls2 (2.4487125876978726 -> 2.0999999901667694)",
+            "tspn05 (178.1165439208231 -> 178.11653801668433)"
+          ],
+          "gained_bound": [],
+          "lost_bound": []
+        },
+        "cand_vs_seam": {
+          "pair": "cand vs seam",
+          "cells_over_budget": {
+            "seam": 14,
+            "cand": 16
+          },
+          "total_overrun_s": {
+            "seam": 56.1,
+            "cand": 53.9
+          },
+          "overrun_delta_s": -2.1,
+          "node_count_total": {
+            "seam": 907,
+            "cand": 877
+          },
+          "cert_gains": [],
+          "cert_regressions": [],
+          "gained_incumbents": [],
+          "lost_incumbents": [],
+          "better_objective": [],
+          "worse_objective": [
+            "tls2 (10.299999999983916 -> 11.299999999980916)"
+          ],
+          "tighter_bound": [
+            "bchoco08 (1.0000000093277979 -> 0.9999999999999977)",
+            "casctanks (-90.17863668805973 -> -90.17863067603525)",
+            "hda (-20747118223745.168 -> -119286.31279576839)",
+            "tspn10 (161.16079717285405 -> 161.16083653483406)",
+            "tspn12 (192.92291097809897 -> 192.92305137670508)"
+          ],
+          "looser_bound": [
+            "4stufen (20755.25555559244 -> 20282.050738742604)",
+            "tls2 (2.4487125876978726 -> 2.0999999901667694)",
+            "tspn05 (178.1165439208231 -> 178.11653801668433)"
+          ],
+          "gained_bound": [],
+          "lost_bound": []
+        },
+        "seam_vs_base": {
+          "pair": "seam vs base",
+          "cells_over_budget": {
+            "base": 17,
+            "seam": 14
+          },
+          "total_overrun_s": {
+            "base": 367.4,
+            "seam": 56.1
+          },
+          "overrun_delta_s": -311.4,
+          "node_count_total": {
+            "base": 615,
+            "seam": 907
+          },
+          "cert_gains": [],
+          "cert_regressions": [],
+          "gained_incumbents": [],
+          "lost_incumbents": [
+            "tspn12"
+          ],
+          "better_objective": [],
+          "worse_objective": [],
+          "tighter_bound": [
+            "4stufen (19713.03606420082 -> 20755.25555559244)",
+            "beuster (6352.061283279524 -> 17698.956442695056)",
+            "heatexch_gen2 (555767.7902849488 -> 576818.7162116509)",
+            "tspn12 (183.3259927436284 -> 192.92291097809897)"
+          ],
+          "looser_bound": [
+            "bchoco08 (1.0000000000136013 -> 1.0000000093277979)"
+          ],
+          "gained_bound": [],
+          "lost_bound": []
+        }
+      },
+      "cert_clean": false
+    },
+    {
+      "rep": 3,
+      "unsound": [],
+      "incumbent_verification_failed": [],
+      "oracle_comparisons_executed": 3,
+      "instances_without_oracle": [
+        "4stufen",
+        "bchoco06",
+        "bchoco07",
+        "bchoco08",
+        "beuster",
+        "casctanks",
+        "contvar",
+        "hda",
+        "heatexch_gen1",
+        "heatexch_gen2",
+        "heatexch_gen3",
+        "nvs05",
+        "syn05hfsg",
+        "tls2",
+        "tspn05",
+        "tspn08",
+        "tspn10",
+        "tspn12"
+      ],
+      "ceiling_comparisons_executed": 21,
+      "ceiling_violations": [],
+      "pairs": {
+        "cand_vs_base": {
+          "pair": "cand vs base",
+          "cells_over_budget": {
+            "base": 16,
+            "cand": 14
+          },
+          "total_overrun_s": {
+            "base": 67.2,
+            "cand": 50.5
+          },
+          "overrun_delta_s": -16.7,
+          "node_count_total": {
+            "base": 537,
+            "cand": 851
+          },
+          "cert_gains": [],
+          "cert_regressions": [],
+          "gained_incumbents": [
+            "tspn08"
+          ],
+          "lost_incumbents": [
+            "tspn12"
+          ],
+          "better_objective": [],
+          "worse_objective": [],
+          "tighter_bound": [
+            "4stufen (19713.036064200816 -> 20738.65467164312)",
+            "bchoco08 (1.0000000093277979 -> 0.9999999999999977)",
+            "beuster (6352.061283279524 -> 17698.956442695056)",
+            "casctanks (-90.17863668805973 -> -90.17863067603525)",
+            "hda (-20747118223745.168 -> -124296.87906625487)",
+            "heatexch_gen2 (555767.7902849488 -> 576818.7162116928)",
+            "tspn10 (161.16079717285405 -> 161.16083653483406)",
+            "tspn12 (183.3259927436284 -> 192.92305137670508)"
+          ],
+          "looser_bound": [
+            "tspn05 (178.1165439208231 -> 177.89283170577465)"
+          ],
+          "gained_bound": [],
+          "lost_bound": []
+        },
+        "cand_vs_seam": {
+          "pair": "cand vs seam",
+          "cells_over_budget": {
+            "seam": 15,
+            "cand": 14
+          },
+          "total_overrun_s": {
+            "seam": 61.6,
+            "cand": 50.5
+          },
+          "overrun_delta_s": -11.1,
+          "node_count_total": {
+            "seam": 645,
+            "cand": 851
+          },
+          "cert_gains": [],
+          "cert_regressions": [],
+          "gained_incumbents": [
+            "tls2"
+          ],
+          "lost_incumbents": [],
+          "better_objective": [],
+          "worse_objective": [],
+          "tighter_bound": [
+            "bchoco08 (1.0000000093277979 -> 0.9999999999999977)",
+            "hda (-20747118223745.168 -> -124296.87906625487)",
+            "tls2 (0.9359146469655356 -> 2.4487125876978726)",
+            "tspn10 (161.16079717285405 -> 161.16083653483406)",
+            "tspn12 (192.92291097809897 -> 192.92305137670508)"
+          ],
+          "looser_bound": [
+            "4stufen (20755.25555559244 -> 20738.65467164312)",
+            "casctanks (5.697893577917501 -> -90.17863067603525)"
+          ],
+          "gained_bound": [],
+          "lost_bound": []
+        },
+        "seam_vs_base": {
+          "pair": "seam vs base",
+          "cells_over_budget": {
+            "base": 16,
+            "seam": 15
+          },
+          "total_overrun_s": {
+            "base": 67.2,
+            "seam": 61.6
+          },
+          "overrun_delta_s": -5.6,
+          "node_count_total": {
+            "base": 537,
+            "seam": 645
+          },
+          "cert_gains": [],
+          "cert_regressions": [],
+          "gained_incumbents": [
+            "tspn08"
+          ],
+          "lost_incumbents": [
+            "tls2",
+            "tspn12"
+          ],
+          "better_objective": [],
+          "worse_objective": [],
+          "tighter_bound": [
+            "4stufen (19713.036064200816 -> 20755.25555559244)",
+            "beuster (6352.061283279524 -> 17698.956442695082)",
+            "casctanks (-90.17863668805973 -> 5.697893577917501)",
+            "heatexch_gen2 (555767.7902849488 -> 576818.7162116509)",
+            "tspn12 (183.3259927436284 -> 192.92291097809897)"
+          ],
+          "looser_bound": [
+            "tls2 (2.4487125876978726 -> 0.9359146469655356)",
+            "tspn05 (178.1165439208231 -> 177.89283170652436)"
+          ],
+          "gained_bound": [],
+          "lost_bound": []
+        }
+      },
+      "cert_clean": false
+    }
+  ],
+  "cells": [
+    {
+      "rep": 1,
+      "instance": "4stufen",
+      "budget": 20.0,
+      "reference_optimum": null,
+      "base": {
+        "instance": "4stufen",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 23.006930807000117,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 19713.03606420082,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 7,
+        "incumbent_verification_failed": false
+      },
+      "seam": {
+        "instance": "4stufen",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 21.039889266000046,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 20365.63091728957,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 63,
+        "incumbent_verification_failed": false
+      },
+      "cand": {
+        "instance": "4stufen",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "1",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 21.090220434999992,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 20282.050738742604,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 63,
+        "incumbent_verification_failed": false
+      }
+    },
+    {
+      "rep": 1,
+      "instance": "bchoco06",
+      "budget": 20.0,
+      "reference_optimum": null,
+      "base": {
+        "instance": "bchoco06",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "max",
+        "wall": 23.254125536999936,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 1.0000000000001477,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 7,
+        "incumbent_verification_failed": false
+      },
+      "seam": {
+        "instance": "bchoco06",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "max",
+        "wall": 21.098578395000004,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 1.0000000000001428,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 47,
+        "incumbent_verification_failed": false
+      },
+      "cand": {
+        "instance": "bchoco06",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "1",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "max",
+        "wall": 20.99170997600004,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 1.0000000000001554,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 31,
+        "incumbent_verification_failed": false
+      }
+    },
+    {
+      "rep": 1,
+      "instance": "bchoco07",
+      "budget": 20.0,
+      "reference_optimum": null,
+      "base": {
+        "instance": "bchoco07",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "max",
+        "wall": 30.71586912099997,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 1.000000000000253,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 7,
+        "incumbent_verification_failed": false
+      },
+      "seam": {
+        "instance": "bchoco07",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "max",
+        "wall": 21.066583102000095,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 1.000000000000253,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 15,
+        "incumbent_verification_failed": false
+      },
+      "cand": {
+        "instance": "bchoco07",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "1",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "max",
+        "wall": 21.186081131000037,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 1.000000000000253,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 13,
+        "incumbent_verification_failed": false
+      }
+    },
+    {
+      "rep": 1,
+      "instance": "bchoco08",
+      "budget": 20.0,
+      "reference_optimum": null,
+      "base": {
+        "instance": "bchoco08",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "max",
+        "wall": 22.647532446000014,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 1.0000000093277979,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 3,
+        "incumbent_verification_failed": false
+      },
+      "seam": {
+        "instance": "bchoco08",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "max",
+        "wall": 21.674700002999998,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 1.0000000093277979,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 3,
+        "incumbent_verification_failed": false
+      },
+      "cand": {
+        "instance": "bchoco08",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "1",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "max",
+        "wall": 21.55063875100018,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 0.9999999999999977,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 3,
+        "incumbent_verification_failed": false
+      }
+    },
+    {
+      "rep": 1,
+      "instance": "beuster",
+      "budget": 20.0,
+      "reference_optimum": null,
+      "base": {
+        "instance": "beuster",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 24.366202807000036,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 6352.061283279524,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 7,
+        "incumbent_verification_failed": false
+      },
+      "seam": {
+        "instance": "beuster",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 21.04487277899989,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 17698.956442695056,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 63,
+        "incumbent_verification_failed": false
+      },
+      "cand": {
+        "instance": "beuster",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "1",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 21.129351983000106,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 17698.956442695056,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 63,
+        "incumbent_verification_failed": false
+      }
+    },
+    {
+      "rep": 1,
+      "instance": "casctanks",
+      "budget": 20.0,
+      "reference_optimum": null,
+      "base": {
+        "instance": "casctanks",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 27.167435448000106,
+        "status": "time_limit",
+        "objective": null,
+        "bound": -90.17863668805973,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 1,
+        "incumbent_verification_failed": false
+      },
+      "seam": {
+        "instance": "casctanks",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 22.554331664000074,
+        "status": "time_limit",
+        "objective": null,
+        "bound": -90.17863668805973,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 1,
+        "incumbent_verification_failed": false
+      },
+      "cand": {
+        "instance": "casctanks",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "1",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 23.751147846999856,
+        "status": "time_limit",
+        "objective": null,
+        "bound": -90.17863067603525,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 1,
+        "incumbent_verification_failed": false
+      }
+    },
+    {
+      "rep": 1,
+      "instance": "clay0303hfsg",
+      "budget": 20.0,
+      "reference_optimum": 26669.10955143,
+      "base": {
+        "instance": "clay0303hfsg",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 66.06387115400003,
+        "status": "time_limit",
+        "objective": null,
+        "bound": null,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 3,
+        "incumbent_verification_failed": false
+      },
+      "seam": {
+        "instance": "clay0303hfsg",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 22.319952640000338,
+        "status": "time_limit",
+        "objective": null,
+        "bound": -1.230904907067064e-05,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 63,
+        "incumbent_verification_failed": false
+      },
+      "cand": {
+        "instance": "clay0303hfsg",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "1",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 21.952235965,
+        "status": "time_limit",
+        "objective": null,
+        "bound": -1.230904907067064e-05,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 63,
+        "incumbent_verification_failed": false
+      }
+    },
+    {
+      "rep": 1,
+      "instance": "contvar",
+      "budget": 20.0,
+      "reference_optimum": null,
+      "base": {
+        "instance": "contvar",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 22.241648022999925,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 171244.81148737553,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 3,
+        "incumbent_verification_failed": false
+      },
+      "seam": {
+        "instance": "contvar",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 22.945337908000056,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 171244.81148737553,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 3,
+        "incumbent_verification_failed": false
+      },
+      "cand": {
+        "instance": "contvar",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "1",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 22.52094767499966,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 171244.81148737573,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 3,
+        "incumbent_verification_failed": false
+      }
+    },
+    {
+      "rep": 1,
+      "instance": "hda",
+      "budget": 20.0,
+      "reference_optimum": null,
+      "base": {
+        "instance": "hda",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 31.879475605999687,
+        "status": "time_limit",
+        "objective": null,
+        "bound": -20747118223745.168,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 1,
+        "incumbent_verification_failed": false
+      },
+      "seam": {
+        "instance": "hda",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 31.71496056800015,
+        "status": "time_limit",
+        "objective": null,
+        "bound": -20747118223745.168,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 1,
+        "incumbent_verification_failed": false
+      },
+      "cand": {
+        "instance": "hda",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "1",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 41.942241705000015,
+        "status": "time_limit",
+        "objective": null,
+        "bound": -124296.87906625487,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 3,
+        "incumbent_verification_failed": false
+      }
+    },
+    {
+      "rep": 1,
+      "instance": "heatexch_gen1",
+      "budget": 20.0,
+      "reference_optimum": null,
+      "base": {
+        "instance": "heatexch_gen1",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 29.730108229999587,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 38183.53174601408,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 3,
+        "incumbent_verification_failed": false
+      },
+      "seam": {
+        "instance": "heatexch_gen1",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 24.800982184000077,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 38183.53174601408,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 3,
+        "incumbent_verification_failed": false
+      },
+      "cand": {
+        "instance": "heatexch_gen1",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "1",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 26.755824744000165,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 38183.53174601912,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 3,
+        "incumbent_verification_failed": false
+      }
+    },
+    {
+      "rep": 1,
+      "instance": "heatexch_gen2",
+      "budget": 20.0,
+      "reference_optimum": null,
+      "base": {
+        "instance": "heatexch_gen2",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 23.603721124000003,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 555767.7902849488,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 7,
+        "incumbent_verification_failed": false
+      },
+      "seam": {
+        "instance": "heatexch_gen2",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 21.472997706000115,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 576818.7162116509,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 95,
+        "incumbent_verification_failed": false
+      },
+      "cand": {
+        "instance": "heatexch_gen2",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "1",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 20.94998892800004,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 578091.8643598154,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 95,
+        "incumbent_verification_failed": false
+      }
+    },
+    {
+      "rep": 1,
+      "instance": "heatexch_gen3",
+      "budget": 20.0,
+      "reference_optimum": null,
+      "base": {
+        "instance": "heatexch_gen3",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 28.38950648500031,
+        "status": "time_limit",
+        "objective": null,
+        "bound": null,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 3,
+        "incumbent_verification_failed": false
+      },
+      "seam": {
+        "instance": "heatexch_gen3",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 26.579066854000303,
+        "status": "time_limit",
+        "objective": null,
+        "bound": null,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 31,
+        "incumbent_verification_failed": false
+      },
+      "cand": {
+        "instance": "heatexch_gen3",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "1",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 35.82750559899978,
+        "status": "time_limit",
+        "objective": null,
+        "bound": null,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 3,
+        "incumbent_verification_failed": false
+      }
+    },
+    {
+      "rep": 1,
+      "instance": "nvs05",
+      "budget": 20.0,
+      "reference_optimum": null,
+      "base": {
+        "instance": "nvs05",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 20.939578267000343,
+        "status": "feasible",
+        "objective": 8.731956986640787,
+        "bound": 3.513911713618342,
+        "gap": 0.597580276793123,
+        "gap_certified": false,
+        "node_count": 21,
+        "incumbent_verification_failed": false
+      },
+      "seam": {
+        "instance": "nvs05",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 20.991639302000294,
+        "status": "feasible",
+        "objective": 8.731956986640787,
+        "bound": 3.513911713618342,
+        "gap": 0.597580276793123,
+        "gap_certified": false,
+        "node_count": 21,
+        "incumbent_verification_failed": false
+      },
+      "cand": {
+        "instance": "nvs05",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "1",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 20.946675528000014,
+        "status": "feasible",
+        "objective": 8.731956986640787,
+        "bound": 3.513911713618342,
+        "gap": 0.597580276793123,
+        "gap_certified": false,
+        "node_count": 29,
+        "incumbent_verification_failed": false
+      }
+    },
+    {
+      "rep": 1,
+      "instance": "syn05hfsg",
+      "budget": 20.0,
+      "reference_optimum": null,
+      "base": {
+        "instance": "syn05hfsg",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "max",
+        "wall": 20.88191871800018,
+        "status": "feasible",
+        "objective": 837.7323012718435,
+        "bound": 840.4893941019175,
+        "gap": 0.0032911382620535424,
+        "gap_certified": false,
+        "node_count": 151,
+        "incumbent_verification_failed": false
+      },
+      "seam": {
+        "instance": "syn05hfsg",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "max",
+        "wall": 20.870862512999793,
+        "status": "feasible",
+        "objective": 837.7323012718435,
+        "bound": 840.4893941019175,
+        "gap": 0.0032911382620535424,
+        "gap_certified": false,
+        "node_count": 171,
+        "incumbent_verification_failed": false
+      },
+      "cand": {
+        "instance": "syn05hfsg",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "1",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "max",
+        "wall": 20.89680484900009,
+        "status": "feasible",
+        "objective": 837.7323012718435,
+        "bound": 840.4893941019117,
+        "gap": 0.0032911382620466213,
+        "gap_certified": false,
+        "node_count": 163,
+        "incumbent_verification_failed": false
+      }
+    },
+    {
+      "rep": 1,
+      "instance": "tls2",
+      "budget": 20.0,
+      "reference_optimum": null,
+      "base": {
+        "instance": "tls2",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 28.213473481000165,
+        "status": "feasible",
+        "objective": 11.3,
+        "bound": 2.0999999901667694,
+        "gap": 0.8141592929055957,
+        "gap_certified": false,
+        "node_count": 229,
+        "incumbent_verification_failed": false
+      },
+      "seam": {
+        "instance": "tls2",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 25.012724156999866,
+        "status": "feasible",
+        "objective": 11.299999999980916,
+        "bound": 2.0999999901667694,
+        "gap": 0.8141592929052819,
+        "gap_certified": false,
+        "node_count": 229,
+        "incumbent_verification_failed": false
+      },
+      "cand": {
+        "instance": "tls2",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "1",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 20.944994683999994,
+        "status": "feasible",
+        "objective": 11.299999999980916,
+        "bound": 2.0999999901667694,
+        "gap": 0.8141592929052819,
+        "gap_certified": false,
+        "node_count": 245,
+        "incumbent_verification_failed": false
+      }
+    },
+    {
+      "rep": 1,
+      "instance": "tspn05",
+      "budget": 20.0,
+      "reference_optimum": null,
+      "base": {
+        "instance": "tspn05",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 20.940024012999856,
+        "status": "feasible",
+        "objective": 191.2552078446695,
+        "bound": 178.1165439208231,
+        "gap": 0.06869702567533306,
+        "gap_certified": false,
+        "node_count": 35,
+        "incumbent_verification_failed": false
+      },
+      "seam": {
+        "instance": "tspn05",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 20.978777432999777,
+        "status": "feasible",
+        "objective": 191.2552078446695,
+        "bound": 178.1165439208231,
+        "gap": 0.06869702567533306,
+        "gap_certified": false,
+        "node_count": 35,
+        "incumbent_verification_failed": false
+      },
+      "cand": {
+        "instance": "tspn05",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "1",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 20.929417242,
+        "status": "feasible",
+        "objective": 191.25520784467014,
+        "bound": 177.89283170577465,
+        "gap": 0.06986673089575618,
+        "gap_certified": false,
+        "node_count": 29,
+        "incumbent_verification_failed": false
+      }
+    },
+    {
+      "rep": 1,
+      "instance": "tspn08",
+      "budget": 20.0,
+      "reference_optimum": null,
+      "base": {
+        "instance": "tspn08",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 21.060388375000002,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 231.98283795409407,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 3,
+        "incumbent_verification_failed": false
+      },
+      "seam": {
+        "instance": "tspn08",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 21.05318046299999,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 231.98283795409407,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 3,
+        "incumbent_verification_failed": false
+      },
+      "cand": {
+        "instance": "tspn08",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "1",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 27.58722990599972,
+        "status": "feasible",
+        "objective": 290.56685396750163,
+        "bound": 231.98283795409407,
+        "gap": 0.20161974847950095,
+        "gap_certified": false,
+        "node_count": 3,
+        "incumbent_verification_failed": false
+      }
+    },
+    {
+      "rep": 1,
+      "instance": "tspn10",
+      "budget": 20.0,
+      "reference_optimum": null,
+      "base": {
+        "instance": "tspn10",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 22.277988517999802,
+        "status": "feasible",
+        "objective": 232.16969389157208,
+        "bound": 161.16079717285405,
+        "gap": 0.30584912065172737,
+        "gap_certified": false,
+        "node_count": 3,
+        "incumbent_verification_failed": false
+      },
+      "seam": {
+        "instance": "tspn10",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 21.913985958000012,
+        "status": "feasible",
+        "objective": 225.1260717001723,
+        "bound": 161.16079717285405,
+        "gap": 0.28413090516014766,
+        "gap_certified": false,
+        "node_count": 3,
+        "incumbent_verification_failed": false
+      },
+      "cand": {
+        "instance": "tspn10",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "1",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 21.969607373000144,
+        "status": "feasible",
+        "objective": 225.1260717001723,
+        "bound": 161.16083653483406,
+        "gap": 0.2841307303159827,
+        "gap_certified": false,
+        "node_count": 3,
+        "incumbent_verification_failed": false
+      }
+    },
+    {
+      "rep": 1,
+      "instance": "tspn12",
+      "budget": 20.0,
+      "reference_optimum": null,
+      "base": {
+        "instance": "tspn12",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 62.0334454609997,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 183.3259927436284,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 7,
+        "incumbent_verification_failed": false
+      },
+      "seam": {
+        "instance": "tspn12",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 21.57461851900007,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 192.92291097809897,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 7,
+        "incumbent_verification_failed": false
+      },
+      "cand": {
+        "instance": "tspn12",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "1",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 22.079265041000326,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 192.92305137670508,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 7,
+        "incumbent_verification_failed": false
+      }
+    },
+    {
+      "rep": 2,
+      "instance": "4stufen",
+      "budget": 20.0,
+      "reference_optimum": null,
+      "base": {
+        "instance": "4stufen",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 21.923508161999962,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 19713.03606420082,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 7,
+        "incumbent_verification_failed": false
+      },
+      "seam": {
+        "instance": "4stufen",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 20.999112337000042,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 20755.25555559244,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 63,
+        "incumbent_verification_failed": false
+      },
+      "cand": {
+        "instance": "4stufen",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "1",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 21.032489802999862,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 20282.050738742604,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 63,
+        "incumbent_verification_failed": false
+      }
+    },
+    {
+      "rep": 2,
+      "instance": "bchoco06",
+      "budget": 20.0,
+      "reference_optimum": null,
+      "base": {
+        "instance": "bchoco06",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "max",
+        "wall": 22.19594939799981,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 1.0000000000001477,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 7,
+        "incumbent_verification_failed": false
+      },
+      "seam": {
+        "instance": "bchoco06",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "max",
+        "wall": 21.085056667000117,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 1.0000000000001428,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 47,
+        "incumbent_verification_failed": false
+      },
+      "cand": {
+        "instance": "bchoco06",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "1",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "max",
+        "wall": 21.009571615000368,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 1.0000000000001554,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 31,
+        "incumbent_verification_failed": false
+      }
+    },
+    {
+      "rep": 2,
+      "instance": "bchoco07",
+      "budget": 20.0,
+      "reference_optimum": null,
+      "base": {
+        "instance": "bchoco07",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "max",
+        "wall": 22.71903849299997,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 1.000000000000253,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 7,
+        "incumbent_verification_failed": false
+      },
+      "seam": {
+        "instance": "bchoco07",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "max",
+        "wall": 21.54540565499974,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 1.000000000000253,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 25,
+        "incumbent_verification_failed": false
+      },
+      "cand": {
+        "instance": "bchoco07",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "1",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "max",
+        "wall": 21.069632371999887,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 1.000000000000253,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 7,
+        "incumbent_verification_failed": false
+      }
+    },
+    {
+      "rep": 2,
+      "instance": "bchoco08",
+      "budget": 20.0,
+      "reference_optimum": null,
+      "base": {
+        "instance": "bchoco08",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "max",
+        "wall": 21.67790326799968,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 1.0000000000136013,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 3,
+        "incumbent_verification_failed": false
+      },
+      "seam": {
+        "instance": "bchoco08",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "max",
+        "wall": 22.09914502899983,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 1.0000000093277979,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 3,
+        "incumbent_verification_failed": false
+      },
+      "cand": {
+        "instance": "bchoco08",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "1",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "max",
+        "wall": 22.0860444609998,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 0.9999999999999977,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 3,
+        "incumbent_verification_failed": false
+      }
+    },
+    {
+      "rep": 2,
+      "instance": "beuster",
+      "budget": 20.0,
+      "reference_optimum": null,
+      "base": {
+        "instance": "beuster",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 22.6405748520001,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 6352.061283279524,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 7,
+        "incumbent_verification_failed": false
+      },
+      "seam": {
+        "instance": "beuster",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 20.958881158000167,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 17698.956442695056,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 63,
+        "incumbent_verification_failed": false
+      },
+      "cand": {
+        "instance": "beuster",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "1",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 22.05846818000009,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 17698.956442695056,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 95,
+        "incumbent_verification_failed": false
+      }
+    },
+    {
+      "rep": 2,
+      "instance": "casctanks",
+      "budget": 20.0,
+      "reference_optimum": null,
+      "base": {
+        "instance": "casctanks",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 39.09113443599972,
+        "status": "time_limit",
+        "objective": null,
+        "bound": -90.17863668805973,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 1,
+        "incumbent_verification_failed": false
+      },
+      "seam": {
+        "instance": "casctanks",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 23.157978358000037,
+        "status": "time_limit",
+        "objective": null,
+        "bound": -90.17863668805973,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 1,
+        "incumbent_verification_failed": false
+      },
+      "cand": {
+        "instance": "casctanks",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "1",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 23.294673913000224,
+        "status": "time_limit",
+        "objective": null,
+        "bound": -90.17863067603525,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 1,
+        "incumbent_verification_failed": false
+      }
+    },
+    {
+      "rep": 2,
+      "instance": "clay0303hfsg",
+      "budget": 20.0,
+      "reference_optimum": 26669.10955143,
+      "base": {
+        "instance": "clay0303hfsg",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 22.34409767399984,
+        "status": "time_limit",
+        "objective": null,
+        "bound": -1.230904907067064e-05,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 63,
+        "incumbent_verification_failed": false
+      },
+      "seam": {
+        "instance": "clay0303hfsg",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 21.995711467000092,
+        "status": "time_limit",
+        "objective": null,
+        "bound": -1.230904907067064e-05,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 63,
+        "incumbent_verification_failed": false
+      },
+      "cand": {
+        "instance": "clay0303hfsg",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "1",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 22.313729521999903,
+        "status": "time_limit",
+        "objective": null,
+        "bound": -1.230904907067064e-05,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 63,
+        "incumbent_verification_failed": false
+      }
+    },
+    {
+      "rep": 2,
+      "instance": "contvar",
+      "budget": 20.0,
+      "reference_optimum": null,
+      "base": {
+        "instance": "contvar",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 22.067423929000142,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 171244.81148737553,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 3,
+        "incumbent_verification_failed": false
+      },
+      "seam": {
+        "instance": "contvar",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 21.591606033000062,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 171244.81148737553,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 3,
+        "incumbent_verification_failed": false
+      },
+      "cand": {
+        "instance": "contvar",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "1",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 21.991033168000286,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 171244.81148737573,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 3,
+        "incumbent_verification_failed": false
+      }
+    },
+    {
+      "rep": 2,
+      "instance": "hda",
+      "budget": 20.0,
+      "reference_optimum": null,
+      "base": {
+        "instance": "hda",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 31.44217969500005,
+        "status": "time_limit",
+        "objective": null,
+        "bound": -20747118223745.168,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 1,
+        "incumbent_verification_failed": false
+      },
+      "seam": {
+        "instance": "hda",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 31.46743516000015,
+        "status": "time_limit",
+        "objective": null,
+        "bound": -20747118223745.168,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 1,
+        "incumbent_verification_failed": false
+      },
+      "cand": {
+        "instance": "hda",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "1",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 26.834565467000175,
+        "status": "time_limit",
+        "objective": null,
+        "bound": -119286.31279576839,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 3,
+        "incumbent_verification_failed": false
+      }
+    },
+    {
+      "rep": 2,
+      "instance": "heatexch_gen1",
+      "budget": 20.0,
+      "reference_optimum": null,
+      "base": {
+        "instance": "heatexch_gen1",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 25.28682864800021,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 38183.53174601408,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 3,
+        "incumbent_verification_failed": false
+      },
+      "seam": {
+        "instance": "heatexch_gen1",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 25.73993675699967,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 38183.53174601408,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 3,
+        "incumbent_verification_failed": false
+      },
+      "cand": {
+        "instance": "heatexch_gen1",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "1",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 28.8444069950001,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 38183.53174601912,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 3,
+        "incumbent_verification_failed": false
+      }
+    },
+    {
+      "rep": 2,
+      "instance": "heatexch_gen2",
+      "budget": 20.0,
+      "reference_optimum": null,
+      "base": {
+        "instance": "heatexch_gen2",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 21.39171343299995,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 555767.7902849488,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 7,
+        "incumbent_verification_failed": false
+      },
+      "seam": {
+        "instance": "heatexch_gen2",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 22.176400072999968,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 576818.7162116509,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 95,
+        "incumbent_verification_failed": false
+      },
+      "cand": {
+        "instance": "heatexch_gen2",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "1",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 21.324706707000132,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 576818.7162116928,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 95,
+        "incumbent_verification_failed": false
+      }
+    },
+    {
+      "rep": 2,
+      "instance": "heatexch_gen3",
+      "budget": 20.0,
+      "reference_optimum": null,
+      "base": {
+        "instance": "heatexch_gen3",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 308.1952847809994,
+        "status": "time_limit",
+        "objective": null,
+        "bound": null,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 3,
+        "incumbent_verification_failed": false
+      },
+      "seam": {
+        "instance": "heatexch_gen3",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 27.173660470999494,
+        "status": "time_limit",
+        "objective": null,
+        "bound": null,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 31,
+        "incumbent_verification_failed": false
+      },
+      "cand": {
+        "instance": "heatexch_gen3",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "1",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 26.405419935000282,
+        "status": "time_limit",
+        "objective": null,
+        "bound": null,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 31,
+        "incumbent_verification_failed": false
+      }
+    },
+    {
+      "rep": 2,
+      "instance": "nvs05",
+      "budget": 20.0,
+      "reference_optimum": null,
+      "base": {
+        "instance": "nvs05",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 20.96362088800015,
+        "status": "feasible",
+        "objective": 8.731956986640787,
+        "bound": 3.513911713618342,
+        "gap": 0.597580276793123,
+        "gap_certified": false,
+        "node_count": 21,
+        "incumbent_verification_failed": false
+      },
+      "seam": {
+        "instance": "nvs05",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 20.8634025930005,
+        "status": "feasible",
+        "objective": 8.731956986640787,
+        "bound": 3.513911713618342,
+        "gap": 0.597580276793123,
+        "gap_certified": false,
+        "node_count": 21,
+        "incumbent_verification_failed": false
+      },
+      "cand": {
+        "instance": "nvs05",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "1",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 20.92980491399976,
+        "status": "feasible",
+        "objective": 8.731956986640787,
+        "bound": 3.513911713618342,
+        "gap": 0.597580276793123,
+        "gap_certified": false,
+        "node_count": 29,
+        "incumbent_verification_failed": false
+      }
+    },
+    {
+      "rep": 2,
+      "instance": "syn05hfsg",
+      "budget": 20.0,
+      "reference_optimum": null,
+      "base": {
+        "instance": "syn05hfsg",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "max",
+        "wall": 20.865652444999796,
+        "status": "feasible",
+        "objective": 837.7323012718435,
+        "bound": 840.4893941019175,
+        "gap": 0.0032911382620535424,
+        "gap_certified": false,
+        "node_count": 171,
+        "incumbent_verification_failed": false
+      },
+      "seam": {
+        "instance": "syn05hfsg",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "max",
+        "wall": 20.858607533000395,
+        "status": "feasible",
+        "objective": 837.7323012718435,
+        "bound": 840.4893941019175,
+        "gap": 0.0032911382620535424,
+        "gap_certified": false,
+        "node_count": 175,
+        "incumbent_verification_failed": false
+      },
+      "cand": {
+        "instance": "syn05hfsg",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "1",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "max",
+        "wall": 20.86667876500087,
+        "status": "feasible",
+        "objective": 837.7323012718435,
+        "bound": 840.4893941019117,
+        "gap": 0.0032911382620466213,
+        "gap_certified": false,
+        "node_count": 163,
+        "incumbent_verification_failed": false
+      }
+    },
+    {
+      "rep": 2,
+      "instance": "tls2",
+      "budget": 20.0,
+      "reference_optimum": null,
+      "base": {
+        "instance": "tls2",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 21.488506484000027,
+        "status": "feasible",
+        "objective": 10.299999999983916,
+        "bound": 2.4487125876978726,
+        "gap": 0.7622609138153692,
+        "gap_certified": false,
+        "node_count": 265,
+        "incumbent_verification_failed": false
+      },
+      "seam": {
+        "instance": "tls2",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 21.52715905199966,
+        "status": "feasible",
+        "objective": 10.299999999983916,
+        "bound": 2.4487125876978726,
+        "gap": 0.7622609138153692,
+        "gap_certified": false,
+        "node_count": 265,
+        "incumbent_verification_failed": false
+      },
+      "cand": {
+        "instance": "tls2",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "1",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 21.544796225999562,
+        "status": "feasible",
+        "objective": 11.299999999980916,
+        "bound": 2.0999999901667694,
+        "gap": 0.8141592929052819,
+        "gap_certified": false,
+        "node_count": 245,
+        "incumbent_verification_failed": false
+      }
+    },
+    {
+      "rep": 2,
+      "instance": "tspn05",
+      "budget": 20.0,
+      "reference_optimum": null,
+      "base": {
+        "instance": "tspn05",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 21.008068035999713,
+        "status": "feasible",
+        "objective": 191.2552078446695,
+        "bound": 178.1165439208231,
+        "gap": 0.06869702567533306,
+        "gap_certified": false,
+        "node_count": 35,
+        "incumbent_verification_failed": false
+      },
+      "seam": {
+        "instance": "tspn05",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 20.915580711000075,
+        "status": "feasible",
+        "objective": 191.2552078446695,
+        "bound": 178.1165439208231,
+        "gap": 0.06869702567533306,
+        "gap_certified": false,
+        "node_count": 35,
+        "incumbent_verification_failed": false
+      },
+      "cand": {
+        "instance": "tspn05",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "1",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 20.95690392100005,
+        "status": "feasible",
+        "objective": 191.25520784467014,
+        "bound": 178.11653801668433,
+        "gap": 0.06869705654580927,
+        "gap_certified": false,
+        "node_count": 29,
+        "incumbent_verification_failed": false
+      }
+    },
+    {
+      "rep": 2,
+      "instance": "tspn08",
+      "budget": 20.0,
+      "reference_optimum": null,
+      "base": {
+        "instance": "tspn08",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 27.7225077209996,
+        "status": "feasible",
+        "objective": 290.56685396750163,
+        "bound": 231.98283795409407,
+        "gap": 0.20161974847950095,
+        "gap_certified": false,
+        "node_count": 3,
+        "incumbent_verification_failed": false
+      },
+      "seam": {
+        "instance": "tspn08",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 27.541586269000618,
+        "status": "feasible",
+        "objective": 290.56685396750163,
+        "bound": 231.98283795409407,
+        "gap": 0.20161974847950095,
+        "gap_certified": false,
+        "node_count": 3,
+        "incumbent_verification_failed": false
+      },
+      "cand": {
+        "instance": "tspn08",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "1",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 27.343430111999623,
+        "status": "feasible",
+        "objective": 290.56685396750163,
+        "bound": 231.98283795409407,
+        "gap": 0.20161974847950095,
+        "gap_certified": false,
+        "node_count": 3,
+        "incumbent_verification_failed": false
+      }
+    },
+    {
+      "rep": 2,
+      "instance": "tspn10",
+      "budget": 20.0,
+      "reference_optimum": null,
+      "base": {
+        "instance": "tspn10",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 30.468379721999554,
+        "status": "feasible",
+        "objective": 225.12607163430593,
+        "bound": 161.16079717285405,
+        "gap": 0.28413090495070187,
+        "gap_certified": false,
+        "node_count": 3,
+        "incumbent_verification_failed": false
+      },
+      "seam": {
+        "instance": "tspn10",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 22.50147682700026,
+        "status": "feasible",
+        "objective": 225.1260717001723,
+        "bound": 161.16079717285405,
+        "gap": 0.28413090516014766,
+        "gap_certified": false,
+        "node_count": 3,
+        "incumbent_verification_failed": false
+      },
+      "cand": {
+        "instance": "tspn10",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "1",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 22.085793885000385,
+        "status": "feasible",
+        "objective": 225.1260717001723,
+        "bound": 161.16083653483406,
+        "gap": 0.2841307303159827,
+        "gap_certified": false,
+        "node_count": 3,
+        "incumbent_verification_failed": false
+      }
+    },
+    {
+      "rep": 2,
+      "instance": "tspn12",
+      "budget": 20.0,
+      "reference_optimum": null,
+      "base": {
+        "instance": "tspn12",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 23.95670061600049,
+        "status": "feasible",
+        "objective": 282.244359359475,
+        "bound": 183.3259927436284,
+        "gap": 0.3504706589720051,
+        "gap_certified": false,
+        "node_count": 5,
+        "incumbent_verification_failed": false
+      },
+      "seam": {
+        "instance": "tspn12",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 21.86122126400005,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 192.92291097809897,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 7,
+        "incumbent_verification_failed": false
+      },
+      "cand": {
+        "instance": "tspn12",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "1",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 21.957268999000007,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 192.92305137670508,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 7,
+        "incumbent_verification_failed": false
+      }
+    },
+    {
+      "rep": 3,
+      "instance": "4stufen",
+      "budget": 20.0,
+      "reference_optimum": null,
+      "base": {
+        "instance": "4stufen",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 21.92333143399992,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 19713.036064200816,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 7,
+        "incumbent_verification_failed": false
+      },
+      "seam": {
+        "instance": "4stufen",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 21.023155322999628,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 20755.25555559244,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 63,
+        "incumbent_verification_failed": false
+      },
+      "cand": {
+        "instance": "4stufen",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "1",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 20.989131115999953,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 20738.65467164312,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 63,
+        "incumbent_verification_failed": false
+      }
+    },
+    {
+      "rep": 3,
+      "instance": "bchoco06",
+      "budget": 20.0,
+      "reference_optimum": null,
+      "base": {
+        "instance": "bchoco06",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "max",
+        "wall": 22.186708259000625,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 1.0000000000001477,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 7,
+        "incumbent_verification_failed": false
+      },
+      "seam": {
+        "instance": "bchoco06",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "max",
+        "wall": 21.18399128300007,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 1.0000000000001428,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 47,
+        "incumbent_verification_failed": false
+      },
+      "cand": {
+        "instance": "bchoco06",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "1",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "max",
+        "wall": 21.011825931000203,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 1.0000000000001554,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 31,
+        "incumbent_verification_failed": false
+      }
+    },
+    {
+      "rep": 3,
+      "instance": "bchoco07",
+      "budget": 20.0,
+      "reference_optimum": null,
+      "base": {
+        "instance": "bchoco07",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "max",
+        "wall": 24.613814296999408,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 1.000000000000253,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 7,
+        "incumbent_verification_failed": false
+      },
+      "seam": {
+        "instance": "bchoco07",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "max",
+        "wall": 21.20837180699982,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 1.000000000000253,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 15,
+        "incumbent_verification_failed": false
+      },
+      "cand": {
+        "instance": "bchoco07",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "1",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "max",
+        "wall": 21.06742821900025,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 1.000000000000253,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 7,
+        "incumbent_verification_failed": false
+      }
+    },
+    {
+      "rep": 3,
+      "instance": "bchoco08",
+      "budget": 20.0,
+      "reference_optimum": null,
+      "base": {
+        "instance": "bchoco08",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "max",
+        "wall": 21.72212342199964,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 1.0000000093277979,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 3,
+        "incumbent_verification_failed": false
+      },
+      "seam": {
+        "instance": "bchoco08",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "max",
+        "wall": 21.586939231000542,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 1.0000000093277979,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 3,
+        "incumbent_verification_failed": false
+      },
+      "cand": {
+        "instance": "bchoco08",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "1",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "max",
+        "wall": 21.32477014699998,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 0.9999999999999977,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 3,
+        "incumbent_verification_failed": false
+      }
+    },
+    {
+      "rep": 3,
+      "instance": "beuster",
+      "budget": 20.0,
+      "reference_optimum": null,
+      "base": {
+        "instance": "beuster",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 21.865007362999677,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 6352.061283279524,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 7,
+        "incumbent_verification_failed": false
+      },
+      "seam": {
+        "instance": "beuster",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 20.978333040000507,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 17698.956442695082,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 63,
+        "incumbent_verification_failed": false
+      },
+      "cand": {
+        "instance": "beuster",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "1",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 21.02556477000053,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 17698.956442695056,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 63,
+        "incumbent_verification_failed": false
+      }
+    },
+    {
+      "rep": 3,
+      "instance": "casctanks",
+      "budget": 20.0,
+      "reference_optimum": null,
+      "base": {
+        "instance": "casctanks",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 24.534621165000317,
+        "status": "time_limit",
+        "objective": null,
+        "bound": -90.17863668805973,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 1,
+        "incumbent_verification_failed": false
+      },
+      "seam": {
+        "instance": "casctanks",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 30.539402410000548,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 5.697893577917501,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 3,
+        "incumbent_verification_failed": false
+      },
+      "cand": {
+        "instance": "casctanks",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "1",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 24.26211315799992,
+        "status": "time_limit",
+        "objective": null,
+        "bound": -90.17863067603525,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 1,
+        "incumbent_verification_failed": false
+      }
+    },
+    {
+      "rep": 3,
+      "instance": "clay0303hfsg",
+      "budget": 20.0,
+      "reference_optimum": 26669.10955143,
+      "base": {
+        "instance": "clay0303hfsg",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 26.585048142999767,
+        "status": "time_limit",
+        "objective": null,
+        "bound": -1.2309090908977703e-05,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 3,
+        "incumbent_verification_failed": false
+      },
+      "seam": {
+        "instance": "clay0303hfsg",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 21.09906510900055,
+        "status": "time_limit",
+        "objective": null,
+        "bound": -1.2309090613876393e-05,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 31,
+        "incumbent_verification_failed": false
+      },
+      "cand": {
+        "instance": "clay0303hfsg",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "1",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 22.401933224999993,
+        "status": "time_limit",
+        "objective": null,
+        "bound": -1.230904907067064e-05,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 63,
+        "incumbent_verification_failed": false
+      }
+    },
+    {
+      "rep": 3,
+      "instance": "contvar",
+      "budget": 20.0,
+      "reference_optimum": null,
+      "base": {
+        "instance": "contvar",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 22.839792216000205,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 171244.81148737553,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 3,
+        "incumbent_verification_failed": false
+      },
+      "seam": {
+        "instance": "contvar",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 22.91705932900004,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 171244.81148737553,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 3,
+        "incumbent_verification_failed": false
+      },
+      "cand": {
+        "instance": "contvar",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "1",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 22.42077825099932,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 171244.81148737573,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 3,
+        "incumbent_verification_failed": false
+      }
+    },
+    {
+      "rep": 3,
+      "instance": "hda",
+      "budget": 20.0,
+      "reference_optimum": null,
+      "base": {
+        "instance": "hda",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 31.08835097699921,
+        "status": "time_limit",
+        "objective": null,
+        "bound": -20747118223745.168,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 1,
+        "incumbent_verification_failed": false
+      },
+      "seam": {
+        "instance": "hda",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 31.201791907999905,
+        "status": "time_limit",
+        "objective": null,
+        "bound": -20747118223745.168,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 1,
+        "incumbent_verification_failed": false
+      },
+      "cand": {
+        "instance": "hda",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "1",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 27.704781485999774,
+        "status": "time_limit",
+        "objective": null,
+        "bound": -124296.87906625487,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 3,
+        "incumbent_verification_failed": false
+      }
+    },
+    {
+      "rep": 3,
+      "instance": "heatexch_gen1",
+      "budget": 20.0,
+      "reference_optimum": null,
+      "base": {
+        "instance": "heatexch_gen1",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 24.147927875999812,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 38183.53174601408,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 3,
+        "incumbent_verification_failed": false
+      },
+      "seam": {
+        "instance": "heatexch_gen1",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 24.8101390490001,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 38183.53174601408,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 3,
+        "incumbent_verification_failed": false
+      },
+      "cand": {
+        "instance": "heatexch_gen1",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "1",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 25.57532476599954,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 38183.53174601912,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 3,
+        "incumbent_verification_failed": false
+      }
+    },
+    {
+      "rep": 3,
+      "instance": "heatexch_gen2",
+      "budget": 20.0,
+      "reference_optimum": null,
+      "base": {
+        "instance": "heatexch_gen2",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 21.350770286000625,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 555767.7902849488,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 7,
+        "incumbent_verification_failed": false
+      },
+      "seam": {
+        "instance": "heatexch_gen2",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 21.495128378000118,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 576818.7162116509,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 95,
+        "incumbent_verification_failed": false
+      },
+      "cand": {
+        "instance": "heatexch_gen2",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "1",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 20.938054020999516,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 576818.7162116928,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 95,
+        "incumbent_verification_failed": false
+      }
+    },
+    {
+      "rep": 3,
+      "instance": "heatexch_gen3",
+      "budget": 20.0,
+      "reference_optimum": null,
+      "base": {
+        "instance": "heatexch_gen3",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 32.883455887999844,
+        "status": "time_limit",
+        "objective": null,
+        "bound": null,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 3,
+        "incumbent_verification_failed": false
+      },
+      "seam": {
+        "instance": "heatexch_gen3",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 26.72097540300001,
+        "status": "time_limit",
+        "objective": null,
+        "bound": null,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 31,
+        "incumbent_verification_failed": false
+      },
+      "cand": {
+        "instance": "heatexch_gen3",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "1",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 26.438418585000363,
+        "status": "time_limit",
+        "objective": null,
+        "bound": null,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 31,
+        "incumbent_verification_failed": false
+      }
+    },
+    {
+      "rep": 3,
+      "instance": "nvs05",
+      "budget": 20.0,
+      "reference_optimum": null,
+      "base": {
+        "instance": "nvs05",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 20.917686484000114,
+        "status": "feasible",
+        "objective": 8.731956986640787,
+        "bound": 3.513911713618342,
+        "gap": 0.597580276793123,
+        "gap_certified": false,
+        "node_count": 21,
+        "incumbent_verification_failed": false
+      },
+      "seam": {
+        "instance": "nvs05",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 20.923270670999955,
+        "status": "feasible",
+        "objective": 8.731956986640787,
+        "bound": 3.513911713618342,
+        "gap": 0.597580276793123,
+        "gap_certified": false,
+        "node_count": 21,
+        "incumbent_verification_failed": false
+      },
+      "cand": {
+        "instance": "nvs05",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "1",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 20.947535821999736,
+        "status": "feasible",
+        "objective": 8.731956986640787,
+        "bound": 3.513911713618342,
+        "gap": 0.597580276793123,
+        "gap_certified": false,
+        "node_count": 29,
+        "incumbent_verification_failed": false
+      }
+    },
+    {
+      "rep": 3,
+      "instance": "syn05hfsg",
+      "budget": 20.0,
+      "reference_optimum": null,
+      "base": {
+        "instance": "syn05hfsg",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "max",
+        "wall": 20.91357457600043,
+        "status": "feasible",
+        "objective": 837.7323012718435,
+        "bound": 840.4893941019175,
+        "gap": 0.0032911382620535424,
+        "gap_certified": false,
+        "node_count": 153,
+        "incumbent_verification_failed": false
+      },
+      "seam": {
+        "instance": "syn05hfsg",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "max",
+        "wall": 20.919826168000327,
+        "status": "feasible",
+        "objective": 837.7323012718435,
+        "bound": 840.4893941019175,
+        "gap": 0.0032911382620535424,
+        "gap_certified": false,
+        "node_count": 151,
+        "incumbent_verification_failed": false
+      },
+      "cand": {
+        "instance": "syn05hfsg",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "1",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "max",
+        "wall": 20.94188083500012,
+        "status": "feasible",
+        "objective": 837.7323012718435,
+        "bound": 840.4893941019157,
+        "gap": 0.003291138262051371,
+        "gap_certified": false,
+        "node_count": 149,
+        "incumbent_verification_failed": false
+      }
+    },
+    {
+      "rep": 3,
+      "instance": "tls2",
+      "budget": 20.0,
+      "reference_optimum": null,
+      "base": {
+        "instance": "tls2",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 21.77615081699969,
+        "status": "feasible",
+        "objective": 10.299999999983916,
+        "bound": 2.4487125876978726,
+        "gap": 0.7622609138153692,
+        "gap_certified": false,
+        "node_count": 265,
+        "incumbent_verification_failed": false
+      },
+      "seam": {
+        "instance": "tls2",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 23.34479232600006,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 0.9359146469655356,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 67,
+        "incumbent_verification_failed": false
+      },
+      "cand": {
+        "instance": "tls2",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "1",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 21.596926916000484,
+        "status": "feasible",
+        "objective": 10.299999999983916,
+        "bound": 2.4487125876978726,
+        "gap": 0.7622609138153692,
+        "gap_certified": false,
+        "node_count": 265,
+        "incumbent_verification_failed": false
+      }
+    },
+    {
+      "rep": 3,
+      "instance": "tspn05",
+      "budget": 20.0,
+      "reference_optimum": null,
+      "base": {
+        "instance": "tspn05",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 20.981217588000618,
+        "status": "feasible",
+        "objective": 191.2552078446695,
+        "bound": 178.1165439208231,
+        "gap": 0.06869702567533306,
+        "gap_certified": false,
+        "node_count": 35,
+        "incumbent_verification_failed": false
+      },
+      "seam": {
+        "instance": "tspn05",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 20.888598782000372,
+        "status": "feasible",
+        "objective": 191.2552078446695,
+        "bound": 177.89283170652436,
+        "gap": 0.0698667308918332,
+        "gap_certified": false,
+        "node_count": 35,
+        "incumbent_verification_failed": false
+      },
+      "cand": {
+        "instance": "tspn05",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "1",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 20.85183923799923,
+        "status": "feasible",
+        "objective": 191.25520784467014,
+        "bound": 177.89283170577465,
+        "gap": 0.06986673089575618,
+        "gap_certified": false,
+        "node_count": 29,
+        "incumbent_verification_failed": false
+      }
+    },
+    {
+      "rep": 3,
+      "instance": "tspn08",
+      "budget": 20.0,
+      "reference_optimum": null,
+      "base": {
+        "instance": "tspn08",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 21.189888063999206,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 231.98283795409407,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 3,
+        "incumbent_verification_failed": false
+      },
+      "seam": {
+        "instance": "tspn08",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 27.06925493899962,
+        "status": "feasible",
+        "objective": 290.56685396750163,
+        "bound": 231.98283795409407,
+        "gap": 0.20161974847950095,
+        "gap_certified": false,
+        "node_count": 3,
+        "incumbent_verification_failed": false
+      },
+      "cand": {
+        "instance": "tspn08",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "1",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 27.365175017999718,
+        "status": "feasible",
+        "objective": 290.56685396750163,
+        "bound": 231.98283795409407,
+        "gap": 0.20161974847950095,
+        "gap_certified": false,
+        "node_count": 3,
+        "incumbent_verification_failed": false
+      }
+    },
+    {
+      "rep": 3,
+      "instance": "tspn10",
+      "budget": 20.0,
+      "reference_optimum": null,
+      "base": {
+        "instance": "tspn10",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 22.044241947000046,
+        "status": "feasible",
+        "objective": 225.1260717001723,
+        "bound": 161.16079717285405,
+        "gap": 0.28413090516014766,
+        "gap_certified": false,
+        "node_count": 3,
+        "incumbent_verification_failed": false
+      },
+      "seam": {
+        "instance": "tspn10",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 21.975008440000238,
+        "status": "feasible",
+        "objective": 225.1260717001723,
+        "bound": 161.16079717285405,
+        "gap": 0.28413090516014766,
+        "gap_certified": false,
+        "node_count": 3,
+        "incumbent_verification_failed": false
+      },
+      "cand": {
+        "instance": "tspn10",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "1",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 22.033316503000606,
+        "status": "feasible",
+        "objective": 225.1260717001723,
+        "bound": 161.16083653483406,
+        "gap": 0.2841307303159827,
+        "gap_certified": false,
+        "node_count": 3,
+        "incumbent_verification_failed": false
+      }
+    },
+    {
+      "rep": 3,
+      "instance": "tspn12",
+      "budget": 20.0,
+      "reference_optimum": null,
+      "base": {
+        "instance": "tspn12",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 23.625187681999705,
+        "status": "feasible",
+        "objective": 282.244359359475,
+        "bound": 183.3259927436284,
+        "gap": 0.3504706589720051,
+        "gap_certified": false,
+        "node_count": 5,
+        "incumbent_verification_failed": false
+      },
+      "seam": {
+        "instance": "tspn12",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 21.688803207000092,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 192.92291097809897,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 7,
+        "incumbent_verification_failed": false
+      },
+      "cand": {
+        "instance": "tspn12",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "1",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 21.61424356400039,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 192.92305137670508,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 7,
+        "incumbent_verification_failed": false
+      }
+    }
+  ]
+}

--- a/discopt_benchmarks/scripts/issue928_round_floor_panel.py
+++ b/discopt_benchmarks/scripts/issue928_round_floor_panel.py
@@ -1,0 +1,217 @@
+"""#928 re-panel: the three coupled budget flags with the round-cut-short floor.
+
+Same three arms and the same metric set as
+``issue966_coupled_graduation_panel.py`` (whose ``soundness``/``compare``/
+``run_one`` this imports rather than re-deriving) — ``base`` / ``seam`` / ``cand``,
+interleaved per instance, every flag named explicitly in every arm — with two
+differences that the environment and the last panel's failure force:
+
+1. **Multi-rep in one run.** §14b's verdict turned on a delta that flipped sign
+   between reps, so a single run cannot settle the net-positive bar. Reps are
+   interleaved at the instance level with the arms, and the per-rep deltas are
+   reported with their spread (CLAUDE.md §9).
+
+2. **The oracle is stated at its real strength, not assumed.** ``minlplib.solu``
+   (the library-wide oracle §14b-qual switched to) is NOT reachable from this
+   container — the network policy denies minlplib.org — so the only oracle here is
+   ``python/tests/data/known_optima.toml``, which covers 1 of the 19 binding
+   instances. Rather than report a soundness result that rests on one instance,
+   this panel adds a **cross-arm primal ceiling**: for a MINIMIZE instance every
+   arm's verified incumbent is an upper bound on the optimum, so the best
+   incumbent found by ANY arm in ANY rep is a valid ceiling for every other arm's
+   bound. Coverage of both oracles is counted and printed; a run that makes zero
+   bound-vs-ceiling comparisons exits non-zero (§6).
+
+Usage:
+    python -u discopt_benchmarks/scripts/issue928_round_floor_panel.py \
+        --budget 20 --reps 3 --out discopt_benchmarks/results/issue928_floor20.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import statistics
+import sys
+import time
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(Path(__file__).parent))
+
+from issue966_coupled_graduation_panel import (  # noqa: E402
+    ARMS,
+    CORPUS,
+    compare,
+    loadavg,
+    run_one,
+    soundness,
+)
+
+BINDING = (
+    "4stufen,bchoco06,bchoco07,bchoco08,beuster,casctanks,clay0303hfsg,contvar,hda,"
+    "heatexch_gen1,heatexch_gen2,heatexch_gen3,nvs05,syn05hfsg,tls2,tspn05,tspn08,"
+    "tspn10,tspn12"
+)
+
+
+def curated_optimum(name: str):
+    """``known_optima.toml`` only — the .solu oracle is unreachable here.
+
+    Only ``KeyError`` (the genuine "not in the registry" outcome) is swallowed;
+    a broken registry crashes, per CLAUDE.md §7.
+    """
+    sys.path.insert(0, str(ROOT / "python/tests"))
+    from _optima import known_optimum  # type: ignore
+
+    try:
+        return known_optimum(name)
+    except KeyError:
+        return None
+
+
+def primal_ceilings(all_cells: list[dict]) -> dict[str, float]:
+    """Best verified incumbent per instance over every arm and rep.
+
+    A feasible point's objective bounds the optimum from above (min sense), so
+    this is a sound ceiling for every arm's dual bound on that instance — and it
+    is measured in this very panel rather than taken on faith. Cells whose
+    incumbent failed verification are excluded.
+    """
+    best: dict[str, float] = {}
+    for c in all_cells:
+        for key, _l, _e in ARMS:
+            rec = c[key]
+            if rec["objective"] is None or rec["incumbent_verification_failed"]:
+                continue
+            v = float(rec["objective"])
+            cur = best.get(c["instance"])
+            better = v < cur if cur is not None else True
+            if rec["sense"] == "max":
+                better = v > cur if cur is not None else True
+            best[c["instance"]] = v if better else cur
+    return best
+
+
+def ceiling_violations(cells: list[dict], ceilings: dict[str, float]) -> tuple[int, list[str]]:
+    """Counted bound-vs-ceiling control. Returns (comparisons, violations)."""
+    cmps, bad = 0, []
+    for c in cells:
+        ceil = ceilings.get(c["instance"])
+        if ceil is None:
+            continue
+        for key, _l, _e in ARMS:
+            rec = c[key]
+            if rec["bound"] is None:
+                continue
+            cmps += 1
+            over = (
+                rec["bound"] < ceil - 1e-4
+                if rec["sense"] == "max"
+                else rec["bound"] > ceil + 1e-4
+            )
+            if over:
+                bad.append(f"rep{c['rep']} {c['instance']}:{key}: bound {rec['bound']} vs {ceil}")
+    return cmps, bad
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--budget", type=float, default=20.0)
+    ap.add_argument("--reps", type=int, default=3)
+    ap.add_argument("--instances", default=BINDING)
+    ap.add_argument("--out", required=True)
+    args = ap.parse_args()
+
+    names = [s for s in args.instances.split(",") if s]
+    all_cells: list[dict] = []
+    t0 = time.perf_counter()
+    load_start = loadavg()
+
+    for rep in range(1, args.reps + 1):
+        for idx, name in enumerate(names, 1):
+            cell = {
+                "rep": rep,
+                "instance": name,
+                "budget": args.budget,
+                "reference_optimum": curated_optimum(name),
+            }
+            for key, _label, env in ARMS:
+                cell[key] = run_one(CORPUS / f"{name}.nl", args.budget, env)
+            all_cells.append(cell)
+            parts = " | ".join(
+                f"{key} {cell[key]['wall']:5.1f}s cert={int(bool(cell[key]['gap_certified']))} "
+                f"b={cell[key]['bound']}"
+                for key, _l, _e in ARMS
+            )
+            print(f"[rep{rep} {idx}/{len(names)}] {name:16s} {parts}", flush=True)
+
+    ceilings = primal_ceilings(all_cells)
+    per_rep = []
+    for rep in range(1, args.reps + 1):
+        cells = [c for c in all_cells if c["rep"] == rep]
+        snd = soundness(cells)
+        pairs = {
+            "cand_vs_base": compare(cells, "base", "cand"),
+            "cand_vs_seam": compare(cells, "seam", "cand"),
+            "seam_vs_base": compare(cells, "base", "seam"),
+        }
+        cmps, bad = ceiling_violations(cells, ceilings)
+        grad = pairs["cand_vs_base"]
+        cert_clean = not (
+            snd["unsound"]
+            or bad
+            or snd["incumbent_verification_failed"]
+            or grad["cert_regressions"]
+            or grad["lost_incumbents"]
+            or grad["lost_bound"]
+        )
+        per_rep.append(
+            {
+                "rep": rep,
+                **snd,
+                "ceiling_comparisons_executed": cmps,
+                "ceiling_violations": bad,
+                "pairs": pairs,
+                "cert_clean": cert_clean,
+            }
+        )
+        print(
+            f"\nrep{rep}: CERT_CLEAN={cert_clean} "
+            f"cand-base overrun {grad['overrun_delta_s']}s  "
+            f"lost_bound={grad['lost_bound']} cert_regressions={grad['cert_regressions']} "
+            f"unsound={snd['unsound']} ceiling_violations={bad}",
+            flush=True,
+        )
+
+    deltas = [r["pairs"]["cand_vs_base"]["overrun_delta_s"] for r in per_rep]
+    seam_deltas = [r["pairs"]["seam_vs_base"]["overrun_delta_s"] for r in per_rep]
+    total_cmps = sum(r["ceiling_comparisons_executed"] for r in per_rep)
+    summary = {
+        "budget": args.budget,
+        "reps": args.reps,
+        "instances": names,
+        "oracle": "known_optima.toml + cross-arm primal ceiling (minlplib.solu unreachable)",
+        "cand_vs_base_overrun_deltas_s": deltas,
+        "seam_vs_base_overrun_deltas_s": seam_deltas,
+        "cert_clean_all_reps": all(r["cert_clean"] for r in per_rep),
+        "ceiling_comparisons_executed": total_cmps,
+        "loadavg_start": [round(x, 2) for x in load_start],
+        "loadavg_end": [round(x, 2) for x in loadavg()],
+        "panel_wall_s": round(time.perf_counter() - t0, 1),
+    }
+    Path(args.out).write_text(json.dumps({"summary": summary, "reps": per_rep, "cells": all_cells}, indent=2))
+
+    print()
+    print(json.dumps(summary, indent=2))
+    mean = statistics.fmean(deltas)
+    sd = statistics.stdev(deltas) if len(deltas) > 1 else 0.0
+    print(f"\nCAND_VS_BASE_OVERRUN_DELTA_S={mean:.1f} +/- {sd:.1f}  (per rep: {deltas})")
+    print(f"CERT_CLEAN_ALL_REPS={summary['cert_clean_all_reps']}")
+    print(f"CEILING_COMPARISONS_EXECUTED={total_cmps}")
+    print(f"COMPARISONS_EXECUTED={len(all_cells)}")
+    return 0 if (total_cmps and all_cells) else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/discopt_benchmarks/scripts/issue928_round_floor_panel.py
+++ b/discopt_benchmarks/scripts/issue928_round_floor_panel.py
@@ -106,9 +106,7 @@ def ceiling_violations(cells: list[dict], ceilings: dict[str, float]) -> tuple[i
                 continue
             cmps += 1
             over = (
-                rec["bound"] < ceil - 1e-4
-                if rec["sense"] == "max"
-                else rec["bound"] > ceil + 1e-4
+                rec["bound"] < ceil - 1e-4 if rec["sense"] == "max" else rec["bound"] > ceil + 1e-4
             )
             if over:
                 bad.append(f"rep{c['rep']} {c['instance']}:{key}: bound {rec['bound']} vs {ceil}")
@@ -200,7 +198,9 @@ def main() -> int:
         "loadavg_end": [round(x, 2) for x in loadavg()],
         "panel_wall_s": round(time.perf_counter() - t0, 1),
     }
-    Path(args.out).write_text(json.dumps({"summary": summary, "reps": per_rep, "cells": all_cells}, indent=2))
+    Path(args.out).write_text(
+        json.dumps({"summary": summary, "reps": per_rep, "cells": all_cells}, indent=2)
+    )
 
     print()
     print(json.dumps(summary, indent=2))

--- a/docs/dev/performance-plan.md
+++ b/docs/dev/performance-plan.md
@@ -1857,6 +1857,124 @@ Stage-1 validation patch (route `diving` through a per-model evaluator cache):
 > both printed, and the panel **exits non-zero** when it made zero oracle comparisons
 > (§6) — the state that produced this retraction can no longer report success.
 
+### 14d. #928: the interaction is a round that throws away the floor it holds (2026-08-11)
+
+> §14b's verdict named the residual precisely — "the pair *LP yields on its deadline*
+> x *round yields on its deadline* compounding into a node result that carries no
+> adoptable bound at all; that is the thing to fix before either flag is
+> re-panelled." It is fixed, and the mechanism turned out to be simpler and more
+> general than "an interaction of two clamps".
+>
+> **The corpus cell does not travel, so the mechanism was probed directly.** contvar
+> @ 20 s is wall-clock-shaped: on the container this work ran in, all four arms of
+> the §14b attribution probe return the same bound (171244.81, 3 nodes) and the 287-node
+> collapse does not reproduce at all. Chasing the cell would have measured the
+> container. So instead: hand `solve_at_node` a `round_deadline` that is already
+> spent — the state #966's clamp produces once the cold build has eaten the round's
+> grant — and compare against an unclamped control, over the same 19 binding
+> instances, in both `DISCOPT_LP_WARM_DEADLINE` arms
+> (`scratchpad/issue928_round_cut_short_entry.py`, 114 counted cells).
+>
+> **16 of 114 cells return NO bound** where the control certifies one — bchoco06/07/08
+> (spent and nearly-spent alike), hda, tls2 — and they return it as `uncertified`, not
+> `time_limit`. **Both flag arms are affected identically**, so the loss is not the
+> interaction of the two clamps: it is the *round* clamp alone, and the LP clamp only
+> ever made it more reachable. The truncated build leaves a **0-row** relaxation which
+> solves to LP optimality and which every certification route then declines (no NS safe
+> bound; the conditioning/free-column guards refuse the vertex).
+>
+> **And the floor was in hand the whole time** (`scratchpad/issue928_floor_inventory.py`,
+> 10 counted rounds). Every lost cell's truncated relaxation carries a valid finite
+> `_objective_floor`:
+>
+> | instance | rows built | `_objective_bound_valid` | floor | unclamped control |
+> |---|---|---|---|---|
+> | bchoco06 | 0 / 134 | True | **-1.0** | -0.9999918 |
+> | bchoco07 | 0 / 153 | True | **-1.0** | -1.0000000 |
+> | bchoco08 | 0 / 190 | True | **-1.0** | -1.0000000 |
+> | tls2 | 0 / 24 | True | **0.0** | 0.0 |
+> | hda | 0 / 718 | True | **-172201.82** | -64675.25 |
+>
+> On four of the five the discarded floor is the control bound to within rounding. The
+> fix is therefore not a new bound source — it is *reporting the one already computed*.
+>
+> **Shipped (both inside the opt-in flags' blast radius, no new flag).**
+> 1. `_solve_at_node_impl` reports that box-interval floor whenever the round was cut
+>    short (`_build_truncated`, or an LP that exited `time_limit`) and no route
+>    certified anything, and takes `max(banked deadline dual, box floor)` on a deadline
+>    exit — the two are not ordered a priori, since §14a measured the hda node LP
+>    banking exactly `g(0)`, the box floor itself. Sound: the floor comes from the cost
+>    columns of the same column box the LP is solved over, independent of which rows
+>    were emitted, so it is below the node's true optimum however truncated the build;
+>    `_objective_bound_valid` gates out the un-relaxable and the #248 garbage-wide cases
+>    (a garbage floor would anchor the tree on a bound that never certifies — the
+>    "sound but harmful" trade §14b measured).
+> 2. The #966 round-admission check no longer declines the **ROOT** round. A branched
+>    node always carries its parent's bound, so declining forgoes tightening only; the
+>    root has no parent, and declining it leaves the tree with no bound source at all —
+>    which is exactly the shape of §14b's contvar collapse (7 → 287 nodes, nothing ever
+>    certified, `bound=None`). This is rule 1 of `_fb_stop`, applied where it was
+>    missing: never skip while no valid bound is in hand.
+>
+> **Verification.** Post-fix re-run of the entry experiment: `LOST_BOUND_CELLS` 16 → 0,
+> with a counted bound-vs-control control on every cell. Default-path
+> bound-neutrality with all three flags OFF: **13/13 certifying instances byte-identical**
+> in `node_count`/`objective`/`bound` against the pre-fix tree, marker-gated in both
+> directions (`scratchpad/issue928_round_floor_neutrality.py` — the marker is
+> `_cut_short_floor` in `_solve_at_node_impl.__code__.co_varnames`). Five mechanism
+> tests in `python/tests/test_928_round_cut_short_floor.py` fail on the pre-fix tree
+> and pass after; a sixth pins the default-path decline that must NOT change.
+>
+> **Oracle caveat, stated up front (§14b-qual's rule).** `minlplib.solu` is not
+> reachable from this container — the network policy denies minlplib.org — so the
+> curated `known_optima.toml` covers **1 of the 19** binding instances. The re-panel
+> below therefore adds a **cross-arm primal ceiling**: every arm's verified incumbent
+> bounds the optimum from above, so the best incumbent found by any arm in any rep is a
+> sound ceiling for every other arm's bound on that instance. Both coverages are
+> counted and printed, and a run making zero ceiling comparisons exits non-zero.
+>
+> **Re-panel: the wall verdict flips clean, the bound ledger flips clean, and the one
+> residual is #966's — the flags still do NOT graduate.** 19 binding instances, 20 s,
+> 3 reps, three arms interleaved per instance
+> (`discopt_benchmarks/scripts/issue928_round_floor_panel.py`; raw
+> `discopt_benchmarks/results/issue928_round_floor_binding20.json`;
+> `COMPARISONS_EXECUTED=57`, `CEILING_COMPARISONS_EXECUTED=63`).
+>
+> | metric (cand vs base) | rep1 | rep2 | rep3 |
+> |---|---|---|---|
+> | overrun delta | **−94.4 s** | **−313.5 s** | **−16.7 s** |
+> | total overrun base → cand | 169.4 → 75.0 | 367.4 → 53.9 | 67.2 → 50.5 |
+> | bounds tighter / looser | 8 / 1 | 7 / 2 | 8 / 1 |
+> | bounds lost / gained | 0 / 1 | 0 / 0 | 0 / 0 |
+> | nodes base → cand | 501 → 823 | 615 → 877 | 537 → 851 |
+>
+> * **Net-positive: passes.** The delta is negative in 3/3 reps (mean −141.5, sd 153.9 —
+>   large because rep2's base arm hit a 313 s severe mode, not because the sign is in
+>   doubt) where §14b measured **+325.4/+68.5/+12.7**. The sign flip is gone.
+> * **The bound ledger is now positive, not merely non-negative.** `lost_bound` is empty
+>   in 3/3 — §14b's contvar `183632.766 → None` does not recur — and rep1 *gains* one
+>   (clay0303hfsg `None → −1.23e-05`). The big movers are exactly the cut-short class:
+>   hda `−2.07e13 → −124296.9`, tspn12 `183.33 → 192.92`, beuster `6352.06 → 17698.96`,
+>   heatexch_gen2 `555767.8 → 578091.9`. Against 1–2 looser cells per rep, all tiny
+>   (tspn05 178.1165 → 177.8928, tls2 2.4487 → 2.1000).
+> * **Soundness: 0 violations**, over 63 counted bound-vs-ceiling comparisons plus the
+>   2–3 curated-oracle comparisons per rep, plus the bound-crosses-incumbent and
+>   incumbent-verification arms, which fire on every cell. Coverage is reported, not
+>   assumed.
+> * **`CERT_CLEAN=False` in reps 2 and 3, on one item: tspn12's incumbent.** The base
+>   arm finds 282.24 (bound 183.33); seam and cand find none (bound 192.92). **This is
+>   the seam's, not #928's**: `seam vs base` shows the same loss (rep3 adds tls2) while
+>   `cand vs seam` loses **no** incumbent in any rep. The round budget declines the
+>   rounds whose search trajectory happened to land that incumbent — the same shape as
+>   §14b's casctanks bound collapse, one level over in the metric set.
+>
+> **Verdict: all three flags stay default-OFF.** Bar 1 is a hard gate with no slack and
+> it fails, even though the failing item is a primal one owned by #966 and is paid for
+> by a materially tighter dual bound in the same cells. The thing this issue names —
+> the callee dropping the deadline, and then the round throwing away the floor it
+> holds — is fixed and measured; what remains is #966's round-admission policy losing
+> a primal trajectory, which belongs on that issue.
+
 ## 15. #956 envelope outward rounding: the defect is real, but it is NOT what drives `n_undecided` (falsified 2026-08-08)
 
 > **The defect (confirmed).** The McCormick row generators in

--- a/python/discopt/_relax/mccormick_lp.py
+++ b/python/discopt/_relax/mccormick_lp.py
@@ -1768,9 +1768,7 @@ class MccormickLPRelaxer:
             # that got further is tighter. ``max`` of two valid floors is valid.
             if res.status == "time_limit":
                 _tl_cands = [
-                    b
-                    for b in (res.bound, _cut_short_floor)
-                    if b is not None and np.isfinite(b)
+                    b for b in (res.bound, _cut_short_floor) if b is not None and np.isfinite(b)
                 ]
                 if _tl_cands:
                     return MccormickLPResult(status="optimal", lower_bound=float(max(_tl_cands)))

--- a/python/discopt/_relax/mccormick_lp.py
+++ b/python/discopt/_relax/mccormick_lp.py
@@ -1692,6 +1692,44 @@ class MccormickLPRelaxer:
                 "treating as inconclusive (no fathom) to avoid a false-infeasible prune"
             )
             return MccormickLPResult(status="numerical")
+        # #928: the rigorous floor a round CUT SHORT still owns. A round is cut
+        # short when its cold build stopped on a deadline (``_build_truncated`` —
+        # the #966 ``round_deadline`` or the #694/#832 root-build flags) or when
+        # its LP yielded on one (``time_limit`` — ``DISCOPT_LP_WARM_DEADLINE``).
+        # In that state the relaxation is weaker, so every certification route
+        # below can decline and the node used to return NOTHING — measured on the
+        # in-repo binding subset with a spent round grant, 16 of 114 cells returned
+        # ``uncertified``/no bound where the same box with an unclamped round
+        # certifies one (``scratchpad/issue928_round_cut_short_entry.py``), and in
+        # every one of them the truncated build (0 rows) still carried a valid
+        # finite ``_objective_floor`` equal to the control bound on 4 of 5
+        # instances: bchoco06/07/08 -1.0 (control -0.99999), tls2 0.0 (control
+        # 0.0), hda -172201.82 (``scratchpad/issue928_floor_inventory.py``).
+        #
+        # SOUNDNESS: ``_objective_floor`` is the box-interval lower bound of the
+        # (minimize-equivalent) objective over this build's COLUMN box, computed
+        # from the cost-column bounds alone — independent of which constraint rows
+        # were emitted. Dropping rows only enlarges the feasible set, and the LP
+        # feasible region is a subset of the column box, so the floor is <= this
+        # node's true optimum however truncated the build was. It is the identical
+        # quantity, with the identical argument, that the ``unbounded`` branch
+        # below already reports. ``_objective_bound_valid`` gates it: False marks
+        # an un-relaxable / under-constrained objective or the #248 garbage-wide
+        # floor, where reporting the value would anchor the tree on a bound that
+        # never certifies (that is the "sound but harmful" trade §14b measured).
+        #
+        # Default path untouched by construction: with the shipped flags neither
+        # ``_build_truncated`` (no build deadline is ever set) nor a ``time_limit``
+        # status (``node_bound_mode="lp"`` makes every node solve a pure LP, and
+        # only ``DISCOPT_LP_WARM_DEADLINE`` produces that status there) can occur,
+        # so ``_cut_short_floor`` is None and nothing below fires.
+        _cut_short_floor: Optional[float] = None
+        if bool(getattr(milp, "_build_truncated", False)) or res.status == "time_limit":
+            if milp._objective_bound_valid:
+                _floor_v = getattr(milp, "_objective_floor", None)
+                if _floor_v is not None and np.isfinite(_floor_v):
+                    _cut_short_floor = float(_floor_v)
+
         if res.status != "optimal" or res.x is None:
             # Objective-floor fallback (issue #640 Bucket 2, nvs22). The conditioning
             # clamp above widens a free non-cost column to true +/-inf, which can make
@@ -1721,8 +1759,21 @@ class MccormickLPRelaxer:
             # which is the wrong trade (CLAUDE.md §1). Reachable only with
             # ``DISCOPT_LP_WARM_DEADLINE`` on: nothing else produces a ``time_limit``
             # node result, so the default path is untouched.
-            if res.status == "time_limit" and res.bound is not None and np.isfinite(res.bound):
-                return MccormickLPResult(status="optimal", lower_bound=float(res.bound))
+            #
+            # #928: the banked dual floor and the round's box floor are BOTH valid
+            # lower bounds on this node, so report the tighter one. They are not
+            # ordered a priori: ``g(y)`` for a partial dual can sit *below* the box
+            # floor — measured, the hda node LP banked exactly ``g(0) = -141697``,
+            # the box floor itself, at every deadline fraction (§14a) — while a dual
+            # that got further is tighter. ``max`` of two valid floors is valid.
+            if res.status == "time_limit":
+                _tl_cands = [
+                    b
+                    for b in (res.bound, _cut_short_floor)
+                    if b is not None and np.isfinite(b)
+                ]
+                if _tl_cands:
+                    return MccormickLPResult(status="optimal", lower_bound=float(max(_tl_cands)))
             # #517 (flag-gated): the node LP broke down numerically but the in-house
             # simplex's own dual yielded a rigorous Neumaier–Shcherbina safe lower
             # bound (``milp.solve`` attached it to ``res.bound``). It is valid for ANY
@@ -1735,6 +1786,11 @@ class MccormickLPRelaxer:
                 and np.isfinite(res.bound)
             ):
                 return MccormickLPResult(status="optimal", lower_bound=float(res.bound))
+            # #928: a cut-short round reports its rigorous box floor rather than
+            # nothing. Last, so it can never displace a tighter certified/banked
+            # bound above — only fill the gap where the round had none.
+            if _cut_short_floor is not None:
+                return MccormickLPResult(status="optimal", lower_bound=_cut_short_floor)
             return MccormickLPResult(status=_no_bound_status(res.status))
 
         def _certify(r) -> Optional[float]:
@@ -1795,6 +1851,15 @@ class MccormickLPRelaxer:
             # contract violation that read as a solved node with no bound. Report
             # the decline as its own non-fathoming status instead; every caller
             # gates on ``lower_bound``, so this only fixes the label, not behavior.
+            #
+            # #928: unless the round was cut short and still owns a rigorous box
+            # floor — this is the exit the measurement above actually lands in (all
+            # 16 lost cells reported ``uncertified``: a 0-row truncated relaxation
+            # solves to LP optimality, and every certification route then declines
+            # it for want of a safe bound). Reporting the floor is sound (see
+            # ``_cut_short_floor``) and is the whole point of the round having run.
+            if _cut_short_floor is not None:
+                return MccormickLPResult(status="optimal", lower_bound=_cut_short_floor)
             return MccormickLPResult(status=_no_bound_status(res.status))
         x_orig = np.asarray(x_source.x)[: self._n_orig].copy()
         _out = MccormickLPResult(status="optimal", lower_bound=float(bound), x=x_orig)

--- a/python/discopt/_relax/milp_relaxation.py
+++ b/python/discopt/_relax/milp_relaxation.py
@@ -452,6 +452,20 @@ def _lp_warm_deadline_enabled() -> bool:
     banked dual; the #966 round-admission check no longer declines the ROOT round,
     which holds no parent bound to fall back on.
 
+    **The re-panel on that build passes the net-positive bar and still does not
+    graduate** (19 binding instances, 20 s, 3 reps, three arms;
+    ``discopt_benchmarks/results/issue928_round_floor_binding20.json``,
+    performance-plan §14d). ON-OFF overrun is **-94.4 / -313.5 / -16.7 s** — negative
+    in 3/3 where §14b measured +325.4/+68.5/+12.7, so the sign flip is gone — with
+    ``lost_bound`` empty in 3/3 (contvar's ``-> None`` does not recur), one bound
+    GAINED (clay0303hfsg ``None -> -1.23e-05``), 7-8 tighter against 1-2 tiny looser
+    per rep, hda ``-2.07e13 -> -124296.9``, and zero soundness violations over 63
+    counted bound-vs-ceiling comparisons. ``CERT_CLEAN`` is False in 2 of 3 reps on
+    exactly one item — tspn12's incumbent — and that item is the ROUND budget's, not
+    this flag's: ``seam vs base`` loses it too while ``cand vs seam`` loses no
+    incumbent in any rep. Bar 1 has no slack, so all three flags stay OFF pending
+    that #966 residual.
+
     Net-positive therefore FAILED at the time of writing: the sign flips with
     budget, which is not
     "measurably helpful broadly" (the ``DISCOPT_CUT_INHERIT`` rule). The residual

--- a/python/discopt/_relax/milp_relaxation.py
+++ b/python/discopt/_relax/milp_relaxation.py
@@ -433,7 +433,27 @@ def _lp_warm_deadline_enabled() -> bool:
       (contvar 500.6 s, bchoco08 80.9 s; the OFF arm has its own pre-existing
       class, heatexch_gen3 200.5 s in the same rep set).
 
-    Net-positive therefore FAILS: the sign flips with budget, which is not
+    **Update 2026-08-11: the compounding this flag hit at the round level is
+    fixed.** The coupled panel (performance-plan §14b) failed ``CERT_CLEAN`` on one
+    item — contvar's bound going ``183632.766 -> None`` with this flag AND
+    ``DISCOPT_NODE_ROUND_BUDGET`` on — and attributed it to the *interaction*, not
+    to either flag alone. The mechanism is now measured directly: hand
+    ``solve_at_node`` a round grant that is already spent and **16 of 114 cells of
+    the binding subset return no bound at all** where the same box under an
+    unclamped round certifies one, in BOTH arms of this flag
+    (``scratchpad/issue928_round_cut_short_entry.py``) — the deadline-truncated
+    build leaves a 0-row relaxation that solves to LP optimality and that every
+    certification route then declines. In every one of those cells the relaxation
+    still carried a valid finite box-interval objective floor, equal to the
+    unclamped control bound on 4 of the 5 instances
+    (``scratchpad/issue928_floor_inventory.py``). ``_solve_at_node_impl`` now
+    reports that floor — the round-level analogue of what this flag's own
+    ``_stash_deadline_bound`` does for an LP — and takes the tighter of it and any
+    banked dual; the #966 round-admission check no longer declines the ROOT round,
+    which holds no parent bound to fall back on.
+
+    Net-positive therefore FAILED at the time of writing: the sign flips with
+    budget, which is not
     "measurably helpful broadly" (the ``DISCOPT_CUT_INHERIT`` rule). The residual
     is measurably NOT this seam any more: per-LP deadline violations are zero
     across every probe, and on contvar the ON arm spends 2.8 s in 30 relaxation

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -10550,7 +10550,11 @@ def solve_model(
                     # the node stays open on its valid parent bound.
                     # #928 rule 1 (see the batch path): the ROOT batch holds no
                     # parent bound, so its round is never declined — declining it
-                    # leaves the tree with no bound source at all.
+                    # leaves the tree with no bound source at all. That covers the
+                    # past-deadline arm of this check too: a root round entered on
+                    # a spent grant truncates its build and reports the relaxation's
+                    # rigorous box floor, which is strictly more than the nothing a
+                    # declined root leaves behind.
                     _serial_remaining = _deadline - time.perf_counter()
                     if _round_budget_enabled and iteration >= 1:
                         _exp_build = _mc_lp_relaxer.expected_build_cost()

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -10160,7 +10160,20 @@ def solve_model(
                     # cannot even cover the measured build cost buys a truncated,
                     # near-empty relaxation for full build wall — decline instead.
                     # Same skip semantics as the past-deadline branch above.
-                    if _round_budget_enabled:
+                    #
+                    # #928 rule 1: NEVER decline while the node holds no valid
+                    # bound of its own. A branched node always carries its parent's
+                    # bound (the Rust import floors every node at it), so declining
+                    # there forgoes tightening only. The ROOT batch has no parent —
+                    # declining its round leaves the whole tree bound-less, which is
+                    # exactly the collapse the coupled panel measured (contvar: the
+                    # root probe sets a build EMA larger than what is left of the
+                    # grant, the root round is then declined, and the search spends
+                    # its budget on cheap uncertified nodes for a final
+                    # ``bound=None``). This is the same rule ``_fb_stop`` already
+                    # applies in the root-relaxation fallback: a phase is optional
+                    # tightening only once some valid bound has landed.
+                    if _round_budget_enabled and iteration >= 1:
                         _exp_build = _mc_lp_relaxer.expected_build_cost()
                         if _exp_build is not None and _node_remaining < _exp_build:
                             continue
@@ -10535,8 +10548,11 @@ def solve_model(
                     # the flag, decline the round once the deadline is past or
                     # the remaining grant cannot cover the measured build cost;
                     # the node stays open on its valid parent bound.
+                    # #928 rule 1 (see the batch path): the ROOT batch holds no
+                    # parent bound, so its round is never declined — declining it
+                    # leaves the tree with no bound source at all.
                     _serial_remaining = _deadline - time.perf_counter()
-                    if _round_budget_enabled:
+                    if _round_budget_enabled and iteration >= 1:
                         _exp_build = _mc_lp_relaxer.expected_build_cost()
                         _round_blocked = _serial_remaining <= 0.0 or (
                             _exp_build is not None and _serial_remaining < _exp_build

--- a/python/discopt/solver_tuning.py
+++ b/python/discopt/solver_tuning.py
@@ -1072,12 +1072,22 @@ class SolverTuning:
       cold-build cost (an EMA over this solve's builds) — the round admission
       check accounting for the round's expected non-LP cost. A declined node
       keeps its inherited (valid) parent bound and stays open, exactly like the
-      existing past-deadline skip.
+      existing past-deadline skip — **except in the ROOT batch, which is never
+      declined** (#928 rule 1). The root has no parent bound, so declining its
+      round leaves the whole tree with no bound source; that is the ``bound=None``
+      collapse the first coupled graduation panel measured on contvar (7 → 287
+      nodes, nothing ever certified). The same rule already governs the
+      root-relaxation fallback's ``_fb_stop``: a phase is optional tightening only
+      once some valid bound is in hand.
 
     Sound by construction: build truncation only drops rows (weaker, never
     falsified — the ``_objective_bound_valid`` gate catches an un-bounded cost
     column), deadline-cut LP solves already bank the Neumaier-Shcherbina floor,
-    and a declined round only leaves a node on its parent's valid bound. Default
+    and a declined round only leaves a node on its parent's valid bound. A round
+    that IS cut short no longer returns nothing: it reports the rigorous
+    box-interval objective floor of the (possibly truncated) relaxation it built
+    — measured, a spent round grant lost the bound outright on 16 of 114 cells of
+    the binding subset before that (#928, see ``_solve_at_node_impl``). Default
     off pending the §5 corpus-wide differential panel (cert-clean AND
     net-positive); graduation is coupled to the #928
     ``DISCOPT_LP_WARM_DEADLINE`` panel this flag exists to unblock."""

--- a/python/tests/test_928_round_cut_short_floor.py
+++ b/python/tests/test_928_round_cut_short_floor.py
@@ -1,0 +1,188 @@
+"""#928 — a per-node round CUT SHORT must return the rigorous floor it holds.
+
+§14a taught a *node LP* cut short by its deadline to bank a sound
+Neumaier–Shcherbina dual floor instead of returning nothing. The coupled
+graduation panel (performance-plan §14b) then failed on the analogous hole one
+level up: with both the #928 LP clamp and the #966 round clamp active, a *round*
+cut short produced a node result carrying **no adoptable bound at all**, and a
+tree whose nodes never certify anything reports ``bound=None``.
+
+Measured on the 19-instance binding subset with a spent round grant
+(``scratchpad/issue928_round_cut_short_entry.py``): 16 of 114 cells returned
+``uncertified``/no bound where the same box under an unclamped round certifies
+one — in BOTH ``DISCOPT_LP_WARM_DEADLINE`` arms, so the loss is the round clamp,
+not the LP clamp. In every one of them the deadline-truncated build (0 constraint
+rows) still carried a valid finite ``_objective_floor``, equal to the unclamped
+control bound on 4 of the 5 instances (``issue928_floor_inventory.py``):
+bchoco06/07/08 -1.0, tls2 0.0, hda -172201.82.
+
+These tests pin both halves of the fix:
+
+* a cut-short round reports that floor rather than declining (and takes the
+  tighter of it and any banked deadline dual);
+* the #966 round-admission check never declines the ROOT round, which holds no
+  parent bound — declining it is what leaves the whole tree bound-less.
+
+Both fail on the pre-fix tree. The default path is asserted untouched: with the
+shipped flags no build is ever truncated and no node solve reports
+``time_limit``, so the new floor is never even computed.
+"""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+
+import discopt._relax.milp_relaxation as mr_mod
+import numpy as np
+import pytest
+from discopt import Model
+from discopt._relax.mccormick_lp import MccormickLPRelaxer
+from discopt._relax.milp_relaxation import MilpRelaxationResult
+from discopt._relax.model_utils import flat_variable_bounds
+from discopt.modeling.core import from_nl
+
+CORPUS = Path(__file__).parent / "data" / "minlplib_nl"
+
+
+def _spent_round() -> float:
+    """A round grant that is already gone — the state #966's clamp produces."""
+    return time.perf_counter() - 1.0
+
+
+def _bilinear_model() -> Model:
+    m = Model()
+    x = m.continuous("x", lb=0.0, ub=4.0)
+    y = m.continuous("y", lb=0.0, ub=4.0)
+    m.minimize(x * y - 2.0 * x + y)
+    m.subject_to(x + y >= 1.0)
+    return m
+
+
+@pytest.mark.parametrize(
+    ("instance", "floor"),
+    [("bchoco06", -1.0), ("tls2", 0.0)],
+)
+def test_cut_short_round_reports_its_rigorous_floor(instance, floor):
+    """A round whose grant is spent returns a sound bound, not ``uncertified``.
+
+    Pre-fix both instances return ``status="uncertified"`` with
+    ``lower_bound=None``: the truncated build solves to LP optimality and every
+    certification route then declines it for want of a safe bound.
+    """
+    model = from_nl(str(CORPUS / f"{instance}.nl"))
+    lb, ub = flat_variable_bounds(model)
+    relaxer = MccormickLPRelaxer(model)
+
+    res = relaxer.solve_at_node(lb, ub, time_limit=5.0, round_deadline=_spent_round())
+
+    assert res.lower_bound is not None, f"{instance}: a cut-short round returned no bound"
+    assert np.isfinite(res.lower_bound)
+    assert res.status == "optimal"
+    assert res.lower_bound == pytest.approx(floor, rel=1e-9, abs=1e-9)
+
+
+def test_cut_short_floor_never_exceeds_the_unclamped_bound():
+    """Soundness: the truncated round's floor is below what the full round proves.
+
+    The floor is the box-interval bound of the same column box the LP is solved
+    over, and the LP feasible region is a subset of that box, so the clamped value
+    can never exceed the unclamped certified one.
+    """
+    model = from_nl(str(CORPUS / "bchoco06.nl"))
+    lb, ub = flat_variable_bounds(model)
+
+    full = MccormickLPRelaxer(model).solve_at_node(lb, ub, time_limit=30.0)
+    cut = MccormickLPRelaxer(model).solve_at_node(
+        lb, ub, time_limit=30.0, round_deadline=_spent_round()
+    )
+
+    assert full.lower_bound is not None and cut.lower_bound is not None
+    assert cut.lower_bound <= full.lower_bound + 1e-6 * max(1.0, abs(full.lower_bound))
+
+
+def test_deadline_exit_takes_the_tighter_of_banked_dual_and_box_floor(monkeypatch):
+    """A yielded LP's banked ``g(y)`` and the round's box floor are both valid.
+
+    They are not ordered a priori — the hda node LP banked exactly ``g(0)``, the
+    box floor itself, at every deadline fraction (§14a) — so the node must report
+    the larger. Here the banked dual is deliberately the weaker of the two.
+    """
+    model = _bilinear_model()
+    relaxer = MccormickLPRelaxer(model)
+    relaxer._inc = None  # force the cold, build-and-solve path
+    lb, ub = flat_variable_bounds(model)
+
+    seen_floor: list[float] = []
+
+    def _yield_on_deadline(self, time_limit=None, *args, **kwargs):
+        # Stand in for a warm LP that ran out of budget having banked a floor
+        # strictly below the relaxation's own box-interval floor.
+        floor = self._objective_floor
+        assert floor is not None and np.isfinite(floor), "no box floor to compare against"
+        seen_floor.append(float(floor))
+        return MilpRelaxationResult(
+            status="time_limit",
+            objective=None,
+            bound=float(floor) - 100.0,
+            x=None,
+            safe_bound=float(floor) - 100.0,
+        )
+
+    monkeypatch.setattr(mr_mod.MilpRelaxationModel, "solve", _yield_on_deadline)
+    res = relaxer.solve_at_node(lb, ub, time_limit=5.0)
+
+    assert seen_floor, "the stubbed LP never ran"
+    assert res.lower_bound == pytest.approx(seen_floor[0])
+
+
+def test_default_path_still_declines_an_uncertifiable_node():
+    """Neutrality: with no clamp in force the new floor is never surfaced.
+
+    ``4stufen``'s root relaxation solves to LP optimality and every certification
+    route declines it, so the shipped contract is ``uncertified`` with no bound.
+    Nothing about this changes — the floor is reachable only from a truncated
+    build or a ``time_limit`` LP status, neither of which the default path
+    produces.
+    """
+    model = from_nl(str(CORPUS / "4stufen.nl"))
+    lb, ub = flat_variable_bounds(model)
+
+    res = MccormickLPRelaxer(model).solve_at_node(lb, ub, time_limit=10.0)
+
+    assert res.status == "uncertified"
+    assert res.lower_bound is None
+
+
+def test_root_round_is_never_declined_by_the_admission_check(monkeypatch):
+    """#966's round admission must not decline the ROOT round (rule 1).
+
+    A branched node always carries its parent's bound, so declining its round
+    forgoes tightening only. The root has no parent: declining it leaves the tree
+    with no bound source at all, which is the ``bound=None`` collapse the coupled
+    panel measured on contvar. Forcing the admission check to refuse every round
+    (an expected build cost no grant can cover) must still let the ROOT round run.
+    Pre-fix this counts zero node-loop rounds; post-fix, one.
+    """
+    monkeypatch.setenv("DISCOPT_NODE_ROUND_BUDGET", "1")
+    monkeypatch.setattr(MccormickLPRelaxer, "expected_build_cost", lambda self: 1e6, raising=True)
+
+    # Count the rounds the NODE LOOPS ran: those are the calls carrying a
+    # ``round_deadline`` (the one-off root LP probe passes None).
+    rounds: list = []
+    orig = MccormickLPRelaxer.solve_at_node
+
+    def _spy(self, node_lb, node_ub, time_limit=None, **kw):
+        if kw.get("round_deadline") is not None:
+            rounds.append(kw["round_deadline"])
+        return orig(self, node_lb, node_ub, time_limit, **kw)
+
+    monkeypatch.setattr(MccormickLPRelaxer, "solve_at_node", _spy)
+
+    # nvs05 is the smallest in-repo instance whose solve actually reaches the
+    # spatial node loop with an LP relaxer attached (``_bilinear_model`` closes at
+    # the root and never gets there, so it cannot see this gate at all).
+    res = from_nl(str(CORPUS / "nvs05.nl")).solve(time_limit=5.0)
+
+    assert rounds, "every round was declined — the root was left with no bound source"
+    assert res.bound is not None and np.isfinite(res.bound)

--- a/scratchpad/issue928_floor_inventory.py
+++ b/scratchpad/issue928_floor_inventory.py
@@ -1,0 +1,90 @@
+"""What rigorous floor IS in hand when a round is cut short?
+
+The entry probe (``issue928_round_cut_short_entry.py``) shows that a round whose
+grant is already spent returns NO bound on several instances where an unclamped
+round certifies one. This asks the follow-up the fix depends on: at that exit,
+what sound floor did the round already own and throw away?
+
+For each instance it re-runs the cut-short round with the build/solve seams
+instrumented and reports, per round: whether the cold build was truncated, the
+relaxation's ``_objective_bound_valid`` / ``_objective_floor`` (the rigorous
+box-interval objective floor), the LP status, and whether ``MilpRelaxationResult``
+carried a banked Neumaier-Shcherbina bound.
+
+Prints ROUNDS_OBSERVED and exits non-zero if it observed none (CLAUDE.md §6).
+Nothing is swallowed (§7).
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import time
+from pathlib import Path
+
+os.environ.setdefault("JAX_PLATFORMS", "cpu")
+os.environ.setdefault("JAX_ENABLE_X64", "1")
+
+import discopt  # noqa: E402
+from discopt._relax import mccormick_lp as _mc  # noqa: E402
+from discopt._relax.mccormick_lp import MccormickLPRelaxer  # noqa: E402
+from discopt._relax.model_utils import flat_variable_bounds  # noqa: E402
+from discopt.modeling.core import from_nl  # noqa: E402
+from discopt.solver_tuning import SolverTuning  # noqa: E402
+from discopt.solver_tuning import reset_current as _reset_tuning  # noqa: E402
+from discopt.solver_tuning import set_current as _set_tuning  # noqa: E402
+
+assert "/python/discopt/" in discopt.__file__, discopt.__file__
+
+ROOT = Path(__file__).resolve().parents[1]
+CORPUS = ROOT / "python/tests/data/minlplib_nl"
+INSTANCES = (sys.argv[1] if len(sys.argv) > 1 else "bchoco06,bchoco07,bchoco08,tls2,hda").split(
+    ","
+)
+
+_orig_build = _mc.build_milp_relaxation
+seen: list[dict] = []
+
+
+def _spy_build(*a, **kw):
+    milp, varmap = _orig_build(*a, **kw)
+    seen.append(
+        {
+            "truncated": bool(getattr(milp, "_build_truncated", False)),
+            "rows_done": getattr(milp, "_build_constraints_done", None),
+            "rows_total": getattr(milp, "_build_constraints_total", None),
+            "obj_bound_valid": bool(milp._objective_bound_valid),
+            "obj_floor": getattr(milp, "_objective_floor", None),
+        }
+    )
+    return milp, varmap
+
+
+_mc.build_milp_relaxation = _spy_build
+
+rounds = 0
+for name in INSTANCES:
+    model = from_nl(str(CORPUS / f"{name}.nl"))
+    lb, ub = flat_variable_bounds(model)
+    for warm in (0, 1):
+        os.environ["DISCOPT_LP_WARM_DEADLINE"] = str(warm)
+        token = _set_tuning(SolverTuning())
+        try:
+            seen.clear()
+            relaxer = MccormickLPRelaxer(model)
+            res = relaxer.solve_at_node(
+                lb, ub, time_limit=5.0, round_deadline=time.perf_counter() - 1.0
+            )
+        finally:
+            _reset_tuning(token)
+        rounds += 1
+        b = seen[-1] if seen else {}
+        print(
+            f"{name:12s} warm={warm} status={res.status:13s} lb={res.lower_bound} | "
+            f"build truncated={b.get('truncated')} rows={b.get('rows_done')}/{b.get('rows_total')} "
+            f"obj_bound_valid={b.get('obj_bound_valid')} obj_floor={b.get('obj_floor')}",
+            flush=True,
+        )
+
+print(f"ROUNDS_OBSERVED={rounds}")
+raise SystemExit(0 if rounds else 1)

--- a/scratchpad/issue928_round_cut_short_entry.py
+++ b/scratchpad/issue928_round_cut_short_entry.py
@@ -1,0 +1,141 @@
+"""Entry experiment (CLAUDE.md §4): what does a round cut short return?
+
+§14b named the residual as an *interaction*: "LP yields on its deadline" x "round
+yields on its deadline" compounding into a node result that carries no adoptable
+bound. The corpus cell that exposed it (contvar @20 s) is wall-clock-shaped and
+does not reproduce on every container, so this probes the mechanism DIRECTLY and
+deterministically: hand ``solve_at_node`` a ``round_deadline`` that is already
+spent, or nearly spent (the states the #966 clamp produces once the cold build
+has eaten the round's grant), and record what comes back in each flag regime
+against an unclamped control.
+
+Hypothesis: a round cut short can return NO bound at all — either because the
+starved LP yields before it can bank a dual (``time_limit``, the #928 arm) or
+because the truncated build leaves a relaxation whose optimum no certification
+route will certify (``uncertified``/``numerical``) — while the same box under an
+unclamped round certifies a finite bound. Any such cell is a bound the round
+threw away, and the analogue of what §14a did for an LP cut short is to floor
+the round on a rigorous bound it already has.
+
+Kill criterion: if every clamped cell returns a finite bound wherever the control
+does, the hypothesis is wrong and the loss is elsewhere.
+
+Prints CELLS_EXECUTED and exits non-zero if it measured nothing (§6). No
+exception is swallowed (§7).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import time
+from pathlib import Path
+
+os.environ.setdefault("JAX_PLATFORMS", "cpu")
+os.environ.setdefault("JAX_ENABLE_X64", "1")
+
+import discopt  # noqa: E402
+from discopt._relax.mccormick_lp import MccormickLPRelaxer  # noqa: E402
+from discopt._relax.model_utils import flat_variable_bounds  # noqa: E402
+from discopt.modeling.core import from_nl  # noqa: E402
+from discopt.solver_tuning import SolverTuning  # noqa: E402
+from discopt.solver_tuning import reset_current as _reset_tuning  # noqa: E402
+from discopt.solver_tuning import set_current as _set_tuning  # noqa: E402
+
+assert "/python/discopt/" in discopt.__file__, discopt.__file__
+assert "round_deadline" in MccormickLPRelaxer.solve_at_node.__code__.co_varnames
+
+ROOT = Path(__file__).resolve().parents[1]
+CORPUS = ROOT / "python/tests/data/minlplib_nl"
+BINDING = (
+    "4stufen,bchoco06,bchoco07,bchoco08,beuster,casctanks,clay0303hfsg,contvar,hda,"
+    "heatexch_gen1,heatexch_gen2,heatexch_gen3,nvs05,syn05hfsg,tls2,tspn05,tspn08,"
+    "tspn10,tspn12"
+)
+INSTANCES = ((sys.argv[1] if len(sys.argv) > 1 else "") or BINDING).split(",")
+OUT = Path(sys.argv[2]) if len(sys.argv) > 2 else None
+
+# (label, how many seconds of the round's grant are left when the round starts)
+ROUNDS = (("ctrl", None), ("spent", -1.0), ("tight", 0.05))
+
+cells = 0
+rows: list[dict] = []
+print(f"loadavg={[round(x, 2) for x in os.getloadavg()]}", flush=True)
+for name in INSTANCES:
+    model = from_nl(str(CORPUS / f"{name}.nl"))
+    lb, ub = flat_variable_bounds(model)
+    for warm in (0, 1):
+        os.environ["DISCOPT_LP_WARM_DEADLINE"] = str(warm)
+        for label, left in ROUNDS:
+            token = _set_tuning(SolverTuning())
+            try:
+                relaxer = MccormickLPRelaxer(model)
+                t = time.perf_counter()
+                res = relaxer.solve_at_node(
+                    lb,
+                    ub,
+                    time_limit=5.0,
+                    round_deadline=None if left is None else time.perf_counter() + left,
+                )
+                wall = time.perf_counter() - t
+            finally:
+                _reset_tuning(token)
+            cells += 1
+            rows.append(
+                {
+                    "instance": name,
+                    "warm": warm,
+                    "round": label,
+                    "status": res.status,
+                    "lb": res.lower_bound,
+                    "wall": wall,
+                }
+            )
+            print(
+                f"{name:14s} warm={warm} {label:5s} status={res.status:14s} "
+                f"lb={res.lower_bound}  wall={wall:.2f}s",
+                flush=True,
+            )
+
+ctrl = {(r["instance"], r["warm"]): r for r in rows if r["round"] == "ctrl"}
+lost = [
+    r
+    for r in rows
+    if r["round"] != "ctrl"
+    and r["lb"] is None
+    and any(
+        c["lb"] is not None
+        for c in rows
+        if c["instance"] == r["instance"] and c["warm"] == r["warm"] and c["round"] == "ctrl"
+    )
+]
+print(f"\nLOST_BOUND_CELLS={len(lost)}")
+for r in lost:
+    print(f"  {r['instance']:14s} warm={r['warm']} {r['round']:5s} status={r['status']}")
+
+# Soundness control, counted (§6). A cut-short round's floor is a lower bound on
+# the SAME box as the unclamped control's certified LP bound, and the LP feasible
+# region is a subset of the column box, so the cut-short value must never exceed
+# the control's. A violation would mean the truncated round reports a bound the
+# full round disproves — the failure class this whole change must not create.
+checked = 0
+violations = []
+for r in rows:
+    if r["round"] == "ctrl" or r["lb"] is None:
+        continue
+    c = ctrl[(r["instance"], r["warm"])]
+    if c["lb"] is None:
+        continue
+    checked += 1
+    if r["lb"] > c["lb"] + 1e-6 * max(1.0, abs(c["lb"])):
+        violations.append((r, c))
+print(f"SOUNDNESS_COMPARISONS_EXECUTED={checked}  violations={len(violations)}")
+for r, c in violations:
+    print(f"  VIOLATION {r['instance']} warm={r['warm']} {r['round']}: {r['lb']} > ctrl {c['lb']}")
+print(f"CELLS_EXECUTED={cells}")
+if violations or not checked:
+    raise SystemExit(2)
+if OUT is not None:
+    OUT.write_text(json.dumps(rows, indent=2))
+raise SystemExit(0 if cells else 1)

--- a/scratchpad/issue928_round_floor_neutral_worker.py
+++ b/scratchpad/issue928_round_floor_neutral_worker.py
@@ -1,0 +1,49 @@
+"""Neutrality worker for the #928 round-cut-short floor. Runs on EITHER tree.
+
+CLAUDE.md §8: the marker is asserted in BOTH directions — ``expect_marker=1``
+requires ``_cut_short_floor`` to be a local of
+``MccormickLPRelaxer._solve_at_node_impl``, ``0`` requires it absent — so a
+baseline run that silently imported the changed tree fails instead of producing a
+bogus "identical" verdict. Every flag this change interacts with is set to its
+shipped default explicitly, so no cell can inherit one from the environment.
+
+Usage: python issue928_round_floor_neutral_worker.py <path.nl> <limit> <0|1>
+"""
+
+import json
+import os
+import sys
+import time
+
+os.environ.setdefault("JAX_PLATFORMS", "cpu")
+os.environ.setdefault("JAX_ENABLE_X64", "1")
+
+import discopt  # noqa: E402
+from discopt._relax.mccormick_lp import MccormickLPRelaxer  # noqa: E402
+from discopt.modeling.core import from_nl  # noqa: E402
+
+path, budget, expect = sys.argv[1], float(sys.argv[2]), sys.argv[3]
+assert "/python/discopt/" in discopt.__file__, discopt.__file__
+present = "_cut_short_floor" in MccormickLPRelaxer._solve_at_node_impl.__code__.co_varnames
+assert present == (expect == "1"), (
+    f"marker mismatch: _cut_short_floor present={present}, expected={expect == '1'}"
+)
+for _flag in ("DISCOPT_LP_WARM_DEADLINE", "DISCOPT_NODE_ROUND_BUDGET", "DISCOPT_HESS_COMPILE_GATE"):
+    assert os.environ.get(_flag) == "0", f"{_flag} must be pinned OFF for the neutrality arm"
+
+m = from_nl(path)
+t0 = time.perf_counter()
+r = m.solve(time_limit=budget)
+print(
+    json.dumps(
+        {
+            "instance": path.split("/")[-1].removesuffix(".nl"),
+            "wall": time.perf_counter() - t0,
+            "status": r.status,
+            "objective": r.objective,
+            "bound": r.bound,
+            "node_count": int(r.node_count or 0),
+            "gap_certified": bool(r.gap_certified),
+        }
+    )
+)

--- a/scratchpad/issue928_round_floor_neutrality.json
+++ b/scratchpad/issue928_round_floor_neutrality.json
@@ -1,0 +1,93 @@
+{
+  "nvs03": {
+    "status": "optimal",
+    "objective": 16.0,
+    "bound": 16.0,
+    "node_count": 3,
+    "gap_certified": true
+  },
+  "nvs07": {
+    "status": "optimal",
+    "objective": 4.0,
+    "bound": 4.0,
+    "node_count": 5,
+    "gap_certified": true
+  },
+  "nvs10": {
+    "status": "optimal",
+    "objective": -310.7999999999999,
+    "bound": -310.7999999999999,
+    "node_count": 5,
+    "gap_certified": true
+  },
+  "nvs11": {
+    "status": "optimal",
+    "objective": -431.0000000000085,
+    "bound": -431.0000000000085,
+    "node_count": 55,
+    "gap_certified": true
+  },
+  "nvs12": {
+    "status": "optimal",
+    "objective": -481.20000000001,
+    "bound": -481.20000000001,
+    "node_count": 231,
+    "gap_certified": true
+  },
+  "nvs15": {
+    "status": "optimal",
+    "objective": 1.0,
+    "bound": 1.0,
+    "node_count": 7,
+    "gap_certified": true
+  },
+  "prob02": {
+    "status": "optimal",
+    "objective": 112235.0,
+    "bound": 112235.0,
+    "node_count": 177,
+    "gap_certified": true
+  },
+  "prob03": {
+    "status": "optimal",
+    "objective": 10.0,
+    "bound": 10.0,
+    "node_count": 11,
+    "gap_certified": true
+  },
+  "st_miqp1": {
+    "status": "optimal",
+    "objective": 280.9999999906497,
+    "bound": 280.9999999906497,
+    "node_count": 15,
+    "gap_certified": true
+  },
+  "st_miqp2": {
+    "status": "optimal",
+    "objective": 2.0,
+    "bound": 2.0,
+    "node_count": 9,
+    "gap_certified": true
+  },
+  "st_miqp3": {
+    "status": "optimal",
+    "objective": -6.0,
+    "bound": -6.0,
+    "node_count": 1,
+    "gap_certified": true
+  },
+  "st_test1": {
+    "status": "optimal",
+    "objective": -1.6495994490692313e-08,
+    "bound": -1.6495994490692313e-08,
+    "node_count": 15,
+    "gap_certified": true
+  },
+  "st_testgr3": {
+    "status": "optimal",
+    "objective": -20.59,
+    "bound": -20.59070709795548,
+    "node_count": 549,
+    "gap_certified": true
+  }
+}

--- a/scratchpad/issue928_round_floor_neutrality.py
+++ b/scratchpad/issue928_round_floor_neutrality.py
@@ -1,0 +1,111 @@
+"""#928 round-cut-short floor: default-path bound-neutrality (CLAUDE.md §5, regime 1).
+
+With the shipped flags (``DISCOPT_LP_WARM_DEADLINE`` /
+``DISCOPT_NODE_ROUND_BUDGET`` / ``DISCOPT_HESS_COMPILE_GATE`` all OFF) this
+change must be a no-op: no build carries a deadline, so ``_build_truncated`` is
+never set, and ``node_bound_mode="lp"`` makes every node solve a pure LP whose
+only ``time_limit`` producer is the #928 flag — so ``_cut_short_floor`` is never
+computed and no exit changes. The round-admission rule-1 edit sits inside
+``if _round_budget_enabled``, which is False.
+
+Assert exact equality of ``node_count`` and the certified ``objective``/``bound``
+on instances that CERTIFY inside the budget (the only budget-independent,
+tree-comparable results — same list as the #928/#917 checks this is adapted
+from). Any drift, in either direction, means the change is not neutral.
+
+Run on the baseline tree with ``--write --expect-marker 0``, then on the changed
+tree with ``--check --expect-marker 1``.
+"""
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKER = Path(__file__).with_name("issue928_round_floor_neutral_worker.py")
+
+CERTIFYING = [
+    ("nvs03", "minlplib_nl"),
+    ("nvs07", "minlplib_nl"),
+    ("nvs10", "minlplib_nl"),
+    ("nvs11", "minlplib_nl"),
+    ("nvs12", "minlplib_nl"),
+    ("nvs15", "minlplib_nl"),
+    ("prob02", "minlplib"),
+    ("prob03", "minlplib"),
+    ("st_miqp1", "minlplib_nl"),
+    ("st_miqp2", "minlplib_nl"),
+    ("st_miqp3", "minlplib_nl"),
+    ("st_test1", "minlplib_nl"),
+    ("st_testgr3", "minlplib_nl"),
+]
+T = 20.0
+OFF = {
+    "DISCOPT_LP_WARM_DEADLINE": "0",
+    "DISCOPT_NODE_ROUND_BUDGET": "0",
+    "DISCOPT_HESS_COMPILE_GATE": "0",
+}
+
+ap = argparse.ArgumentParser()
+ap.add_argument("--write", action="store_true")
+ap.add_argument("--check", action="store_true")
+ap.add_argument(
+    "--store", default=str(Path(__file__).with_name("issue928_round_floor_neutrality.json"))
+)
+ap.add_argument("--expect-marker", choices=["0", "1"], required=True)
+args = ap.parse_args()
+
+rows = {}
+for name, corpus in CERTIFYING:
+    nl = ROOT / f"python/tests/data/{corpus}/{name}.nl"
+    proc = subprocess.run(
+        [sys.executable, "-u", str(WORKER), str(nl), str(T), args.expect_marker],
+        capture_output=True,
+        text=True,
+        timeout=10 * T + 600,
+        env={**os.environ, **OFF},
+    )
+    if proc.returncode != 0:
+        sys.stderr.write(proc.stdout[-2000:] + proc.stderr[-4000:])
+        raise SystemExit(f"worker failed on {name}")
+    r = json.loads(proc.stdout.strip().splitlines()[-1])
+    rows[name] = {
+        "status": r["status"],
+        "objective": r["objective"],
+        "bound": r["bound"],
+        "node_count": r["node_count"],
+        "gap_certified": r["gap_certified"],
+    }
+    print(f"{name:11s} {rows[name]}", flush=True)
+
+store = Path(args.store)
+if args.write:
+    store.write_text(json.dumps(rows, indent=2))
+    print(f"wrote baseline: {store}")
+    raise SystemExit(0)
+
+if args.check:
+    base = json.loads(store.read_text())
+    compared = 0
+    drift = []
+    for name, cur in rows.items():
+        ref = base.get(name)
+        if ref is None:
+            drift.append(f"{name}: absent from baseline")
+            continue
+        compared += 1
+        if ref != cur:
+            drift.append(f"{name}: baseline={ref} current={cur}")
+    print(f"\nCOMPARED={compared}")
+    for d in drift:
+        print("DRIFT:", d)
+    if compared == 0:
+        print("PROBE FIRED NOTHING", file=sys.stderr)
+        raise SystemExit(1)
+    print("BOUND_NEUTRAL=" + str(not drift))
+    raise SystemExit(1 if drift else 0)
+
+raise SystemExit("pass --write or --check")

--- a/scratchpad/issue928_round_floor_probe.py
+++ b/scratchpad/issue928_round_floor_probe.py
@@ -1,0 +1,107 @@
+"""Where does the contvar bound go when BOTH #928 and #966 clamps are on?
+
+§14b's verdict names the suspect as an *interaction*: "LP yields on its deadline"
+x "round yields on its deadline" compounding into a node result that carries no
+adoptable bound. This probe instruments every bound-producing seam of one solve
+and prints what each one returned, so the loss has a call site rather than a
+theory.
+
+Usage:  DISCOPT_LP_WARM_DEADLINE=1 DISCOPT_NODE_ROUND_BUDGET=1 \
+        DISCOPT_HESS_COMPILE_GATE=1 python -u issue928_round_floor_probe.py contvar 20
+
+Prints OBSERVATIONS_EXECUTED and exits non-zero when it observed nothing
+(CLAUDE.md §6). Nothing is wrapped in a bare ``except`` (§7).
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import time
+from collections import Counter
+from pathlib import Path
+
+os.environ.setdefault("JAX_PLATFORMS", "cpu")
+os.environ.setdefault("JAX_ENABLE_X64", "1")
+
+import discopt  # noqa: E402
+from discopt import solver as _solver  # noqa: E402
+from discopt._relax import mccormick_lp as _mc  # noqa: E402
+from discopt._relax import milp_relaxation as _mr  # noqa: E402
+from discopt.modeling.core import from_nl  # noqa: E402
+
+assert "/python/discopt/" in discopt.__file__, discopt.__file__
+assert "round_deadline" in _mc.MccormickLPRelaxer.solve_at_node.__code__.co_varnames
+
+ROOT = Path(__file__).resolve().parents[1]
+name, budget = sys.argv[1], float(sys.argv[2])
+
+fired = Counter()
+t0 = time.perf_counter()
+
+
+def _stamp() -> float:
+    return time.perf_counter() - t0
+
+
+_orig_node = _mc.MccormickLPRelaxer.solve_at_node
+
+
+def _node(self, lb, ub, time_limit=None, **kw):
+    t = time.perf_counter()
+    r = _orig_node(self, lb, ub, time_limit, **kw)
+    fired["solve_at_node"] += 1
+    rd = kw.get("round_deadline")
+    print(
+        f"[{_stamp():6.2f}] solve_at_node tl={time_limit} "
+        f"round_left={None if rd is None else round(rd - t, 3)} "
+        f"-> status={r.status} lb={r.lower_bound} wall={time.perf_counter() - t:.2f}",
+        flush=True,
+    )
+    return r
+
+
+_orig_lp = _mr.MilpRelaxationModel.solve
+
+
+def _lp(self, time_limit=None, gap_tolerance=1e-4, backend="auto", **kw):
+    t = time.perf_counter()
+    r = _orig_lp(self, time_limit, gap_tolerance, backend, **kw)
+    fired["milp_solve"] += 1
+    fired[f"milp_solve:{backend}:{r.status}"] += 1
+    if r.status != "optimal":
+        print(
+            f"[{_stamp():6.2f}]   lp.solve backend={backend} tl={time_limit} "
+            f"-> status={r.status} bound={r.bound} wall={time.perf_counter() - t:.2f}",
+            flush=True,
+        )
+    return r
+
+
+_orig_fb = _solver._root_relaxation_lower_bound
+
+
+def _fb(*a, **kw):
+    t = time.perf_counter()
+    r = _orig_fb(*a, **kw)
+    fired["root_fallback"] += 1
+    print(
+        f"[{_stamp():6.2f}] ROOT FALLBACK -> {r} (wall={time.perf_counter() - t:.2f})",
+        flush=True,
+    )
+    return r
+
+
+_mc.MccormickLPRelaxer.solve_at_node = _node
+_mr.MilpRelaxationModel.solve = _lp
+_solver._root_relaxation_lower_bound = _fb
+
+m = from_nl(str(ROOT / "python/tests/data/minlplib_nl" / f"{name}.nl"))
+res = m.solve(time_limit=budget)
+print(
+    f"\nRESULT status={res.status} bound={res.bound} obj={res.objective} "
+    f"nodes={res.node_count} wall={res.wall_time:.1f}"
+)
+print("counters:", dict(fired))
+print(f"OBSERVATIONS_EXECUTED={fired['solve_at_node'] + fired['milp_solve']}")
+raise SystemExit(0 if (fired["solve_at_node"] + fired["milp_solve"]) else 1)


### PR DESCRIPTION
## Summary

The #928/#966 coupled graduation panel failed `CERT_CLEAN` on one item — contvar
`183632.766 → None` with both clamps on — and attributed it to the *interaction* of
"LP yields on its deadline" × "round yields on its deadline". This measures that
mechanism and fixes it.

The corpus cell is wall-clock-shaped and does not travel: on this container all four
arms of the §14b attribution probe return the same bound (171244.81, 3 nodes) and the
287-node collapse does not reproduce. So the mechanism was probed directly instead —
hand `solve_at_node` a `round_deadline` that is already spent (the state #966's clamp
produces once the cold build has eaten the round's grant) and compare against an
unclamped control, over the 19 binding instances, in both `DISCOPT_LP_WARM_DEADLINE`
arms (`scratchpad/issue928_round_cut_short_entry.py`, 114 counted cells).

**16 of 114 cells return no bound at all** where the control certifies one, and they
return it as `uncertified`, not `time_limit`. **Both flag arms are affected
identically**, so this is not an interaction of the two clamps: it is the *round* clamp
alone, and the LP clamp only made it more reachable. The truncated build leaves a
**0-row** relaxation that solves to LP optimality and that every certification route
then declines — while the rigorous floor it computed sits unused
(`scratchpad/issue928_floor_inventory.py`, 10 counted rounds):

| instance | rows built | `_objective_bound_valid` | discarded floor | unclamped control |
|---|---|---|---|---|
| bchoco06 | 0 / 134 | True | **-1.0** | -0.9999918 |
| bchoco07 | 0 / 153 | True | **-1.0** | -1.0000000 |
| bchoco08 | 0 / 190 | True | **-1.0** | -1.0000000 |
| tls2 | 0 / 24 | True | **0.0** | 0.0 |
| hda | 0 / 718 | True | **-172201.82** | -64675.25 |

On four of five the discarded floor *is* the control bound to within rounding, so the
fix is not a new bound source — it is reporting the one already computed.

Two coupled changes, both inside the opt-in flags' blast radius:

* `_solve_at_node_impl` reports that box-interval floor whenever the round was cut short
  (`_build_truncated`, or an LP that exited `time_limit`) and no route certified
  anything — the round-level analogue of what #928 already does for an LP cut short —
  and takes `max(banked deadline dual, box floor)` on a deadline exit, since the two are
  not ordered a priori (§14a measured the hda node LP banking exactly `g(0)`, the box
  floor itself).
* The #966 round-admission check no longer declines the **ROOT** round. A branched node
  always carries its parent's bound so declining forgoes tightening only; the root has
  no parent, and declining it leaves the tree with no bound source at all — the shape of
  §14b's contvar collapse. This is rule 1 of `_fb_stop`, applied where it was missing.

Contributes to #928. The remaining graduation blocker is a primal-trajectory loss the
panel attributes to #966 (see below), not to this change.

## Correctness

The new bound is `_objective_floor`: the box-interval lower bound of the
minimize-equivalent objective over this build's **column box**, computed from the
cost-column bounds alone and therefore independent of which constraint rows were
emitted. Dropping rows only enlarges the feasible set, and the LP feasible region is a
subset of the column box, so the floor is ≤ the node's true optimum however truncated
the build was. It is the identical quantity, with the identical argument, that the
existing `unbounded` branch already reports. `_objective_bound_valid` gates it, which
excludes the un-relaxable/under-constrained objective and the #248 garbage-wide floor —
the case where reporting the value would anchor the tree on a bound that never
certifies. The floor is consulted **last**, so it can only fill a gap, never displace a
tighter certified or banked bound. Panel soundness: **0 violations over 63 counted
bound-vs-ceiling comparisons** plus the curated-oracle, bound-crosses-incumbent and
incumbent-verification arms.

Nothing was weakened. In particular the panel's oracle instrument was left exactly as
§14b-qual hardened it: `minlplib.solu` is unreachable from this container (network
policy denies minlplib.org), which would put its coverage back at 1/19, so rather than
loosen that instrument the new runner reuses its `soundness`/`compare`/`run_one`
unchanged and *adds* a counted cross-arm primal ceiling.

- [x] Cannot produce a false certificate
- [x] No validation, fallback, or safety guard was weakened to make a check pass

## Tests run (state the result — numbers, not adjectives)

- [x] `pytest -m smoke` → 18 failed, 915 passed, 22 skipped, 2 xpassed. The same 18
      fail **identically on the pre-fix tree** (verified by re-running those seven files
      against a stashed working tree): environmental — this container's POUNCE build
      lacks `NlExpr`/`build_nl_problem`, so the tape NLP evaluator is unavailable.
- [x] `pytest -m slow python/tests/test_adversarial_recent_fixes.py` → 10 passed
      (207 s). The first run of this file reported 1 failure
      (`test_large_dense_jacobian_no_crash`) at 288 s wall; it did not reproduce in
      isolation (34 s, passed) nor on a second full-file run, and is timeout-shaped.
- [x] `cargo test -p discopt-core` → N/A, no Rust touched.
- [x] `ruff check` / `ruff format --check` clean.
- Flag suites: `test_917_lp_warm_deadline.py` + `test_966_node_round_budget.py` +
  `test_928_round_cut_short_floor.py` → 35 passed.
- `test_time_limit_contract.py` → `[hda-5.0]` and `[casctanks-5.0]` fail **identically
  pre-fix** on this container (its solves are slower than the tolerances assume);
  `[hda-10.0]` still xfails, as expected — it measures the default path, which this
  change deliberately leaves untouched.

## Regression test

`python/tests/test_928_round_cut_short_floor.py` — six tests. Five fail on the pre-fix
tree and pass after (verified by stashing the two source files):

* `test_cut_short_round_reports_its_rigorous_floor[bchoco06]` / `[tls2]` — a spent round
  grant returns a sound bound, not `uncertified`;
* `test_cut_short_floor_never_exceeds_the_unclamped_bound` — soundness ordering;
* `test_deadline_exit_takes_the_tighter_of_banked_dual_and_box_floor` — the `max`, with
  the banked dual deliberately the weaker of the two;
* `test_root_round_is_never_declined_by_the_admission_check` — counts node-loop rounds
  under an admission check forced to refuse everything: 0 before, 1 after.

The sixth, `test_default_path_still_declines_an_uncertifiable_node`, is the neutrality
pin and is green on **both** trees by design.

- [x] Added a regression test that fails before / passes after

## Bound-changing / performance change?

- [x] Behind the existing default-OFF flags — no new flag. With the shipped defaults
      neither `_build_truncated` (no build deadline is ever set) nor a `time_limit` node
      status (`node_bound_mode="lp"` makes every node solve a pure LP, whose only
      `time_limit` producer is `DISCOPT_LP_WARM_DEADLINE`) can occur, so the new floor is
      never even computed; the solver-side edit sits inside `if _round_budget_enabled`.
      **Flag-OFF path verified byte-identical**: 13/13 certifying instances identical in
      `node_count`/`objective`/`bound`, marker-gated in both directions
      (`scratchpad/issue928_round_floor_neutrality.py`).
- [x] Differential-bound evidence: post-fix re-run of the entry experiment,
      `LOST_BOUND_CELLS` 16 → 0, with a counted bound-vs-control comparison on every
      cell; the panel's `looser/tighter` ledger below is the corpus-level version.
- [x] Graduation panel evidence attached — **not graduating**: the flags stay
      default-OFF.

**Measurement** — 19 binding instances, 20 s, 3 reps, three arms (`base` / `seam` /
`cand`) interleaved per instance;
`discopt_benchmarks/results/issue928_round_floor_binding20.json`;
`COMPARISONS_EXECUTED=57`, `CEILING_COMPARISONS_EXECUTED=63`; loadavg recorded in the
artifact.

| cand vs base | rep1 | rep2 | rep3 |
|---|---|---|---|
| overrun delta | **-94.4 s** | **-313.5 s** | **-16.7 s** |
| total overrun base → cand | 169.4 → 75.0 | 367.4 → 53.9 | 67.2 → 50.5 |
| bounds tighter / looser | 8 / 1 | 7 / 2 | 8 / 1 |
| bounds lost / gained | 0 / 1 | 0 / 0 | 0 / 0 |
| nodes base → cand | 501 → 823 | 615 → 877 | 537 → 851 |

* **Net-positive: passes.** Negative in 3/3 reps where §14b measured **+325.4 / +68.5 /
  +12.7** — the sign flip is gone. (Mean -141.5, sd 153.9; the spread is rep2's base arm
  hitting a 313 s severe mode, not the sign being in doubt.)
* **The bound ledger is positive, not merely non-negative.** `lost_bound` empty in 3/3 —
  contvar `183632.766 → None` does not recur — and rep1 *gains* one (clay0303hfsg
  `None → -1.23e-05`). The movers are exactly the cut-short class: hda
  `-2.07e13 → -124296.9`, tspn12 `183.33 → 192.92`, beuster `6352.06 → 17698.96`,
  heatexch_gen2 `555767.8 → 578091.9`. The looser cells are tiny (tspn05
  178.1165 → 177.8928; tls2 2.4487 → 2.1000).
* **`CERT_CLEAN=False` in reps 2 and 3, on exactly one item: tspn12's incumbent** (base
  282.24 with bound 183.33; seam and cand none, with the tighter bound 192.92). The
  artifact attributes it to the **round budget, not to #928**: `seam vs base` loses the
  same incumbent (rep3 adds tls2) while `cand vs seam` loses **no** incumbent in any rep.

Bar 1 is a hard gate with no slack, so **all three flags stay default-OFF** even though
the failing item is a primal one owned by #966 and is paid for by a materially tighter
dual bound in the same cells. Full record in `docs/dev/performance-plan.md` §14d.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WdpRcHJ9W6vgE6vbCouoXd

---
_Generated by [Claude Code](https://claude.ai/code/session_01WdpRcHJ9W6vgE6vbCouoXd)_