### PR TITLE
docs: fix tutorial_oa to the current API and add a GBD tutorial

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,26 @@ The release procedure that produces these entries is documented in
 
 ### Changed
 
+- **`tutorial_oa` documented an API that no longer selects OA** (`docs`). Every
+  solve cell used `gdp_method="oa"`, which was deprecated in favour of
+  `solver="mip-nlp", mip_nlp_method="oa"`: it now emits a `DeprecationWarning`
+  and is reinterpreted as `gdp_method="big-m"`, a *GDP reformulation*. So the
+  notebook ran spatial branch & bound throughout — its "Comparing OA with Branch
+  & Bound" cell was comparing B&B against B&B, and its ECP cell never entered ECP
+  mode. All five solve cells now use the current spelling, with a note explaining
+  that `gdp_method=` and `solver=` are orthogonal axes.
+
+  Two further corrections. The primary example (`example_simple_minlp`) closes
+  the gap on its first master/subproblem pair, so it illustrates nothing about
+  the alternation; the notebook now also builds `synthes1` (Duran & Grossmann
+  1986, test problem 1), which gives a genuine four-iteration loop, and prints
+  the per-iteration `mip_nlp_trace` — LB 1.411895 → 6.009759 against UB 7.092732
+  → 6.009759 — plus the OA/ECP counter contrast (OA: 4 masters, 4 NLPs, 35 cuts;
+  ECP: 8 masters, 0 NLPs, 20 cuts). The Limitations section claimed single-tree
+  LP/NLP B&B and level-method regularization were "not yet implemented"; both
+  exist (`mip_nlp_method="lp_nlp_bb"`, which needs `milp_solver="gurobi"`, and
+  `add_regularization`/`level_coef`), and the section now says so.
+
 - **All 62 documentation notebooks re-executed** (`docs`). Their committed
   outputs dated from 2026-04-25 and `docs/_config.yml` has
   `execute_notebooks: "off"`, so nothing had re-run them in three and a half
@@ -146,6 +166,22 @@ The release procedure that produces these entries is documented in
   Tests: `test_932_native_base_thread_sharing.py`.
 
 ### Added
+
+- **`docs/notebooks/tutorial_gbd.ipynb`** — a tutorial for Generalized Benders
+  Decomposition (`docs`). `solve_gbd` had shipped with no notebook of its own;
+  `tutorial_benders` covers only the classical linear-recourse case. The new
+  notebook derives the Lagrangian cut, then runs the master/subproblem loop by
+  hand on a model whose value function and multiplier are closed form
+  (`v(y) = (3 - 2y₁ - y₂)₊²`, `μ = 2(3 - 2y₁ - y₂)₊`), so the mechanics are
+  visible without a solver in the loop — it converges in two iterations, LB
+  4 → 5 against UB 9 → 5, and `solve_gbd` reproduces the same optimum. A
+  capacity-expansion model with convex-quadratic congestion cost then shows the
+  three entry points (`solve_gbd`, `solve_benders` dispatch, and
+  `Model.solve(decomposition="benders")`) and a GBD/OA/spatial-B&B comparison, all
+  three agreeing on 20.8000. Covers the dominance hierarchy `z_OA ≥ z_GBD ≥ z_LP`
+  (Grossmann 2002), the convexity requirement for a rigorous bound, and the #946
+  degenerate-recourse failure mode with its integer L-shaped fallback (Laporte &
+  Louveaux 1993). New BibTeX entries: `Grossmann2002`, `Laporte1993`.
 
 - **Anytime dual bound: root seeding + one unified report** (`fix`, #933).
   27% of a 200-instance MINLPLib sweep reported **no dual bound at all** at

--- a/docs/_toc.yml
+++ b/docs/_toc.yml
@@ -25,6 +25,7 @@ parts:
       - file: notebooks/tutorial_oa
       - file: mip_nlp
       - file: notebooks/tutorial_benders
+      - file: notebooks/tutorial_gbd
       - file: notebooks/tutorial_lagrangian
       - file: notebooks/decomposition_advisor
       - file: notebooks/amp_global_minlp

--- a/docs/design/solver-review.md
+++ b/docs/design/solver-review.md
@@ -81,7 +81,7 @@ Classification: `python/discopt/_relax/problem_classifier.py` (`ProblemClass`
 |---|---|---|---|
 | **AMP** | `solver="amp"` (`solver.py:2036`) | Adaptive multivariate-partitioning global MINLP (discopt's own) | MILP relaxation (HiGHS/POUNCE) + POUNCE NLP sub-solves |
 | **GP** | `solver="gp"` or auto-detect | Geometric programming via log-space convex reformulation | single POUNCE NLP |
-| **OA / GDP-LOA** | `gdp_method="oa"`/`"loa"` | Outer approximation for convex MINLP / disjunctive | MILP master (HiGHS/POUNCE) + POUNCE NLP |
+| **OA / GDP-LOA** | `solver="mip-nlp", mip_nlp_method="oa"` / `gdp_method="loa"` | Outer approximation for convex MINLP / disjunctive | MILP master (HiGHS/POUNCE) + POUNCE NLP |
 | **DAE, RO, MO, NN** | modules `dae/ ro/ mo/ nn/` | Reformulate the `Model`, then call `Model.solve()` | whatever the resulting class dispatches to |
 | **MPEC** | `discopt.mpec.solve_mpec` | Scholtes regularization | POUNCE NLP |
 

--- a/docs/notebooks/tutorial_benders.ipynb
+++ b/docs/notebooks/tutorial_benders.ipynb
@@ -9,7 +9,7 @@
     "\n",
     "**Benders decomposition** {cite:p}`Benders1962` solves block-angular / two-stage problems by splitting the variables into *complicating* (first-stage / master) variables and *recourse* (subproblem) variables. For a fixed master point the recourse subproblem is an independent program; its optimal **dual** (or KKT multipliers) yields a cut that under-estimates the recourse cost, and its infeasibility yields a cut that excludes the offending master point. Iterating the master/subproblem loop drives the master's lower bound up to meet the incumbent's upper bound.\n",
     "\n",
-    "discopt's `solve_benders` implements **classical Benders** for linear-recourse problems (linear constraints and objective, integer variables first-stage so the recourse is a continuous LP) **and Generalized Benders Decomposition** {cite:p}`Geoffrion1972` for a *convex nonlinear* recourse subproblem — the solver detects nonlinearity and dispatches to GBD automatically. Because each cut is a valid *global* under-estimator (LP weak duality, or — for GBD — the envelope theorem on the convex value function), the master objective is a **rigorous lower bound** whenever the model is convex; the solver never reports an unsound bound. For a broad survey of the method and its modern variants, see {cite:t}`Rahmaniani2017`."
+    "discopt's `solve_benders` implements **classical Benders** for linear-recourse problems (linear constraints and objective, integer variables first-stage so the recourse is a continuous LP) **and Generalized Benders Decomposition** {cite:p}`Geoffrion1972` for a *convex nonlinear* recourse subproblem \u2014 the solver detects nonlinearity and dispatches to GBD automatically. Because each cut is a valid *global* under-estimator (LP weak duality, or \u2014 for GBD \u2014 the envelope theorem on the convex value function), the master objective is a **rigorous lower bound** whenever the model is convex; the solver never reports an unsound bound. For a broad survey of the method and its modern variants, see {cite:t}`Rahmaniani2017`."
    ]
   },
   {
@@ -137,10 +137,10 @@
    "source": [
     "## Declaring the decomposition structure\n",
     "\n",
-    "By default the **complicating variables are the integer variables** — the canonical Benders split for two-stage mixed-integer programs. For a purely continuous two-stage model, or to override the split, annotate the model directly:\n",
+    "By default the **complicating variables are the integer variables** \u2014 the canonical Benders split for two-stage mixed-integer programs. For a purely continuous two-stage model, or to override the split, annotate the model directly:\n",
     "\n",
-    "- `m.first_stage(u)` / `m.second_stage(v)` — mark complicating vs recourse variables.\n",
-    "- `m.mark_coupling(constraint)` — mark a linking constraint (used by Lagrangian relaxation).\n",
+    "- `m.first_stage(u)` / `m.second_stage(v)` \u2014 mark complicating vs recourse variables.\n",
+    "- `m.mark_coupling(constraint)` \u2014 mark a linking constraint (used by Lagrangian relaxation).\n",
     "\n",
     "`discopt.detect_decomposition(model)` resolves these annotations and reports the structure it will use."
    ]
@@ -198,12 +198,14 @@
    "source": [
     "## When to use Benders\n",
     "\n",
-    "Benders shines when fixing a few complicating variables makes the remaining problem an easy, possibly decomposable, subproblem — two-stage stochastic programs, network/facility design, and capacity-expansion models. The implementation handles:\n",
+    "Benders shines when fixing a few complicating variables makes the remaining problem an easy, possibly decomposable, subproblem \u2014 two-stage stochastic programs, network/facility design, and capacity-expansion models. The implementation handles:\n",
     "\n",
     "- **classical Benders**: linear constraints and objective, with all integer variables first-stage (continuous LP recourse), and\n",
     "- **Generalized Benders** {cite:p}`Geoffrion1972`: a convex nonlinear recourse subproblem (cuts from the recourse NLP's KKT multipliers), dispatched automatically when the model is nonlinear.\n",
     "\n",
-    "The reported lower `bound` is rigorous when the model is convex. For a **nonconvex** model GBD still returns a heuristic incumbent but reports `bound=None` (the value function is no longer guaranteed convex, so no valid global cut can be certified); use `m.solve()` (spatial branch & bound) for a guaranteed bound there, or `m.solve(gdp_method=\"oa\")` (Outer Approximation) {cite:p}`Duran1986` for convex MINLP."
+    "The reported lower `bound` is rigorous when the model is convex. For a **nonconvex** model GBD still returns a heuristic incumbent but reports `bound=None` (the value function is no longer guaranteed convex, so no valid global cut can be certified); use `m.solve()` (spatial branch & bound) for a guaranteed bound there, or `m.solve(solver=\"mip-nlp\", mip_nlp_method=\"oa\")` (Outer Approximation) {cite:p}`Duran1986` for convex MINLP.\n",
+    "\n",
+    "GBD gets a tutorial of its own \u2014 see [Generalized Benders Decomposition](tutorial_gbd.ipynb), which derives the Lagrangian cut, runs the loop by hand, and compares GBD against OA and spatial B&B on the same model."
    ]
   },
   {
@@ -251,21 +253,6 @@
     "print(\"objective:\", round(res.objective, 4))\n",
     "print(\"bound    :\", round(res.bound, 4))\n",
     "print(\"monolithic:\", round(gbd.solve().objective, 4))"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "b8a51e56",
-   "metadata": {},
-   "source": [
-    "## When to use Benders\n",
-    "\n",
-    "Benders shines when fixing a few complicating variables makes the remaining problem an easy, possibly decomposable, LP — two-stage stochastic programs, network/facility design, and capacity-expansion models. The v1 implementation requires:\n",
-    "\n",
-    "- linear constraints and a linear objective, and\n",
-    "- all integer variables in the first stage (continuous recourse).\n",
-    "\n",
-    "For nonlinear models, use `m.solve()` (spatial branch & bound) or `m.solve(gdp_method=\"oa\")` (Outer Approximation) {cite:p}`Duran1986` meanwhile; generalized Benders with convex-NLP recourse is on the roadmap."
    ]
   }
  ],

--- a/docs/notebooks/tutorial_gbd.ipynb
+++ b/docs/notebooks/tutorial_gbd.ipynb
@@ -1,0 +1,580 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "3d87cff2",
+   "metadata": {},
+   "source": [
+    "# Generalized Benders Decomposition\n",
+    "\n",
+    "**Generalized Benders Decomposition** (GBD) {cite:p}`Geoffrion1972` solves a MINLP by\n",
+    "alternating between two much smaller problems: an NLP with the integers *fixed*, and a\n",
+    "MILP master that decides the next integer assignment. It is the nonlinear generalization\n",
+    "of classical Benders {cite:p}`Benders1962`, which requires the subproblem to be an LP —\n",
+    "see the [Benders tutorial](tutorial_benders.ipynb) for that case.\n",
+    "\n",
+    "This is the answer to a question that comes up often: *is there such a thing as a \"local\"\n",
+    "MINLP solver?* Yes — GBD and [Outer Approximation](tutorial_oa.ipynb) are both\n",
+    "decomposition schemes that never build a spatial branch & bound tree. On a **convex**\n",
+    "MINLP they converge finitely to the global optimum; on a non-convex one they are\n",
+    "local-solution heuristics with no certificate.\n",
+    "\n",
+    "## The two-stage picture\n",
+    "\n",
+    "Split the variables into a **first stage** $y$ (the complicating ones — typically the\n",
+    "integers) and a **recourse** stage $x$ (continuous):\n",
+    "\n",
+    "$$\\min_{y \\in Y,\\; x} \\; f(y) + g(y, x) \\quad \\text{s.t.}\\quad h(y, x) \\le 0$$\n",
+    "\n",
+    "Fixing $y = \\hat{y}$ leaves a pure NLP in $x$. Its optimal value defines the **value\n",
+    "function** $v(\\hat y) = \\min_x \\{\\, g(\\hat y, x) : h(\\hat y, x) \\le 0 \\,\\}$, and the\n",
+    "original problem collapses to $\\min_{y \\in Y} f(y) + v(y)$ — an optimization over the\n",
+    "integers alone, if only we knew $v$.\n",
+    "\n",
+    "We don't. But when the model is convex, $v$ is convex in $y$, and the Lagrangian dual of\n",
+    "the recourse NLP hands us a **supporting hyperplane** of $v$ at $\\hat y$ for free: with\n",
+    "multipliers $\\mu \\ge 0$ from the recourse solve,\n",
+    "\n",
+    "$$v(y) \\;\\ge\\; L(\\hat x, \\hat y, \\mu) + \\nabla_y L(\\hat x, \\hat y, \\mu)^{\\!\\top}(y - \\hat y).$$\n",
+    "\n",
+    "Accumulating these gives a piecewise-linear *under*-estimator of $v$, which is exactly\n",
+    "the MILP master:\n",
+    "\n",
+    "$$\\min_{y \\in Y,\\; \\eta} \\; f(y) + \\eta \\quad \\text{s.t.}\\quad \\eta \\ge \\text{(all cuts so far)}.$$\n",
+    "\n",
+    "The master value is a **lower bound** (it under-estimates $v$); each recourse solve gives\n",
+    "a feasible point, hence an **upper bound**. The loop stops when they meet."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "055c600c",
+   "metadata": {},
+   "source": [
+    "## The algorithm, written out\n",
+    "\n",
+    "The mechanics are easiest to see with no solver in the loop at all. Take\n",
+    "\n",
+    "$$\\min_{y \\in \\{0,1\\}^2,\\; x \\in [0,5]} \\; 4y_1 + 3y_2 + x^2\n",
+    "\\quad \\text{s.t.}\\quad x + 2y_1 + y_2 \\ge 3,$$\n",
+    "\n",
+    "whose recourse value and multiplier are both closed form:\n",
+    "\n",
+    "$$v(y) = \\big(3 - 2y_1 - y_2\\big)_+^2, \\qquad\n",
+    "  \\mu(y) = 2\\big(3 - 2y_1 - y_2\\big)_+,$$\n",
+    "\n",
+    "so the cut generated at $\\hat y$ is\n",
+    "$\\eta \\ge v(\\hat y) - \\mu(\\hat y)\\big[2(y_1 - \\hat y_1) + (y_2 - \\hat y_2)\\big]$.\n",
+    "With only four candidate $y$ vectors we can solve the master by enumeration and watch\n",
+    "the bounds close."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "0854dc87",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-11T18:19:58.027530Z",
+     "iopub.status.busy": "2026-08-11T18:19:58.027312Z",
+     "iopub.status.idle": "2026-08-11T18:19:58.061109Z",
+     "shell.execute_reply": "2026-08-11T18:19:58.060733Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "iter     y_hat   v(y_hat)      mu         LB         UB\n",
+      "   1    (0, 0)     9.0000   6.000   4.000000   9.000000\n",
+      "   2    (1, 0)     1.0000   2.000   5.000000   5.000000\n",
+      "\n",
+      "converged in 2 iterations: optimum 5.0 at y=(1, 0)\n"
+     ]
+    }
+   ],
+   "source": [
+    "import itertools\n",
+    "\n",
+    "import numpy as np\n",
+    "\n",
+    "C = np.array([4.0, 3.0])   # first-stage cost\n",
+    "A = np.array([2.0, 1.0])   # coupling coefficients\n",
+    "D = 3.0                    # demand\n",
+    "YS = list(itertools.product([0, 1], repeat=2))\n",
+    "\n",
+    "\n",
+    "def value(y):\n",
+    "    '''Recourse optimal value with the first stage fixed.'''\n",
+    "    return max(0.0, D - A @ np.asarray(y, float)) ** 2\n",
+    "\n",
+    "\n",
+    "def multiplier(y):\n",
+    "    '''Optimal multiplier of the coupling row (the Lagrangian dual solution).'''\n",
+    "    return 2.0 * max(0.0, D - A @ np.asarray(y, float))\n",
+    "\n",
+    "\n",
+    "cuts = []                       # each entry: (const, grad) meaning eta >= const + grad . y\n",
+    "y_hat, ub, lb = (0, 0), np.inf, -np.inf\n",
+    "\n",
+    "print(f\"{'iter':>4}  {'y_hat':>8}  {'v(y_hat)':>9}  {'mu':>6}  {'LB':>9}  {'UB':>9}\")\n",
+    "for it in range(1, 11):\n",
+    "    v, mu = value(y_hat), multiplier(y_hat)\n",
+    "    ub = min(ub, C @ np.array(y_hat, float) + v)          # incumbent from the recourse solve\n",
+    "    cuts.append((v + mu * (A @ np.array(y_hat, float)), -mu * A))\n",
+    "\n",
+    "    # MILP master, solved here by enumerating the four y vectors.\n",
+    "    lb, y_next = min(\n",
+    "        (C @ np.array(y, float) + max([0.0] + [c + g @ np.array(y, float) for c, g in cuts]), y)\n",
+    "        for y in YS\n",
+    "    )\n",
+    "    print(f\"{it:>4}  {str(y_hat):>8}  {v:>9.4f}  {mu:>6.3f}  {lb:>9.6f}  {ub:>9.6f}\")\n",
+    "    if ub - lb <= 1e-9:\n",
+    "        break\n",
+    "    y_hat = y_next\n",
+    "\n",
+    "print(f\"\\nconverged in {it} iterations: optimum {ub} at y={y_hat}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "98666fbb",
+   "metadata": {},
+   "source": [
+    "Two iterations, two cuts, and the master's lower bound rises from 4 to 5 while the\n",
+    "incumbent falls from 9 to 5. Note what the master never saw: the nonlinearity. All it\n",
+    "ever handles is $f(y)$ plus a few linear inequalities in $y$ and $\\eta$.\n",
+    "\n",
+    "`solve_gbd` does the same thing with real NLP solves and real multipliers."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "5070a498",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-11T18:19:58.062358Z",
+     "iopub.status.busy": "2026-08-11T18:19:58.062251Z",
+     "iopub.status.idle": "2026-08-11T18:19:58.668956Z",
+     "shell.execute_reply": "2026-08-11T18:19:58.668554Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "status=optimal  objective=5.000000  bound=5.000000  certified=True\n"
+     ]
+    }
+   ],
+   "source": [
+    "import discopt.modeling as dm\n",
+    "from discopt.decomposition.benders import solve_gbd\n",
+    "\n",
+    "m = dm.Model(\"toy\")\n",
+    "y = m.binary(\"y\", shape=(2,))\n",
+    "x = m.continuous(\"x\", lb=0.0, ub=5.0)\n",
+    "m.first_stage(y)                          # declare the complicating variables\n",
+    "m.minimize(4 * y[0] + 3 * y[1] + x * x)\n",
+    "m.subject_to(x + 2 * y[0] + y[1] >= D)\n",
+    "\n",
+    "r = solve_gbd(m, time_limit=60)\n",
+    "print(f\"status={r.status}  objective={r.objective:.6f}  bound={r.bound:.6f}  \"\n",
+    "      f\"certified={r.gap_certified}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "58b7ca2e",
+   "metadata": {},
+   "source": [
+    "## A worked example: capacity expansion with congestion\n",
+    "\n",
+    "A more realistic shape. Three candidate units, each with a fixed build cost $f_i$ and a\n",
+    "capacity $\\bar{u}_i$; the operating cost is **convex quadratic** in throughput (a\n",
+    "congestion or efficiency-loss term), which is what makes the recourse an NLP rather than\n",
+    "an LP:\n",
+    "\n",
+    "$$\n",
+    "\\begin{aligned}\n",
+    "\\min \\quad & \\sum_i f_i y_i + \\sum_i \\big(a_i x_i + b_i x_i^2\\big) \\\\\n",
+    "\\text{s.t.}\\quad & \\sum_i x_i \\ge D, \\qquad x_i \\le \\bar{u}_i\\, y_i, \\qquad\n",
+    "y_i \\in \\{0,1\\},\\; x_i \\ge 0\n",
+    "\\end{aligned}\n",
+    "$$\n",
+    "\n",
+    "The binaries are the complicating variables — with $y$ fixed this is a small convex QP."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "4999820a",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-11T18:19:58.670324Z",
+     "iopub.status.busy": "2026-08-11T18:19:58.670228Z",
+     "iopub.status.idle": "2026-08-11T18:19:58.975209Z",
+     "shell.execute_reply": "2026-08-11T18:19:58.974816Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Evaluator FeasibilityPhaseEvaluator declares no `timing_bucket`; its derivative-callback time will be left with the enclosing solver region and the layer profile will over-report that layer [timing-bucket-unknown].\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Evaluator FeasibilityPhaseEvaluator declares no `timing_bucket`; its derivative-callback time will be left with the enclosing solver region and the layer profile will over-report that layer [timing-bucket-unknown].\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Evaluator FeasibilityPhaseEvaluator declares no `timing_bucket`; its derivative-callback time will be left with the enclosing solver region and the layer profile will over-report that layer [timing-bucket-unknown].\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Evaluator FeasibilityPhaseEvaluator declares no `timing_bucket`; its derivative-callback time will be left with the enclosing solver region and the layer profile will over-report that layer [timing-bucket-unknown].\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "GBD: status=optimal  objective=20.8000  bound=20.8000  certified=True\n",
+      "built units: [1, 1, 0]\n"
+     ]
+    }
+   ],
+   "source": [
+    "FIXED = [3.5, 2.0, 4.5]     # build cost\n",
+    "LIN = [1.0, 2.0, 0.6]       # linear operating cost\n",
+    "QUAD = [0.30, 0.10, 0.45]   # congestion coefficient\n",
+    "CAP = [4.0, 5.0, 3.0]\n",
+    "DEMAND = 7.0\n",
+    "\n",
+    "\n",
+    "def capacity_expansion():\n",
+    "    m = dm.Model(\"capacity\")\n",
+    "    y = m.binary(\"y\", shape=(3,))\n",
+    "    x = m.continuous(\"x\", shape=(3,), lb=0.0, ub=5.0)\n",
+    "    m.first_stage(y)\n",
+    "    m.minimize(\n",
+    "        sum(FIXED[i] * y[i] for i in range(3))\n",
+    "        + sum(LIN[i] * x[i] + QUAD[i] * x[i] * x[i] for i in range(3))\n",
+    "    )\n",
+    "    m.subject_to(sum(x[i] for i in range(3)) >= DEMAND)\n",
+    "    for i in range(3):\n",
+    "        m.subject_to(x[i] <= CAP[i] * y[i])\n",
+    "    return m\n",
+    "\n",
+    "\n",
+    "r_gbd = solve_gbd(capacity_expansion(), time_limit=120)\n",
+    "print(f\"GBD: status={r_gbd.status}  objective={r_gbd.objective:.4f}  \"\n",
+    "      f\"bound={r_gbd.bound:.4f}  certified={r_gbd.gap_certified}\")\n",
+    "print(\"built units:\", [round(float(v)) for v in r_gbd.x[\"y\"]])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cca8ac0c",
+   "metadata": {},
+   "source": [
+    "### Three ways to ask for it\n",
+    "\n",
+    "`solve_gbd` is the direct entry point. `solve_benders` inspects the model and dispatches\n",
+    "to GBD when the subproblem is nonlinear (and to classical Benders when it is an LP), and\n",
+    "`model.solve(decomposition=\"benders\")` routes through the same dispatcher."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "bf8232ea",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-11T18:19:58.976464Z",
+     "iopub.status.busy": "2026-08-11T18:19:58.976401Z",
+     "iopub.status.idle": "2026-08-11T18:19:59.620807Z",
+     "shell.execute_reply": "2026-08-11T18:19:59.620401Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Evaluator FeasibilityPhaseEvaluator declares no `timing_bucket`; its derivative-callback time will be left with the enclosing solver region and the layer profile will over-report that layer [timing-bucket-unknown].\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Evaluator FeasibilityPhaseEvaluator declares no `timing_bucket`; its derivative-callback time will be left with the enclosing solver region and the layer profile will over-report that layer [timing-bucket-unknown].\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Evaluator FeasibilityPhaseEvaluator declares no `timing_bucket`; its derivative-callback time will be left with the enclosing solver region and the layer profile will over-report that layer [timing-bucket-unknown].\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Evaluator FeasibilityPhaseEvaluator declares no `timing_bucket`; its derivative-callback time will be left with the enclosing solver region and the layer profile will over-report that layer [timing-bucket-unknown].\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Evaluator FeasibilityPhaseEvaluator declares no `timing_bucket`; its derivative-callback time will be left with the enclosing solver region and the layer profile will over-report that layer [timing-bucket-unknown].\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Evaluator FeasibilityPhaseEvaluator declares no `timing_bucket`; its derivative-callback time will be left with the enclosing solver region and the layer profile will over-report that layer [timing-bucket-unknown].\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Evaluator FeasibilityPhaseEvaluator declares no `timing_bucket`; its derivative-callback time will be left with the enclosing solver region and the layer profile will over-report that layer [timing-bucket-unknown].\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Evaluator FeasibilityPhaseEvaluator declares no `timing_bucket`; its derivative-callback time will be left with the enclosing solver region and the layer profile will over-report that layer [timing-bucket-unknown].\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "solve_benders(...)                    -> 20.8000\n",
+      "model.solve(decomposition='benders')  -> 20.8000\n"
+     ]
+    }
+   ],
+   "source": [
+    "from discopt.decomposition.benders import solve_benders\n",
+    "\n",
+    "r_dispatch = solve_benders(capacity_expansion(), time_limit=120)\n",
+    "r_kwarg = capacity_expansion().solve(decomposition=\"benders\", time_limit=120)\n",
+    "\n",
+    "print(f\"solve_benders(...)                    -> {r_dispatch.objective:.4f}\")\n",
+    "print(f\"model.solve(decomposition='benders')  -> {r_kwarg.objective:.4f}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c220d2a4",
+   "metadata": {},
+   "source": [
+    "### Declaring the structure\n",
+    "\n",
+    "`m.first_stage(y)` annotates the complicating variables. If you omit it,\n",
+    "`detect_decomposition` infers a structure — by default the integers become the first\n",
+    "stage, which is the right guess for most MINLPs but not for every model."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "d656f115",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-11T18:19:59.621968Z",
+     "iopub.status.busy": "2026-08-11T18:19:59.621902Z",
+     "iopub.status.idle": "2026-08-11T18:19:59.623902Z",
+     "shell.execute_reply": "2026-08-11T18:19:59.623650Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "first-stage (complicating) variables: ['y']\n",
+      "inferred from: annotated\n"
+     ]
+    }
+   ],
+   "source": [
+    "from discopt import detect_decomposition\n",
+    "\n",
+    "structure = detect_decomposition(capacity_expansion())\n",
+    "print(\"first-stage (complicating) variables:\", structure.complicating_vars)\n",
+    "print(\"inferred from:\", structure.source)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cfbb3b6a",
+   "metadata": {},
+   "source": [
+    "## GBD vs. Outer Approximation vs. spatial B&B\n",
+    "\n",
+    "All three solve this model to the same optimum, by very different routes.\n",
+    "{cite:t}`Grossmann2002` establishes the relationship between the first two: the OA\n",
+    "master problem is **at least as tight** as the GBD master, which is at least as tight as\n",
+    "the continuous relaxation,\n",
+    "\n",
+    "$$z_{\\text{OA}} \\;\\ge\\; z_{\\text{GBD}} \\;\\ge\\; z_{\\text{LP}},$$\n",
+    "\n",
+    "because a single GBD cut is a particular non-negative aggregation of the per-constraint\n",
+    "OA linearizations. GBD therefore usually needs *more* iterations than OA — the trade-off\n",
+    "is that its master grows by exactly **one** row per iteration regardless of how many\n",
+    "nonlinear constraints the model has, whereas OA adds one per constraint. GBD wins when\n",
+    "the master must stay small; OA wins almost everywhere else.\n",
+    "\n",
+    "The three agree on $20.8$ below. They agree only to solver tolerance, not to the last\n",
+    "bit: GBD stops at the default relative gap of $10^{-4}$, and its incumbent carries the\n",
+    "recourse NLP's own feasibility tolerance, so the reported bound and incumbent can differ\n",
+    "in the eighth digit — including in the direction that *looks* like an inverted\n",
+    "certificate. Read the pair as \"equal to within `gap_tolerance`\"."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "fe903ec9",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-11T18:19:59.624995Z",
+     "iopub.status.busy": "2026-08-11T18:19:59.624928Z",
+     "iopub.status.idle": "2026-08-11T18:19:59.714205Z",
+     "shell.execute_reply": "2026-08-11T18:19:59.713705Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      method    objective        bound   time (s)   nodes   masters\n",
+      "         GBD      20.8000      20.8000      0.302       0         -\n",
+      "          OA      20.8000      20.8000      0.068       0         4\n",
+      " spatial B&B      20.8000      20.8000      0.015      11         -\n"
+     ]
+    }
+   ],
+   "source": [
+    "r_oa = capacity_expansion().solve(solver=\"mip-nlp\", mip_nlp_method=\"oa\", time_limit=120)\n",
+    "r_bb = capacity_expansion().solve(time_limit=120)\n",
+    "\n",
+    "rows = [\n",
+    "    (\"GBD\", r_gbd, None),\n",
+    "    (\"OA\", r_oa, r_oa.mip_nlp_trace[\"summary\"]),\n",
+    "    (\"spatial B&B\", r_bb, None),\n",
+    "]\n",
+    "print(f\"{'method':>12}  {'objective':>11}  {'bound':>11}  {'time (s)':>9}  {'nodes':>6}  {'masters':>8}\")\n",
+    "for name, res, summary in rows:\n",
+    "    masters = \"-\" if summary is None else summary[\"mip_count\"]\n",
+    "    print(f\"{name:>12}  {res.objective:>11.4f}  {res.bound:>11.4f}  \"\n",
+    "          f\"{res.wall_time:>9.3f}  {res.node_count:>6}  {str(masters):>8}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "41df633c",
+   "metadata": {},
+   "source": [
+    "## When GBD is the right tool\n",
+    "\n",
+    "| Situation | Use |\n",
+    "|---|---|\n",
+    "| Convex MINLP, moderate number of nonlinear constraints | **OA** — tighter master, fewer iterations |\n",
+    "| Convex MINLP where the master must stay small (many nonlinear rows, few first-stage vars) | **GBD** |\n",
+    "| Two-stage stochastic program with *linear* recourse | **Classical Benders** {cite:p}`Benders1962` |\n",
+    "| Non-convex MINLP, global certificate required | **Spatial B&B** — `model.solve()` |\n",
+    "\n",
+    "The [Decomposition Advisor](decomposition_advisor.ipynb) will make this call for you; it\n",
+    "ranks OA above GBD automatically on a convex model."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0bab0991",
+   "metadata": {},
+   "source": [
+    "## Caveats\n",
+    "\n",
+    "```{warning}\n",
+    "**Convexity is what makes the bound rigorous.** The cut is a supporting hyperplane of\n",
+    "$v$ only when $v$ is convex. On a non-convex model `solve_gbd` runs in *heuristic mode*:\n",
+    "it returns a feasible point and withholds the dual bound (`bound is None`). A `None`\n",
+    "bound is the honest answer, not a failure — it means \"no certificate\", and you should\n",
+    "reach for spatial B&B if you need one.\n",
+    "```\n",
+    "\n",
+    "```{warning}\n",
+    "**Degenerate recourse.** If the recourse NLP has an empty interior at some $\\hat y$\n",
+    "(Slater's condition fails), no finite multiplier exists, and the Lagrangian cut is tight\n",
+    "at $\\hat y$ but vacuous everywhere else. The master then re-proposes points it has\n",
+    "already cut and the lower bound stalls — GBD exits with `status=\"iteration_limit\"` and a\n",
+    "weak-but-valid bound, and logs a warning saying exactly this. When the first stage is\n",
+    "all 0/1, discopt adds a multiplier-free **integer L-shaped** cut\n",
+    "{cite:p}`Laporte1993` alongside the Lagrangian one, which restores progress in most such\n",
+    "cases.\n",
+    "```\n",
+    "\n",
+    "Two structural limits of the current implementation: master-only constraints (those\n",
+    "touching no recourse variable) must be **linear**, and infeasible recourse is handled by\n",
+    "a no-good cut, which requires an all-0/1 first stage. A model with general-integer\n",
+    "first-stage variables therefore needs *relatively complete recourse* — every first-stage\n",
+    "assignment must leave the recourse problem feasible.\n",
+    "\n",
+    "## Further reading\n",
+    "\n",
+    "{cite:t}`Geoffrion1972` is the original; {cite:t}`Rahmaniani2017` is a thorough modern\n",
+    "survey of the Benders family including acceleration strategies.\n",
+    "{cite:t}`Grossmann2002` and {cite:t}`Kronqvist2019` compare GBD against OA, ECP and\n",
+    "LP/NLP branch & bound on convex MINLP."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/notebooks/tutorial_oa.ipynb
+++ b/docs/notebooks/tutorial_oa.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "ec621c28825d",
+   "id": "8498d239",
    "metadata": {},
    "source": [
     "# Outer Approximation Solver\n",
@@ -11,6 +11,24 @@
     "Mixed-Integer Nonlinear Programming (MINLP). OA decomposes a MINLP into alternating\n",
     "NLP subproblems and MILP master problems, and is especially effective for **convex MINLP**\n",
     "problems with many binary/integer variables {cite:p}`Duran1986`.\n",
+    "\n",
+    "## Selecting the solver\n",
+    "\n",
+    "OA is one of the *MIP–NLP decomposition* methods, selected with `solver=\"mip-nlp\"`:\n",
+    "\n",
+    "```python\n",
+    "result = model.solve(solver=\"mip-nlp\", mip_nlp_method=\"oa\")\n",
+    "```\n",
+    "\n",
+    "```{note}\n",
+    "The old spelling `gdp_method=\"oa\"` is **deprecated** and no longer selects OA. It now\n",
+    "emits a `DeprecationWarning` and is interpreted as `gdp_method=\"big-m\"`, a *GDP\n",
+    "reformulation* — so a solve written that way silently runs spatial branch & bound.\n",
+    "The `gdp_method=` and `solver=\"mip-nlp\"` axes are orthogonal: `gdp_method` says how\n",
+    "disjunctions are reformulated, `solver` says which algorithm solves the result.\n",
+    "(`gdp_method=\"loa\"` is a different thing again — native *logic-based* OA, which\n",
+    "linearizes inside disjunctions; see the GDP tutorial.)\n",
+    "```\n",
     "\n",
     "## When to use OA vs. Branch & Bound\n",
     "\n",
@@ -31,19 +49,23 @@
     "   - Fix integers at master solution, solve **NLP subproblem** → upper bound\n",
     "   - Generate OA cuts (tangent hyperplanes) at NLP solution\n",
     "   - If NLP infeasible: add feasibility cuts {cite:p}`Fletcher1994` or no-good cuts\n",
-    "3. **Terminate** when gap converges or master becomes infeasible"
+    "3. **Terminate** when gap converges or master becomes infeasible\n",
+    "\n",
+    "Because the master accumulates *supporting hyperplanes* of a convex feasible set, its\n",
+    "optimum is a valid lower bound, and the fixed-integer NLP gives a valid upper bound.\n",
+    "On a convex model the two meet in finitely many iterations."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "2158283e5108",
+   "id": "bfaf0bf2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-11T02:53:48.785625Z",
-     "iopub.status.busy": "2026-08-11T02:53:48.785325Z",
-     "iopub.status.idle": "2026-08-11T02:53:48.915139Z",
-     "shell.execute_reply": "2026-08-11T02:53:48.914753Z"
+     "iopub.execute_input": "2026-08-11T18:19:56.138644Z",
+     "iopub.status.busy": "2026-08-11T18:19:56.138482Z",
+     "iopub.status.idle": "2026-08-11T18:19:56.252217Z",
+     "shell.execute_reply": "2026-08-11T18:19:56.251816Z"
     }
    },
    "outputs": [],
@@ -58,7 +80,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d5360b017967",
+   "id": "0696fc43",
    "metadata": {},
    "source": [
     "## Example 1: Simple Convex MINLP\n",
@@ -72,13 +94,13 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "b93f8c3bde45",
+   "id": "155c587c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-11T02:53:48.916432Z",
-     "iopub.status.busy": "2026-08-11T02:53:48.916340Z",
-     "iopub.status.idle": "2026-08-11T02:53:49.449772Z",
-     "shell.execute_reply": "2026-08-11T02:53:49.449362Z"
+     "iopub.execute_input": "2026-08-11T18:19:56.253624Z",
+     "iopub.status.busy": "2026-08-11T18:19:56.253534Z",
+     "iopub.status.idle": "2026-08-11T18:19:56.757471Z",
+     "shell.execute_reply": "2026-08-11T18:19:56.757090Z"
     }
    },
    "outputs": [
@@ -100,7 +122,7 @@
       "Status: optimal\n",
       "Objective: 0.5000\n",
       "Solution: {'x1': array(0.5), 'x2': array(0.5), 'x3': array(0.)}\n",
-      "Wall time: 0.37s\n"
+      "Wall time: 0.35s\n"
      ]
     }
    ],
@@ -108,7 +130,7 @@
     "from discopt.modeling.examples import example_simple_minlp\n",
     "\n",
     "m = example_simple_minlp()\n",
-    "result = m.solve(gdp_method=\"oa\", time_limit=60)\n",
+    "result = m.solve(solver=\"mip-nlp\", mip_nlp_method=\"oa\", time_limit=60)\n",
     "\n",
     "print(f\"Status: {result.status}\")\n",
     "print(f\"Objective: {result.objective:.4f}\")\n",
@@ -118,7 +140,141 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0fe3d57db4bb",
+   "id": "44504c12",
+   "metadata": {},
+   "source": [
+    "## Watching the loop: a problem that actually iterates\n",
+    "\n",
+    "The model above is so small that OA closes the gap on its first master/subproblem pair —\n",
+    "which teaches nothing about the alternation. `synthes1`, the first process-synthesis test\n",
+    "problem of {cite:t}`Duran1986`, is the standard textbook instance: three binaries choosing\n",
+    "between process alternatives, three continuous flows, and logarithmic (concave, hence\n",
+    "convex when negated in a minimization) yield terms.\n",
+    "\n",
+    "$$\n",
+    "\\begin{aligned}\n",
+    "\\min \\quad & 5y_1 + 6y_2 + 8y_3 + 10x_1 - 7x_3 - 18\\ln(x_2+1) - 19.2\\ln(x_1-x_2+1) + 10\\\\\n",
+    "\\text{s.t.}\\quad & 0.8\\ln(x_2+1) + 0.96\\ln(x_1-x_2+1) - 0.8x_3 \\geq 0\\\\\n",
+    "& \\ln(x_2+1) + 1.2\\ln(x_1-x_2+1) - x_3 - 2y_3 \\geq -2\\\\\n",
+    "& x_2 \\le x_1, \\quad x_2 \\le 2y_1, \\quad x_1 - x_2 \\le 2y_2, \\quad y_1 + y_2 \\le 1\n",
+    "\\end{aligned}\n",
+    "$$\n",
+    "\n",
+    "The reported optimum is $6.00976$."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "63dea2ac",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-11T18:19:56.758761Z",
+     "iopub.status.busy": "2026-08-11T18:19:56.758683Z",
+     "iopub.status.idle": "2026-08-11T18:19:56.855908Z",
+     "shell.execute_reply": "2026-08-11T18:19:56.855578Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Status: optimal, objective: 6.009759\n",
+      "Dual bound: 6.009759, certified: True\n"
+     ]
+    }
+   ],
+   "source": [
+    "def synthes1():\n",
+    "    '''Duran & Grossmann (1986), test problem 1 — a convex MINLP.'''\n",
+    "    m = dm.Model(\"synthes1\")\n",
+    "    x1 = m.continuous(\"x1\", lb=0, ub=2)\n",
+    "    x2 = m.continuous(\"x2\", lb=0, ub=2)\n",
+    "    x3 = m.continuous(\"x3\", lb=0, ub=1)\n",
+    "    y1, y2, y3 = m.binary(\"y1\"), m.binary(\"y2\"), m.binary(\"y3\")\n",
+    "    m.minimize(\n",
+    "        5 * y1 + 6 * y2 + 8 * y3 + 10 * x1 - 7 * x3\n",
+    "        - 18 * dm.log(x2 + 1) - 19.2 * dm.log(x1 - x2 + 1) + 10\n",
+    "    )\n",
+    "    m.subject_to(0.8 * dm.log(x2 + 1) + 0.96 * dm.log(x1 - x2 + 1) - 0.8 * x3 >= 0)\n",
+    "    m.subject_to(dm.log(x2 + 1) + 1.2 * dm.log(x1 - x2 + 1) - x3 - 2 * y3 >= -2)\n",
+    "    m.subject_to(x2 - x1 <= 0)\n",
+    "    m.subject_to(x2 - 2 * y1 <= 0)\n",
+    "    m.subject_to(x1 - x2 - 2 * y2 <= 0)\n",
+    "    m.subject_to(y1 + y2 <= 1)\n",
+    "    return m\n",
+    "\n",
+    "\n",
+    "result_oa = synthes1().solve(solver=\"mip-nlp\", mip_nlp_method=\"oa\", time_limit=60)\n",
+    "print(f\"Status: {result_oa.status}, objective: {result_oa.objective:.6f}\")\n",
+    "print(f\"Dual bound: {result_oa.bound:.6f}, certified: {result_oa.gap_certified}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e2eddb30",
+   "metadata": {},
+   "source": [
+    "### The iteration trace\n",
+    "\n",
+    "Every MIP–NLP solve attaches a structured `mip_nlp_trace` to the result: a `summary`\n",
+    "dict of counters and an `iterations` list with the lower bound, upper bound, gap and\n",
+    "cuts added at each pass. This is the algorithm made visible — watch the bounds squeeze\n",
+    "together from both sides."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "cf4f9ae7",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-11T18:19:56.857217Z",
+     "iopub.status.busy": "2026-08-11T18:19:56.857149Z",
+     "iopub.status.idle": "2026-08-11T18:19:56.859461Z",
+     "shell.execute_reply": "2026-08-11T18:19:56.859087Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "iter   lower bound   upper bound         gap   cuts\n",
+      "   0      1.411895      7.092732    8.01e-01      7\n",
+      "   1      1.687599      6.009759    7.19e-01      7\n",
+      "   2      5.312482      6.009759    1.16e-01      7\n",
+      "   3      6.009759      6.009759    0.00e+00      7\n",
+      "\n",
+      "terminated because: gap\n",
+      "MILP masters solved:     4\n",
+      "NLP subproblems solved:  4\n",
+      "OA cuts generated:       35\n"
+     ]
+    }
+   ],
+   "source": [
+    "trace = result_oa.mip_nlp_trace\n",
+    "summary = trace[\"summary\"]\n",
+    "\n",
+    "print(f\"{'iter':>4}  {'lower bound':>12}  {'upper bound':>12}  {'gap':>10}  {'cuts':>5}\")\n",
+    "for it in trace[\"iterations\"]:\n",
+    "    ub = it[\"ub\"] if it[\"ub\"] is not None else float(\"inf\")\n",
+    "    print(\n",
+    "        f\"{it['index']:>4}  {it['lb']:>12.6f}  {ub:>12.6f}  \"\n",
+    "        f\"{it['gap']:>10.2e}  {it['cuts_added']:>5}\"\n",
+    "    )\n",
+    "\n",
+    "print(f\"\\nterminated because: {trace['termination_reason']}\")\n",
+    "print(f\"MILP masters solved:     {summary['mip_count']}\")\n",
+    "print(f\"NLP subproblems solved:  {summary['nlp_subproblem_count']}\")\n",
+    "print(f\"OA cuts generated:       {summary['cut_count']}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1c558492",
    "metadata": {},
    "source": [
     "## Example 2: Quadratic Objective with Binary Activation\n",
@@ -132,14 +288,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
-   "id": "8a4e9131cda0",
+   "execution_count": 5,
+   "id": "213ad524",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-11T02:53:49.450922Z",
-     "iopub.status.busy": "2026-08-11T02:53:49.450834Z",
-     "iopub.status.idle": "2026-08-11T02:53:49.501293Z",
-     "shell.execute_reply": "2026-08-11T02:53:49.500876Z"
+     "iopub.execute_input": "2026-08-11T18:19:56.860515Z",
+     "iopub.status.busy": "2026-08-11T18:19:56.860454Z",
+     "iopub.status.idle": "2026-08-11T18:19:56.903763Z",
+     "shell.execute_reply": "2026-08-11T18:19:56.903342Z"
     }
    },
    "outputs": [
@@ -162,32 +318,37 @@
     "m.subject_to(y1 + y2 <= 1)\n",
     "m.subject_to(x <= 2 * y1 + 4 * y2)\n",
     "\n",
-    "result = m.solve(gdp_method=\"oa\", time_limit=60)\n",
+    "result = m.solve(solver=\"mip-nlp\", mip_nlp_method=\"oa\", time_limit=60)\n",
     "print(f\"Status: {result.status}, Objective: {result.objective:.4f}\")\n",
     "print(f\"x={result.x['x']:.3f}, y1={result.x['y1']:.0f}, y2={result.x['y2']:.0f}\")"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "626b0e7be898",
+   "id": "1a84fbe6",
    "metadata": {},
    "source": [
     "## Comparing OA with Branch & Bound\n",
     "\n",
-    "Both solvers find the same optimum for convex MINLP, but OA is typically\n",
-    "faster when the integer structure dominates."
+    "Both find the same optimum on a convex MINLP — they differ in *how* they get there.\n",
+    "OA spends its effort in a MILP master and a handful of NLPs and never builds a search\n",
+    "tree (`node_count` is 0); spatial B&B builds a tree and reports nodes. At `synthes1`'s\n",
+    "size the two are within noise of each other on wall time — three binaries is not enough\n",
+    "combinatorics for either approach to pull ahead. The separation appears as the integer\n",
+    "count grows: OA's work per iteration is one MILP, while B&B's tree can grow\n",
+    "exponentially in the binaries."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
-   "id": "643c820ea588",
+   "execution_count": 6,
+   "id": "3893a238",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-11T02:53:49.502358Z",
-     "iopub.status.busy": "2026-08-11T02:53:49.502296Z",
-     "iopub.status.idle": "2026-08-11T02:53:49.565735Z",
-     "shell.execute_reply": "2026-08-11T02:53:49.565379Z"
+     "iopub.execute_input": "2026-08-11T18:19:56.904854Z",
+     "iopub.status.busy": "2026-08-11T18:19:56.904793Z",
+     "iopub.status.idle": "2026-08-11T18:19:57.010334Z",
+     "shell.execute_reply": "2026-08-11T18:19:57.009919Z"
     }
    },
    "outputs": [
@@ -195,59 +356,45 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Model: textbook\n",
-      "  Variables: 3 (2 continuous, 1 integer/binary)\n",
-      "  Constraints: 2\n",
-      "  Objective: minimize (((x1 ** 2) + (x2 ** 2)) + x3)\n",
-      "  Parameters: 0\n",
-      "Model: textbook\n",
-      "  Variables: 3 (2 continuous, 1 integer/binary)\n",
-      "  Constraints: 2\n",
-      "  Objective: minimize (((x1 ** 2) + (x2 ** 2)) + x3)\n",
-      "  Parameters: 0\n",
-      "OA:  obj=0.5000, time=0.03s, status=optimal\n",
-      "B&B: obj=0.5000, time=0.03s, status=optimal\n"
+      "OA:  obj=6.009759  bound=6.009759  time=0.088s  nodes=0  masters=4\n",
+      "B&B: obj=6.009759  bound=6.009759  time=0.095s  nodes=5\n"
      ]
     }
    ],
    "source": [
-    "m_oa = example_simple_minlp()\n",
-    "m_bb = example_simple_minlp()\n",
+    "result_bb = synthes1().solve(time_limit=60)\n",
     "\n",
-    "result_oa = m_oa.solve(gdp_method=\"oa\", time_limit=60)\n",
-    "result_bb = m_bb.solve(time_limit=60)\n",
-    "\n",
-    "oa_obj = result_oa.objective\n",
-    "oa_t = result_oa.wall_time\n",
-    "bb_obj = result_bb.objective\n",
-    "bb_t = result_bb.wall_time\n",
-    "print(f\"OA:  obj={oa_obj:.4f}, time={oa_t:.2f}s, status={result_oa.status}\")\n",
-    "print(f\"B&B: obj={bb_obj:.4f}, time={bb_t:.2f}s, status={result_bb.status}\")"
+    "print(f\"OA:  obj={result_oa.objective:.6f}  bound={result_oa.bound:.6f}  \"\n",
+    "      f\"time={result_oa.wall_time:.3f}s  nodes={result_oa.node_count}  \"\n",
+    "      f\"masters={result_oa.mip_nlp_trace['summary']['mip_count']}\")\n",
+    "print(f\"B&B: obj={result_bb.objective:.6f}  bound={result_bb.bound:.6f}  \"\n",
+    "      f\"time={result_bb.wall_time:.3f}s  nodes={result_bb.node_count}\")"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "cd5fb5d5bbe9",
+   "id": "bf73cc95",
    "metadata": {},
    "source": [
     "## Extended Cutting Plane (ECP) Mode\n",
     "\n",
     "The Extended Cutting Plane method {cite:p}`Westerlund1995` avoids NLP\n",
-    "subproblem solves entirely. Instead, it generates OA cuts at the MILP\n",
+    "subproblem solves entirely. Instead, it generates cuts at the MILP\n",
     "master solution for violated nonlinear constraints. This is simpler but\n",
-    "converges more slowly."
+    "converges more slowly — the counters below make the trade-off concrete:\n",
+    "ECP solves **zero** NLP subproblems, and pays for that with more master solves."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
-   "id": "2047b1acd5e3",
+   "execution_count": 7,
+   "id": "8cca94ff",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-11T02:53:49.566873Z",
-     "iopub.status.busy": "2026-08-11T02:53:49.566809Z",
-     "iopub.status.idle": "2026-08-11T02:53:49.597305Z",
-     "shell.execute_reply": "2026-08-11T02:53:49.596998Z"
+     "iopub.execute_input": "2026-08-11T18:19:57.011460Z",
+     "iopub.status.busy": "2026-08-11T18:19:57.011394Z",
+     "iopub.status.idle": "2026-08-11T18:19:57.106917Z",
+     "shell.execute_reply": "2026-08-11T18:19:57.106536Z"
     }
    },
    "outputs": [
@@ -255,27 +402,27 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Model: textbook\n",
-      "  Variables: 3 (2 continuous, 1 integer/binary)\n",
-      "  Constraints: 2\n",
-      "  Objective: minimize (((x1 ** 2) + (x2 ** 2)) + x3)\n",
-      "  Parameters: 0\n",
-      "ECP Status: optimal\n",
-      "ECP Objective: 0.5000000050139568\n"
+      "ECP: status=optimal, objective=6.009759\n",
+      "        masters   NLPs   cuts\n",
+      "    OA        4      4     35\n",
+      "   ECP        8      0     20\n"
      ]
     }
    ],
    "source": [
-    "m = example_simple_minlp()\n",
-    "result_ecp = m.solve(gdp_method=\"oa\", ecp_mode=True, time_limit=60)\n",
+    "result_ecp = synthes1().solve(solver=\"mip-nlp\", mip_nlp_method=\"ecp\", time_limit=60)\n",
+    "ecp = result_ecp.mip_nlp_trace[\"summary\"]\n",
+    "oa = result_oa.mip_nlp_trace[\"summary\"]\n",
     "\n",
-    "print(f\"ECP Status: {result_ecp.status}\")\n",
-    "print(f\"ECP Objective: {result_ecp.objective}\")"
+    "print(f\"ECP: status={result_ecp.status}, objective={result_ecp.objective:.6f}\")\n",
+    "print(f\"{'':>6}{'masters':>9}{'NLPs':>7}{'cuts':>7}\")\n",
+    "print(f\"{'OA':>6}{oa['mip_count']:>9}{oa['nlp_subproblem_count']:>7}{oa['cut_count']:>7}\")\n",
+    "print(f\"{'ECP':>6}{ecp['mip_count']:>9}{ecp['nlp_subproblem_count']:>7}{ecp['cut_count']:>7}\")"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "970c1102d058",
+   "id": "b09abf73",
    "metadata": {},
    "source": [
     "## Equality Relaxation\n",
@@ -283,19 +430,27 @@
     "For problems with nonlinear equality constraints, the OA linearizations\n",
     "can make the MILP master infeasible. The **Equality Relaxation** strategy\n",
     "{cite:p}`Viswanathan1990` relaxes these to inequalities in the OA cuts,\n",
-    "restoring master feasibility."
+    "restoring master feasibility.\n",
+    "\n",
+    "```{warning}\n",
+    "A nonlinear equality makes the feasible set non-convex, so the convex-case\n",
+    "convergence guarantee no longer applies. Equality relaxation (and the augmented\n",
+    "penalty that usually accompanies it) is a **robustness heuristic**: it keeps the\n",
+    "master solvable, but it does not restore the guarantee. Use spatial B&B — the\n",
+    "default `model.solve()` — when you need a global certificate.\n",
+    "```"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
-   "id": "690c16f29e28",
+   "execution_count": 8,
+   "id": "a1438efe",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-11T02:53:49.598437Z",
-     "iopub.status.busy": "2026-08-11T02:53:49.598382Z",
-     "iopub.status.idle": "2026-08-11T02:53:49.786497Z",
-     "shell.execute_reply": "2026-08-11T02:53:49.786155Z"
+     "iopub.execute_input": "2026-08-11T18:19:57.108003Z",
+     "iopub.status.busy": "2026-08-11T18:19:57.107931Z",
+     "iopub.status.idle": "2026-08-11T18:19:57.263228Z",
+     "shell.execute_reply": "2026-08-11T18:19:57.262769Z"
     }
    },
    "outputs": [
@@ -310,7 +465,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Status: optimal, Objective: 3.388131789017204e-25\n"
+      "Status: optimal, Objective: 0.000000\n"
      ]
     }
    ],
@@ -321,53 +476,93 @@
     "m.minimize(x**2 + y)\n",
     "m.subject_to(x**2 - y == 0)  # nonlinear equality\n",
     "\n",
-    "result_er = m.solve(gdp_method=\"oa\", equality_relaxation=True, time_limit=60)\n",
-    "print(f\"Status: {result_er.status}, Objective: {result_er.objective}\")"
+    "result_er = m.solve(\n",
+    "    solver=\"mip-nlp\",\n",
+    "    mip_nlp_method=\"oa\",\n",
+    "    equality_relaxation=True,\n",
+    "    time_limit=60,\n",
+    ")\n",
+    "print(f\"Status: {result_er.status}, Objective: {result_er.objective:.6f}\")"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "4c5cb8ef706b",
+   "id": "b3746cee",
+   "metadata": {},
+   "source": [
+    "## Other MIP–NLP methods\n",
+    "\n",
+    "`mip_nlp_method` selects among several members of the same family:\n",
+    "\n",
+    "| Method | What it does |\n",
+    "|---|---|\n",
+    "| `\"oa\"` | Outer approximation: MILP master + fixed-integer NLP {cite:p}`Duran1986` |\n",
+    "| `\"ecp\"` | Extended cutting plane: no NLP subproblems {cite:p}`Westerlund1995` |\n",
+    "| `\"goa\"` | Global OA — a convex under-estimator is built first, so the cuts stay valid on a non-convex model |\n",
+    "| `\"fp\"` | Feasibility pump: chases a feasible point rather than an optimal one |\n",
+    "| `\"lp_nlp_bb\"` | Single-tree LP/NLP branch & bound {cite:p}`Quesada1992` — OA cuts injected as lazy constraints into **one** MILP tree instead of re-solving the master from scratch. Requires `milp_solver=\"gurobi\"`. |\n",
+    "\n",
+    "Level-method regularization {cite:p}`Kronqvist2020`, which stabilizes the integer\n",
+    "selection between iterations, is available as `add_regularization=True` with strength\n",
+    "`level_coef`."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9a2bdeae",
    "metadata": {},
    "source": [
     "## Configuration Options\n",
     "\n",
     "| Parameter | Default | Description |\n",
     "|---|---|---|\n",
-    "| `gdp_method=\"oa\"` | — | Select the OA solver |\n",
+    "| `solver=\"mip-nlp\"` | — | Select the MIP–NLP decomposition family |\n",
+    "| `mip_nlp_method` | `\"oa\"` | `\"oa\"`, `\"ecp\"`, `\"goa\"`, `\"fp\"`, `\"lp_nlp_bb\"` |\n",
     "| `time_limit` | 3600 | Wall-clock time limit (seconds) |\n",
     "| `gap_tolerance` | 1e-4 | Relative optimality gap |\n",
-    "| `max_nodes` | 100000 | Maximum OA iterations |\n",
-    "| `ecp_mode` | False | Extended Cutting Plane mode |\n",
-    "| `equality_relaxation` | False | Relax nonlinear equalities |\n",
+    "| `max_iterations` | 100 | Maximum OA iterations |\n",
+    "| `equality_relaxation` | False | Relax nonlinear equalities (heuristic — see the warning above) |\n",
     "| `feasibility_cuts` | True | Gradient-based feasibility cuts |\n",
-    "| `nlp_solver` | \"ipm\" | NLP backend: \"ipm\", \"ipopt\", \"pounce\" |"
+    "| `add_no_good_cuts` | False | Exclude visited integer assignments |\n",
+    "| `add_regularization` | False | Level-method regularization {cite:p}`Kronqvist2020` |\n",
+    "| `level_coef` | — | Regularization strength |\n",
+    "| `init_strategy` | `\"rNLP\"` | `\"rNLP\"`, `\"initial_binary\"`, `\"max_binary\"`, `\"fp\"` |\n",
+    "| `nlp_solver` | `\"pounce\"` | NLP backend: `\"pounce\"`, `\"ipm\"`, `\"ipopt\"`, `\"cyipopt\"`, `\"sparse_ipm\"` |\n",
+    "| `milp_solver` | auto | MILP backend; `\"gurobi\"` is required by `lp_nlp_bb` and `solution_pool` |\n",
+    "\n",
+    "All of these are passed straight through `model.solve(...)` as keyword arguments."
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "6d7011ddabf2",
+   "id": "6d641ad3",
    "metadata": {},
    "source": [
     "## Limitations\n",
     "\n",
-    "- **Non-convex problems**: OA only guarantees local optimality. For global\n",
-    "  optimality on non-convex MINLP, use the default spatial B&B solver.\n",
-    "- **Single-tree**: The current implementation uses a multi-tree approach\n",
-    "  (re-solves the MILP from scratch each iteration). Single-tree LP/NLP\n",
-    "  Branch-and-Bound {cite:p}`Quesada1992` is a future enhancement.\n",
-    "- **Regularization**: Level-method regularization {cite:p}`Kronqvist2020`\n",
-    "  to stabilize integer selections is not yet implemented.\n",
+    "- **Non-convex problems**: OA only guarantees local optimality, because a linearization\n",
+    "  of a non-convex constraint can cut off feasible points. For a global certificate on a\n",
+    "  non-convex MINLP, use the default spatial B&B solver (`model.solve()`), or\n",
+    "  `mip_nlp_method=\"goa\"`, which linearizes a convex under-estimator instead.\n",
+    "- **Nonlinear equalities** are non-convex by construction; see the equality-relaxation\n",
+    "  warning above.\n",
+    "- **Single-tree mode needs a commercial MILP backend**: `lp_nlp_bb` is implemented but\n",
+    "  relies on Gurobi's lazy-constraint callbacks (`milp_solver=\"gurobi\"`). Without it, OA\n",
+    "  runs in multi-tree mode and re-solves the master each iteration.\n",
     "\n",
     "For a comprehensive review and comparison of convex MINLP solvers, see\n",
     "{cite:p}`Kronqvist2019`. The Bonmin solver {cite:p}`Bonami2009` provides\n",
-    "multiple algorithmic variants including OA, NLP-BB, and hybrid approaches."
+    "multiple algorithmic variants including OA, NLP-BB, and hybrid approaches.\n",
+    "A related decomposition, **Generalized Benders** {cite:p}`Geoffrion1972`, cuts with\n",
+    "Lagrangian duals of the NLP rather than per-constraint linearizations; its master is\n",
+    "smaller but weaker than OA's {cite:p}`Grossmann2002` — see the\n",
+    "[GBD tutorial](tutorial_gbd.ipynb)."
    ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "jax-mps",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },

--- a/docs/references.bib
+++ b/docs/references.bib
@@ -1331,6 +1331,28 @@
   doi     = {10.1007/BF00934810},
 }
 
+@article{Grossmann2002,
+  author  = {Grossmann, Ignacio E.},
+  title   = {Review of nonlinear mixed-integer and disjunctive programming techniques},
+  journal = {Optimization and Engineering},
+  volume  = {3},
+  number  = {3},
+  pages   = {227--252},
+  year    = {2002},
+  doi     = {10.1023/A:1021039126272},
+}
+
+@article{Laporte1993,
+  author  = {Laporte, Gilbert and Louveaux, Fran{\c{c}}ois V.},
+  title   = {The integer {L}-shaped method for stochastic integer programs with complete recourse},
+  journal = {Operations Research Letters},
+  volume  = {13},
+  number  = {3},
+  pages   = {133--142},
+  year    = {1993},
+  doi     = {10.1016/0167-6377(93)90002-X},
+}
+
 @article{Rahmaniani2017,
   author  = {Rahmaniani, Ragheb and Crainic, Teodor Gabriel and Gendreau, Michel and Rei, Walter},
   title   = {The {Benders} decomposition algorithm: A literature review},


### PR DESCRIPTION
tutorial_oa.ipynb documented an API that no longer selects OA. Every solve
cell used gdp_method="oa", which is deprecated: it emits a DeprecationWarning
and is reinterpreted as gdp_method="big-m", a GDP reformulation. The notebook
therefore ran spatial branch & bound throughout -- its "Comparing OA with
Branch & Bound" cell was comparing B&B against B&B, and its ECP cell never
entered ECP mode. All five solve cells now use
solver="mip-nlp", mip_nlp_method="oa".

Two further corrections there. example_simple_minlp closes the gap on its
first master/subproblem pair, so it teaches nothing about the alternation;
the notebook now also builds synthes1 (Duran & Grossmann 1986 test problem 1),
which gives a real four-iteration loop, and prints the per-iteration
mip_nlp_trace plus the OA/ECP counter contrast. The Limitations section
claimed single-tree LP/NLP B&B and level-method regularization were "not yet
implemented"; both exist (mip_nlp_method="lp_nlp_bb", which needs
milp_solver="gurobi", and add_regularization/level_coef).

New: docs/notebooks/tutorial_gbd.ipynb. solve_gbd had no notebook of its own
and tutorial_benders covers only the classical linear-recourse case. The new
one derives the Lagrangian cut, runs the master/subproblem loop by hand on a
model whose value function and multiplier are closed form (so the mechanics
are visible with no solver in the loop), then shows solve_gbd, solve_benders
dispatch and Model.solve(decomposition="benders") on a capacity-expansion
model with convex-quadratic congestion cost, and compares GBD / OA / spatial
B&B. Covers the z_OA >= z_GBD >= z_LP dominance hierarchy, the convexity
requirement for a rigorous bound, and the #946 degenerate-recourse failure
mode with its integer L-shaped fallback.

tutorial_benders.ipynb had a duplicated "When to use Benders" section whose
stale copy said generalized Benders was "on the roadmap" (it shipped) and
recommended the deprecated gdp_method="oa"; removed, and the surviving copy
now links to the GBD tutorial. docs/design/solver-review.md's selector table
carried the same deprecated spelling.

Entry experiments before writing any prose (scratchpad, not committed):
synthes1 measured at 4 masters / 4 NLPs / 35 cuts for OA vs 8 masters /
0 NLPs / 20 cuts for ECP vs 5 nodes for B&B, all certifying 6.00975891;
the capacity-expansion model measured with GBD, OA, B&B, solve_benders and
the decomposition= kwarg all agreeing on 20.8 against an independent SLSQP
enumeration oracle, each with bound <= optimum.

Verified: both notebooks executed in place (committed outputs are real);
jupyter-book build docs/ from a clean _build, zero warnings; pytest -m smoke
943 passed, 1 skipped, 2 xpassed; pytest -m slow
python/tests/test_adversarial_recent_fixes.py 10 passed. No Rust touched.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_017PQaiDVuY5Rs3tga98tnNo
