### PR TITLE
fix(decomposition): #986 solve every linear master exactly, and keep the certificate

### DIFF
--- a/python/discopt/decomposition/benders/gbd.py
+++ b/python/discopt/decomposition/benders/gbd.py
@@ -289,17 +289,20 @@ def solve_gbd(
     # ``bound <= incumbent``. ``get_milp_solver`` still falls back to POUNCE when the
     # Rust simplex binding is unavailable, so POUNCE-only installs keep working.
     #
-    # Scope note (#977, falsified extension): the same conflation exists in
-    # *classical* Benders (``solver.py``) and in the Lagrangian solver/node bounder.
-    # Pinning those masters to the simplex too was tried and reverted — it is sound
-    # but not free. An exact master returns a vertex where the recourse LP is
-    # degenerate, and classical Benders' cut generation then produces no separating
-    # cut and stalls out with the gap still open (measured in CI: three
-    # ``test_decomposition_solve_equivalence`` cases fell to ``iteration_limit``,
-    # with "added no separating cut" twice per run). The interior-point master had
-    # been masking that weakness by proposing luckier points. Fixing it is the
-    # classical-Benders analogue of the #946 degenerate-recourse work and needs its
-    # own change; this line stays scoped to GBD, where #977 actually fired.
+    # Scope note (#977 -> #986, resolved): the same conflation existed in
+    # *classical* Benders (``solver.py``) and in the Lagrangian solver/node
+    # bounder. Pinning those masters here was tried in #977, reverted when CI
+    # showed classical Benders then stalling out at ``iteration_limit``, and
+    # completed in #986 once the mechanism was measured. It is **not** the
+    # degenerate-recourse-dual weakness #977 guessed at (that hypothesis was
+    # falsified: at every stalling iteration the optimality cuts classify as
+    # converged, ``eta_b >= Q_b``). An exact master returns a vertex whose sub-ulp
+    # violation of its own variable bounds is scaled by the recourse row
+    # coefficients into ``r - A_x x_hat``, which makes a gated recourse row pair
+    # inconsistent by ~1e-14; an exact presolve then reports the recourse
+    # INFEASIBLE at a feasible point. #986 clamps the master point to its bounds
+    # and takes the recourse duals from the exact oracle. All four masters now
+    # run on the exact-vertex engine.
     milp = get_milp_solver(backend="simplex")
 
     if structure is None:

--- a/python/discopt/decomposition/benders/solver.py
+++ b/python/discopt/decomposition/benders/solver.py
@@ -18,14 +18,21 @@ Every cut is the **complete LP dual objective** as an affine function of the
 master variables: the row-dual term ``lam^T(r - A_x x)`` plus the variable
 reduced-cost term ``bt = sum_j rc_j·(lb_j if rc_j>0 else ub_j)``. By LP weak
 duality this is a lower bound on the recourse value for *every* master point and
-*any* dual-feasible ``(lam, rc)``, so the cut is always a valid global
-underestimator. This is robust to two failure modes that simpler anchors have:
-an interior-point recourse solve returning a slightly *suboptimal* primal
-(anchoring at that primal would over-cut), and the row duals alone being an
-*incomplete* dual when a variable bound is active (the ``rc`` term restores the
-missing contribution). The solver therefore runs soundly on whichever LP/MILP
-backend is installed, including POUNCE's interior-point duals (**no HiGHS
-dependency**), and the master objective is a rigorous lower bound.
+*any* dual-feasible ``(lam, rc)``, so the cut is a valid global underestimator.
+This is robust to two failure modes that simpler anchors have: a recourse solve
+returning a slightly *suboptimal* primal (anchoring at that primal would
+over-cut), and the row duals alone being an *incomplete* dual when a variable
+bound is active (the ``rc`` term restores the missing contribution).
+
+Both the master and the recourse-dual generator are pinned to the **exact-vertex**
+engines (the Rust simplex B&B / simplex), falling back to POUNCE only where the
+binding is unavailable — HiGHS-free either way. #986 retracts the claim this
+docstring used to make, that the weak-duality argument above makes the solver
+sound on POUNCE's interior-point duals: weak duality needs the returned point to
+*be* dual-feasible, and an interior-point method reaches ``c - A^T lam - rc = 0``
+only to its convergence tolerance, so its anchor can exceed the recourse value it
+underestimates (measured worst ``D - Q = 1.391725e-07``). The master objective is
+a rigorous lower bound only when the engines producing it are exact.
 
 A *nonlinear* model is routed to Generalized Benders (:mod:`.gbd`), which
 handles a convex-NLP recourse subproblem with KKT-multiplier cuts.
@@ -182,7 +189,11 @@ def solve_benders(
     SolveResult
         With a rigorous lower ``bound`` (the master objective) on convergence.
     """
-    from discopt.solvers.lp_backend import get_lp_solver, get_milp_solver
+    from discopt.solvers.lp_backend import (
+        get_exact_dual_lp_solver,
+        get_lp_solver,
+        get_milp_solver,
+    )
 
     cfg = config or BendersConfig(
         time_limit=time_limit,
@@ -192,13 +203,37 @@ def solve_benders(
     )
     t0 = time.time()
 
-    # Recourse-LP dual generator. The cuts below use the *complete* LP dual
-    # objective (row duals + variable reduced costs), which is a valid lower
-    # bound by weak duality for any dual-feasible point — so it stays sound even
-    # with POUNCE's interior-point (analytic-centre) duals and an inexact primal,
-    # with no HiGHS dependency. Whichever LP backend is installed is used.
-    dual_lp = get_lp_solver(prefer_pounce=cfg.prefer_pounce)
-    milp = get_milp_solver(prefer_pounce=cfg.prefer_pounce)
+    # Recourse-LP dual generator. Every Benders cut is built from this solve's
+    # duals, and the master objective those cuts define *is* the reported dual
+    # ``bound`` — so this is a certificate-producing oracle and gets the exact
+    # (vertex) one when it is available, exactly as OBBT/DBBT do (#145, #356).
+    #
+    # #986: the weak-duality argument that used to justify running this on the
+    # POUNCE IPM ("valid for any dual-feasible point") needs the returned point to
+    # *be* dual-feasible; an interior-point method satisfies ``c - A^T lam - rc =
+    # 0`` only to its convergence tolerance, so its cut anchor ``D`` can sit above
+    # the recourse value ``Q`` it is supposed to underestimate, and the cut then
+    # over-cuts. Measured on the 148 recourse LPs of 12 seeded two-stage
+    # instances, both oracles on identical LP data (290 comparisons): worst dual
+    # residual 3.670730e-11 and worst over-cut ``D - Q = 1.391725e-07`` on the
+    # IPM, against 0.0 / 0.0 on the exact basis. That is what let the reported
+    # ``bound`` sit above the incumbent it certifies once an exact master stopped
+    # masking it (+1.052606e-06 worst, over 120 seeded instances).
+    #
+    # ``get_exact_dual_lp_solver`` returns ``None`` when the Rust simplex binding
+    # is unavailable; POUNCE-only installs then keep today's behaviour, with the
+    # approximate-dual caveat above.
+    dual_lp = get_exact_dual_lp_solver() or get_lp_solver(prefer_pounce=cfg.prefer_pounce)
+    # #986: the master is a *linear* MILP, so it is pinned to the exact-vertex
+    # simplex B&B and NOT routed by ``nlp_solver``, which selects the engine for
+    # the *recourse* subproblem. Reusing it here sent the master to the
+    # POUNCE-IPM-backed B&B, whose returned points are interior rather than
+    # vertices, and whose objective — which *is* this solver's reported dual
+    # ``bound`` — is an analytic-centre value that can drift above the incumbent it
+    # certifies. Same conflation and same fix as the GBD master (#977, ``gbd.py``);
+    # ``get_milp_solver`` still falls back to POUNCE when the Rust simplex binding
+    # is unavailable, so POUNCE-only installs keep working.
+    milp = get_milp_solver(backend="simplex")
 
     if structure is None:
         structure = detect_decomposition(model)
@@ -250,6 +285,8 @@ def solve_benders(
 
     c_master = lin.c[mcols]
     master_bounds = [(float(lb_all[i]), float(ub_all[i])) for i in mcols]
+    lb_master = np.array([b[0] for b in master_bounds], dtype=np.float64)
+    ub_master = np.array([b[1] for b in master_bounds], dtype=np.float64)
 
     # ── partition the recourse into independent blocks (T1.3 multicut) ──
     # Two sub-variables share a block iff they co-occur in a recourse row; the
@@ -344,6 +381,40 @@ def solve_benders(
             gap_tolerance=cfg.gap_tolerance,
         )
         return res
+
+    def _master_x(res) -> np.ndarray:
+        """The first-stage point of a master solve, clamped to its own bounds.
+
+        A MILP engine can return a point that violates the variable bounds it was
+        handed by a sub-tolerance amount (measured over these masters: up to
+        1.8e-07, and 1.8e-15 on the instance behind #986). ``x_hat`` reaches the
+        recourse only through the rhs shift ``r - A_x x_hat``, where each row
+        coefficient scales that noise — enough to turn a pair of rows that pin a
+        recourse variable to a bound (``y <= a·x``, ``y >= a·x``) into a pair that
+        is *mutually inconsistent by ~1e-14*. An exact LP presolve then reports the
+        recourse INFEASIBLE at a point where it is feasible, which costs the
+        incumbent for that iteration and emits a feasibility cut that cannot
+        separate — the loop then stalls out at ``iteration_limit`` with no
+        incumbent at all (the three ``test_decomposition_solve_equivalence``
+        failures in #986). Clamping kills that noise at its source, which is the
+        only defence on a POUNCE-only install: there the recourse LP is solved by
+        the IPM, whose presolve is exact enough to reject such a pair of rows.
+
+        Only sub-tolerance noise is repaired silently. A violation beyond the
+        repo's declared ``abs=1e-6`` is an engine defect, not noise, and clamping
+        it would be a silent approximation — so it is logged with its magnitude.
+        """
+        x = np.asarray(res.x[:n_master], dtype=np.float64)
+        clamped = np.clip(x, lb_master, ub_master)
+        worst = float(np.max(np.abs(clamped - x))) if x.size else 0.0
+        if worst > 1e-6:
+            logger.warning(
+                "Benders master returned a point %.6e outside its own variable "
+                "bounds; clamping, but this is past the declared abs=1e-6 and "
+                "points at the MILP engine rather than at rounding noise.",
+                worst,
+            )
+        return clamped
 
     def _recourse_block(blk: "_Block", x_hat: np.ndarray):
         """Classify one recourse block's LP at x̂ (kinds as in the single-block
@@ -477,7 +548,7 @@ def solve_benders(
         return SolveResult(status="infeasible", wall_time=time.time() - t0, gap_certified=True)
     if init.status != SolveStatus.OPTIMAL or init.x is None:
         return SolveResult(status="error", wall_time=time.time() - t0)
-    x_hat = np.asarray(init.x[:n_master], dtype=np.float64)
+    x_hat = _master_x(init)
 
     results = _recourse_all(x_hat)
     if any(r is not None and r[0] == "recourse_fail" for r in results):
@@ -557,7 +628,7 @@ def solve_benders(
         if mres.x is None:
             status = "error"
             break
-        x_hat = np.asarray(mres.x[:n_master], dtype=np.float64)
+        x_hat = _master_x(mres)
         eta_vec = np.asarray(mres.x[n_master : n_master + n_blocks], dtype=np.float64)
         if x_center is None:
             x_center = x_hat.copy()  # first stabilization centre (T2.2)

--- a/python/discopt/decomposition/lagrangian/node_bounder.py
+++ b/python/discopt/decomposition/lagrangian/node_bounder.py
@@ -65,16 +65,16 @@ class LagrangianNodeBounder:
     # ── construction ──────────────────────────────────────────
 
     @classmethod
-    def try_build(
-        cls,
-        model: Model,
-        *,
-        prefer_pounce: bool = True,
-    ) -> "LagrangianNodeBounder | None":
+    def try_build(cls, model: Model) -> "LagrangianNodeBounder | None":
         """Build a bounder, or return ``None`` if the hook does not apply.
 
         Applies only to minimization, linear models that have coupling
         constraints (annotated via ``model.mark_coupling`` or auto-detected).
+
+        Takes no engine preference (#986): the relaxed subproblem it solves is a
+        *linear* MILP whose objective becomes a node lower bound, so it is pinned
+        to the exact-vertex simplex B&B below rather than routed by the caller's
+        ``nlp_solver``. The argument is removed rather than left as a dead flag.
         """
         obj = model._objective
         if obj is not None and obj.sense != ObjectiveSense.MINIMIZE:
@@ -122,7 +122,7 @@ class LagrangianNodeBounder:
         from discopt.solvers.lp_backend import get_milp_solver
 
         try:
-            milp = get_milp_solver(prefer_pounce=prefer_pounce)
+            milp = get_milp_solver(backend="simplex")
         except ImportError:
             return None
         return cls(lin.c, lin.c_offset, A_c, r_c, A_b, r_b, integrality, milp)

--- a/python/discopt/decomposition/lagrangian/solver.py
+++ b/python/discopt/decomposition/lagrangian/solver.py
@@ -120,7 +120,20 @@ def solve_lagrangian(
         )
     t0 = time.time()
 
-    milp = get_milp_solver(prefer_pounce=cfg.prefer_pounce)
+    # #986: the per-block relaxed subproblems are *linear* MILPs whose returned
+    # ``bound`` sums into the Lagrangian dual bound this solver reports, so they
+    # are pinned to the exact-vertex simplex B&B rather than routed by
+    # ``nlp_solver`` — which selects the engine for the *NLP* subproblem and has
+    # no business choosing the engine for a linear one. The POUNCE-IPM-backed B&B
+    # returns an analytic-centre objective that is not a rigorous bound on an
+    # ill-conditioned LP (#145), and here that value *is* the certificate.
+    # ``get_milp_solver`` still falls back to POUNCE when the Rust simplex binding
+    # is unavailable, so POUNCE-only installs keep working.
+    milp = get_milp_solver(backend="simplex")
+    # ``lp`` only picks the next multiplier iterate (the Kelley/bundle master over
+    # λ) and recovers a primal incumbent; the dual bound at that λ is always
+    # recomputed by ``_subproblem``, so this seam is not certificate-producing and
+    # stays on the caller's engine.
     lp = get_lp_solver(prefer_pounce=cfg.prefer_pounce)
     # The level-bundle projection is a small QP; fall back to Kelley if no QP
     # backend is installed (T2.1).

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -18567,7 +18567,7 @@ def _solve_milp_bb(
         try:
             from discopt.decomposition.lagrangian.node_bounder import LagrangianNodeBounder
 
-            _lag_bounder = LagrangianNodeBounder.try_build(model, prefer_pounce=prefer_pounce)
+            _lag_bounder = LagrangianNodeBounder.try_build(model)
             if _lag_bounder is not None:
                 _lag_bounder.solve_root_dual(lb, ub)
             else:

--- a/python/tests/test_952_miqp_incumbent_feasibility.py
+++ b/python/tests/test_952_miqp_incumbent_feasibility.py
@@ -371,29 +371,55 @@ def test_injection_funnel_declines_an_off_row_heuristic_incumbent(vub, caplog):
     """An exactly-integral candidate outside a declared row must be declined where
     it is injected, not discovered at the exit gate.
 
-    The Benders master for ``min y - v`` s.t. ``v <= vub*y`` is the reproducer:
-    the master's LP relaxation lands ``y`` a hair under 1,
-    ``_pounce_snap_incumbent`` fixes ``y = 1`` and re-solves for ``v``, and the IPM
-    returns ``v`` about ``1e-8*vub`` past the big-M row — 1e-2 at ``vub = 1e6``,
-    four orders of magnitude outside the declared ``abs=1e-6``. Nothing downstream
-    re-examines it (it is already integral), so it reached the exit gate as the
-    answer and the whole solve died with ``MILP-BB returned an infeasible point
-    labeled feasible/optimal``.
+    The reproducer is a two-row big-M master handed straight to the POUNCE-IPM
+    matrix-MILP engine (``get_milp_solver(backend="pounce")`` ->
+    ``_solve_milp_bb(prefer_pounce=True)``)::
+
+        min  y + eta
+        s.t. -M*y - eta <= 0          (a big-M row, slack at the optimum)
+             -s*y - eta <= vub - s    (the binding row, rhs of order vub)
+             y in {0,1},  eta >= -1e12
+
+    The relaxation lands ``y`` a hair under 1, ``_pounce_snap_incumbent`` fixes
+    ``y = 1`` and re-solves for ``eta``, and the IPM returns ``eta`` about
+    ``1e-8*vub`` past the binding row — 1e-5 at ``vub = 1e3`` and 1e-2 at
+    ``vub = 1e6``, four orders of magnitude outside the declared ``abs=1e-6``.
+    Nothing downstream re-examines it (it is already integral), so it reached the
+    exit gate as the answer and the whole solve died with ``MILP-BB returned an
+    infeasible point labeled feasible/optimal``.
 
     Declining at the funnel is free — injection is a heuristic accelerator, the
     subtree stays open — so the solve completes and its answer is exact.
-    """
-    from discopt.decomposition.benders import solve_benders
 
-    m = dm.Model("bigM")
-    y = m.binary("y")
-    v = m.continuous("v", lb=0, ub=vub)
-    m.first_stage(y)
-    m.minimize(y - v)
-    m.subject_to(v <= vub * y)
+    This used to drive the same funnel through ``solve_benders`` on a linear
+    model, i.e. through the classical-Benders master. #986 pinned that master to
+    the exact-vertex simplex (an interior master point is not a valid Benders
+    iterate and its objective is the reported dual bound), which removed the IPM
+    path this test exists to exercise. The guard it pins is still needed for the
+    ``_solve_milp_bb`` callers that do run on the IPM engine — the matrix-MILP
+    seam used here, OA masters, GDP-LOA, ``milp_relaxation`` — so the test is
+    re-pointed at one of those rather than deleted. The rows above are the shape
+    the Benders master actually produced, and reproduce the funnel's violation
+    magnitudes exactly (9.994994e-06 / 9.999995e-03).
+    """
+    from discopt.solvers import SolveStatus
+    from discopt.solvers.lp_backend import get_milp_solver
+
+    milp = get_milp_solver(backend="pounce")
+    big_m, slope = 3.0 * vub, 0.25
+    A_ub = np.array([[-big_m, -1.0], [-slope, -1.0]])
+    b_ub = np.array([0.0, vub - slope])
 
     with caplog.at_level(logging.DEBUG, logger="discopt.solver"):
-        r = solve_benders(m, time_limit=60)
+        r = milp(
+            np.array([1.0, 1.0]),
+            A_ub=A_ub,
+            b_ub=b_ub,
+            bounds=[(0.0, 1.0), (-1e12, 1e20)],
+            integrality=np.array([1, 0], dtype=np.int32),
+            time_limit=60.0,
+            gap_tolerance=1e-4,
+        )
 
     declined = [
         rec.getMessage()
@@ -405,8 +431,6 @@ def test_injection_funnel_declines_an_off_row_heuristic_incumbent(vub, caplog):
         "reason (the off-row candidate is what it is meant to exercise)"
     )
 
-    # And the solve still lands on the exact optimum (y=1, v=vub -> 1 - vub).
-    assert r.status in ("optimal", "iteration_limit")
+    # And the solve still lands on the exact optimum (y=1, eta=-vub -> 1 - vub).
+    assert r.status == SolveStatus.OPTIMAL
     assert r.objective == pytest.approx(1.0 - vub, rel=1e-9)
-    if r.bound is not None:
-        assert r.bound <= (1.0 - vub) + 1e-3 * (1.0 + abs(1.0 - vub))

--- a/python/tests/test_986_decomposition_master_engine.py
+++ b/python/tests/test_986_decomposition_master_engine.py
@@ -1,0 +1,248 @@
+"""#986: a *linear* decomposition master must be solved exactly, and stay exact.
+
+``nlp_solver`` selects the engine for the **NLP/LP recourse subproblem**. Three
+sites reused it to route their **master** — a pure linear MILP — to the
+POUNCE-IPM-backed B&B, whose returned points are interior rather than vertices
+and whose objective is an analytic-centre value. That objective *is* the reported
+dual ``bound``, so the conflation is a certificate defect, not a style one:
+measured over 40 seeded two-stage instances on ``main``, 19 returned a ``bound``
+strictly above the incumbent it certifies (worst +1.67e-07).
+
+Pinning the masters to the exact simplex was tried once before (#977, PR #983
+commit 53dbc17) and reverted, because on its own it makes classical Benders stall
+out at ``iteration_limit`` with no incumbent at all. The mechanism, measured (the
+#986 entry experiment) rather than assumed: an exact master returns a *vertex*,
+whose sub-ulp violation of its own variable bounds (measured up to 1.8e-07, and
+1.8e-15 on the instance in the reverted CI run) is scaled by the recourse row
+coefficients into ``rhs = r - A_x x_hat``. A gated recourse row pair
+(``y <= a*b``, ``y >= a*b``) then becomes *mutually inconsistent by ~1e-14*, an
+exact LP presolve reports the recourse INFEASIBLE at a point where it is
+feasible, and the block yields a feasibility cut that cannot separate instead of
+an incumbent. The hypothesis recorded in #986 — degenerate recourse duals giving
+a near-zero cut slope — was **falsified**: at every stalling iteration the
+optimality cuts classify as converged (``eta_b >= Q_b``), i.e. the duals are fine.
+
+So the tests below pin both halves: the masters are exact, *and* the classes that
+stall when a master is exact still reach ``optimal``.
+"""
+
+import os
+
+os.environ.setdefault("JAX_PLATFORMS", "cpu")
+os.environ.setdefault("JAX_ENABLE_X64", "1")
+
+from itertools import product
+
+import numpy as np
+import pytest
+
+pytest.importorskip("pounce", reason="the decomposition solvers need an LP/MILP engine")
+
+import discopt.modeling as dm  # noqa: E402
+from discopt.solvers import SolveStatus, lp_backend  # noqa: E402
+
+pytestmark = pytest.mark.requires_pounce
+
+
+# ── corpus ────────────────────────────────────────────────────
+
+
+def _two_stage(seed: int):
+    """A two-stage MILP with capacity-gated recourse.
+
+    Even seeds use the ``gate`` shape — a recourse variable pinned between
+    ``lo*b`` and ``hi*b``, which collapses to a single point when the gating
+    binary is 0. That is the structure whose recourse LP an exact presolve calls
+    infeasible once the master point carries sub-ulp noise (#986). Odd seeds use
+    the classic single-sided capacity form.
+    """
+    rng = np.random.default_rng(seed)
+    gate = seed % 2 == 0
+    nb = int(rng.integers(2, 6))
+    nx = int(rng.integers(2, 6))
+    m = dm.Model(f"ts{seed}")
+    b = [m.binary(f"b{i}") for i in range(nb)]
+    x = [m.continuous(f"x{i}", lb=0, ub=20) for i in range(nx)]
+    if gate:
+        for i in range(nx):
+            j = i % nb
+            m.subject_to(x[i] <= float(rng.uniform(6.0, 15.0)) * b[j])
+            m.subject_to(x[i] >= float(rng.uniform(1.0, 5.0)) * b[j])
+        m.subject_to(sum(b) >= max(1, nb // 2))
+    else:
+        cap = rng.uniform(3.0, 12.0, size=(nx, nb))
+        dem = rng.uniform(1.0, 6.0, size=nx)
+        for i in range(nx):
+            m.subject_to(x[i] <= sum(float(cap[i, j]) * b[j] for j in range(nb)))
+            m.subject_to(x[i] >= float(dem[i]))
+        m.subject_to(sum(b) >= 1)
+    cb = rng.uniform(1.0, 5.0, size=nb)
+    cx = rng.uniform(0.5, 3.0, size=nx)
+    m.minimize(
+        sum(float(cx[i]) * x[i] for i in range(nx)) + sum(float(cb[j]) * b[j] for j in range(nb))
+    )
+    return m
+
+
+def _enumerated_optimum(model):
+    """The instance's true optimum by enumeration + exact LP, not by a solver.
+
+    ``model.solve()`` is itself only accurate to ~1e-06 on these instances, so it
+    cannot adjudicate a 1e-07 question about the Benders bound. Every first-stage
+    assignment is enumerated and its recourse solved on the exact simplex.
+    """
+    from discopt.decomposition._linear import extract_linear
+    from discopt.decomposition.benders.solver import _partition_columns
+    from discopt.decomposition.structure import detect_decomposition, flat_bounds
+
+    spx = lp_backend.get_exact_lp_solver()
+    if spx is None:
+        pytest.skip("no exact simplex oracle available")
+    lin = extract_linear(model)
+    part = _partition_columns(model, detect_decomposition(model))
+    mcols, scols = part.master_cols, part.sub_cols
+    lb_all, ub_all = flat_bounds(model)
+    A_leq, b_leq, _ = lin.rows_leq()
+    A = np.asarray(A_leq, dtype=float)
+    b = np.asarray(b_leq, dtype=float)
+    A_sub = A[:, scols]
+    recourse_rows = np.any(np.abs(A_sub) > 0, axis=1)
+    sub_bounds = [(float(lb_all[j]), float(ub_all[j])) for j in scols]
+    best = None
+    for assign in product([0.0, 1.0], repeat=len(mcols)):
+        x_m = np.array(assign, dtype=float)
+        rhs = b - A[:, mcols] @ x_m
+        if np.any(rhs[~recourse_rows] < -1e-9):
+            continue  # master-only row violated
+        r = spx(lin.c[scols], A_ub=A_sub[recourse_rows], b_ub=rhs[recourse_rows], bounds=sub_bounds)
+        if r.status != SolveStatus.OPTIMAL:
+            continue
+        val = float(lin.c[mcols] @ x_m) + float(r.objective) + lin.c_offset
+        if best is None or val < best:
+            best = val
+    return best
+
+
+# ── the three sites are routed to the exact engine ────────────
+
+
+def _record_milp_selection(monkeypatch):
+    """Record every ``get_milp_solver`` selection the solvers make."""
+    selections: list[dict] = []
+    original = lp_backend.get_milp_solver
+
+    def spy(prefer_pounce: bool = False, backend: str = "auto"):
+        selections.append({"prefer_pounce": prefer_pounce, "backend": backend})
+        return original(prefer_pounce=prefer_pounce, backend=backend)
+
+    monkeypatch.setattr(lp_backend, "get_milp_solver", spy)
+    return selections
+
+
+def test_benders_master_is_not_routed_by_nlp_solver(monkeypatch):
+    selections = _record_milp_selection(monkeypatch)
+    from discopt.decomposition.benders.solver import solve_benders
+
+    solve_benders(_two_stage(0), nlp_solver="pounce", max_iterations=50)
+
+    assert selections, "no MILP engine was selected; the test measured nothing"
+    for sel in selections:
+        assert sel["backend"] == "simplex", (
+            f"the Benders master asked for backend={sel['backend']!r}; a linear "
+            "master must be pinned to the exact-vertex engine (#986)"
+        )
+        assert not sel["prefer_pounce"], "the master is still routed by nlp_solver (#986)"
+
+
+def test_lagrangian_master_is_not_routed_by_nlp_solver(monkeypatch):
+    selections = _record_milp_selection(monkeypatch)
+    from discopt.decomposition.lagrangian.solver import solve_lagrangian
+
+    m = _two_stage(1)
+    solve_lagrangian(m, nlp_solver="pounce", max_iterations=3, time_limit=30.0)
+
+    assert selections, "no MILP engine was selected; the test measured nothing"
+    for sel in selections:
+        assert sel["backend"] == "simplex", (
+            f"the Lagrangian subproblem asked for backend={sel['backend']!r}; its "
+            "bound is the reported certificate and must come from the exact engine"
+        )
+        assert not sel["prefer_pounce"]
+
+
+def test_lagrangian_node_bounder_is_not_routed_by_nlp_solver(monkeypatch):
+    selections = _record_milp_selection(monkeypatch)
+    from discopt.decomposition.lagrangian.node_bounder import LagrangianNodeBounder
+
+    m = _two_stage(3)
+    bounder = LagrangianNodeBounder.try_build(m)
+    if bounder is None:
+        pytest.skip("the node-bounder hook does not apply to this instance")
+
+    assert selections, "no MILP engine was selected; the test measured nothing"
+    for sel in selections:
+        assert sel["backend"] == "simplex", (
+            f"the node bounder asked for backend={sel['backend']!r}; its objective "
+            "is a node lower bound and must come from the exact engine"
+        )
+        assert not sel["prefer_pounce"]
+
+
+# ── and the certificate the exact master now reports is sound ──
+
+
+def test_benders_bound_never_exceeds_the_incumbent_it_certifies():
+    """``bound <= incumbent`` on the classical-Benders path.
+
+    Live on ``main``: 19 of these 40 instances returned ``bound > objective``,
+    worst +1.67e-07. The master objective is the reported bound, so an
+    analytic-centre master value drifts straight into the certificate; the cut
+    anchors have the same problem one level down when the recourse duals come from
+    an interior-point solve that satisfies ``c - A^T lam - rc = 0`` only to its
+    convergence tolerance.
+    """
+    from discopt.decomposition.benders.solver import solve_benders
+
+    checked = 0
+    violations = []
+    for seed in range(40):
+        res = solve_benders(_two_stage(seed), max_iterations=200)
+        if res.bound is None or res.objective is None:
+            continue
+        checked += 1
+        scale = max(1.0, abs(float(res.objective)))
+        excess = float(res.bound) - float(res.objective)
+        if excess > 1e-9 * scale:
+            violations.append((seed, float(res.bound), float(res.objective), excess))
+
+    assert checked >= 30, f"only {checked} certificate comparisons executed; expected >= 30"
+    assert not violations, f"bound > incumbent on {len(violations)} instances: {violations[:5]}"
+
+
+def test_benders_gate_structured_recourse_still_reaches_optimal():
+    """The class that stalls when the master is exact but its noise is unguarded.
+
+    This is the regression the reverted PR #983 commit tripped: with an exact
+    master and no clamp on the master point, a gated recourse row pair becomes
+    inconsistent by ~1e-14, the recourse is reported INFEASIBLE at a feasible
+    point, and the run ends at ``iteration_limit`` with ``objective is None``.
+    """
+    from discopt.decomposition.benders.solver import solve_benders
+
+    checked = 0
+    for seed in range(0, 40, 2):  # even seeds are the gated shape
+        model = _two_stage(seed)
+        truth = _enumerated_optimum(model)
+        if truth is None:
+            continue
+        res = solve_benders(model, max_iterations=200)
+        checked += 1
+        assert res.objective is not None, (
+            f"seed {seed}: no incumbent at all (status={res.status}) — the recourse "
+            "was declared infeasible at a feasible master point (#986)"
+        )
+        assert res.status == "optimal", f"seed {seed}: status={res.status}, expected optimal"
+        assert float(res.objective) == pytest.approx(truth, rel=1e-6, abs=1e-6)
+        assert res.bound is not None and float(res.bound) <= truth + 1e-6 * max(1.0, abs(truth))
+
+    assert checked >= 15, f"only {checked} gated instances exercised; expected >= 15"

--- a/python/tests/test_lagrangian_bb_hook.py
+++ b/python/tests/test_lagrangian_bb_hook.py
@@ -81,7 +81,7 @@ def test_node_bound_never_exceeds_true_optimum(seed):
     opt = _brute_force(cost, w, cap, K, N)
     if not np.isfinite(opt):
         pytest.skip("infeasible instance")
-    b = LagrangianNodeBounder.try_build(m, prefer_pounce=True)
+    b = LagrangianNodeBounder.try_build(m)
     assert b is not None
     lb, ub = flat_bounds(m)
     root = b.solve_root_dual(lb, ub)
@@ -107,7 +107,7 @@ def test_bound_can_beat_lp_relaxation():
     beat = False
     for seed in range(40):
         m, cost, w, cap, K, N = _build_gap(seed, K=3, N=6)
-        b = LagrangianNodeBounder.try_build(m, prefer_pounce=True)
+        b = LagrangianNodeBounder.try_build(m)
         if b is None:
             continue
         lb, ub = flat_bounds(m)


### PR DESCRIPTION
## Summary

`nlp_solver` selects the engine for the **NLP/LP recourse subproblem**, and was then
reused to route the **master** — a pure linear MILP — to the POUNCE-IPM-backed B&B.
#977 fixed the GBD master; the other three sites (classical-Benders master,
Lagrangian subproblem, Lagrangian node bounder) were changed in the same PR and then
reverted, because pinning them alone made classical Benders stall out at
`iteration_limit`. This completes them, with the stall mechanism **measured** rather
than assumed.

**#986's recorded hypothesis is falsified.** It proposed degenerate recourse duals
giving a near-zero cut slope. The entry experiment classified every (iteration,
block) at each stalling iteration by comparing the master's `eta_b`, the recourse
primal `Q_b`, and the value the generated cut asserts at `x_hat`: across 21
instances, 84 of 86 classifications are CONVERGED (`eta_b >= Q_b`) and **0 are weak
anchors**. The duals are fine and the cuts are right.

What actually happens: an exact master returns a *vertex* whose sub-ulp violation of
its own declared bounds (measured up to 1.799159e-07 over 443 column checks; 1.8e-15
on the instance in the reverted CI run) is scaled by the recourse row coefficients
into `rhs = r - A_x x_hat`. A gated row pair (`y <= a*b`, `y >= a*b`) then becomes
*mutually inconsistent by 2.5e-14*, and an exact presolve is right to reject it —
identical LP data to both oracles:

```
min y  s.t.  y <= -1.7763568e-14,  -y <= 7.1054274e-15,  y in [0,10]
POUNCE IPM -> INFEASIBLE        Rust simplex -> OPTIMAL, y = 0
```

Benders then emits a feasibility cut for a feasible block, records no incumbent, and
that cut cannot separate — so the loop hits `stall >= 2` and exits with
`objective is None`. The interior-point master had been masking this by never
proposing such a point.

**Changes**

- All three sites ask for `get_milp_solver(backend="simplex")`; `try_build`'s
  `prefer_pounce` argument is removed rather than left as a dead flag.
- The Benders master point is clamped to its declared bounds before reaching the
  recourse; a violation past the declared `abs=1e-6` is **logged**, not silently
  repaired.
- The Benders recourse-dual generator moves to `get_exact_dual_lp_solver()`. This is
  required, not incidental — see Correctness.

For the default `nlp_solver` this is a no-op (`get_lp_solver`/`get_milp_solver`
already order simplex-first), so only the POUNCE-preferring path changes; both
selectors still fall back to POUNCE, so POUNCE-only installs are unaffected.

Closes #986

## Correctness

The master objective **is** the reported dual `bound`, so this is a certificate
change in both directions, and both were measured.

Pinning the master alone made the certificate **worse**: with the analytic-centre
master value no longer masking it, `bound` rose *above* the incumbent it certifies
by up to **+1.052606e-06**. Root cause one level down: the module docstring claimed
weak duality makes the cut sound on interior-point duals, but weak duality needs the
returned point to *be* dual-feasible, and an IPM reaches `c - A^T lam - rc = 0` only
to its convergence tolerance. That claim is **retracted in the docstring**. Measured
over 148 recourse LPs, both oracles on identical LP data (290 comparisons): worst
dual residual **3.670730e-11** and worst over-cut **`D - Q = 1.391725e-07`** on the
IPM, against **0.0 / 0.0** on the exact basis. Hence the exact dual oracle.

120 seeded two-stage instances, oracle = enumeration + exact LP (the monolithic
solve is itself only accurate to ~1e-06 and cannot adjudicate a 1e-07 question):

| metric | `main` | this change |
| --- | --- | --- |
| worst \|obj − truth\| (relative) | 3.223996e-08 | **3.286048e-16** |
| worst `bound − incumbent` | **+1.757660e-07** | **0.0** |
| worst `bound − true optimum` | +7.084466e-11 | **0.0** |
| reached `optimal` | 120/120 | 120/120 |

This answers #986's open question (item 4) directly: **`bound > incumbent` is live on
the classical-Benders path on `main`** — 19 of 40 instances, worst +1.67e-07 — and is
driven to exactly 0 here.

Lagrangian node bounder, 30 generalized-assignment instances vs brute force: **0
bounds above the optimum on either arm** (sound before and after), and the mean
relative root gap tightens 2.467064e-03 → 1.864236e-03.

No tolerance was widened and no guard was weakened. The #952 exit gate is
untouched; its funnel test is re-pointed, not relaxed (below).

- [x] Cannot produce a false certificate
- [x] No validation, fallback, or safety guard was weakened to make a check pass

## Tests run (state the result — numbers, not adjectives)

- [x] `pytest -m smoke` → **939 passed, 16 skipped, 2 xpassed, 0 failed**
- [x] `pytest -m slow python/tests/test_adversarial_recent_fixes.py` → **10 passed**
- [x] `cargo test -p discopt-core` → N/A, Rust untouched
- [x] `ruff check` clean; `ruff format --check` has the same **2 pre-existing**
      failures as `main` (`test_log_square_relaxation.py`,
      `test_mo_augmecon2.py`), both untouched here — verified by re-running on a
      stashed tree

Also: `test_decomposition_solve_equivalence` **5 passed** and
`test_952_miqp_incumbent_feasibility` **8 passed** — these are the five CI failures
that caused the #977 revert, all reproduced locally first. Decomposition selection
(`-k "decomposition or benders or gbd or lagrangian or oa_ or gdp"`): **711 passed,
15 skipped**.

All measurements were taken against a POUNCE built from `jkitchin/pounce@main`
(`pounce.NlExpr` present, `pounce_usable()` True) — the #986 landmine build, on
which all five reverted-CI failures reproduce locally. The PyPI `pounce-solver`
0.9.0 build hides them, exactly as #986 warns.

## Regression test

New `python/tests/test_986_decomposition_master_engine.py`, 5 tests. Every
panel-style test asserts an executed-check count so it cannot pass by measuring
nothing (CLAUDE.md §6). Confirmed against all three before-states:

| tree | result |
| --- | --- |
| `main` | **4 of 5 fail** (3 routing tests + `bound <= incumbent`) |
| pin-only (the reverted `53dbc17` state) | **2 fail**, including the gate-structured stall (`added no separating cut … stall=2`) |
| this change | **5 pass** |

`test_952`'s funnel test is re-pointed, not deleted: it reached
`_pounce_snap_incumbent` through `solve_benders` on a *linear* model, i.e. through
the classical-Benders master, so pinning that master removes the IPM path the test
exists to exercise. The guard is still needed for the `_solve_milp_bb` callers that
do run on the IPM, so it now drives the matrix MILP directly via
`get_milp_solver(backend="pounce")` on the two-row big-M master shape the Benders
master actually produced. It reproduces the funnel's violation magnitudes exactly
(9.994994e-06 / 9.999995e-03), fires on 10/10 repeats, and **still fails when the
#952 guard is disabled** — verified, so its coverage is intact.

- [x] Added a regression test that fails before / passes after

---
_Generated by [Claude Code](https://claude.ai/code/session_015U5N5k1RuH7iM6iU8NtiTm)_