### PR TITLE
fix(budget): #966 a short-granted node round yields instead of skipping

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -101,3 +101,8 @@ scratchpad/*.log
 scratchpad/**/*_out*.txt
 scratchpad/**/*.log
 scratchpad/**/*.out
+# per-cell worker scripts a probe WRITES at run time (same rule: keep the
+# harness, drop what it generates). The leading underscore is the convention —
+# a hand-written harness like ``issue966_neutral_worker.py`` has none and stays
+# tracked; ``_issue966_yield_fix_worker.py`` is re-emitted on every run.
+scratchpad/_*_worker.py

--- a/discopt_benchmarks/results/issue966_yield_binding20_rep1.json
+++ b/discopt_benchmarks/results/issue966_yield_binding20_rep1.json
@@ -1,0 +1,1294 @@
+{
+  "summary": {
+    "instances": 19,
+    "budget": 20.0,
+    "arms": {
+      "base": "all OFF (today's default)",
+      "seam": "#966 ON, #928 OFF",
+      "cand": "all three ON"
+    },
+    "unsound": [],
+    "incumbent_verification_failed": [],
+    "oracle_comparisons_executed": 3,
+    "instances_without_oracle": [
+      "4stufen",
+      "bchoco06",
+      "bchoco07",
+      "bchoco08",
+      "beuster",
+      "casctanks",
+      "contvar",
+      "hda",
+      "heatexch_gen1",
+      "heatexch_gen2",
+      "heatexch_gen3",
+      "nvs05",
+      "syn05hfsg",
+      "tls2",
+      "tspn05",
+      "tspn08",
+      "tspn10",
+      "tspn12"
+    ],
+    "pairs": [
+      {
+        "pair": "cand vs base",
+        "cells_over_budget": {
+          "base": 16,
+          "cand": 10
+        },
+        "total_overrun_s": {
+          "base": 104.9,
+          "cand": 51.8
+        },
+        "overrun_delta_s": -53.1,
+        "node_count_total": {
+          "base": 647,
+          "cand": 981
+        },
+        "cert_gains": [],
+        "cert_regressions": [],
+        "gained_incumbents": [],
+        "lost_incumbents": [],
+        "better_objective": [],
+        "worse_objective": [
+          "tls2 (5.299999999987421 -> 6.299999999986951)"
+        ],
+        "tighter_bound": [
+          "4stufen (20282.050738739534 -> 20781.828426007993)",
+          "bchoco06 (1.0000000000001477 -> 0.9999875077256566)",
+          "bchoco08 (1.0000000093277979 -> 1.0000000000006108)",
+          "beuster (6352.061283279516 -> 17698.956442696926)",
+          "casctanks (-90.17863668805973 -> -90.17863067603525)",
+          "hda (-20747118223745.168 -> -119286.31279576839)",
+          "heatexch_gen2 (555767.7902849488 -> 579990.0125074089)",
+          "nvs05 (3.513911309952577 -> 3.542487394239276)",
+          "tspn05 (178.27199109143874 -> 179.44338081801095)",
+          "tspn10 (161.16079717285405 -> 161.16083653483406)",
+          "tspn12 (183.3259927436284 -> 192.92305137670508)"
+        ],
+        "looser_bound": [
+          "contvar (180782.85932797543 -> 171244.81148737646)",
+          "tls2 (3.1706801036010077 -> 2.4487125876978726)"
+        ],
+        "gained_bound": [],
+        "lost_bound": []
+      },
+      {
+        "pair": "cand vs seam",
+        "cells_over_budget": {
+          "seam": 14,
+          "cand": 10
+        },
+        "total_overrun_s": {
+          "seam": 44.3,
+          "cand": 51.8
+        },
+        "overrun_delta_s": 7.5,
+        "node_count_total": {
+          "seam": 1089,
+          "cand": 981
+        },
+        "cert_gains": [],
+        "cert_regressions": [],
+        "gained_incumbents": [
+          "tspn10"
+        ],
+        "lost_incumbents": [],
+        "better_objective": [],
+        "worse_objective": [
+          "tls2 (5.299999999987421 -> 6.299999999986951)"
+        ],
+        "tighter_bound": [
+          "4stufen (20742.036713116195 -> 20781.828426007993)",
+          "bchoco06 (0.9999880430650611 -> 0.9999875077256566)",
+          "casctanks (-90.17863668805973 -> -90.17863067603525)",
+          "hda (-20747118223745.168 -> -119286.31279576839)",
+          "heatexch_gen2 (578091.8643598395 -> 579990.0125074089)",
+          "nvs05 (3.513911309952577 -> 3.542487394239276)",
+          "tspn05 (178.27199109143874 -> 179.44338081801095)",
+          "tspn10 (161.15822038513005 -> 161.16083653483406)",
+          "tspn12 (192.92291097809897 -> 192.92305137670508)"
+        ],
+        "looser_bound": [
+          "contvar (180782.85932797543 -> 171244.81148737646)",
+          "tls2 (3.1706801036010077 -> 2.4487125876978726)"
+        ],
+        "gained_bound": [],
+        "lost_bound": []
+      },
+      {
+        "pair": "seam vs base",
+        "cells_over_budget": {
+          "base": 16,
+          "seam": 14
+        },
+        "total_overrun_s": {
+          "base": 104.9,
+          "seam": 44.3
+        },
+        "overrun_delta_s": -60.6,
+        "node_count_total": {
+          "base": 647,
+          "seam": 1089
+        },
+        "cert_gains": [],
+        "cert_regressions": [],
+        "gained_incumbents": [],
+        "lost_incumbents": [
+          "tspn10"
+        ],
+        "better_objective": [],
+        "worse_objective": [],
+        "tighter_bound": [
+          "4stufen (20282.050738739534 -> 20742.036713116195)",
+          "bchoco06 (1.0000000000001477 -> 0.9999880430650611)",
+          "bchoco08 (1.0000000093277979 -> 1.0000000000136013)",
+          "beuster (6352.061283279516 -> 17698.956442696926)",
+          "heatexch_gen2 (555767.7902849488 -> 578091.8643598395)",
+          "tspn12 (183.3259927436284 -> 192.92291097809897)"
+        ],
+        "looser_bound": [
+          "tspn10 (161.16079717285405 -> 161.15822038513005)"
+        ],
+        "gained_bound": [],
+        "lost_bound": []
+      }
+    ],
+    "solu_oracle": "none",
+    "panel_wall_s": 1388.4,
+    "loadavg_start": [
+      0.58,
+      0.66,
+      0.56
+    ],
+    "loadavg_end": [
+      1.09,
+      1.23,
+      1.09
+    ]
+  },
+  "cells": [
+    {
+      "instance": "4stufen",
+      "budget": 20.0,
+      "reference_optimum": null,
+      "base": {
+        "instance": "4stufen",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 22.487398641000254,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 20282.050738739534,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 7,
+        "incumbent_verification_failed": false
+      },
+      "seam": {
+        "instance": "4stufen",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 21.108149853000214,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 20742.036713116195,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 95,
+        "incumbent_verification_failed": false
+      },
+      "cand": {
+        "instance": "4stufen",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "1",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 20.987014675999944,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 20781.828426007993,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 63,
+        "incumbent_verification_failed": false
+      }
+    },
+    {
+      "instance": "bchoco06",
+      "budget": 20.0,
+      "reference_optimum": null,
+      "base": {
+        "instance": "bchoco06",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "max",
+        "wall": 22.63624693699967,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 1.0000000000001477,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 7,
+        "incumbent_verification_failed": false
+      },
+      "seam": {
+        "instance": "bchoco06",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "max",
+        "wall": 21.59602718499991,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 0.9999880430650611,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 41,
+        "incumbent_verification_failed": false
+      },
+      "cand": {
+        "instance": "bchoco06",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "1",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "max",
+        "wall": 20.834332889000052,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 0.9999875077256566,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 45,
+        "incumbent_verification_failed": false
+      }
+    },
+    {
+      "instance": "bchoco07",
+      "budget": 20.0,
+      "reference_optimum": null,
+      "base": {
+        "instance": "bchoco07",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "max",
+        "wall": 29.307530928999768,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 1.000000000000253,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 7,
+        "incumbent_verification_failed": false
+      },
+      "seam": {
+        "instance": "bchoco07",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "max",
+        "wall": 21.423076746999868,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 1.000000000000253,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 15,
+        "incumbent_verification_failed": false
+      },
+      "cand": {
+        "instance": "bchoco07",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "1",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "max",
+        "wall": 20.846837908999987,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 1.000000000000253,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 13,
+        "incumbent_verification_failed": false
+      }
+    },
+    {
+      "instance": "bchoco08",
+      "budget": 20.0,
+      "reference_optimum": null,
+      "base": {
+        "instance": "bchoco08",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "max",
+        "wall": 21.570233755000118,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 1.0000000093277979,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 3,
+        "incumbent_verification_failed": false
+      },
+      "seam": {
+        "instance": "bchoco08",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "max",
+        "wall": 21.04514819699989,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 1.0000000000136013,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 7,
+        "incumbent_verification_failed": false
+      },
+      "cand": {
+        "instance": "bchoco08",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "1",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "max",
+        "wall": 21.155544139000085,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 1.0000000000006108,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 7,
+        "incumbent_verification_failed": false
+      }
+    },
+    {
+      "instance": "beuster",
+      "budget": 20.0,
+      "reference_optimum": null,
+      "base": {
+        "instance": "beuster",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 23.053081615000337,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 6352.061283279516,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 7,
+        "incumbent_verification_failed": false
+      },
+      "seam": {
+        "instance": "beuster",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 21.569854720999956,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 17698.956442696926,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 95,
+        "incumbent_verification_failed": false
+      },
+      "cand": {
+        "instance": "beuster",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "1",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 21.371794271,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 17698.956442696926,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 95,
+        "incumbent_verification_failed": false
+      }
+    },
+    {
+      "instance": "casctanks",
+      "budget": 20.0,
+      "reference_optimum": null,
+      "base": {
+        "instance": "casctanks",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 24.177511041999878,
+        "status": "time_limit",
+        "objective": null,
+        "bound": -90.17863668805973,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 3,
+        "incumbent_verification_failed": false
+      },
+      "seam": {
+        "instance": "casctanks",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 23.629010539999854,
+        "status": "time_limit",
+        "objective": null,
+        "bound": -90.17863668805973,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 3,
+        "incumbent_verification_failed": false
+      },
+      "cand": {
+        "instance": "casctanks",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "1",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 22.82449647400017,
+        "status": "time_limit",
+        "objective": null,
+        "bound": -90.17863067603525,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 3,
+        "incumbent_verification_failed": false
+      }
+    },
+    {
+      "instance": "clay0303hfsg",
+      "budget": 20.0,
+      "reference_optimum": 26669.10955143,
+      "base": {
+        "instance": "clay0303hfsg",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 24.863203498000075,
+        "status": "time_limit",
+        "objective": null,
+        "bound": -1.2309090908977703e-05,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 3,
+        "incumbent_verification_failed": false
+      },
+      "seam": {
+        "instance": "clay0303hfsg",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 21.658934432000024,
+        "status": "time_limit",
+        "objective": null,
+        "bound": -1.230904907067064e-05,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 95,
+        "incumbent_verification_failed": false
+      },
+      "cand": {
+        "instance": "clay0303hfsg",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "1",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 21.9082773680002,
+        "status": "time_limit",
+        "objective": null,
+        "bound": -1.2309090908977703e-05,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 3,
+        "incumbent_verification_failed": false
+      }
+    },
+    {
+      "instance": "contvar",
+      "budget": 20.0,
+      "reference_optimum": null,
+      "base": {
+        "instance": "contvar",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 26.558362275000036,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 180782.85932797543,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 1,
+        "incumbent_verification_failed": false
+      },
+      "seam": {
+        "instance": "contvar",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 29.08470305400033,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 180782.85932797543,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 3,
+        "incumbent_verification_failed": false
+      },
+      "cand": {
+        "instance": "contvar",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "1",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 21.248433418999866,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 171244.81148737646,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 7,
+        "incumbent_verification_failed": false
+      }
+    },
+    {
+      "instance": "hda",
+      "budget": 20.0,
+      "reference_optimum": null,
+      "base": {
+        "instance": "hda",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 26.158538435999617,
+        "status": "time_limit",
+        "objective": null,
+        "bound": -20747118223745.168,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 1,
+        "incumbent_verification_failed": false
+      },
+      "seam": {
+        "instance": "hda",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 26.234976004000146,
+        "status": "time_limit",
+        "objective": null,
+        "bound": -20747118223745.168,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 1,
+        "incumbent_verification_failed": false
+      },
+      "cand": {
+        "instance": "hda",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "1",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 47.34436788200037,
+        "status": "time_limit",
+        "objective": null,
+        "bound": -119286.31279576839,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 3,
+        "incumbent_verification_failed": false
+      }
+    },
+    {
+      "instance": "heatexch_gen1",
+      "budget": 20.0,
+      "reference_optimum": null,
+      "base": {
+        "instance": "heatexch_gen1",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 22.912661839000066,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 38183.53174601408,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 3,
+        "incumbent_verification_failed": false
+      },
+      "seam": {
+        "instance": "heatexch_gen1",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 26.925541874999908,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 38183.53174601408,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 3,
+        "incumbent_verification_failed": false
+      },
+      "cand": {
+        "instance": "heatexch_gen1",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "1",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 22.737724591000188,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 38183.53174601912,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 3,
+        "incumbent_verification_failed": false
+      }
+    },
+    {
+      "instance": "heatexch_gen2",
+      "budget": 20.0,
+      "reference_optimum": null,
+      "base": {
+        "instance": "heatexch_gen2",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 22.778446985999835,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 555767.7902849488,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 7,
+        "incumbent_verification_failed": false
+      },
+      "seam": {
+        "instance": "heatexch_gen2",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 21.04364634700005,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 578091.8643598395,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 95,
+        "incumbent_verification_failed": false
+      },
+      "cand": {
+        "instance": "heatexch_gen2",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "1",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 20.885835257000053,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 579990.0125074089,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 127,
+        "incumbent_verification_failed": false
+      }
+    },
+    {
+      "instance": "heatexch_gen3",
+      "budget": 20.0,
+      "reference_optimum": null,
+      "base": {
+        "instance": "heatexch_gen3",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 31.044251303999772,
+        "status": "time_limit",
+        "objective": null,
+        "bound": null,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 3,
+        "incumbent_verification_failed": false
+      },
+      "seam": {
+        "instance": "heatexch_gen3",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 21.70713063700032,
+        "status": "time_limit",
+        "objective": null,
+        "bound": null,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 7,
+        "incumbent_verification_failed": false
+      },
+      "cand": {
+        "instance": "heatexch_gen3",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "1",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 21.94107721799992,
+        "status": "time_limit",
+        "objective": null,
+        "bound": null,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 7,
+        "incumbent_verification_failed": false
+      }
+    },
+    {
+      "instance": "nvs05",
+      "budget": 20.0,
+      "reference_optimum": null,
+      "base": {
+        "instance": "nvs05",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 20.937540992999857,
+        "status": "feasible",
+        "objective": 8.731956986640789,
+        "bound": 3.513911309952577,
+        "gap": 0.5975803230216792,
+        "gap_certified": false,
+        "node_count": 39,
+        "incumbent_verification_failed": false
+      },
+      "seam": {
+        "instance": "nvs05",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 20.661392668999724,
+        "status": "feasible",
+        "objective": 8.731956986640789,
+        "bound": 3.513911309952577,
+        "gap": 0.5975803230216792,
+        "gap_certified": false,
+        "node_count": 39,
+        "incumbent_verification_failed": false
+      },
+      "cand": {
+        "instance": "nvs05",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "1",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 20.66219765200003,
+        "status": "feasible",
+        "objective": 8.731956986640789,
+        "bound": 3.542487394239276,
+        "gap": 0.5943077365521837,
+        "gap_certified": false,
+        "node_count": 39,
+        "incumbent_verification_failed": false
+      }
+    },
+    {
+      "instance": "syn05hfsg",
+      "budget": 20.0,
+      "reference_optimum": null,
+      "base": {
+        "instance": "syn05hfsg",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "max",
+        "wall": 20.7017575509999,
+        "status": "feasible",
+        "objective": 837.7323012718435,
+        "bound": 838.387862224017,
+        "gap": 0.0007825422884830729,
+        "gap_certified": false,
+        "node_count": 251,
+        "incumbent_verification_failed": false
+      },
+      "seam": {
+        "instance": "syn05hfsg",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "max",
+        "wall": 20.641028087999985,
+        "status": "feasible",
+        "objective": 837.7323012718435,
+        "bound": 838.387862224017,
+        "gap": 0.0007825422884830729,
+        "gap_certified": false,
+        "node_count": 259,
+        "incumbent_verification_failed": false
+      },
+      "cand": {
+        "instance": "syn05hfsg",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "1",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "max",
+        "wall": 20.79745194399993,
+        "status": "feasible",
+        "objective": 837.7323012718435,
+        "bound": 838.3878622240114,
+        "gap": 0.0007825422884764232,
+        "gap_certified": false,
+        "node_count": 259,
+        "incumbent_verification_failed": false
+      }
+    },
+    {
+      "instance": "tls2",
+      "budget": 20.0,
+      "reference_optimum": null,
+      "base": {
+        "instance": "tls2",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 21.132843110000067,
+        "status": "feasible",
+        "objective": 5.299999999987421,
+        "bound": 3.1706801036010077,
+        "gap": 0.401758471017258,
+        "gap_certified": false,
+        "node_count": 261,
+        "incumbent_verification_failed": false
+      },
+      "seam": {
+        "instance": "tls2",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 21.23733589199992,
+        "status": "feasible",
+        "objective": 5.299999999987421,
+        "bound": 3.1706801036010077,
+        "gap": 0.401758471017258,
+        "gap_certified": false,
+        "node_count": 261,
+        "incumbent_verification_failed": false
+      },
+      "cand": {
+        "instance": "tls2",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "1",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 20.85270436799965,
+        "status": "feasible",
+        "objective": 6.299999999986951,
+        "bound": 2.4487125876978726,
+        "gap": 0.6113154622693738,
+        "gap_certified": false,
+        "node_count": 251,
+        "incumbent_verification_failed": false
+      }
+    },
+    {
+      "instance": "tspn05",
+      "budget": 20.0,
+      "reference_optimum": null,
+      "base": {
+        "instance": "tspn05",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 20.751711283000077,
+        "status": "feasible",
+        "objective": 191.2552078446695,
+        "bound": 178.27199109143874,
+        "gap": 0.06788425214426198,
+        "gap_certified": false,
+        "node_count": 31,
+        "incumbent_verification_failed": false
+      },
+      "seam": {
+        "instance": "tspn05",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 20.73545263899996,
+        "status": "feasible",
+        "objective": 191.2552078446695,
+        "bound": 178.27199109143874,
+        "gap": 0.06788425214426198,
+        "gap_certified": false,
+        "node_count": 49,
+        "incumbent_verification_failed": false
+      },
+      "cand": {
+        "instance": "tspn05",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "1",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 20.650077878000047,
+        "status": "feasible",
+        "objective": 191.25520784467014,
+        "bound": 179.44338081801095,
+        "gap": 0.061759505321561145,
+        "gap_certified": false,
+        "node_count": 35,
+        "incumbent_verification_failed": false
+      }
+    },
+    {
+      "instance": "tspn08",
+      "budget": 20.0,
+      "reference_optimum": null,
+      "base": {
+        "instance": "tspn08",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 24.416711005999787,
+        "status": "feasible",
+        "objective": 290.56685396750163,
+        "bound": 231.98283795409407,
+        "gap": 0.20161974847950095,
+        "gap_certified": false,
+        "node_count": 3,
+        "incumbent_verification_failed": false
+      },
+      "seam": {
+        "instance": "tspn08",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 22.33962297900007,
+        "status": "feasible",
+        "objective": 290.56685396750163,
+        "bound": 231.98283795409407,
+        "gap": 0.20161974847950095,
+        "gap_certified": false,
+        "node_count": 3,
+        "incumbent_verification_failed": false
+      },
+      "cand": {
+        "instance": "tspn08",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "1",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 21.941010943000038,
+        "status": "feasible",
+        "objective": 290.56685396750163,
+        "bound": 231.98283795409407,
+        "gap": 0.20161974847950095,
+        "gap_certified": false,
+        "node_count": 3,
+        "incumbent_verification_failed": false
+      }
+    },
+    {
+      "instance": "tspn10",
+      "budget": 20.0,
+      "reference_optimum": null,
+      "base": {
+        "instance": "tspn10",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 21.53213562699966,
+        "status": "feasible",
+        "objective": 225.1260717001723,
+        "bound": 161.16079717285405,
+        "gap": 0.28413090516014766,
+        "gap_certified": false,
+        "node_count": 3,
+        "incumbent_verification_failed": false
+      },
+      "seam": {
+        "instance": "tspn10",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 20.888426763000098,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 161.15822038513005,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 3,
+        "incumbent_verification_failed": false
+      },
+      "cand": {
+        "instance": "tspn10",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "1",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 21.945678569999927,
+        "status": "feasible",
+        "objective": 225.1260717001723,
+        "bound": 161.16083653483406,
+        "gap": 0.2841307303159827,
+        "gap_certified": false,
+        "node_count": 3,
+        "incumbent_verification_failed": false
+      }
+    },
+    {
+      "instance": "tspn12",
+      "budget": 20.0,
+      "reference_optimum": null,
+      "base": {
+        "instance": "tspn12",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 57.831469682999796,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 183.3259927436284,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 7,
+        "incumbent_verification_failed": false
+      },
+      "seam": {
+        "instance": "tspn12",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 20.768504441999994,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 192.92291097809897,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 15,
+        "incumbent_verification_failed": false
+      },
+      "cand": {
+        "instance": "tspn12",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "1",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 20.84146924999959,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 192.92305137670508,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 15,
+        "incumbent_verification_failed": false
+      }
+    }
+  ]
+}

--- a/discopt_benchmarks/results/issue966_yield_binding20_rep2.json
+++ b/discopt_benchmarks/results/issue966_yield_binding20_rep2.json
@@ -1,0 +1,1293 @@
+{
+  "summary": {
+    "instances": 19,
+    "budget": 20.0,
+    "arms": {
+      "base": "all OFF (today's default)",
+      "seam": "#966 ON, #928 OFF",
+      "cand": "all three ON"
+    },
+    "unsound": [],
+    "incumbent_verification_failed": [],
+    "oracle_comparisons_executed": 3,
+    "instances_without_oracle": [
+      "4stufen",
+      "bchoco06",
+      "bchoco07",
+      "bchoco08",
+      "beuster",
+      "casctanks",
+      "contvar",
+      "hda",
+      "heatexch_gen1",
+      "heatexch_gen2",
+      "heatexch_gen3",
+      "nvs05",
+      "syn05hfsg",
+      "tls2",
+      "tspn05",
+      "tspn08",
+      "tspn10",
+      "tspn12"
+    ],
+    "pairs": [
+      {
+        "pair": "cand vs base",
+        "cells_over_budget": {
+          "base": 16,
+          "cand": 13
+        },
+        "total_overrun_s": {
+          "base": 300.8,
+          "cand": 31.4
+        },
+        "overrun_delta_s": -269.3,
+        "node_count_total": {
+          "base": 765,
+          "cand": 1087
+        },
+        "cert_gains": [],
+        "cert_regressions": [],
+        "gained_incumbents": [],
+        "lost_incumbents": [
+          "tspn12"
+        ],
+        "better_objective": [],
+        "worse_objective": [
+          "tls2 (5.299999999987421 -> 6.299999999986951)"
+        ],
+        "tighter_bound": [
+          "4stufen (20282.050738739534 -> 20742.036713116195)",
+          "bchoco06 (1.0000000000001477 -> 0.9999875077256566)",
+          "beuster (6352.061283279516 -> 17698.956442696926)",
+          "casctanks (-90.17863668805973 -> -90.17863067603525)",
+          "hda (-20747118223745.168 -> -119286.31279576839)",
+          "heatexch_gen2 (555767.7902849488 -> 578091.8643598154)",
+          "nvs05 (3.513911309952577 -> 3.542487394239276)",
+          "tspn05 (179.44337578426806 -> 179.44338081801095)",
+          "tspn10 (161.16079717285405 -> 161.16083653483406)",
+          "tspn12 (183.3259927436284 -> 192.92305137670508)"
+        ],
+        "looser_bound": [
+          "syn05hfsg (838.387862224017 -> 840.4893941019108)",
+          "tls2 (3.1706801036010077 -> 2.4487125876978726)"
+        ],
+        "gained_bound": [],
+        "lost_bound": []
+      },
+      {
+        "pair": "cand vs seam",
+        "cells_over_budget": {
+          "seam": 12,
+          "cand": 13
+        },
+        "total_overrun_s": {
+          "seam": 39.0,
+          "cand": 31.4
+        },
+        "overrun_delta_s": -7.6,
+        "node_count_total": {
+          "seam": 833,
+          "cand": 1087
+        },
+        "cert_gains": [],
+        "cert_regressions": [],
+        "gained_incumbents": [
+          "tls2"
+        ],
+        "lost_incumbents": [],
+        "better_objective": [],
+        "worse_objective": [],
+        "tighter_bound": [
+          "bchoco06 (0.9999880430650611 -> 0.9999875077256566)",
+          "casctanks (-90.17863668805973 -> -90.17863067603525)",
+          "hda (-20747118223745.168 -> -119286.31279576839)",
+          "nvs05 (3.513911309952577 -> 3.542487394239276)",
+          "tls2 (0.7183065609201987 -> 2.4487125876978726)",
+          "tspn05 (179.44337578426806 -> 179.44338081801095)",
+          "tspn10 (161.16079717285405 -> 161.16083653483406)",
+          "tspn12 (192.92291097809897 -> 192.92305137670508)"
+        ],
+        "looser_bound": [
+          "contvar (180782.85932797543 -> 171244.81148737646)",
+          "syn05hfsg (838.387862224017 -> 840.4893941019108)"
+        ],
+        "gained_bound": [],
+        "lost_bound": []
+      },
+      {
+        "pair": "seam vs base",
+        "cells_over_budget": {
+          "base": 16,
+          "seam": 12
+        },
+        "total_overrun_s": {
+          "base": 300.8,
+          "seam": 39.0
+        },
+        "overrun_delta_s": -261.7,
+        "node_count_total": {
+          "base": 765,
+          "seam": 833
+        },
+        "cert_gains": [],
+        "cert_regressions": [],
+        "gained_incumbents": [],
+        "lost_incumbents": [
+          "tls2",
+          "tspn12"
+        ],
+        "better_objective": [],
+        "worse_objective": [],
+        "tighter_bound": [
+          "4stufen (20282.050738739534 -> 20742.036713116195)",
+          "bchoco06 (1.0000000000001477 -> 0.9999880430650611)",
+          "beuster (6352.061283279516 -> 17698.956442696926)",
+          "contvar (171244.81148737553 -> 180782.85932797543)",
+          "heatexch_gen2 (555767.7902849488 -> 578091.8643598395)",
+          "tspn12 (183.3259927436284 -> 192.92291097809897)"
+        ],
+        "looser_bound": [
+          "tls2 (3.1706801036010077 -> 0.7183065609201987)"
+        ],
+        "gained_bound": [],
+        "lost_bound": []
+      }
+    ],
+    "solu_oracle": "none",
+    "panel_wall_s": 1553.9,
+    "loadavg_start": [
+      0.72,
+      1.13,
+      1.06
+    ],
+    "loadavg_end": [
+      1.16,
+      1.25,
+      1.17
+    ]
+  },
+  "cells": [
+    {
+      "instance": "4stufen",
+      "budget": 20.0,
+      "reference_optimum": null,
+      "base": {
+        "instance": "4stufen",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 22.165408931,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 20282.050738739534,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 7,
+        "incumbent_verification_failed": false
+      },
+      "seam": {
+        "instance": "4stufen",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 20.901467892000255,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 20742.036713116195,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 95,
+        "incumbent_verification_failed": false
+      },
+      "cand": {
+        "instance": "4stufen",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "1",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 21.23903684300012,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 20742.036713116195,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 95,
+        "incumbent_verification_failed": false
+      }
+    },
+    {
+      "instance": "bchoco06",
+      "budget": 20.0,
+      "reference_optimum": null,
+      "base": {
+        "instance": "bchoco06",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "max",
+        "wall": 21.856887153000116,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 1.0000000000001477,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 7,
+        "incumbent_verification_failed": false
+      },
+      "seam": {
+        "instance": "bchoco06",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "max",
+        "wall": 20.85780008399979,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 0.9999880430650611,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 41,
+        "incumbent_verification_failed": false
+      },
+      "cand": {
+        "instance": "bchoco06",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "1",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "max",
+        "wall": 20.706749718999617,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 0.9999875077256566,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 45,
+        "incumbent_verification_failed": false
+      }
+    },
+    {
+      "instance": "bchoco07",
+      "budget": 20.0,
+      "reference_optimum": null,
+      "base": {
+        "instance": "bchoco07",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "max",
+        "wall": 22.089202544999807,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 1.000000000000253,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 7,
+        "incumbent_verification_failed": false
+      },
+      "seam": {
+        "instance": "bchoco07",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "max",
+        "wall": 21.435684692999985,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 1.000000000000253,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 15,
+        "incumbent_verification_failed": false
+      },
+      "cand": {
+        "instance": "bchoco07",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "1",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "max",
+        "wall": 20.811828417000015,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 1.000000000000253,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 13,
+        "incumbent_verification_failed": false
+      }
+    },
+    {
+      "instance": "bchoco08",
+      "budget": 20.0,
+      "reference_optimum": null,
+      "base": {
+        "instance": "bchoco08",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "max",
+        "wall": 86.16766235299974,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 1.0000000000136013,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 7,
+        "incumbent_verification_failed": false
+      },
+      "seam": {
+        "instance": "bchoco08",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "max",
+        "wall": 20.961633470999914,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 1.0000000000136013,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 7,
+        "incumbent_verification_failed": false
+      },
+      "cand": {
+        "instance": "bchoco08",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "1",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "max",
+        "wall": 21.068254998000157,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 1.0000000000006108,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 3,
+        "incumbent_verification_failed": false
+      }
+    },
+    {
+      "instance": "beuster",
+      "budget": 20.0,
+      "reference_optimum": null,
+      "base": {
+        "instance": "beuster",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 21.54119442299998,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 6352.061283279516,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 7,
+        "incumbent_verification_failed": false
+      },
+      "seam": {
+        "instance": "beuster",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 21.58415879100039,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 17698.956442696926,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 95,
+        "incumbent_verification_failed": false
+      },
+      "cand": {
+        "instance": "beuster",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "1",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 21.383229016000314,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 17698.956442696926,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 95,
+        "incumbent_verification_failed": false
+      }
+    },
+    {
+      "instance": "casctanks",
+      "budget": 20.0,
+      "reference_optimum": null,
+      "base": {
+        "instance": "casctanks",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 23.098341252999944,
+        "status": "time_limit",
+        "objective": null,
+        "bound": -90.17863668805973,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 3,
+        "incumbent_verification_failed": false
+      },
+      "seam": {
+        "instance": "casctanks",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 22.67829845999995,
+        "status": "time_limit",
+        "objective": null,
+        "bound": -90.17863668805973,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 3,
+        "incumbent_verification_failed": false
+      },
+      "cand": {
+        "instance": "casctanks",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "1",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 22.865288943999985,
+        "status": "time_limit",
+        "objective": null,
+        "bound": -90.17863067603525,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 3,
+        "incumbent_verification_failed": false
+      }
+    },
+    {
+      "instance": "clay0303hfsg",
+      "budget": 20.0,
+      "reference_optimum": 26669.10955143,
+      "base": {
+        "instance": "clay0303hfsg",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 21.441481348000252,
+        "status": "time_limit",
+        "objective": null,
+        "bound": -1.230904907067064e-05,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 95,
+        "incumbent_verification_failed": false
+      },
+      "seam": {
+        "instance": "clay0303hfsg",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 21.815447825999854,
+        "status": "time_limit",
+        "objective": null,
+        "bound": -1.230904907067064e-05,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 95,
+        "incumbent_verification_failed": false
+      },
+      "cand": {
+        "instance": "clay0303hfsg",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "1",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 21.704016189999948,
+        "status": "time_limit",
+        "objective": null,
+        "bound": -1.230904907067064e-05,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 95,
+        "incumbent_verification_failed": false
+      }
+    },
+    {
+      "instance": "contvar",
+      "budget": 20.0,
+      "reference_optimum": null,
+      "base": {
+        "instance": "contvar",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 29.176714876000005,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 171244.81148737553,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 1,
+        "incumbent_verification_failed": false
+      },
+      "seam": {
+        "instance": "contvar",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 24.184230440999727,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 180782.85932797543,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 3,
+        "incumbent_verification_failed": false
+      },
+      "cand": {
+        "instance": "contvar",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "1",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 21.215809303000242,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 171244.81148737646,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 7,
+        "incumbent_verification_failed": false
+      }
+    },
+    {
+      "instance": "hda",
+      "budget": 20.0,
+      "reference_optimum": null,
+      "base": {
+        "instance": "hda",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 26.053333331999966,
+        "status": "time_limit",
+        "objective": null,
+        "bound": -20747118223745.168,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 1,
+        "incumbent_verification_failed": false
+      },
+      "seam": {
+        "instance": "hda",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 25.997475119999763,
+        "status": "time_limit",
+        "objective": null,
+        "bound": -20747118223745.168,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 1,
+        "incumbent_verification_failed": false
+      },
+      "cand": {
+        "instance": "hda",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "1",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 23.570947858999716,
+        "status": "time_limit",
+        "objective": null,
+        "bound": -119286.31279576839,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 3,
+        "incumbent_verification_failed": false
+      }
+    },
+    {
+      "instance": "heatexch_gen1",
+      "budget": 20.0,
+      "reference_optimum": null,
+      "base": {
+        "instance": "heatexch_gen1",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 24.524181771000258,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 38183.53174601408,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 3,
+        "incumbent_verification_failed": false
+      },
+      "seam": {
+        "instance": "heatexch_gen1",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 26.962029901999813,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 38183.53174601408,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 3,
+        "incumbent_verification_failed": false
+      },
+      "cand": {
+        "instance": "heatexch_gen1",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "1",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 23.258844682000017,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 38183.53174601912,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 3,
+        "incumbent_verification_failed": false
+      }
+    },
+    {
+      "instance": "heatexch_gen2",
+      "budget": 20.0,
+      "reference_optimum": null,
+      "base": {
+        "instance": "heatexch_gen2",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 21.076209339000343,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 555767.7902849488,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 7,
+        "incumbent_verification_failed": false
+      },
+      "seam": {
+        "instance": "heatexch_gen2",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 21.005972621000183,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 578091.8643598395,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 95,
+        "incumbent_verification_failed": false
+      },
+      "cand": {
+        "instance": "heatexch_gen2",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "1",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 21.150236810000024,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 578091.8643598154,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 127,
+        "incumbent_verification_failed": false
+      }
+    },
+    {
+      "instance": "heatexch_gen3",
+      "budget": 20.0,
+      "reference_optimum": null,
+      "base": {
+        "instance": "heatexch_gen3",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 210.0579117239995,
+        "status": "time_limit",
+        "objective": null,
+        "bound": null,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 3,
+        "incumbent_verification_failed": false
+      },
+      "seam": {
+        "instance": "heatexch_gen3",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 21.787613880000208,
+        "status": "time_limit",
+        "objective": null,
+        "bound": null,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 7,
+        "incumbent_verification_failed": false
+      },
+      "cand": {
+        "instance": "heatexch_gen3",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "1",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 21.59423668599993,
+        "status": "time_limit",
+        "objective": null,
+        "bound": null,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 7,
+        "incumbent_verification_failed": false
+      }
+    },
+    {
+      "instance": "nvs05",
+      "budget": 20.0,
+      "reference_optimum": null,
+      "base": {
+        "instance": "nvs05",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 20.74944610499915,
+        "status": "feasible",
+        "objective": 8.731956986640789,
+        "bound": 3.513911309952577,
+        "gap": 0.5975803230216792,
+        "gap_certified": false,
+        "node_count": 39,
+        "incumbent_verification_failed": false
+      },
+      "seam": {
+        "instance": "nvs05",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 20.731782965000093,
+        "status": "feasible",
+        "objective": 8.731956986640789,
+        "bound": 3.513911309952577,
+        "gap": 0.5975803230216792,
+        "gap_certified": false,
+        "node_count": 39,
+        "incumbent_verification_failed": false
+      },
+      "cand": {
+        "instance": "nvs05",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "1",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 20.672190940999826,
+        "status": "feasible",
+        "objective": 8.731956986640789,
+        "bound": 3.542487394239276,
+        "gap": 0.5943077365521837,
+        "gap_certified": false,
+        "node_count": 39,
+        "incumbent_verification_failed": false
+      }
+    },
+    {
+      "instance": "syn05hfsg",
+      "budget": 20.0,
+      "reference_optimum": null,
+      "base": {
+        "instance": "syn05hfsg",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "max",
+        "wall": 20.68960762000006,
+        "status": "feasible",
+        "objective": 837.7323012718435,
+        "bound": 838.387862224017,
+        "gap": 0.0007825422884830729,
+        "gap_certified": false,
+        "node_count": 259,
+        "incumbent_verification_failed": false
+      },
+      "seam": {
+        "instance": "syn05hfsg",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "max",
+        "wall": 20.767690064999442,
+        "status": "feasible",
+        "objective": 837.7323012718435,
+        "bound": 838.387862224017,
+        "gap": 0.0007825422884830729,
+        "gap_certified": false,
+        "node_count": 263,
+        "incumbent_verification_failed": false
+      },
+      "cand": {
+        "instance": "syn05hfsg",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "1",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "max",
+        "wall": 20.68441348899978,
+        "status": "feasible",
+        "objective": 837.7323012718435,
+        "bound": 840.4893941019108,
+        "gap": 0.0032911382620455358,
+        "gap_certified": false,
+        "node_count": 243,
+        "incumbent_verification_failed": false
+      }
+    },
+    {
+      "instance": "tls2",
+      "budget": 20.0,
+      "reference_optimum": null,
+      "base": {
+        "instance": "tls2",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 21.407215000999713,
+        "status": "feasible",
+        "objective": 5.299999999987421,
+        "bound": 3.1706801036010077,
+        "gap": 0.401758471017258,
+        "gap_certified": false,
+        "node_count": 261,
+        "incumbent_verification_failed": false
+      },
+      "seam": {
+        "instance": "tls2",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 22.072410148999552,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 0.7183065609201987,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 3,
+        "incumbent_verification_failed": false
+      },
+      "cand": {
+        "instance": "tls2",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "1",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 22.230039058999864,
+        "status": "feasible",
+        "objective": 6.299999999986951,
+        "bound": 2.4487125876978726,
+        "gap": 0.6113154622693738,
+        "gap_certified": false,
+        "node_count": 251,
+        "incumbent_verification_failed": false
+      }
+    },
+    {
+      "instance": "tspn05",
+      "budget": 20.0,
+      "reference_optimum": null,
+      "base": {
+        "instance": "tspn05",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 20.76551994500005,
+        "status": "feasible",
+        "objective": 191.2552078446695,
+        "bound": 179.44337578426806,
+        "gap": 0.061759531641065665,
+        "gap_certified": false,
+        "node_count": 47,
+        "incumbent_verification_failed": false
+      },
+      "seam": {
+        "instance": "tspn05",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 20.73421139200036,
+        "status": "feasible",
+        "objective": 191.2552078446695,
+        "bound": 179.44337578426806,
+        "gap": 0.061759531641065665,
+        "gap_certified": false,
+        "node_count": 47,
+        "incumbent_verification_failed": false
+      },
+      "cand": {
+        "instance": "tspn05",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "1",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 20.689507310999943,
+        "status": "feasible",
+        "objective": 191.25520784467014,
+        "bound": 179.44338081801095,
+        "gap": 0.061759505321561145,
+        "gap_certified": false,
+        "node_count": 37,
+        "incumbent_verification_failed": false
+      }
+    },
+    {
+      "instance": "tspn08",
+      "budget": 20.0,
+      "reference_optimum": null,
+      "base": {
+        "instance": "tspn08",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 23.033060106999983,
+        "status": "feasible",
+        "objective": 290.56685396750163,
+        "bound": 231.98283795409407,
+        "gap": 0.20161974847950095,
+        "gap_certified": false,
+        "node_count": 3,
+        "incumbent_verification_failed": false
+      },
+      "seam": {
+        "instance": "tspn08",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 22.271248045999528,
+        "status": "feasible",
+        "objective": 290.56685396750163,
+        "bound": 231.98283795409407,
+        "gap": 0.20161974847950095,
+        "gap_certified": false,
+        "node_count": 3,
+        "incumbent_verification_failed": false
+      },
+      "cand": {
+        "instance": "tspn08",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "1",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 23.788534444000106,
+        "status": "feasible",
+        "objective": 290.56685396750163,
+        "bound": 231.98283795409407,
+        "gap": 0.20161974847950095,
+        "gap_certified": false,
+        "node_count": 3,
+        "incumbent_verification_failed": false
+      }
+    },
+    {
+      "instance": "tspn10",
+      "budget": 20.0,
+      "reference_optimum": null,
+      "base": {
+        "instance": "tspn10",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 21.89353207699969,
+        "status": "feasible",
+        "objective": 225.1260717001723,
+        "bound": 161.16079717285405,
+        "gap": 0.28413090516014766,
+        "gap_certified": false,
+        "node_count": 3,
+        "incumbent_verification_failed": false
+      },
+      "seam": {
+        "instance": "tspn10",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 21.619752174000496,
+        "status": "feasible",
+        "objective": 225.1260717001723,
+        "bound": 161.16079717285405,
+        "gap": 0.28413090516014766,
+        "gap_certified": false,
+        "node_count": 3,
+        "incumbent_verification_failed": false
+      },
+      "cand": {
+        "instance": "tspn10",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "1",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 22.13103528800002,
+        "status": "feasible",
+        "objective": 225.1260717001723,
+        "bound": 161.16083653483406,
+        "gap": 0.2841307303159827,
+        "gap_certified": false,
+        "node_count": 3,
+        "incumbent_verification_failed": false
+      }
+    },
+    {
+      "instance": "tspn12",
+      "budget": 20.0,
+      "reference_optimum": null,
+      "base": {
+        "instance": "tspn12",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 22.982441391000066,
+        "status": "feasible",
+        "objective": 282.244359359475,
+        "bound": 183.3259927436284,
+        "gap": 0.3504706589720051,
+        "gap_certified": false,
+        "node_count": 5,
+        "incumbent_verification_failed": false
+      },
+      "seam": {
+        "instance": "tspn12",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 20.669714305000525,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 192.92291097809897,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 15,
+        "incumbent_verification_failed": false
+      },
+      "cand": {
+        "instance": "tspn12",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "1",
+          "DISCOPT_NODE_ROUND_BUDGET": "1",
+          "DISCOPT_HESS_COMPILE_GATE": "1"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 20.683214657999997,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 192.92305137670508,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 15,
+        "incumbent_verification_failed": false
+      }
+    }
+  ]
+}

--- a/discopt_benchmarks/scripts/issue966_coupled_graduation_panel.py
+++ b/discopt_benchmarks/scripts/issue966_coupled_graduation_panel.py
@@ -93,6 +93,20 @@ def reference_optimum(name: str):
 
 
 def _solu_ceiling(name: str):
+    """``minlplib.solu``'s ceiling for ``name``, or ``None`` when unnamed there.
+
+    ``DISCOPT_MINLPLIB_SOLU=none`` declares the library oracle **unavailable in
+    this environment** (the benchmark snapshot is not mounted and minlplib.org is
+    unreachable). It is an explicit, recorded declaration -- ``solu_oracle`` in
+    the panel summary -- not a swallowed error: a .solu path that is *set* but
+    unreadable still crashes, which is the §7 state this keeps distinguishable.
+    Under it every instance falls through to the narrow ``_optima`` fallback, so
+    the run's oracle coverage collapses (1/19 on this panel's names) and the
+    printed ``oracle_comparisons_executed`` / ``instances_without_oracle`` counts
+    are what the soundness claim may rest on -- exactly the §14b-qual lesson.
+    """
+    if solu_oracle_state() == "none":
+        return None
     sys.path.insert(0, str(Path(__file__).parent))
     from minlplib_solu import load, primal_ceiling  # type: ignore
 
@@ -100,6 +114,11 @@ def _solu_ceiling(name: str):
     if _SOLU is None:
         _SOLU = load()
     return primal_ceiling(name, _SOLU)
+
+
+def solu_oracle_state() -> str:
+    """``"none"`` when the library oracle is declared unavailable, else its path."""
+    return "none" if os.environ.get("DISCOPT_MINLPLIB_SOLU", "").strip() == "none" else "solu"
 
 
 _SOLU: dict | None = None
@@ -307,6 +326,7 @@ def main() -> int:
         "arms": {k: lbl for k, lbl, _e in ARMS},
         **snd,
         "pairs": pairs,
+        "solu_oracle": solu_oracle_state(),
         "panel_wall_s": round(time.perf_counter() - t_panel, 1),
         "loadavg_start": [round(x, 2) for x in load_start],
         "loadavg_end": [round(x, 2) for x in loadavg()],

--- a/discopt_benchmarks/scripts/issue966_coupled_worker.py
+++ b/discopt_benchmarks/scripts/issue966_coupled_worker.py
@@ -31,6 +31,10 @@ assert hasattr(_ms, "_dual_start_slack_basis"), "#928 marker '_dual_start_slack_
 assert "round_deadline" in _mc.MccormickLPRelaxer.solve_at_node.__code__.co_varnames, (
     "#966 marker 'round_deadline' absent from solve_at_node"
 )
+assert "yield_round" in _mc.MccormickLPRelaxer.solve_at_node.__code__.co_varnames, (
+    "#966 yield-mode marker 'yield_round' absent from solve_at_node — this tree "
+    "predates the fix that makes a short-granted round yield instead of skip"
+)
 
 FLAGS = ("DISCOPT_LP_WARM_DEADLINE", "DISCOPT_NODE_ROUND_BUDGET", "DISCOPT_HESS_COMPILE_GATE")
 for _f in FLAGS:

--- a/docs/dev/performance-plan.md
+++ b/docs/dev/performance-plan.md
@@ -1993,6 +1993,15 @@ Stage-1 validation patch (route `diving` through a per-model evaluator cache):
 > yields only on non-root nodes so §14d's rule-1 root exemption governs both. The
 > panel numbers below therefore understate the merged tree, and the §5 verdict for
 > the merged code needs its own panel run: see the residual note at the end.
+>
+> **§14d does not subsume this entry, measured on the merged base.** Re-running the
+> A/B there (nvs05 @ 20 s, forced-admission regime) with §14d's cut-short floor
+> present: base 3.5425 / incumbent 8.7320 / 39 nodes, **skip 0.6323 / 6.3870 / 77**,
+> **yield 3.5067 / 8.7320 / 59** (38 yields counted). The floor rescues a round that
+> RUNS and is cut short; it can do nothing for a round that never runs, which is why
+> the skip arm still loses the bound and the incumbent on the merged tree.
+> Flag-OFF bound-neutrality was re-verified against the merged base as well
+> (13/13 byte-identical, markers both ways).
 
 > **FALSIFIED (H1): the cheap tier is the incremental fast path.** A round the grant
 > cannot afford could fall back to `_try_incremental_node` (patch + warm start, ~ms).

--- a/docs/dev/performance-plan.md
+++ b/docs/dev/performance-plan.md
@@ -1857,6 +1857,115 @@ Stage-1 validation patch (route `diving` through a per-model evaluator cache):
 > both printed, and the panel **exits non-zero** when it made zero oracle comparisons
 > (§6) — the state that produced this retraction can no longer report success.
 
+### 14d. #966: a short-granted round YIELDS instead of skipping — §14b's bound ledger root-caused and fixed; graduation still fails (2026-08-11)
+
+> §14b's coupled panel failed on one thing: the `seam` arm (#966's two flags) bought
+> wall time (−4.9 ± 1.0 s, cert-clean 3/3) and paid in the metric the solver's product
+> actually is — 4 looser bounds against 3 non-reproducible tighter, node counts
+> 1329 → 1811, casctanks collapsing `2.9098 → −56.5001` in every rep. Its closing
+> sentence named the fix: *"a round that yields on its deadline must still be able to
+> bank a bound, the way §14a taught an LP cut short to export its dual."* That is what
+> this entry implements — after two hypotheses died on the way.
+>
+> **FALSIFIED (H1): the cheap tier is the incremental fast path.** A round the grant
+> cannot afford could fall back to `_try_incremental_node` (patch + warm start, ~ms).
+> Measured (`scratchpad/issue966_inc_scope.py`, 5/5 instances the flag hurt):
+> `IncrementalMcCormickLP` is **out of scope on every one** — nvs05, tspn10, casctanks,
+> contvar, tls2 all construct with `_inc = None`, and the whole-solve probes see
+> `fast_path_hits = 0`. There is no incremental tier on this class.
+>
+> **CONFIRMED (H2): the #694 anytime build already is the cheap tier**
+> (`scratchpad/issue966_truncated_floor.py`, 2 reps/instance). A build whose deadline
+> is already spent emits zero constraint rows but still linearizes the objective, so it
+> returns a valid weaker relaxation *and* the rigorous box-interval `_objective_floor`:
+>
+> | instance | full build | truncated build | full round | truncated-round bound |
+> |---|---|---|---|---|
+> | contvar | 0.39–1.83 s | **0.008 s** | 19.6–23.9 s | 87754.998 (full: 164927.75) |
+> | casctanks | 0.06–0.16 s | **0.025 s** | 0.16–0.27 s | 0.0 (full: *no bound at all*) |
+> | tspn10 | 0.18–0.91 s | **0.068 s** | 2.2–16.0 s | 0.0 (full: 161.16) |
+> | nvs05 | 0.74 s | **0.002 s** | 0.93 s | 0.674 (full: −323.05) |
+>
+> Truncation is effective at the *build* and nowhere else, so a yield must skip the
+> separation chain too (tspn10's truncated-build round still cost 1.85–1.94 s with
+> separation on).
+>
+> **What the flag's skip actually cost** (`scratchpad/issue966_yield_vs_decline.py`,
+> nvs05 @ 20 s, every round forced through the admission branch): a skipped round banks
+> no bound **and no LP point**, and the point is what the spatial brancher and the
+> primal heuristics consume:
+>
+> | arm | bound | incumbent | nodes | wall |
+> |---|---|---|---|---|
+> | base (flag off) | 3.5139 | 8.7320 | 29–39 | 20.9 s |
+> | every round SKIPPED | 0.6842 | **523.69** | **1** | **4.1 s** (16 s of budget unused) |
+> | every round YIELDED | 1.3529 | 8.7320 | 45 | 21.0 s |
+>
+> **The fix** (`DISCOPT_NODE_ROUND_BUDGET`, still default OFF). A round whose grant
+> cannot cover the measured cold-build EMA now runs with `yield_round=True` —
+> separation off, build truncated at the grant — instead of being skipped. Sound by the
+> same argument as the truncation: dropping cuts and rows only enlarges the relaxed
+> set. Shipped-code A/B (`scratchpad/issue966_yield_fix_ab.py`, same forced regime):
+>
+> | nvs05 @ 20 s | bound | incumbent | nodes |
+> |---|---|---|---|
+> | base | 3.5139 | 8.7320 | 39 |
+> | skip (pre-fix) | 0.6323 | 6.9358 | 35 |
+> | yield (shipped) | **3.5061** | **8.7320** | 59 |
+>
+> Second half: a yielded round that banks *nothing* must not leave its node holding the
+> failure sentinel. The slot carries `_INFEASIBILITY_SENTINEL` when the per-node NLP
+> failed and the LP round is what replaces it; leaving it hands the node to the Rust
+> tree's bound-cut — a fathom with no proof, which `_nonrigorous_sentinel_fathom` turns
+> into a *discarded global dual bound* (§14b's contvar `183632.766 → None` has exactly
+> this shape). `_yield_keeps_node_open` imports `-inf` instead: the node stays open,
+> floored at its proved parent bound, and nothing is decertified.
+>
+> **Flag-OFF bound-neutrality** (§5 regime 1): 13 certifying instances,
+> `node_count`/`objective`/`bound`/`status`/`gap_certified` byte-identical against the
+> pre-change tree, markers asserted in both directions (§8) —
+> `scratchpad/issue966_neutrality.py`, `BOUND_NEUTRAL=True  COMPARED=13`.
+>
+> **Coupled panel re-run**, same script and instance list as §14b (19 binding
+> instances, 20 s, 3 arms interleaved per instance, 2 reps;
+> `discopt_benchmarks/results/issue966_yield_binding20_rep{1,2}.json`):
+>
+> | pair | rep1 | rep2 |
+> |---|---|---|
+> | total overrun, base | 104.9 s | 300.8 s |
+> | seam − base overrun | **−60.6 s** | **−261.7 s** |
+> | cand − base overrun | −53.1 s | −269.3 s |
+> | seam bound ledger vs base | 6 tighter / 1 looser | 6 tighter / 1 looser |
+> | cand bound ledger vs base | 11 tighter / 2 looser | 10 tighter / 2 looser |
+> | `CERT_CLEAN` (cand vs base) | **True** | **False** (tspn12 lost incumbent) |
+>
+> §14b's two named casualties are gone: casctanks is *tighter* in both flag arms in
+> both reps (no collapse), and contvar keeps a finite bound in `cand` (180782.86 →
+> 171244.81, sound) instead of losing it. The severe modes the base arm still hits are
+> what the overrun deltas are made of — heatexch_gen3 base 210.1 s (10.5×) vs seam
+> 21.8 s in rep2, bchoco08 base 86.2 s (4.31×) vs 21.0 s, tspn12 base 57.8 s (2.89×)
+> vs 20.8 s in rep1 — each with an equal or *tighter* flag-arm bound.
+>
+> **Verdict: the flags stay default-OFF.** §14b's failure mode is fixed (the bound
+> ledger is now positive and the wall win is large and reproducible), but §5 bar 1 is
+> per-run and rep2's graduation pair is not cert-clean: tspn12 loses its incumbent
+> (rep1 lost tspn10's in the `seam` arm). Lost incumbents are the residual, and they
+> are not reproducible rep-to-rep — which is itself the signal that the *anytime*
+> character of a yielded round is now trading primal luck, not bound quality.
+>
+> **Two honest limits on this measurement, both environmental.** (1) It ran in a
+> container where POUNCE lacks the tape NLP evaluator, so every cell used the JAX
+> evaluator; absolute walls and even base bounds differ from §14b's machine
+> (casctanks base is −90.1786 here vs 2.9098 there), so this is the same panel on a
+> different machine, not a reproduction of §14b's cells. (2) `minlplib.solu` is not
+> reachable here, so oracle coverage was **1/19 instances (3 comparisons)** — the very
+> state §14b-qual retracted a claim over. It is declared explicitly
+> (`DISCOPT_MINLPLIB_SOLU=none`, recorded as `solu_oracle` in every artifact) rather
+> than swallowed, and the panel's other soundness checks (bound-crosses-incumbent,
+> incumbent verification) fired on all 19 × 3 cells with `unsound=[]`. **No soundness
+> claim over the corpus may rest on these two runs**; re-run on the benchmark machine
+> with the .solu oracle before graduating anything.
+
 ## 15. #956 envelope outward rounding: the defect is real, but it is NOT what drives `n_undecided` (falsified 2026-08-08)
 
 > **The defect (confirmed).** The McCormick row generators in

--- a/python/discopt/_relax/mccormick_lp.py
+++ b/python/discopt/_relax/mccormick_lp.py
@@ -454,12 +454,16 @@ class MccormickLPRelaxer:
         self._lazy_skip_ctr: int = 0
         # Measured cold-build cost EMA (#966, ``DISCOPT_NODE_ROUND_BUDGET``): the
         # wall of this relaxer's ``build_milp_relaxation`` calls, exponentially
-        # averaged (alpha 0.5) so the node loop's round-admission check can
-        # decline a round whose grant cannot cover the round's expected non-LP
-        # cost. ``None`` until the first cold build; the incremental fast path
-        # does not update it (its per-node cost is negligible by construction).
+        # averaged (alpha 0.5) so the node loop's round-admission check can tell
+        # a round whose grant covers a full round from one that must yield.
+        # ``None`` until the first cold build; the incremental fast path does not
+        # update it (its per-node cost is negligible by construction).
         # Pure measurement — read via :meth:`expected_build_cost`.
         self._build_wall_ema: Optional[float] = None
+        # Count of rounds run in yield mode (#966). Read by the node loops for
+        # ``solver_stats`` and by the tests to prove the mechanism fired
+        # (CLAUDE.md §6: a gate that never fires must not read as a pass).
+        self.yield_rounds: int = 0
         # Spatial-BB uses standard McCormick globally — no partitioning here.
         self._disc = DiscretizationState(partitions={})
         self._n_orig = sum(v.size for v in model._variables)
@@ -947,8 +951,9 @@ class MccormickLPRelaxer:
         """EMA of this relaxer's cold-build wall (#966), ``None`` before any build.
 
         The node loop's round-admission check reads this (under
-        ``DISCOPT_NODE_ROUND_BUDGET``) to decline a round whose remaining grant
-        cannot cover the round's expected non-LP cost.
+        ``DISCOPT_NODE_ROUND_BUDGET``) to decide whether a round's remaining
+        grant can cover a FULL round; a round whose grant falls short is run in
+        yield mode (``yield_round``) rather than skipped.
         """
         return self._build_wall_ema
 
@@ -966,6 +971,7 @@ class MccormickLPRelaxer:
         skip_pool_separators: bool = False,
         build_deadline: Optional[float] = None,
         round_deadline: Optional[float] = None,
+        yield_round: bool = False,
     ) -> MccormickLPResult:
         """Solve the McCormick LP relaxation restricted to the given bound box.
 
@@ -1031,6 +1037,7 @@ class MccormickLPRelaxer:
             skip_pool_separators=skip_pool_separators,
             build_deadline=build_deadline,
             round_deadline=round_deadline,
+            yield_round=yield_round,
         )
         # C-43 pool-infeasible re-verification. Only relevant when (a) this was a
         # regular node solve (not a root pool-capture call, which passes no pool),
@@ -1175,6 +1182,7 @@ class MccormickLPRelaxer:
         skip_pool_separators: bool = False,
         build_deadline: Optional[float] = None,
         round_deadline: Optional[float] = None,
+        yield_round: bool = False,
     ) -> MccormickLPResult:
         """Solve the McCormick LP relaxation restricted to the given bound box.
 
@@ -1184,6 +1192,18 @@ class MccormickLPRelaxer:
         so the round's non-LP cost cannot restart the clock. Passed only by the
         spatial node loops under ``DISCOPT_NODE_ROUND_BUDGET``; every other
         caller's behavior is byte-identical.
+
+        ``yield_round`` (#966) runs the round in **yield mode**: the round's
+        grant cannot cover a full round, so instead of banking nothing the round
+        buys whatever the grant affords — the per-node separation chain is
+        skipped and the cold build is truncated by ``round_deadline`` (the #694
+        anytime mechanism, one whole constraint at a time), leaving a valid but
+        weaker outer relaxation. Dropping cuts and constraint rows only ENLARGES
+        the relaxed feasible set, so the LP optimum is still a valid lower bound
+        on this box — a yielded round is sound, just looser. Requires
+        ``round_deadline`` (the clamp is the whole point); the incremental fast
+        path, when in scope, is cheaper *and* full-strength, so it is still tried
+        first and its result is preferred.
 
         Returns a :class:`MccormickLPResult`. ``lower_bound`` is a valid lower
         bound on the original problem within this box (for minimization).
@@ -1244,6 +1264,20 @@ class MccormickLPRelaxer:
         # is bound-independent (an empty McCormick polytope over a finite box is a
         # rigorous infeasibility proof), so it is always trusted; pooled spatial
         # nodes, which DO inherit cuts, keep the fast path for both verdicts.
+        # #966 yield mode: the round's grant cannot cover a full round, so buy what
+        # it affords instead of banking nothing. Skipping the separation chain and
+        # truncating the build only DROP rows, which enlarges the relaxed feasible
+        # set — the LP optimum stays a valid lower bound on this box (sound, looser).
+        # ``round_deadline`` carries the grant, so a yield without one would be an
+        # unclamped round wearing the yield's weaker relaxation: refuse loudly.
+        if yield_round:
+            if round_deadline is None:
+                raise ValueError(
+                    "solve_at_node(yield_round=True) requires round_deadline: the "
+                    "yield's whole purpose is to fit the round inside its grant"
+                )
+            separate = False
+            self.yield_rounds += 1
         _skip_fast_for_lift = (
             separate
             and self._inc is not None

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -3147,6 +3147,38 @@ def _nonrigorous_sentinel_fathom(node_lower_bound: float, node_infeasible: bool)
     return node_lower_bound >= _SENTINEL_THRESHOLD and not node_infeasible
 
 
+def _yield_keeps_node_open(
+    yielded: bool,
+    nlp_failed: bool,
+    result_lbs,
+    i: int,
+) -> bool:
+    """Keep a node whose YIELDED round banked no bound OPEN instead of fathomed.
+
+    #966. A node whose per-node NLP failed carries the failure sentinel
+    (``_INFEASIBILITY_SENTINEL``) into the LP round; the round is what normally
+    replaces it with a real bound. When the round is cut short by the budget and
+    returns none, leaving the sentinel hands the node to the Rust tree's
+    bound-cut (``1e30 >= incumbent``) — a fathom with NO proof, which
+    :func:`_nonrigorous_sentinel_fathom` then turns into a discarded global dual
+    bound. That converts a *scheduling* decision into a lost certificate, which
+    is the wrong trade (CLAUDE.md §1): the solver's product is the bound.
+
+    Importing ``-inf`` instead keeps the node OPEN, floored on import at its
+    inherited (proved) parent bound — the same sound mechanism the batch path's
+    past-deadline branch uses (#138). It fathoms nothing, so nothing is
+    decertified; the node is simply re-visited or branched.
+
+    Only fires for a round the caller ran in yield mode (i.e. under
+    ``DISCOPT_NODE_ROUND_BUDGET``), so the default path is untouched. Returns
+    True when the node was kept open, for the caller's counters/tests.
+    """
+    if not (yielded and nlp_failed):
+        return False
+    result_lbs[i] = -np.inf
+    return True
+
+
 def _certified_callback_bound(
     global_lower_bound: Optional[float],
     tree_bound_valid: bool,
@@ -10157,13 +10189,22 @@ def solve_model(
                         continue
                     # #966 round admission: the round's non-LP cost (the cold
                     # build) is spent regardless of the LP grant, so a grant that
-                    # cannot even cover the measured build cost buys a truncated,
-                    # near-empty relaxation for full build wall — decline instead.
-                    # Same skip semantics as the past-deadline branch above.
+                    # cannot cover the measured build cost cannot buy a full
+                    # round. It does NOT follow that the round should buy nothing:
+                    # a skipped round banks no bound AND no LP point, which costs
+                    # the brancher and the primal heuristics too (measured:
+                    # nvs05@20 s with every round skipped loses the bound
+                    # 3.514 -> 0.684, the incumbent 8.73 -> 523.69, and the search
+                    # itself 29 -> 1 nodes, ending 16 s inside its own budget).
+                    # Yield instead: no separation chain, build truncated by the
+                    # grant, valid weaker bound + vertex for a fraction of the
+                    # cost (same cell, yield mode: bound 1.353, incumbent 8.73
+                    # recovered, 45 nodes). Sound — dropped rows only enlarge the
+                    # relaxed set.
+                    _yield_round = False
                     if _round_budget_enabled:
                         _exp_build = _mc_lp_relaxer.expected_build_cost()
-                        if _exp_build is not None and _node_remaining < _exp_build:
-                            continue
+                        _yield_round = _exp_build is not None and _node_remaining < _exp_build
                     nlp_failed = result_lbs[i] >= _SENTINEL_THRESHOLD
                     try:
                         mc_res = _mc_lp_relaxer.solve_at_node(
@@ -10171,6 +10212,7 @@ def solve_model(
                             np.asarray(batch_ub[i]),
                             time_limit=max(_node_remaining, _DEADLINE_NODE_FLOOR_S),
                             round_deadline=(_deadline if _round_budget_enabled else None),
+                            yield_round=_yield_round,
                             inherited_cuts=_root_cut_pool,
                             separate=True,
                             want_marginals=_phase2_dbbt_enabled,
@@ -10186,6 +10228,7 @@ def solve_model(
                         )
                     except Exception as e:
                         logger.debug("McCormick LP failed at node %d: %s", i, e)
+                        _yield_keeps_node_open(_yield_round, nlp_failed, result_lbs, i)
                         continue
                     if mc_res.status == "infeasible":
                         # Rigorous fathom: the McCormick LP is a valid outer
@@ -10196,7 +10239,12 @@ def solve_model(
                         result_lbs[i] = _INFEASIBILITY_SENTINEL
                         result_feas[i] = False
                         continue
-                    if mc_res.lower_bound is not None and np.isfinite(mc_res.lower_bound):
+                    if mc_res.lower_bound is None or not np.isfinite(mc_res.lower_bound):
+                        # A yielded round that banked no bound must not leave the
+                        # node fathomed-without-proof on the failure sentinel
+                        # (#966; see :func:`_yield_keeps_node_open`).
+                        _yield_keeps_node_open(_yield_round, nlp_failed, result_lbs, i)
+                    else:
                         if nlp_failed:
                             # A failed / locally-infeasible NLP solve is not an
                             # infeasibility proof. Adopt the LP bound + LP point
@@ -10528,17 +10576,21 @@ def solve_model(
                 # and a feasible LP point usable for spatial branching even
                 # when the NLP was skipped (root) or returned infeasible /
                 # iteration_limit (any node).
+                _serial_yield_round = False
                 if _mc_lp_relaxer is not None and not _reduced_done_serial:
                     # #966 round admission (serial path). Unlike the batch path
                     # this loop had NO past-deadline skip at all — a spent budget
                     # still admitted a full build+separate round per node. Under
-                    # the flag, decline the round once the deadline is past or
-                    # the remaining grant cannot cover the measured build cost;
-                    # the node stays open on its valid parent bound.
+                    # the flag, a spent deadline skips the round (the node stays
+                    # open on its valid parent bound, mirroring the batch path);
+                    # a grant that is merely too short for a full round YIELDS
+                    # instead of skipping, so it still banks a valid weaker bound
+                    # and an LP point (see the batch-path note above).
                     _serial_remaining = _deadline - time.perf_counter()
                     if _round_budget_enabled:
                         _exp_build = _mc_lp_relaxer.expected_build_cost()
-                        _round_blocked = _serial_remaining <= 0.0 or (
+                        _round_blocked = _serial_remaining <= 0.0
+                        _serial_yield_round = not _round_blocked and (
                             _exp_build is not None and _serial_remaining < _exp_build
                         )
                     else:
@@ -10552,6 +10604,7 @@ def solve_model(
                             node_ub,
                             time_limit=max(_deadline - time.perf_counter(), _DEADLINE_NODE_FLOOR_S),
                             round_deadline=(_deadline if _round_budget_enabled else None),
+                            yield_round=_serial_yield_round,
                             inherited_cuts=_root_cut_pool,
                             separate=True,
                             want_marginals=_phase2_dbbt_enabled,
@@ -10597,6 +10650,16 @@ def solve_model(
                             result_feas[i] = False
                         else:
                             result_lbs[i] = max(cur, mc_lp_lb)
+                    else:
+                        # A yielded round that banked no bound must not leave the
+                        # node fathomed-without-proof on the failure sentinel
+                        # (#966; see :func:`_yield_keeps_node_open`).
+                        _yield_keeps_node_open(
+                            _serial_yield_round,
+                            result_lbs[i] >= _SENTINEL_THRESHOLD,
+                            result_lbs,
+                            i,
+                        )
                     # Phase 2 (#764): free DBBT + cutoff-FBBT from this serial node
                     # solve's marginals; stage the tightened child box. Skip the root
                     # batch (iteration 0) — see the batch-path note above (#287).

--- a/python/discopt/solver_tuning.py
+++ b/python/discopt/solver_tuning.py
@@ -1068,19 +1068,31 @@ class SolverTuning:
       rows is a valid weaker outer relaxation) and (b) anchors the node's
       internal solve/separation deadline at the grant instead of restarting the
       clock after the build; and
-    * decline to START a round whose grant cannot cover the relaxer's measured
-      cold-build cost (an EMA over this solve's builds) — the round admission
-      check accounting for the round's expected non-LP cost. A declined node
-      keeps its inherited (valid) parent bound and stays open, exactly like the
-      existing past-deadline skip.
+    * run a round whose grant cannot cover the relaxer's measured cold-build cost
+      (an EMA over this solve's builds) in **yield mode** instead of a full
+      round: no per-node separation chain, and the cold build truncated at the
+      grant, so the round banks the weaker-but-valid bound and the LP vertex it
+      can afford rather than nothing.
 
-    Sound by construction: build truncation only drops rows (weaker, never
-    falsified — the ``_objective_bound_valid`` gate catches an un-bounded cost
-    column), deadline-cut LP solves already bank the Neumaier-Shcherbina floor,
-    and a declined round only leaves a node on its parent's valid bound. Default
-    off pending the §5 corpus-wide differential panel (cert-clean AND
-    net-positive); graduation is coupled to the #928
-    ``DISCOPT_LP_WARM_DEADLINE`` panel this flag exists to unblock."""
+    Yield mode replaced an outright *decline* (the first cut of this flag, and
+    the measured cause of the coupled panel's bound ledger: casctanks
+    2.9098 → −56.5001, contvar's bound lost outright). A skipped round banks no
+    bound AND no LP point, and the point is what the spatial brancher and the
+    primal heuristics run on: forcing every round to skip on nvs05 @ 20 s cost
+    the bound (3.514 → 0.684), the incumbent (8.73 → 523.69) and the search
+    itself (29 → 1 nodes, ending 16 s inside its own budget), while yielding the
+    same rounds kept the incumbent, recovered half the lost bound (1.353) and
+    branched 45 nodes (``scratchpad/issue966_yield_vs_decline.py``).
+
+    Sound by construction: build truncation and skipped separation only drop
+    rows/cuts (weaker, never falsified — the ``_objective_bound_valid`` gate
+    catches an un-bounded cost column), deadline-cut LP solves already bank the
+    Neumaier-Shcherbina floor, and a yielded round that banks nothing leaves its
+    node OPEN at ``-inf`` (floored at the proved parent bound) rather than
+    fathomed-without-proof on the failure sentinel — see
+    ``solver._yield_keeps_node_open``. Default off pending the §5 corpus-wide
+    differential panel (cert-clean AND net-positive); graduation is coupled to
+    the #928 ``DISCOPT_LP_WARM_DEADLINE`` panel this flag exists to unblock."""
 
     hessian_compile_gate: bool = field(
         default_factory=lambda: _env_flag("DISCOPT_HESS_COMPILE_GATE", default=False)

--- a/python/tests/test_966_node_round_budget.py
+++ b/python/tests/test_966_node_round_budget.py
@@ -159,6 +159,121 @@ def test_flag_default_off():
 
 
 # --------------------------------------------------------------------------- #
+# #966 follow-up — a round that cannot afford its grant YIELDS instead of being
+# declined. The first cut of this flag skipped such a round outright, which
+# banks neither a bound nor an LP point; the point is what the spatial brancher
+# and the primal heuristics consume, so the skip cost the search itself
+# (nvs05 @ 20 s, every round skipped: bound 3.514 -> 0.684, incumbent
+# 8.73 -> 523.69, 29 -> 1 nodes; yielding the same rounds: bound 3.506,
+# incumbent 8.73, 59 nodes — scratchpad/issue966_yield_{vs_decline,fix_ab}.py).
+# --------------------------------------------------------------------------- #
+
+
+def test_yield_round_requires_a_round_deadline():
+    """A yield with no grant to yield to is an unclamped weaker round — refuse."""
+    model = _bilinear_model()
+    relaxer = MccormickLPRelaxer(model)
+    lb, ub = _box(model)
+    with pytest.raises(ValueError, match="requires round_deadline"):
+        relaxer.solve_at_node(lb, ub, time_limit=5.0, yield_round=True)
+
+
+def test_yield_round_truncates_build_and_skips_separation(build_spy, monkeypatch):
+    """Yield mode buys what the grant affords: truncated build, no separation."""
+    model = _bilinear_model()
+    relaxer = MccormickLPRelaxer(model)
+    relaxer._inc = None  # force the cold path (the fast path is cheaper anyway)
+    lb, ub = _box(model)
+
+    separated: list = []
+    orig_impl = MccormickLPRelaxer._solve_at_node_impl
+
+    def spy_impl(self, *args, **kwargs):
+        separated.append(kwargs.get("separate"))
+        return orig_impl(self, *args, **kwargs)
+
+    monkeypatch.setattr(MccormickLPRelaxer, "_solve_at_node_impl", spy_impl)
+
+    rd = time.perf_counter() - 1.0  # a spent grant: the build truncates at once
+    assert relaxer.yield_rounds == 0
+    res = relaxer.solve_at_node(lb, ub, time_limit=5.0, round_deadline=rd, yield_round=True)
+
+    assert relaxer.yield_rounds == 1, "yield mode did not fire (§6: a vacuous pass)"
+    assert build_spy.deadlines and build_spy.deadlines[0] == rd
+    # ``separate`` is switched off INSIDE the impl, so what the impl received is
+    # the caller's request; the observable effect is the yield counter plus the
+    # truncated build above. Assert the caller still asked for separation, so the
+    # skip is attributable to yield mode and not to the call site.
+    assert separated and separated[0] is True
+    assert res.status in ("optimal", "uncertified", "time_limit", "numerical")
+
+
+def test_yield_round_banks_a_sound_bound_and_a_point():
+    """A yielded round's bound is valid (never above the box optimum) and it
+    carries an LP vertex for the brancher — the two things a skipped round
+    banked neither of."""
+    model = _bilinear_model()
+    relaxer = MccormickLPRelaxer(model)
+    relaxer._inc = None
+    lb, ub = _box(model)
+
+    full = relaxer.solve_at_node(lb, ub, time_limit=5.0)
+    yielded = relaxer.solve_at_node(
+        lb,
+        ub,
+        time_limit=5.0,
+        round_deadline=time.perf_counter() - 1.0,
+        yield_round=True,
+    )
+
+    assert full.lower_bound is not None
+    assert yielded.lower_bound is not None, "the yielded round banked no bound"
+    assert yielded.x is not None, "the yielded round banked no point"
+    # Soundness: dropping rows/cuts only enlarges the relaxed set, so the yielded
+    # bound is <= the full round's bound, and both are <= the true box optimum
+    # (min of x*y - 2x + y over [0,4]^2 subject to x+y>=1 is -8 at (4,0)).
+    true_opt = -8.0
+    assert yielded.lower_bound <= full.lower_bound + 1e-9
+    assert yielded.lower_bound <= true_opt + 1e-6
+    assert full.lower_bound <= true_opt + 1e-6
+
+
+def test_yield_round_default_off_leaves_the_path_untouched(build_spy):
+    """No ``yield_round`` -> no yield accounting, no build deadline."""
+    model = _bilinear_model()
+    relaxer = MccormickLPRelaxer(model)
+    relaxer._inc = None
+    lb, ub = _box(model)
+    relaxer.solve_at_node(lb, ub, time_limit=5.0)
+    assert relaxer.yield_rounds == 0
+    assert build_spy.deadlines == [None]
+
+
+def test_yielded_round_without_a_bound_keeps_the_node_open():
+    """A yielded round that banks nothing must not leave the node fathomed
+    without proof — that is what discards the run's certified dual bound."""
+    from discopt.constants import SENTINEL_THRESHOLD
+    from discopt.solver import _nonrigorous_sentinel_fathom, _yield_keeps_node_open
+
+    sentinel = float(SENTINEL_THRESHOLD) * 10.0
+
+    # The certificate consequence this guard exists to prevent.
+    assert _nonrigorous_sentinel_fathom(sentinel, False) is True
+    assert _nonrigorous_sentinel_fathom(-np.inf, False) is False
+
+    lbs = np.array([sentinel, sentinel, 1.5])
+    # Yielded round + failed NLP (the sentinel is still in the slot): keep open.
+    assert _yield_keeps_node_open(True, True, lbs, 0) is True
+    assert lbs[0] == -np.inf
+    # Not a yielded round: untouched (the default path must not move).
+    assert _yield_keeps_node_open(False, True, lbs, 1) is False
+    assert lbs[1] == sentinel
+    # A node that already carries a real bound is never disturbed.
+    assert _yield_keeps_node_open(True, False, lbs, 2) is False
+    assert lbs[2] == 1.5
+
+
+# --------------------------------------------------------------------------- #
 # #966 item 2 — the first-time sparse-Hessian XLA compile entry gate
 # (``DISCOPT_HESS_COMPILE_GATE``). The severe modes (124 s compile against a
 # 20 s budget on heatexch_gen3, caught in flight with faulthandler) enter

--- a/scratchpad/issue966_decline_floor_probe.py
+++ b/scratchpad/issue966_decline_floor_probe.py
@@ -1,0 +1,120 @@
+"""#966 entry experiment 3: what does a DECLINED round cost the certificate?
+
+The round-budget flag's decline branch is documented as "the node stays open on
+its valid parent bound".  That is true only when the node's slot does not
+already hold the failure sentinel (``_INFEASIBILITY_SENTINEL`` = 1e30, written
+when the per-node NLP failed/diverged).  When it does, the declined round is the
+only thing that would have replaced the sentinel with a real bound, so the node
+is left *fathomed without proof* -- ``_node_decertifies`` fires and the whole
+run's dual bound is discarded (the panel's contvar ``183632.766 -> None``).
+
+This probe forces EVERY round to be declined (``expected_build_cost`` -> 1e9,
+which is what the admission check reads) and compares against the same solve
+with the flag off.
+
+Kill criterion: if the forced-decline arm still reports a finite CERTIFIED bound
+on every instance, a decline does not cost the certificate and this hypothesis
+is falsified.
+
+Counted output; exits non-zero if no arm pair ran (CLAUDE.md §6).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+
+WORKER = r"""
+import json, os, sys, time
+os.environ.setdefault("JAX_PLATFORMS", "cpu")
+os.environ.setdefault("JAX_ENABLE_X64", "1")
+import discopt
+from discopt._relax import mccormick_lp as mc
+from discopt.modeling.core import from_nl
+
+assert "/python/discopt/" in discopt.__file__, discopt.__file__
+assert "round_deadline" in mc.MccormickLPRelaxer.solve_at_node.__code__.co_varnames
+
+path, budget, force = sys.argv[1], float(sys.argv[2]), sys.argv[3] == "1"
+
+DECLINED = {"checks": 0, "rounds": 0}
+_orig_expected = mc.MccormickLPRelaxer.expected_build_cost
+_orig_solve = mc.MccormickLPRelaxer.solve_at_node
+
+def _expected(self):
+    DECLINED["checks"] += 1
+    return 1e9 if force else _orig_expected(self)
+
+def _solve(self, *a, **kw):
+    if kw.get("round_deadline") is not None:
+        DECLINED["rounds"] += 1
+    return _orig_solve(self, *a, **kw)
+
+mc.MccormickLPRelaxer.expected_build_cost = _expected
+mc.MccormickLPRelaxer.solve_at_node = _solve
+
+m = from_nl(path)
+t0 = time.perf_counter()
+r = m.solve(time_limit=budget)
+print(json.dumps({
+    "wall": round(time.perf_counter() - t0, 2),
+    "status": r.status,
+    "bound": r.bound,
+    "objective": r.objective,
+    "gap_certified": bool(r.gap_certified),
+    "node_count": int(r.node_count or 0),
+    "admission_checks": DECLINED["checks"],
+    "rounds_run": DECLINED["rounds"],
+    "declines": DECLINED["checks"] - DECLINED["rounds"],
+}))
+"""
+
+worker_path = os.path.join(HERE, "_issue966_decline_worker.py")
+with open(worker_path, "w") as fh:
+    fh.write(WORKER)
+
+
+def run(inst: str, budget: float, flag: str, force: str) -> dict:
+    env = dict(os.environ)
+    env["DISCOPT_NODE_ROUND_BUDGET"] = flag
+    env["DISCOPT_LP_WARM_DEADLINE"] = os.environ.get("DISCOPT_LP_WARM_DEADLINE", "0")
+    env["DISCOPT_HESS_COMPILE_GATE"] = "0"
+    out = subprocess.run(
+        [
+            sys.executable,
+            "-u",
+            worker_path,
+            f"python/tests/data/minlplib_nl/{inst}.nl",
+            str(budget),
+            force,
+        ],
+        capture_output=True,
+        text=True,
+        env=env,
+        check=True,
+    )
+    return json.loads(out.stdout.strip().splitlines()[-1])
+
+
+budget = float(os.environ.get("PROBE_BUDGET", "20"))
+pairs = 0
+for inst in sys.argv[1:]:
+    base = run(inst, budget, "0", "0")
+    forced = run(inst, budget, "1", "1")
+    pairs += 1
+    print(
+        f"{inst:12s} base   bound={base['bound']!r} cert={base['gap_certified']} "
+        f"nodes={base['node_count']} wall={base['wall']}\n"
+        f"{'':12s} forced bound={forced['bound']!r} cert={forced['gap_certified']} "
+        f"nodes={forced['node_count']} wall={forced['wall']} "
+        f"declines={forced['declines']}/{forced['admission_checks']}",
+        flush=True,
+    )
+
+print(f"ARM_PAIRS_EXECUTED={pairs}")
+if pairs == 0:
+    sys.exit(2)

--- a/scratchpad/issue966_decline_probe.py
+++ b/scratchpad/issue966_decline_probe.py
@@ -1,0 +1,147 @@
+"""#966 entry experiment: what does the round-admission check actually decline?
+
+Hypothesis (H1). ``DISCOPT_NODE_ROUND_BUDGET``'s admission check compares the
+round's remaining grant against ``expected_build_cost()`` -- an EMA of the COLD
+``build_uniform_relaxation`` wall -- for *every* node, including the nodes the
+relaxer would serve from its incremental fast path (patch + warm start, orders
+of magnitude cheaper than a cold build).  If most node rounds take the fast
+path, the check is estimating a cost the round would not have paid, so it
+declines rounds that were cheap, losing their bounds for nothing.  That is the
+mechanism behind the measured casctanks collapse (2.9098 -> -56.5001, §14b).
+
+Kill criterion: if fewer than 50% of the node rounds in the OFF arm take the
+incremental fast path -- i.e. rounds really are cold builds -- H1 is falsified
+and over-declining is not an estimator-fidelity problem.
+
+Instrumentation (CLAUDE.md §6: every count is printed; zero counts exit
+non-zero).  Declines are derived exactly: under the flag each node-loop
+iteration calls ``expected_build_cost()`` once and then either declines or calls
+``solve_at_node(round_deadline=...)``, so
+
+    declines = admission_checks - rounds_with_round_deadline
+
+No exception is swallowed anywhere in this file (§7).
+
+Usage:  python -u issue966_decline_probe.py <instance.nl> <budget_s> <0|1>
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import time
+
+os.environ.setdefault("JAX_PLATFORMS", "cpu")
+os.environ.setdefault("JAX_ENABLE_X64", "1")
+
+path = sys.argv[1]
+budget = float(sys.argv[2])
+round_budget = sys.argv[3]
+os.environ["DISCOPT_NODE_ROUND_BUDGET"] = round_budget
+os.environ.setdefault("DISCOPT_LP_WARM_DEADLINE", "0")
+os.environ.setdefault("DISCOPT_HESS_COMPILE_GATE", "0")
+
+import discopt  # noqa: E402
+from discopt._relax import mccormick_lp as _mc  # noqa: E402
+from discopt.modeling.core import from_nl  # noqa: E402
+
+# §8: prove the tree under test carries the mechanism being probed.
+assert "/python/discopt/" in discopt.__file__, discopt.__file__
+assert "round_deadline" in _mc.MccormickLPRelaxer.solve_at_node.__code__.co_varnames
+assert hasattr(_mc.MccormickLPRelaxer, "expected_build_cost")
+
+STATS = {
+    "admission_checks": 0,
+    "rounds": 0,
+    "rounds_with_round_deadline": 0,
+    "fast_path_calls": 0,
+    "fast_path_hits": 0,
+    "ema_at_check": [],
+    "round_walls": [],  # (wall, fast_hit, status, bound)
+}
+
+_orig_expected = _mc.MccormickLPRelaxer.expected_build_cost
+_orig_solve = _mc.MccormickLPRelaxer.solve_at_node
+_orig_fast = _mc.MccormickLPRelaxer._try_incremental_node
+
+
+def _expected(self):
+    v = _orig_expected(self)
+    STATS["admission_checks"] += 1
+    STATS["ema_at_check"].append(v)
+    return v
+
+
+_FAST_HIT = {"v": False}
+
+
+def _fast(self, *a, **kw):
+    r = _orig_fast(self, *a, **kw)
+    STATS["fast_path_calls"] += 1
+    _FAST_HIT["v"] = r is not None
+    if r is not None:
+        STATS["fast_path_hits"] += 1
+    return r
+
+
+def _solve(self, node_lb, node_ub, time_limit=None, **kw):
+    _FAST_HIT["v"] = False
+    t0 = time.perf_counter()
+    res = _orig_solve(self, node_lb, node_ub, time_limit, **kw)
+    wall = time.perf_counter() - t0
+    STATS["rounds"] += 1
+    if kw.get("round_deadline") is not None:
+        STATS["rounds_with_round_deadline"] += 1
+    STATS["round_walls"].append((round(wall, 4), _FAST_HIT["v"], res.status, res.lower_bound))
+    return res
+
+
+_mc.MccormickLPRelaxer.expected_build_cost = _expected
+_mc.MccormickLPRelaxer.solve_at_node = _solve
+_mc.MccormickLPRelaxer._try_incremental_node = _fast
+
+m = from_nl(path)
+t0 = time.perf_counter()
+r = m.solve(time_limit=budget)
+wall = time.perf_counter() - t0
+
+walls = STATS["round_walls"]
+fast_rounds = sum(1 for w in walls if w[1])
+declines = STATS["admission_checks"] - STATS["rounds_with_round_deadline"]
+out = {
+    "instance": path.split("/")[-1].removesuffix(".nl"),
+    "budget": budget,
+    "DISCOPT_NODE_ROUND_BUDGET": round_budget,
+    "wall": round(wall, 2),
+    "status": r.status,
+    "bound": r.bound,
+    "objective": r.objective,
+    "node_count": int(r.node_count or 0),
+    "admission_checks": STATS["admission_checks"],
+    "rounds": STATS["rounds"],
+    "rounds_with_round_deadline": STATS["rounds_with_round_deadline"],
+    "declines": declines,
+    "fast_path_calls": STATS["fast_path_calls"],
+    "fast_path_hits": STATS["fast_path_hits"],
+    "rounds_taking_fast_path": fast_rounds,
+    "fast_round_fraction": (fast_rounds / len(walls)) if walls else None,
+    "build_ema_last": STATS["ema_at_check"][-1] if STATS["ema_at_check"] else None,
+    "round_wall_total": round(sum(w[0] for w in walls), 3),
+    "round_wall_max": max((w[0] for w in walls), default=None),
+    "round_walls_head": walls[:12],
+    "round_walls_tail": walls[-6:],
+}
+print(json.dumps(out, indent=2))
+
+# §6: the probe must prove it measured something.
+if STATS["rounds"] == 0:
+    print("PROBE MEASURED NOTHING: zero solve_at_node rounds", file=sys.stderr)
+    sys.exit(2)
+if round_budget == "1" and STATS["admission_checks"] == 0:
+    print("PROBE MEASURED NOTHING: flag ON but zero admission checks", file=sys.stderr)
+    sys.exit(3)
+print(
+    f"COUNTS_EXECUTED rounds={STATS['rounds']} admission_checks={STATS['admission_checks']} "
+    f"declines={declines} fast_hits={STATS['fast_path_hits']}"
+)

--- a/scratchpad/issue966_inc_scope.py
+++ b/scratchpad/issue966_inc_scope.py
@@ -1,0 +1,52 @@
+"""#966: is the cheap incremental node path in scope on the instances the
+round-budget flag hurts?  (Entry experiment for "a declined round banks a floor":
+the incremental patch+warm-start IS the cheap bound producer a declined round
+would fall back to, so its availability decides whether that fallback exists.)
+
+Counted output; exits non-zero if it examined nothing (CLAUDE.md §6).
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import time
+
+os.environ.setdefault("JAX_PLATFORMS", "cpu")
+os.environ.setdefault("JAX_ENABLE_X64", "1")
+
+from discopt._relax.mccormick_lp import MccormickLPRelaxer  # noqa: E402
+from discopt._relax.model_utils import flat_variable_bounds  # noqa: E402
+from discopt.modeling.core import from_nl  # noqa: E402
+
+names = sys.argv[1:]
+examined = 0
+for name in names:
+    path = f"python/tests/data/minlplib_nl/{name}.nl"
+    m = from_nl(path)
+    t0 = time.perf_counter()
+    r = MccormickLPRelaxer(m)
+    t_build = time.perf_counter() - t0
+    lb, ub = flat_variable_bounds(m)
+    inc_ok = r._inc is not None
+    fast = None
+    t_fast = None
+    if inc_ok:
+        t1 = time.perf_counter()
+        fast = r._try_incremental_node(lb, ub, None)
+        t_fast = time.perf_counter() - t1
+    t2 = time.perf_counter()
+    res = r.solve_at_node(lb, ub, time_limit=10.0)
+    t_round = time.perf_counter() - t2
+    examined += 1
+    print(
+        f"{name:16s} inc={inc_ok!s:5s} fast={'hit' if fast is not None else 'miss':4s} "
+        f"t_fast={t_fast if t_fast is None else round(t_fast, 4)} "
+        f"round={t_round:.3f}s status={res.status} lb={res.lower_bound} "
+        f"(relaxer ctor {t_build:.2f}s)",
+        flush=True,
+    )
+
+print(f"INSTANCES_EXAMINED={examined}")
+if examined == 0:
+    sys.exit(2)

--- a/scratchpad/issue966_neutral_worker.py
+++ b/scratchpad/issue966_neutral_worker.py
@@ -1,0 +1,46 @@
+"""#966 yield-mode neutrality-check worker that runs on EITHER tree.
+
+CLAUDE.md §8: the marker is asserted in both directions — ``expect_marker=1``
+requires ``yield_round`` (the #966 yield-mode round parameter) to be
+present in ``MccormickLPRelaxer.solve_at_node``, ``0`` requires it absent — so a
+baseline run that silently imported the changed tree fails instead of producing a
+bogus "identical" verdict.
+
+Usage: python issue928_neutral_worker.py <path.nl> <time_limit> <expect_marker:0|1>
+"""
+
+import json
+import os
+import sys
+import time
+
+os.environ.setdefault("JAX_PLATFORMS", "cpu")
+os.environ.setdefault("JAX_ENABLE_X64", "1")
+
+import discopt  # noqa: E402
+from discopt._relax.mccormick_lp import MccormickLPRelaxer  # noqa: E402
+from discopt.modeling.core import from_nl  # noqa: E402
+
+path, budget, expect = sys.argv[1], float(sys.argv[2]), sys.argv[3]
+assert "/python/discopt/" in discopt.__file__, discopt.__file__
+present = "yield_round" in MccormickLPRelaxer.solve_at_node.__code__.co_varnames
+assert present == (expect == "1"), (
+    f"marker mismatch: yield_round present={present}, expected={expect == '1'}"
+)
+
+m = from_nl(path)
+t0 = time.perf_counter()
+r = m.solve(time_limit=budget)
+print(
+    json.dumps(
+        {
+            "instance": path.split("/")[-1].removesuffix(".nl"),
+            "wall": time.perf_counter() - t0,
+            "status": r.status,
+            "objective": r.objective,
+            "bound": r.bound,
+            "node_count": int(r.node_count or 0),
+            "gap_certified": bool(r.gap_certified),
+        }
+    )
+)

--- a/scratchpad/issue966_neutrality.json
+++ b/scratchpad/issue966_neutrality.json
@@ -1,0 +1,93 @@
+{
+  "nvs03": {
+    "status": "optimal",
+    "objective": 16.0,
+    "bound": 16.0,
+    "node_count": 3,
+    "gap_certified": true
+  },
+  "nvs07": {
+    "status": "optimal",
+    "objective": 4.0,
+    "bound": 4.0,
+    "node_count": 5,
+    "gap_certified": true
+  },
+  "nvs10": {
+    "status": "optimal",
+    "objective": -310.7999999999999,
+    "bound": -310.7999999999999,
+    "node_count": 5,
+    "gap_certified": true
+  },
+  "nvs11": {
+    "status": "optimal",
+    "objective": -431.0000000000085,
+    "bound": -431.0000000000085,
+    "node_count": 55,
+    "gap_certified": true
+  },
+  "nvs12": {
+    "status": "optimal",
+    "objective": -481.20000000001,
+    "bound": -481.20000000001,
+    "node_count": 231,
+    "gap_certified": true
+  },
+  "nvs15": {
+    "status": "optimal",
+    "objective": 1.0,
+    "bound": 1.0,
+    "node_count": 7,
+    "gap_certified": true
+  },
+  "prob02": {
+    "status": "optimal",
+    "objective": 112235.0,
+    "bound": 112235.0,
+    "node_count": 177,
+    "gap_certified": true
+  },
+  "prob03": {
+    "status": "optimal",
+    "objective": 10.0,
+    "bound": 10.0,
+    "node_count": 11,
+    "gap_certified": true
+  },
+  "st_miqp1": {
+    "status": "optimal",
+    "objective": 280.9999999906497,
+    "bound": 280.9999999906497,
+    "node_count": 15,
+    "gap_certified": true
+  },
+  "st_miqp2": {
+    "status": "optimal",
+    "objective": 2.0,
+    "bound": 2.0,
+    "node_count": 9,
+    "gap_certified": true
+  },
+  "st_miqp3": {
+    "status": "optimal",
+    "objective": -6.0,
+    "bound": -6.0,
+    "node_count": 1,
+    "gap_certified": true
+  },
+  "st_test1": {
+    "status": "optimal",
+    "objective": -1.6495994490692313e-08,
+    "bound": -1.6495994490692313e-08,
+    "node_count": 15,
+    "gap_certified": true
+  },
+  "st_testgr3": {
+    "status": "optimal",
+    "objective": -20.59,
+    "bound": -20.59070709795548,
+    "node_count": 549,
+    "gap_certified": true
+  }
+}

--- a/scratchpad/issue966_neutrality.py
+++ b/scratchpad/issue966_neutrality.py
@@ -1,0 +1,104 @@
+"""#966 flag-OFF bound-neutrality check (CLAUDE.md §5, regime 1).
+
+With ``DISCOPT_NODE_ROUND_BUDGET`` OFF (the default) the #966 yield-mode change
+must be a no-op: ``yield_round`` is False on every ``solve_at_node`` call the
+flag-OFF path makes, and ``_yield_keeps_node_open`` returns without touching a
+bound unless the caller ran the round in yield mode. Assert exact
+equality of ``node_count`` and the certified ``objective``/``bound`` on instances
+that CERTIFY inside the budget (the only budget-independent, tree-comparable
+results; same instance list as the #917 check this is adapted from).
+
+Run once on the baseline tree with ``--write`` (marker absent), then on the
+changed tree with ``--check`` (marker present).
+"""
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKER = Path(__file__).with_name("issue966_neutral_worker.py")
+
+CERTIFYING = [
+    ("nvs03", "minlplib_nl"),
+    ("nvs07", "minlplib_nl"),
+    ("nvs10", "minlplib_nl"),
+    ("nvs11", "minlplib_nl"),
+    ("nvs12", "minlplib_nl"),
+    ("nvs15", "minlplib_nl"),
+    ("prob02", "minlplib"),
+    ("prob03", "minlplib"),
+    ("st_miqp1", "minlplib_nl"),
+    ("st_miqp2", "minlplib_nl"),
+    ("st_miqp3", "minlplib_nl"),
+    ("st_test1", "minlplib_nl"),
+    ("st_testgr3", "minlplib_nl"),
+]
+T = 20.0
+
+ap = argparse.ArgumentParser()
+ap.add_argument("--write", action="store_true")
+ap.add_argument("--check", action="store_true")
+ap.add_argument("--store", default=str(Path(__file__).with_name("issue966_neutrality.json")))
+ap.add_argument("--expect-marker", choices=["0", "1"], required=True)
+args = ap.parse_args()
+
+rows = {}
+for name, corpus in CERTIFYING:
+    nl = ROOT / f"python/tests/data/{corpus}/{name}.nl"
+    proc = subprocess.run(
+        [sys.executable, "-u", str(WORKER), str(nl), str(T), args.expect_marker],
+        capture_output=True,
+        text=True,
+        timeout=10 * T + 600,
+        env={
+            **os.environ,
+            "DISCOPT_LP_WARM_DEADLINE": "0",
+            "DISCOPT_NODE_ROUND_BUDGET": "0",
+            "DISCOPT_HESS_COMPILE_GATE": "0",
+        },
+    )
+    if proc.returncode != 0:
+        sys.stderr.write(proc.stdout[-2000:] + proc.stderr[-4000:])
+        raise SystemExit(f"worker failed on {name}")
+    r = json.loads(proc.stdout.strip().splitlines()[-1])
+    rows[name] = {
+        "status": r["status"],
+        "objective": r["objective"],
+        "bound": r["bound"],
+        "node_count": r["node_count"],
+        "gap_certified": r["gap_certified"],
+    }
+    print(f"{name:11s} {rows[name]}", flush=True)
+
+store = Path(args.store)
+if args.write:
+    store.write_text(json.dumps(rows, indent=2))
+    print(f"wrote baseline: {store}")
+    raise SystemExit(0)
+
+if args.check:
+    base = json.loads(store.read_text())
+    compared = 0
+    drift = []
+    for name, cur in rows.items():
+        ref = base.get(name)
+        if ref is None:
+            drift.append(f"{name}: absent from baseline")
+            continue
+        compared += 1
+        if ref != cur:
+            drift.append(f"{name}: baseline={ref} current={cur}")
+    print(f"\nCOMPARED={compared}")
+    for d in drift:
+        print("DRIFT:", d)
+    if compared == 0:
+        print("PROBE FIRED NOTHING", file=sys.stderr)
+        raise SystemExit(1)
+    print("BOUND_NEUTRAL=" + str(not drift))
+    raise SystemExit(1 if drift else 0)
+
+raise SystemExit("pass --write or --check")

--- a/scratchpad/issue966_truncated_floor.py
+++ b/scratchpad/issue966_truncated_floor.py
@@ -1,0 +1,102 @@
+"""#966 entry experiment 2: can a round that cannot afford its build still bank
+a floor?
+
+H1 (falsified, see issue966_inc_scope.py): the cheap tier a declined round could
+fall back to is the incremental fast path.  Measured: ``_inc`` is unavailable on
+all five instances the round-budget flag hurts (nvs05, tspn10, casctanks,
+contvar, tls2), so that tier does not exist for this class.
+
+H2 (this probe): the #694 anytime build already IS the cheap tier.  A build whose
+``build_deadline`` is already spent emits zero constraint rows but still
+linearizes the objective, so it yields (a) a valid, weaker LP relaxation and (b)
+``milp._objective_floor`` -- the rigorous box-interval objective floor the node
+solver falls back to.  If a fully-truncated round is much cheaper than a full
+round AND still reports a finite bound, then "decline the round" (bank nothing)
+can be replaced by "yield the round" (bank a floor), which is what #966's
+remaining item asks for.
+
+Kill criterion: a fully-truncated round costing more than 25% of the full round's
+wall on these instances means truncation is not a cheap floor producer, and the
+decline branch has to stay as it is.
+
+Counted output; exits non-zero if nothing was compared (CLAUDE.md §6).
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import time
+
+os.environ.setdefault("JAX_PLATFORMS", "cpu")
+os.environ.setdefault("JAX_ENABLE_X64", "1")
+
+import numpy as np  # noqa: E402
+from discopt._relax import mccormick_lp as mc_mod  # noqa: E402
+from discopt._relax.mccormick_lp import MccormickLPRelaxer  # noqa: E402
+from discopt._relax.model_utils import flat_variable_bounds  # noqa: E402
+from discopt.modeling.core import from_nl  # noqa: E402
+
+SEEN: list = []
+_orig_build = mc_mod.build_milp_relaxation
+
+
+def _spy(*a, **kw):
+    t0 = time.perf_counter()
+    out = _orig_build(*a, **kw)
+    wall = time.perf_counter() - t0
+    milp = out[0] if isinstance(out, tuple) else out
+    inner = getattr(milp, "model", milp)
+    SEEN.append(
+        {
+            "wall": round(wall, 4),
+            "truncated": bool(getattr(inner, "_build_truncated", False)),
+            "rows_done": getattr(inner, "_build_constraints_done", None),
+            "rows_total": getattr(inner, "_build_constraints_total", None),
+            "objective_floor": getattr(inner, "_objective_floor", None),
+        }
+    )
+    return out
+
+
+mc_mod.build_milp_relaxation = _spy
+
+REPS = int(os.environ.get("PROBE_REPS", "2"))
+compared = 0
+for name in sys.argv[1:]:
+    m = from_nl(f"python/tests/data/minlplib_nl/{name}.nl")
+    relaxer = MccormickLPRelaxer(m)
+    lb, ub = flat_variable_bounds(m)
+
+    for rep in range(REPS):
+        SEEN.clear()
+        t0 = time.perf_counter()
+        full = relaxer.solve_at_node(np.asarray(lb), np.asarray(ub), time_limit=30.0)
+        full_wall = time.perf_counter() - t0
+        full_builds = list(SEEN)
+
+        SEEN.clear()
+        t0 = time.perf_counter()
+        cut = relaxer.solve_at_node(
+            np.asarray(lb),
+            np.asarray(ub),
+            time_limit=30.0,
+            build_deadline=time.perf_counter(),  # already spent: full truncation
+        )
+        cut_wall = time.perf_counter() - t0
+        cut_builds = list(SEEN)
+        compared += 1
+
+        print(
+            f"{name:12s} rep{rep} FULL round={full_wall:7.3f}s status={full.status:12s} "
+            f"lb={full.lower_bound} x={full.x is not None}\n"
+            f"{'':12s}      CUT  round={cut_wall:7.3f}s status={cut.status:12s} "
+            f"lb={cut.lower_bound} x={cut.x is not None} ratio={cut_wall / full_wall:.3f}\n"
+            f"{'':12s}      full builds={full_builds}\n"
+            f"{'':12s}      cut  builds={cut_builds}",
+            flush=True,
+        )
+
+print(f"INSTANCES_COMPARED={compared}")
+if compared == 0:
+    sys.exit(2)

--- a/scratchpad/issue966_yield_fix_ab.py
+++ b/scratchpad/issue966_yield_fix_ab.py
@@ -1,0 +1,131 @@
+"""#966 verification: the shipped yield-mode fix, A/B against the pre-fix decline.
+
+Three arms per instance, one process each, interleaved (CLAUDE.md §9):
+
+* ``base``    -- ``DISCOPT_NODE_ROUND_BUDGET=0`` (the reference);
+* ``decline`` -- the flag ON with yield mode monkeypatched back OFF (i.e. the
+  merged pre-fix behaviour: a short grant skips the round entirely);
+* ``yield``   -- the flag ON as shipped.
+
+Every arm forces the admission check to fire on every round
+(``expected_build_cost`` -> 1e9) so the branch under test is exercised
+deterministically instead of only in the budget's last seconds -- this is a
+mechanism differential, not a wall-time panel.
+
+Counted output (§6): the yield arm must report a non-zero yield count, else the
+probe exits non-zero rather than reporting a vacuous pass.
+
+Honest limit of the ``decline`` arm: it emulates the merged behaviour by returning
+a bound-less result from ``solve_at_node`` rather than by the node loop's ``continue``,
+so the node still passes through ``_yield_keeps_node_open``. The arm therefore
+isolates the *banking* half of the fix (bound + LP point) and already carries its
+certificate half -- which makes the measured yield-vs-decline gap a LOWER bound on
+the fix's effect, never an inflated one.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+
+WORKER = r"""
+import json, os, sys, time
+os.environ.setdefault("JAX_PLATFORMS", "cpu")
+os.environ.setdefault("JAX_ENABLE_X64", "1")
+import discopt
+from discopt._relax import mccormick_lp as mc
+from discopt.modeling.core import from_nl
+
+assert "/python/discopt/" in discopt.__file__, discopt.__file__
+assert "yield_round" in mc.MccormickLPRelaxer.solve_at_node.__code__.co_varnames, \
+    "#966 yield-mode marker absent from solve_at_node"
+
+path, budget, arm = sys.argv[1], float(sys.argv[2]), sys.argv[3]
+N = {"checks": 0, "rounds": 0}
+RELAXERS = {}
+
+_orig_expected = mc.MccormickLPRelaxer.expected_build_cost
+_orig_solve = mc.MccormickLPRelaxer.solve_at_node
+
+def _expected(self):
+    N["checks"] += 1
+    RELAXERS[id(self)] = self
+    return 1e9 if arm != "base" else _orig_expected(self)
+
+def _solve(self, node_lb, node_ub, time_limit=None, **kw):
+    if kw.get("round_deadline") is not None:
+        N["rounds"] += 1
+    if arm == "decline" and kw.pop("yield_round", False):
+        # Pre-fix behaviour: a grant too short for a full round skipped it.
+        return mc.MccormickLPResult(status="time_limit")
+    return _orig_solve(self, node_lb, node_ub, time_limit, **kw)
+
+mc.MccormickLPRelaxer.expected_build_cost = _expected
+mc.MccormickLPRelaxer.solve_at_node = _solve
+
+m = from_nl(path)
+t0 = time.perf_counter()
+r = m.solve(time_limit=budget)
+print(json.dumps({
+    "arm": arm,
+    "wall": round(time.perf_counter() - t0, 2),
+    "status": r.status,
+    "bound": r.bound,
+    "objective": r.objective,
+    "gap_certified": bool(r.gap_certified),
+    "node_count": int(r.node_count or 0),
+    "checks": N["checks"], "rounds": N["rounds"],
+    "yield_rounds": sum(getattr(x, "yield_rounds", 0) for x in RELAXERS.values()),
+}))
+"""
+
+worker = os.path.join(HERE, "_issue966_yield_fix_worker.py")
+with open(worker, "w") as fh:
+    fh.write(WORKER)
+
+
+def run(inst: str, budget: float, arm: str) -> dict:
+    env = dict(os.environ)
+    env["DISCOPT_NODE_ROUND_BUDGET"] = "0" if arm == "base" else "1"
+    env["DISCOPT_LP_WARM_DEADLINE"] = os.environ.get("DISCOPT_LP_WARM_DEADLINE", "0")
+    env["DISCOPT_HESS_COMPILE_GATE"] = "0"
+    out = subprocess.run(
+        [
+            sys.executable,
+            "-u",
+            worker,
+            f"python/tests/data/minlplib_nl/{inst}.nl",
+            str(budget),
+            arm,
+        ],
+        capture_output=True,
+        text=True,
+        env=env,
+        check=True,
+    )
+    return json.loads(out.stdout.strip().splitlines()[-1])
+
+
+budget = float(os.environ.get("PROBE_BUDGET", "20"))
+triples = 0
+yields_seen = 0
+for inst in sys.argv[1:]:
+    rows = [run(inst, budget, arm) for arm in ("base", "decline", "yield")]
+    triples += 1
+    for r in rows:
+        if r["arm"] == "yield":
+            yields_seen += r["yield_rounds"]
+        print(
+            f"{inst:12s} {r['arm']:8s} bound={r['bound']!r:24s} obj={r['objective']!r:22s} "
+            f"cert={r['gap_certified']!s:5s} nodes={r['node_count']:5d} wall={r['wall']:6.2f} "
+            f"rounds={r['rounds']} yield_rounds={r['yield_rounds']} status={r['status']}",
+            flush=True,
+        )
+
+print(f"ARM_TRIPLES_EXECUTED={triples} YIELD_ROUNDS_OBSERVED={yields_seen}")
+if triples == 0 or yields_seen == 0:
+    sys.exit(2)

--- a/scratchpad/issue966_yield_vs_decline.py
+++ b/scratchpad/issue966_yield_vs_decline.py
@@ -1,0 +1,125 @@
+"""#966 entry experiment 4: yield the round instead of declining it.
+
+Three arms on the same instance/budget, each a fresh process:
+
+* ``base``    -- flag off (the reference bound/incumbent/nodes);
+* ``decline`` -- every round declined (``expected_build_cost`` -> 1e9), i.e. the
+  flag's current behaviour taken to its limit;
+* ``yield``   -- every round *yielded* instead: the cold build is fully truncated
+  (``build_deadline`` already spent, the #694 anytime mechanism) and the
+  separation chain is skipped, so the round costs ~a base-LP solve and still
+  returns a valid weaker bound AND an LP vertex for branching.
+
+Hypothesis: the ``decline`` arm's damage (nvs05: bound 3.514 -> 0.684, incumbent
+8.73 -> 523.69, nodes 39 -> 1, and 16 s of the budget left unused) is caused by
+the round banking *nothing* -- no bound and, just as important, no LP point for
+the spatial brancher and the primal heuristics.  A yielded round banks both at a
+fraction of the cost.
+
+Kill criterion: if ``yield`` is no better than ``decline`` on bound/incumbent, a
+yielded round is not a usable floor and the fix must look elsewhere.
+
+Counted output (CLAUDE.md §6); exits non-zero if no arm triple ran.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+
+WORKER = r"""
+import json, os, sys, time
+os.environ.setdefault("JAX_PLATFORMS", "cpu")
+os.environ.setdefault("JAX_ENABLE_X64", "1")
+import discopt
+from discopt._relax import mccormick_lp as mc
+from discopt.modeling.core import from_nl
+
+assert "/python/discopt/" in discopt.__file__, discopt.__file__
+assert "round_deadline" in mc.MccormickLPRelaxer.solve_at_node.__code__.co_varnames
+
+path, budget, arm = sys.argv[1], float(sys.argv[2]), sys.argv[3]
+N = {"checks": 0, "rounds": 0, "yielded": 0}
+
+_orig_expected = mc.MccormickLPRelaxer.expected_build_cost
+_orig_solve = mc.MccormickLPRelaxer.solve_at_node
+
+def _expected(self):
+    N["checks"] += 1
+    return 1e9 if arm == "decline" else _orig_expected(self)
+
+def _solve(self, node_lb, node_ub, time_limit=None, **kw):
+    if kw.get("round_deadline") is not None:
+        N["rounds"] += 1
+        if arm == "yield":
+            N["yielded"] += 1
+            kw["separate"] = False
+            kw["build_deadline"] = time.perf_counter()
+    return _orig_solve(self, node_lb, node_ub, time_limit, **kw)
+
+mc.MccormickLPRelaxer.expected_build_cost = _expected
+mc.MccormickLPRelaxer.solve_at_node = _solve
+
+m = from_nl(path)
+t0 = time.perf_counter()
+r = m.solve(time_limit=budget)
+print(json.dumps({
+    "arm": arm,
+    "wall": round(time.perf_counter() - t0, 2),
+    "status": r.status,
+    "bound": r.bound,
+    "objective": r.objective,
+    "gap_certified": bool(r.gap_certified),
+    "node_count": int(r.node_count or 0),
+    "checks": N["checks"], "rounds": N["rounds"], "yielded": N["yielded"],
+}))
+"""
+
+worker = os.path.join(HERE, "_issue966_yield_worker.py")
+with open(worker, "w") as fh:
+    fh.write(WORKER)
+
+
+def run(inst: str, budget: float, arm: str) -> dict:
+    env = dict(os.environ)
+    env["DISCOPT_NODE_ROUND_BUDGET"] = "0" if arm == "base" else "1"
+    env["DISCOPT_LP_WARM_DEADLINE"] = os.environ.get("DISCOPT_LP_WARM_DEADLINE", "0")
+    env["DISCOPT_HESS_COMPILE_GATE"] = "0"
+    out = subprocess.run(
+        [
+            sys.executable,
+            "-u",
+            worker,
+            f"python/tests/data/minlplib_nl/{inst}.nl",
+            str(budget),
+            arm,
+        ],
+        capture_output=True,
+        text=True,
+        env=env,
+        check=True,
+    )
+    return json.loads(out.stdout.strip().splitlines()[-1])
+
+
+budget = float(os.environ.get("PROBE_BUDGET", "20"))
+triples = 0
+for inst in sys.argv[1:]:
+    # Interleaved within the instance (CLAUDE.md §9), one process per cell.
+    rows = [run(inst, budget, arm) for arm in ("base", "decline", "yield")]
+    triples += 1
+    for r in rows:
+        print(
+            f"{inst:12s} {r['arm']:8s} bound={r['bound']!r:24s} obj={r['objective']!r:22s} "
+            f"cert={r['gap_certified']!s:5s} nodes={r['node_count']:5d} wall={r['wall']:6.2f} "
+            f"rounds={r['rounds']} yielded={r['yielded']} status={r['status']}",
+            flush=True,
+        )
+
+print(f"ARM_TRIPLES_EXECUTED={triples}")
+if triples == 0:
+    sys.exit(2)


### PR DESCRIPTION
## Summary

The #966 round-budget flag *declined* a round whose remaining grant could not cover the relaxer&#39;s measured cold-build cost. A declined round banks no bound **and no LP point**, and the point is what the spatial brancher and the primal heuristics run on — which is why the coupled graduation panel scored the flag&#39;s wall win against a collapsing bound ledger (casctanks `2.9098 → −56.5001`, contvar losing its bound outright). This implements the fix that issue comment named: *a round that yields on its deadline must still be able to bank a bound.*

A round that cannot afford a full round now **yields**: the per-node separation chain is skipped and the cold build is truncated at the grant (the #694 anytime mechanism), so it banks the weaker-but-valid bound and the LP vertex it can afford. Second half: a yielded round that banks nothing no longer leaves its node on the failure sentinel — `_yield_keeps_node_open` imports `-inf` so the node stays OPEN at its proved parent bound instead of being fathomed-without-proof.

Contributes to #966 (item 3 advanced, not finished — the flags stay default-OFF; see below).

> **Merged with #984 mid-review.** #984 (*"a round cut short must return the floor it holds"*) landed on `main` while this was open and touches the same admission check. The two compose: #984 makes a round that **is cut short** report its rigorous box floor and exempts the ROOT round; this PR makes a short-granted **non-root** round *run at all*, in yield mode. Merged resolution: the check is `_round_budget_enabled and iteration >= 1`, and when it fires the round yields rather than skipping. Measured on the merged base, #984 does **not** subsume this PR — see the merge comment below and §14e.

## Correctness

Yield mode only **drops** cuts and constraint rows, which enlarges the relaxed feasible set, so the LP optimum stays a valid lower bound on the node&#39;s box — sound, just looser (the same argument that licenses #694&#39;s anytime truncation, which this reuses rather than re-deriving). A yield without a `round_deadline` would be an unclamped round wearing the weaker relaxation, so it raises instead of proceeding.

The sentinel guard strictly *improves* the certificate: leaving the failure sentinel hands the node to the Rust tree&#39;s bound-cut — a fathom with no proof, which `_nonrigorous_sentinel_fathom` turns into a discarded global dual bound. Importing `-inf` keeps the node open, floored on import at its inherited (proved) parent bound; it fathoms nothing, so nothing is decertified.

Both paths are reachable only under `DISCOPT_NODE_ROUND_BUDGET` (default OFF).

- [x] Cannot produce a false certificate
- [x] No validation, fallback, or safety guard was weakened to make a check pass

## Tests run (state the result — numbers, not adjectives)

- [x] `pytest -m smoke` → **915 passed, 18 failed, 22 skipped, 2 xpassed**. All 18 failures reproduce **identically on the parent commit** (verified by checking out `aca13dd`&#39;s files and re-running the same 7 files: 18 failed / 79 passed both ways) — this container&#39;s POUNCE build lacks the tape NLP evaluator, so the JAX evaluator is used. CI&#39;s Python lanes (proper build) are green.
- [x] `pytest -m slow python/tests/test_adversarial_recent_fixes.py` → **10 passed** (267 s run under panel load had 1 flake in `test_large_dense_jacobian_no_crash`; passes on a re-run of the whole file and twice in isolation on an idle machine)
- [x] `cargo test -p discopt-core` → N/A, no Rust touched
- [x] `ruff check` / `ruff format --check` clean

`pytest python/tests/test_966_node_round_budget.py python/tests/test_928_round_cut_short_floor.py` → **21 passed** on the merged tree (my 15 + #984&#39;s 6 — both mechanisms coexist).

## Regression test

Five new tests in `python/tests/test_966_node_round_budget.py`, all **verified failing on the parent commit `aca13dd` and passing here**:

- `test_yield_round_requires_a_round_deadline`
- `test_yield_round_truncates_build_and_skips_separation`
- `test_yield_round_banks_a_sound_bound_and_a_point` (asserts the yielded bound ≤ the full round&#39;s bound ≤ the true box optimum, and that a point comes back)
- `test_yield_round_default_off_leaves_the_path_untouched`
- `test_yielded_round_without_a_bound_keeps_the_node_open` (pins the certificate consequence: `_nonrigorous_sentinel_fathom(sentinel, False)` is True, `(-inf, False)` is False)

- [x] Added a regression test that fails before / passes after

## Bound-changing / performance change?

- [x] Default-OFF flag: `DISCOPT_NODE_ROUND_BUDGET` — flag-OFF path verified byte-identical
- [x] Differential-bound test + soundness assertion (see the regression test above; the panel additionally checks bound-crosses-incumbent and verifies incumbents on all cells)
- [x] **Not graduating — default-off only.** Panel evidence attached below; §5 bar 1 fails in 1 of 2 reps.

### Entry experiments (counted, §4/§6)

**FALSIFIED** — the cheap tier is *not* the incremental fast path: `IncrementalMcCormickLP` is out of scope on all five instances the flag hurt (nvs05, tspn10, casctanks, contvar, tls2 → `_inc = None`; `fast_path_hits = 0` in-solve). `scratchpad/issue966_inc_scope.py`

**CONFIRMED** — the #694 anytime build already is the cheap tier (`scratchpad/issue966_truncated_floor.py`, 2 reps/instance):

| instance | full build | truncated build | full round | truncated-round bound |
|---|---|---|---|---|
| contvar | 0.39–1.83 s | **0.008 s** | 19.6–23.9 s | 87754.998 (full: 164927.75) |
| casctanks | 0.06–0.16 s | **0.025 s** | 0.16–0.27 s | 0.0 (full: *no bound at all*) |
| tspn10 | 0.18–0.91 s | **0.068 s** | 2.2–16.0 s | 0.0 (full: 161.16) |
| nvs05 | 0.74 s | **0.002 s** | 0.93 s | 0.674 (full: −323.05) |

**What the skip cost** (nvs05 @ 20 s, every round forced through the admission branch):

| arm | bound | incumbent | nodes | wall |
|---|---|---|---|---|
| base (flag off) | 3.5139 | 8.7320 | 29–39 | 20.9 s |
| every round SKIPPED | 0.6842 | **523.69** | **1** | **4.1 s** (16 s of budget unused) |
| every round YIELDED | 1.3529 | 8.7320 | 45 | 21.0 s |

Shipped-code A/B (`scratchpad/issue966_yield_fix_ab.py`): nvs05 base 3.5139 / 8.7320 / 39 nodes → skip 0.6323 / 6.9358 / 35 → **yield 3.5061 / 8.7320 / 59**. Re-run on the **merged (post-#984) base**: base 3.5425 / 8.7320 / 39 → skip 0.6323 / 6.3870 / 77 → **yield 3.5067 / 8.7320 / 59**, 38 yields counted.

### Flag-OFF bound-neutrality (§5 regime 1)

13 certifying instances, `node_count`/`objective`/`bound`/`status`/`gap_certified` byte-identical, §8 markers asserted in both directions → `BOUND_NEUTRAL=True  COMPARED=13` (`scratchpad/issue966_neutrality.py`). Run twice: against `aca13dd`, and **re-baselined against the merged base `cf16b73`** after the #984 merge.

### Coupled panel re-run

Same script and same 19 binding instances as the earlier panel; 20 s budget, 3 arms interleaved per instance, 2 reps. Artifacts: `discopt_benchmarks/results/issue966_yield_binding20_rep{1,2}.json`.

| pair | rep1 | rep2 |
|---|---|---|
| total overrun, base | 104.9 s | 300.8 s |
| **seam − base overrun** | **−60.6 s** | **−261.7 s** |
| cand − base overrun | −53.1 s | −269.3 s |
| seam bound ledger vs base | 6 tighter / 1 looser | 6 tighter / 1 looser |
| cand bound ledger vs base | 11 tighter / 2 looser | 10 tighter / 2 looser |
| `CERT_CLEAN` (cand vs base) | **True** | **False** (tspn12 lost incumbent) |

Both previously-named casualties are gone: **casctanks is tighter in both flag arms in both reps**, and **contvar keeps a finite bound in `cand`** (180782.86 → 171244.81, sound). The overrun deltas are made of severe modes the base arm still hits — heatexch_gen3 base **210.1 s (10.5×)** vs seam 21.8 s, bchoco08 base 86.2 s (4.31×) vs 21.0 s, tspn12 base 57.8 s (2.89×) vs 20.8 s — each with an equal or tighter flag-arm bound.

**Why it still does not graduate:** §5 bar 1 is per-run and rep2&#39;s graduation pair is not cert-clean (tspn12 loses its incumbent; rep1 lost tspn10&#39;s in the `seam` arm). Lost incumbents are the whole residual now, and they are not reproducible rep-to-rep.

### Three honest limits, recorded not papered over

1. **The panel ran on `aca13dd`, before #984.** Those numbers do not describe the merged tree. #984&#39;s own verdict names the same lost-incumbent residual from the other side (*"#966&#39;s round-admission policy losing a primal trajectory"*), and yield mode is the candidate treatment for it — but that is **unmeasured on the merged base**. The graduation panel owed to #966 item 3 needs one run on the merged tree.
2. It ran **without the POUNCE tape NLP evaluator**, so absolute walls and even base bounds differ from the earlier panel&#39;s machine (casctanks base is −90.1786 here vs 2.9098 there). Same panel, different machine — not a reproduction of those cells.
3. **`minlplib.solu` is unreachable in this container**, so oracle coverage was **1/19 instances (3 comparisons)** — the state the §14b-qual retraction was about. It is declared explicitly (`DISCOPT_MINLPLIB_SOLU=none`, stamped into every artifact as `solu_oracle`) rather than swallowed; a `.solu` path that is *set but unreadable* still crashes. The panel&#39;s other soundness checks fired on all 19 × 3 cells with `unsound=[]`. **No corpus-wide soundness claim rests on these two runs.**

Full record in `docs/dev/performance-plan.md` **§14e** (#984 keeps §14d — it landed first).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011enaWRqp1Fbw3J7wKFNbBT

---
_Generated by [Claude Code](https://claude.ai/code/session_011enaWRqp1Fbw3J7wKFNbBT)_