### PR TITLE
fix(heuristics): #966 cap heuristic sub-NLPs by the deadline, not just poll them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,6 +98,67 @@ The release procedure that produces these entries is documented in
 
 ### Fixed
 
+- **`solve(time_limit=T)` overran `T` because heuristic sub-NLPs were polled but
+  never capped** (`fix(heuristics)`, contributes to #966). Every deadline guard in
+  `_relax/primal_heuristics.py` gated whether a sub-NLP *starts*; none bounded how
+  long the started solve *runs*. Polling therefore caps the **number** of
+  overshooting solves at one and says nothing about its duration — and
+  `feasibility_pump`'s round 0 was not polled at all. `_HEURISTIC_NLP_MAX_ITER`
+  does not cover this: an iteration cap is not a time cap, and on the
+  no-relaxation flowsheet class a single IPM iteration carrying an exact Hessian
+  is itself seconds long.
+
+  **Attribution (measured, not assumed).** A post-deadline stack sampler put
+  **100 % of its 73 post-deadline samples** inside one `nlp_pounce.solve_nlp`
+  call — 91.8 % reached from `feasibility_pump`, 8.2 % from
+  `integer_local_search`. The overrun reproduced with all three coupled #966 flags
+  ON and OFF alike, within ~0.5 s of each other, which is what makes it a
+  **default-configuration** defect rather than a flag effect. (It is also what was
+  masking the flags' benefit in the #966 graduation panel; the flags themselves
+  remain default-OFF, and #966 stays open.)
+
+  **The fix.** `_deadline_wall_cap()` derives a per-solve `max_wall_time` as
+  `max(0.1, min(3.0, deadline - now))` — the same clamp `solver.py` already
+  applies to the root relaxation — and it is now applied in `feasibility_pump`,
+  `integer_local_search` (both `subnlp` repairs and its relaxation seed) and
+  `diving`, whose own comment already recorded `heatexch_gen3` running "tens of
+  seconds past the deadline" after it gained an entry poll. A caller that passes
+  no deadline gets `None` and is unchanged bit-for-bit; an explicit caller
+  `max_wall_time` still wins.
+
+  `feasibility_pump` now also accepts a `TIME_LIMIT` result: a cap that discards
+  its own truncated points merely trades an overrun for a lost incumbent, which is
+  a different regression, not a fix. The status was **verified, not assumed** —
+  `nlp_ipopt._IPOPT_STATUS_MAP` maps Ipopt −5 `Maximum_WallTime_Exceeded` to
+  exactly this status. This widening is deliberately **not** folded into the
+  shared `_is_nlp_feasible` (used at sites with no re-verification behind it): the
+  pump re-verifies the point independently of its status via
+  `_is_integer_feasible` + `_check_constraint_feasibility`, with `inject_incumbent`
+  enforcing strict improvement — the same footing that already licenses `subnlp`'s
+  `ITERATION_LIMIT`. Two tests pin that soundness: a time-limited but *infeasible*
+  point is still rejected, and `_is_nlp_feasible` itself still refuses
+  `TIME_LIMIT`.
+
+  **Measured.** Interleaved A/B (never blocked), 3 reps, arm asserted inside each
+  child process by a version marker — present for fixed, **absent** for base — so
+  a stale `.pyc` crashes instead of reporting the wrong arm's number:
+  `bchoco07` **+1.65 ± 0.18 s → +0.22 ± 0.04 s**, `bchoco08`
+  **+1.05 ± 0.12 s → +0.25 ± 0.00 s** on a 20 s budget. `heatexch_gen3` overran
+  neither arm in this run (+0.16 s both), so it is neither confirmed nor refuted
+  here. **Bound-neutral (CLAUDE.md §5):** the 52-instance cert panel is
+  **52/52 identical in `node_count`, all 52 `optimal`, max |Δobj| = 0.00e+00**,
+  with a real objective comparison on every row (zero `nan`s). Note the panel
+  shows *no regression* rather than stressing the cap — those instances certify
+  well inside their budgets, so the cap never binds; the binding behaviour is
+  covered by `test_966_heuristic_deadline_wall_cap.py` (7 of its 11 tests fail
+  before the change).
+
+  **Not a hard guarantee**, and recorded as such in the code: POUNCE tests
+  `max_wall_time` between IPM iterations, so one expensive iteration still
+  overruns it (`test_f4_root_budget_gate` records the same observation). This
+  converts an *unbounded* overrun into roughly a one-iteration one; F4's entry
+  gating and this duration cap are complementary, not alternatives.
+
 - **Vectorized models silently got no relaxation at all** (#981). A `Constraint`
   body may be array-valued — `k * x - b == 0` on a 3-vector is *one* `Constraint`
   object standing for *three* scalar rows, the same one-object-many-rows

--- a/python/discopt/_relax/primal_heuristics.py
+++ b/python/discopt/_relax/primal_heuristics.py
@@ -110,6 +110,48 @@ def _heuristic_nlp_options(caller_options: Optional[dict] = None) -> dict:
     return opts
 
 
+# Wall-clock floor/cap for a single heuristic sub-NLP launched against a caller
+# deadline (#966). ``solver.py`` already clamps the root relaxation exactly this
+# way (``max(_DEADLINE_NODE_FLOOR_S, min(3.0, deadline - now))``); these give the
+# primal heuristics the same contract, and ``continuous_multistart`` below has
+# used the ``min(3.0, remaining)`` form since F4.
+#
+# WHY A CAP AND NOT JUST A POLL: the deadline polls in this module gate whether a
+# solve *starts*, never how long it runs, so polling alone bounds the *number* of
+# overshooting solves to one and says nothing about that one's duration. Measured
+# on a 20 s budget, bchoco07/bchoco08/heatexch_gen3 ran 2.4–4.7 s past the
+# deadline in every arm of the #966 panel (all three coupled flags ON and OFF
+# alike, within ~0.5 s of each other — i.e. a default-configuration defect, not a
+# flag effect), and a post-deadline stack sampler put 100 % of its 73 samples
+# inside one ``nlp_pounce.solve_nlp`` call: 91.8 % reached from
+# ``feasibility_pump``, 8.2 % from ``integer_local_search``. An ITERATION cap
+# (``_HEURISTIC_NLP_MAX_ITER``) is not a TIME cap — on the no-relaxation
+# flowsheet class a single IPM iteration carrying an exact Hessian is itself
+# seconds long.
+#
+# NOT A HARD GUARANTEE: POUNCE tests its own ``max_wall_time`` between IPM
+# iterations, so one expensive iteration still overruns it (``diving`` below and
+# ``test_f4_root_budget_gate`` both record the same observation). The cap turns
+# an UNBOUNDED overrun into a roughly one-iteration one; entry gating (F4) and
+# this duration cap are complementary, not alternatives.
+_DEADLINE_NLP_FLOOR_S = 0.1
+_DEADLINE_NLP_CAP_S = 3.0
+
+
+def _deadline_wall_cap(deadline: Optional[float]) -> Optional[float]:
+    """Wall-clock cap for one heuristic sub-NLP, derived from ``deadline``.
+
+    Returns ``None`` when there is no finite deadline, so a caller that never
+    passed one keeps its existing unclamped behaviour bit-for-bit. The floor
+    keeps a just-expired deadline from handing the backend a zero/negative
+    ``max_wall_time`` (whose meaning is backend-defined) — a solve started at the
+    edge gets a small positive slice rather than an undefined one.
+    """
+    if deadline is None or not np.isfinite(deadline):
+        return None
+    return max(_DEADLINE_NLP_FLOOR_S, min(_DEADLINE_NLP_CAP_S, float(deadline) - _now()))
+
+
 # VOLUME-1 (docs/dev/nlp-solve-volume-2026-07-06.md) + ILS-DEFAULT
 # (docs/dev/ils-default-validation-2026-07-06.md): the objective-improvement
 # coordinate descent inside ``integer_local_search`` (``_objective_improve``) is
@@ -195,6 +237,29 @@ def _generate_starts(
 def _is_nlp_feasible(result: NLPResult) -> bool:
     """Check whether an NLP result represents a feasible solution."""
     return result.status in (SolveStatus.OPTIMAL,) and result.x is not None
+
+
+# Statuses ``feasibility_pump`` accepts from its fix-and-solve round.
+#
+# TIME_LIMIT is in the set *because* the pump now caps each projection from the
+# caller's deadline (``_deadline_wall_cap``): a cap whose own time-limited points
+# are then thrown away would trade the overshoot for a lost incumbent, which is
+# not an improvement — it is a different regression. ``nlp_ipopt``'s status map
+# turns Ipopt −5 ``Maximum_WallTime_Exceeded`` into exactly this status, so this
+# is the status a clamped solve actually returns (verified, not assumed).
+#
+# Trusting a non-converged point here is sound ONLY because the pump re-verifies
+# it independently of the status immediately below — ``_is_integer_feasible``
+# after snapping the pinned integers, then ``_check_constraint_feasibility`` on
+# the real constraint bodies — and ``inject_incumbent`` enforces strict
+# improvement on top. That is the same footing on which ``subnlp`` and
+# ``_solve_root_node_multistart`` already accept ITERATION_LIMIT. The status is
+# a hint about convergence, never the feasibility evidence.
+#
+# Deliberately NOT folded into ``_is_nlp_feasible``: that gate is shared with
+# call sites where no such re-verification follows, and widening it there would
+# be weakening a check rather than relocating one.
+_PUMP_ACCEPT_STATUSES = (SolveStatus.OPTIMAL, SolveStatus.TIME_LIMIT)
 
 
 def _is_integer_feasible(
@@ -312,11 +377,13 @@ def feasibility_pump(
         backend: ``solve_nlp(evaluator, x0, options=...)`` callable. If None,
             resolves to ``get_nlp_solver("auto")``
             (POUNCE-preferred, falling back to cyipopt).
-        deadline: Optional ``time.perf_counter()`` wall-clock deadline. When the
-            current time reaches it, the pump stops at the start of the next
-            round and returns the best feasible solution found so far (or None).
-            Keeps a tight global ``time_limit`` from being overrun by the root
-            heuristic's per-round NLP solves.
+        deadline: Optional ``time.perf_counter()`` wall-clock deadline. Bounds the
+            pump two ways: the extra perturbation rounds stop once it has passed,
+            AND each round's NLP solve is capped by ``_deadline_wall_cap`` so a
+            projection already under way cannot run past it unbounded (#966 — the
+            poll alone left a 2.4–4.7 s overrun on a 20 s budget). Returns the
+            best feasible solution found so far (or None). Keeps a tight global
+            ``time_limit`` from being overrun by the root heuristic's NLP solves.
         evaluator: Optional prebuilt :class:`NLPEvaluator` for ``model``. Reusing
             the caller's evaluator avoids rebuilding (and recompiling, ~3s) the
             JAX sparse-Hessian/Jacobian kernels for the same model structure.
@@ -383,8 +450,17 @@ def feasibility_pump(
                     v.lb = fixed.copy()
                     v.ub = fixed.copy()
                 offset += sz
+            solve_opts = dict(opts)
+            _wall_cap = _deadline_wall_cap(deadline)
+            if _wall_cap is not None:
+                # Bound THIS solve, not merely the gap between rounds. The poll at
+                # the top of the loop cannot stop a projection that has already
+                # started, and round 0 is not polled at all — which is how a pump
+                # launched just under the deadline ran seconds past it (#966). An
+                # explicit caller ``max_wall_time`` still wins (setdefault).
+                solve_opts.setdefault("max_wall_time", _wall_cap)
             try:
-                nlp_result = backend(evaluator, x0, options=opts)
+                nlp_result = backend(evaluator, x0, options=solve_opts)
             except BaseException as exc:
                 # Some NLP backends (pounce via PyO3) raise PanicException, which
                 # is not a subclass of Exception; treat any failure as this round
@@ -396,7 +472,7 @@ def feasibility_pump(
                 v.lb = lb_v
                 v.ub = ub_v
 
-        if not _is_nlp_feasible(nlp_result) or nlp_result.x is None:
+        if nlp_result.status not in _PUMP_ACCEPT_STATUSES or nlp_result.x is None:
             continue
 
         x_cand = np.asarray(nlp_result.x).copy()
@@ -902,6 +978,11 @@ def integer_local_search(
                             nlp_options=nlp_options,
                             evaluator=evaluator,
                             feas_tol=feas_tol,
+                            # #966: cap the repair from whichever deadline the
+                            # budget is actually enforcing. ``budget.exhausted()``
+                            # is polled BETWEEN solves, so without this a descent
+                            # step launched just under the wall runs past it.
+                            time_budget=_deadline_wall_cap(budget.deadline),
                         )
                         if cand is None:
                             continue
@@ -942,6 +1023,9 @@ def integer_local_search(
         # coordinate is a finite, usable start.
         mid = np.clip(0.5 * (np.clip(lb, -1e3, 1e3) + np.clip(ub, -1e3, 1e3)), -1e3, 1e3)
         relax_opts = _heuristic_nlp_options(nlp_options)
+        _relax_cap = _deadline_wall_cap(budget.deadline)  # #966
+        if _relax_cap is not None:
+            relax_opts.setdefault("max_wall_time", _relax_cap)
         budget.charge(NLP_SOLVE)
         relax_res = backend(evaluator, mid, options=relax_opts)
         if relax_res is not None and relax_res.x is not None:
@@ -1036,6 +1120,7 @@ def integer_local_search(
             nlp_options=nlp_options,
             evaluator=evaluator,
             feas_tol=feas_tol,
+            time_budget=_deadline_wall_cap(budget.deadline),  # #966
         )
         if repaired is not None:
             x_ok, obj_ok = repaired
@@ -1446,10 +1531,20 @@ def diving(
             # affects the dual bound.
             if deadline is not None and _now() >= deadline:
                 return None
+            dive_opts = dict(opts)
+            _dive_cap = _deadline_wall_cap(deadline)
+            if _dive_cap is not None:
+                # The poll above bounds how many dive steps START, not how long
+                # the one that started runs — which is why the overrun this
+                # comment describes survived the poll (#966). Cap the step too.
+                dive_opts.setdefault("max_wall_time", _dive_cap)
             try:
-                res = backend(evaluator, x_cur, options=opts)
+                res = backend(evaluator, x_cur, options=dive_opts)
             except BaseException:
                 return None
+            # A capped step that hits TIME_LIMIT ends the dive, exactly as the
+            # poll above would have one step later. Sound either way: diving is a
+            # primal heuristic and never touches the dual bound.
             if not _is_nlp_feasible(res):
                 return None
             x = np.asarray(res.x, dtype=np.float64)

--- a/python/tests/test_966_heuristic_deadline_wall_cap.py
+++ b/python/tests/test_966_heuristic_deadline_wall_cap.py
@@ -1,0 +1,264 @@
+"""#966: a heuristic sub-NLP must be capped by the deadline, not just polled.
+
+THE DEFECT. ``bchoco07``, ``bchoco08`` and ``heatexch_gen3`` overran a 20 s
+``solve(time_limit=...)`` by 2.4–4.7 s in EVERY arm of the #966 coupled panel —
+all three flags ON and all three OFF, within ~0.5 s of each other. That makes it
+a defect of the DEFAULT configuration rather than a flag effect. A post-deadline
+stack sampler attributed 100 % of its 73 post-deadline samples to a single
+``nlp_pounce.solve_nlp`` call: 91.8 % reached from ``feasibility_pump``, 8.2 %
+from ``integer_local_search``.
+
+THE CAUSE. Every deadline guard in ``primal_heuristics`` gated whether a solve
+*starts*. None bounded how long the started solve *runs*. Polling therefore caps
+the NUMBER of overshooting solves at one and says nothing about its duration; the
+pump's round 0 is not polled at all. ``_HEURISTIC_NLP_MAX_ITER`` does not help —
+an iteration cap is not a time cap, and one IPM iteration carrying an exact
+Hessian is seconds long on the no-relaxation flowsheet class.
+
+THE FIX, and what these tests pin:
+  * every deadline-aware heuristic derives ``max_wall_time`` for its sub-NLP from
+    the remaining budget (``_deadline_wall_cap``);
+  * a caller that passes NO deadline is bit-for-bit unchanged (no key added);
+  * an explicit caller ``max_wall_time`` still wins;
+  * ``feasibility_pump`` ACCEPTS a TIME_LIMIT point — a cap whose own truncated
+    points are discarded merely trades an overrun for a lost incumbent — but
+    accepts it only through the SAME independent re-verification that already
+    licenses ``subnlp``'s ITERATION_LIMIT, never by relaxing a feasibility check.
+
+The last bullet is the soundness pin: ``test_time_limited_but_INFEASIBLE_point_is_still_rejected``
+must fail loudly if anyone ever widens the acceptance set without the
+verification behind it.
+
+Deterministic by construction: every test drives a recording fake backend, so
+nothing here depends on machine speed or on POUNCE being installed.
+"""
+
+from __future__ import annotations
+
+import os
+
+os.environ.setdefault("JAX_PLATFORMS", "cpu")
+os.environ.setdefault("JAX_ENABLE_X64", "1")
+
+import discopt.modeling as dm  # noqa: E402
+import numpy as np  # noqa: E402
+import pytest  # noqa: E402
+from discopt._relax import primal_heuristics as ph  # noqa: E402
+from discopt._tape_nlp_evaluator import make_evaluator as cached_evaluator  # noqa: E402
+from discopt.solvers import NLPResult, SolveStatus  # noqa: E402
+
+pytestmark = pytest.mark.unit
+
+
+def _small_minlp() -> dm.Model:
+    """A 3-binary/1-continuous MINLP whose rounding is trivially repairable."""
+    m = dm.Model("c")
+    y = m.binary("y", shape=(3,))
+    x = m.continuous("x", lb=0.0, ub=10.0)
+    m.minimize(x + y[0] + 2 * y[1] + 3 * y[2])
+    m.subject_to(x + y[0] + y[1] + y[2] >= 1.0)
+    return m
+
+
+def _recorder(status=SolveStatus.OPTIMAL, x_of=None):
+    """A fake NLP backend that records the options dict it was handed."""
+    captured: list[dict] = []
+
+    def backend(evaluator, x0, options=None):
+        captured.append(dict(options or {}))
+        x = np.asarray(x0, dtype=float) if x_of is None else x_of(np.asarray(x0, dtype=float))
+        return NLPResult(
+            status=status,
+            x=x,
+            objective=float(np.sum(x)),
+            multipliers=None,
+            bound_multipliers_lower=None,
+            bound_multipliers_upper=None,
+            iterations=1,
+            wall_time=0.0,
+        )
+
+    return backend, captured
+
+
+# ── the cap helper itself ──────────────────────────────────────────────────────
+
+
+def test_no_deadline_means_no_cap():
+    """A caller that never passed a deadline keeps its unclamped behaviour."""
+    assert ph._deadline_wall_cap(None) is None
+    assert ph._deadline_wall_cap(float("inf")) is None
+
+
+def test_cap_shrinks_with_the_remaining_budget_and_never_exceeds_the_ceiling():
+    now = ph._now()
+    # Plenty of budget left: the constant ceiling binds, not the deadline.
+    assert ph._deadline_wall_cap(now + 600.0) == pytest.approx(ph._DEADLINE_NLP_CAP_S)
+    # Little budget left: the deadline binds.
+    tight = ph._deadline_wall_cap(now + 1.0)
+    assert 0.0 < tight <= 1.0
+
+
+def test_expired_deadline_yields_a_positive_floor_not_zero_or_negative():
+    """A zero/negative ``max_wall_time`` has backend-defined meaning; never emit one."""
+    assert ph._deadline_wall_cap(ph._now() - 50.0) == pytest.approx(ph._DEADLINE_NLP_FLOOR_S)
+    assert ph._DEADLINE_NLP_FLOOR_S > 0.0
+
+
+# ── feasibility_pump ───────────────────────────────────────────────────────────
+
+
+def test_pump_caps_each_solve_from_the_deadline():
+    """THE REGRESSION: fails before the fix — the pump forwarded no wall cap."""
+    m = _small_minlp()
+    ev = cached_evaluator(m)
+    backend, captured = _recorder(status=SolveStatus.INFEASIBLE)
+
+    ph.feasibility_pump(
+        m,
+        np.array([0.4, 0.6, 0.5, 1.0]),
+        backend=backend,
+        evaluator=ev,
+        deadline=ph._now() + 1.0,
+    )
+
+    assert captured, "pump never invoked the NLP backend (vacuous pass)"
+    for o in captured:
+        assert "max_wall_time" in o, "a pump solve ran with no wall cap under a deadline"
+        assert 0.0 < o["max_wall_time"] <= ph._DEADLINE_NLP_CAP_S
+
+
+def test_pump_without_a_deadline_is_unchanged():
+    m = _small_minlp()
+    ev = cached_evaluator(m)
+    backend, captured = _recorder(status=SolveStatus.INFEASIBLE)
+
+    ph.feasibility_pump(m, np.array([0.4, 0.6, 0.5, 1.0]), backend=backend, evaluator=ev)
+
+    assert captured, "pump never invoked the NLP backend (vacuous pass)"
+    assert all("max_wall_time" not in o for o in captured)
+
+
+def test_explicit_caller_wall_time_still_wins():
+    m = _small_minlp()
+    ev = cached_evaluator(m)
+    backend, captured = _recorder(status=SolveStatus.INFEASIBLE)
+
+    ph.feasibility_pump(
+        m,
+        np.array([0.4, 0.6, 0.5, 1.0]),
+        backend=backend,
+        evaluator=ev,
+        deadline=ph._now() + 1.0,
+        ipopt_options={"max_wall_time": 99.0},
+    )
+
+    assert captured, "pump never invoked the NLP backend (vacuous pass)"
+    assert all(o["max_wall_time"] == 99.0 for o in captured)
+
+
+def test_time_limited_but_feasible_point_is_accepted():
+    """Capping is only an improvement if truncated-but-feasible points survive.
+
+    Fails before the fix: the pump's gate accepted OPTIMAL alone, so a clamped
+    solve's point was discarded and the cap would have traded an overrun for a
+    lost incumbent.
+    """
+    m = _small_minlp()
+    ev = cached_evaluator(m)
+    # y = (1,0,0), x = 1 satisfies x + y0 + y1 + y2 >= 1 comfortably.
+    feasible = np.array([1.0, 0.0, 0.0, 1.0])
+    backend, captured = _recorder(status=SolveStatus.TIME_LIMIT, x_of=lambda _x: feasible.copy())
+
+    out = ph.feasibility_pump(
+        m,
+        np.array([0.6, 0.4, 0.4, 1.0]),
+        backend=backend,
+        evaluator=ev,
+        deadline=ph._now() + 1.0,
+    )
+
+    assert captured, "pump never invoked the NLP backend (vacuous pass)"
+    assert out is not None, "a feasible TIME_LIMIT point was discarded"
+    np.testing.assert_allclose(out, feasible)
+
+
+def test_time_limited_but_INFEASIBLE_point_is_still_rejected():
+    """SOUNDNESS PIN. Accepting TIME_LIMIT relocates a status hint; it must never
+    relax the feasibility evidence. This point violates ``x + y0 + y1 + y2 >= 1``
+    (all-zero), and the constraint check — not the status — must reject it."""
+    m = _small_minlp()
+    ev = cached_evaluator(m)
+    infeasible = np.zeros(4)
+    backend, captured = _recorder(status=SolveStatus.TIME_LIMIT, x_of=lambda _x: infeasible.copy())
+
+    out = ph.feasibility_pump(
+        m,
+        np.array([0.6, 0.4, 0.4, 1.0]),
+        backend=backend,
+        evaluator=ev,
+        deadline=ph._now() + 1.0,
+    )
+
+    assert captured, "pump never invoked the NLP backend (vacuous pass)"
+    assert out is None, "an INFEASIBLE point was accepted on the strength of its status"
+
+
+def test_pump_does_not_widen_the_shared_feasibility_gate():
+    """``_is_nlp_feasible`` is shared with call sites that do NOT re-verify; the
+    #966 acceptance widening must stay local to the pump."""
+    res = NLPResult(
+        status=SolveStatus.TIME_LIMIT,
+        x=np.zeros(4),
+        objective=0.0,
+        multipliers=None,
+        bound_multipliers_lower=None,
+        bound_multipliers_upper=None,
+        iterations=1,
+        wall_time=0.0,
+    )
+    assert ph._is_nlp_feasible(res) is False
+
+
+# ── the other two attributed paths ─────────────────────────────────────────────
+
+
+def test_integer_local_search_caps_its_subnlp_solves():
+    """8.2 % of the measured post-deadline samples came from this path."""
+    m = _small_minlp()
+    ev = cached_evaluator(m)
+    backend, captured = _recorder(status=SolveStatus.INFEASIBLE)
+
+    ph.integer_local_search(
+        m,
+        np.array([0.4, 0.6, 0.5, 1.0]),
+        backend=backend,
+        evaluator=ev,
+        deadline=ph._now() + 1.0,
+    )
+
+    assert captured, "integer_local_search never invoked the NLP backend (vacuous pass)"
+    for o in captured:
+        assert "max_wall_time" in o
+        assert 0.0 < o["max_wall_time"] <= ph._DEADLINE_NLP_CAP_S
+
+
+def test_diving_caps_each_dive_step():
+    """``diving``'s own comment records heatexch_gen3 running tens of seconds past
+    the deadline; the entry poll it gained bounds the step COUNT, not the step."""
+    m = _small_minlp()
+    ev = cached_evaluator(m)
+    backend, captured = _recorder(status=SolveStatus.OPTIMAL)
+
+    ph.diving(
+        m,
+        np.array([0.4, 0.6, 0.5, 1.0]),
+        backend=backend,
+        evaluator=ev,
+        deadline=ph._now() + 1.0,
+    )
+
+    assert captured, "diving never invoked the NLP backend (vacuous pass)"
+    for o in captured:
+        assert "max_wall_time" in o
+        assert 0.0 < o["max_wall_time"] <= ph._DEADLINE_NLP_CAP_S


### PR DESCRIPTION
## The defect

`solve(time_limit=T)` overran `T`. Every deadline guard in
`_relax/primal_heuristics.py` gated whether a heuristic sub-NLP **starts**; none
bounded how long the started solve **runs**. Polling therefore caps the *number*
of overshooting solves at one and says nothing about its duration — and
`feasibility_pump`'s round 0 was not polled at all.

`_HEURISTIC_NLP_MAX_ITER` does not cover this: an iteration cap is not a time
cap, and on the no-relaxation flowsheet class a single IPM iteration carrying an
exact Hessian is itself seconds long.

## Attribution (measured, not hypothesised)

A post-deadline stack sampler put **100% of its 73 post-deadline samples** inside
one `nlp_pounce.solve_nlp` call — **91.8%** reached from `feasibility_pump`,
**8.2%** from `integer_local_search`. The probe exits non-zero if it overshoots
while sampling nothing, so "no frames" and "the sampler never fired" cannot look
alike.

The overrun reproduced with all three coupled #966 flags **ON and OFF alike**,
within ~0.5 s of each other. That is what makes this a **default-configuration**
defect rather than a flag effect — and it is what was masking the flags' benefit
in the #966 graduation panel. The flags themselves stay default-OFF; #966 remains
open.

## The fix

`_deadline_wall_cap()` derives a per-solve `max_wall_time` as
`max(0.1, min(3.0, deadline - now))` — the clamp `solver.py` already applies to
the root relaxation — applied in `feasibility_pump`, `integer_local_search` (both
`subnlp` repairs and its relaxation seed) and `diving`, whose own comment already
recorded `heatexch_gen3` running "tens of seconds past the deadline" after it
gained an entry poll.

A caller that passes no deadline gets `None` and is unchanged bit-for-bit; an
explicit caller `max_wall_time` still wins.

### The one judgement call

`feasibility_pump` now accepts a `TIME_LIMIT` result. A cap that discards its own
truncated points merely trades an overrun for a lost incumbent — a different
regression, not a fix. Specifics:

- **Verified, not assumed:** `nlp_ipopt._IPOPT_STATUS_MAP` maps Ipopt −5
  `Maximum_WallTime_Exceeded` to exactly this status.
- **Not folded into the shared `_is_nlp_feasible`**, which is used at call sites
  with no re-verification behind it. Widening it there would be weakening a
  check; this relocates one.
- **Sound only because of independent re-verification:** the pump snaps the
  pinned integers, then requires `_is_integer_feasible` *and*
  `_check_constraint_feasibility` on the real constraint bodies, with
  `inject_incumbent` enforcing strict improvement — the same footing that already
  licenses `subnlp`'s and `_solve_root_node_multistart`'s `ITERATION_LIMIT`.

Two tests pin that: a time-limited but **infeasible** point is still rejected,
and `_is_nlp_feasible` itself still refuses `TIME_LIMIT`.

## Measurement

Interleaved A/B (never blocked into two runs), 3 reps, 20 s budget, load-gated.
The arm is asserted **inside each child process** by a version marker — present
for fixed, **absent** for base — so a stale `.pyc` or a failed copy crashes
instead of reporting the wrong arm's number.

| instance | base | fixed |
|---|---|---|
| `bchoco07` | +1.65 ± 0.18 s | **+0.22 ± 0.04 s** |
| `bchoco08` | +1.05 ± 0.12 s | **+0.25 ± 0.00 s** |
| `heatexch_gen3` | +0.16 ± 0.00 s | +0.16 ± 0.00 s |

**Bound-neutral (CLAUDE.md §5):** 52-instance cert panel — **52/52 identical
`node_count`, all 52 `optimal`, max |Δobj| = 0.00e+00**, with a real objective
comparison on every row (zero `nan`s).

## What this does NOT show — stated rather than buried

- **`heatexch_gen3` overran neither arm** in this run (+0.16 s both), so the third
  instance from the original report is neither confirmed nor refuted here.
- **The cert panel shows no regression rather than stressing the cap.** Those
  instances certify well inside their budgets, so the deadline is far away, the
  cap returns its 3.0 s ceiling and never binds. The binding behaviour is covered
  by the new unit tests, not by the panel.
- **My first incumbent-preservation check was vacuous** and is reported as such:
  the three overshoot instances return `objective=None` in *both* arms within
  20 s, so `INCUMBENTS_LOST=0` compared nothing. The cert panel above is the
  replacement — 52 rows that all carry an incumbent on both sides.
- **The cap is not a hard guarantee,** and this is recorded in the code comment:
  POUNCE tests `max_wall_time` between IPM iterations, so one expensive iteration
  still overruns it (`test_f4_root_budget_gate` records the same observation). It
  converts an *unbounded* overrun into roughly a one-iteration one. F4's entry
  gating and this duration cap are complementary, not alternatives.

## Verification

- `python/tests/test_966_heuristic_deadline_wall_cap.py` — **11 passed; 7 of them
  fail before this change.** The 4 that pass in both arms are the invariants that
  must hold either way (no-deadline unchanged, explicit override wins,
  infeasible-point rejection, shared gate untouched).
- `pytest -m smoke` — 943 passed, 1 skipped, 2 xpassed.
- `pytest -m slow python/tests/test_adversarial_recent_fixes.py` — 10 passed.
- `pytest` on the heuristic-adjacent modules (#268, #945, F4) — 32 passed.
- `ruff check` / `ruff format --check` / `mypy` clean via pre-commit.
- **`cargo test` not run: no Rust was touched** (the diff is 3 Python/docs files).

Contributes to #966.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017PQaiDVuY5Rs3tga98tnNo
