### PR TITLE
feat(primal): #823 disjunct-selection primal constructor for GDPs (default OFF)

### DIFF
--- a/discopt_benchmarks/benchmarks/gdplib_runner.py
+++ b/discopt_benchmarks/benchmarks/gdplib_runner.py
@@ -50,6 +50,7 @@ from __future__ import annotations
 import argparse
 import importlib
 import pkgutil
+import sys
 import time
 from dataclasses import dataclass, field
 from datetime import datetime
@@ -78,6 +79,7 @@ _STATUS_MAP = {
     "maxiterations": SolveStatus.TIME_LIMIT,
     "error": SolveStatus.ERROR,
 }
+
 
 @dataclass
 class GDPModelSpec:
@@ -299,10 +301,47 @@ class ModelRun:
     minimize: bool
     oracle_objective: float | None = None
     oracle_source: str | None = None  # "highs" | "scip" | "reference" | None
+    # True when the objective came from a point that ended at a non-feasible
+    # status (e.g. ``time_limit``) and was feasibility-verified before reporting.
+    # Such an incumbent must face the same oracle cross-check as any other.
+    incumbent_verified: bool = False
     # Soundness flags — any True is a hard failure (never mask these).
     false_optimum: bool = False  # certified optimal but disagrees with oracle
     bound_crosses: bool = False  # dual bound on the wrong side of the oracle
     note: str = ""
+
+
+def _decide_objective(
+    status: SolveStatus,
+    candidate: float | None,
+    violation: float | None,
+) -> tuple[float | None, bool]:
+    """Decide what objective to report for a run, and whether it needed verifying.
+
+    Returns ``(objective, incumbent_verified)``.
+
+    A run that ends at the time limit can still carry a real incumbent: the discopt
+    pyomo bridge loads the solution whenever ``result.x`` is set, regardless of
+    termination condition, so the point is sitting in the model. Discarding it on
+    the status alone under-reports the primal — measured on cstr, discopt exits
+    ``time_limit`` having found 3.3700327 (violation 1.6e-06, inside this file's
+    own ``_ORACLE_FEAS_TOL``) and the sweep recorded "no incumbent".
+
+    Such a point is reported ONLY if it verifies feasible in the real pyomo model,
+    by the same standard applied to an oracle incumbent. An unevaluable or
+    incompletely-loaded solution returns ``None`` and stays unreported — never
+    treated as OK. Note the incumbent is genuinely absent, not merely unreported,
+    on syngas and batch_processing, where no point is loaded at all.
+
+    ``incumbent_verified`` is what re-arms the soundness checks: ``is_feasible`` is
+    OPTIMAL|FEASIBLE only, so without it a reported time-limit objective would slip
+    past the impossible-incumbent test (``CLAUDE.md`` §1).
+    """
+    if status in (SolveStatus.OPTIMAL, SolveStatus.FEASIBLE):
+        return candidate, False
+    if candidate is not None and violation is not None and violation <= _ORACLE_FEAS_TOL:
+        return candidate, True
+    return None, False
 
 
 def solve_model(
@@ -371,15 +410,13 @@ def solve_model(
 
     tc = str(res.solver.termination_condition).lower()
     status = _STATUS_MAP.get(tc, SolveStatus.UNKNOWN)
-    objective = (
-        _objective_value(model)
-        if status
-        in (
-            SolveStatus.OPTIMAL,
-            SolveStatus.FEASIBLE,
-        )
-        else None
+    candidate = _objective_value(model)
+    violation = (
+        None
+        if status in (SolveStatus.OPTIMAL, SolveStatus.FEASIBLE)
+        else _max_constraint_violation(model)
     )
+    objective, incumbent_verified = _decide_objective(status, candidate, violation)
     bound = _problem_bound(res, minimize)
     nodes = _node_count(res)
 
@@ -399,6 +436,7 @@ def solve_model(
         discopt=discopt_result,
         is_linear=is_linear,
         minimize=minimize,
+        incumbent_verified=incumbent_verified,
     )
     if oracle:
         _attach_oracle(run, spec, method, time_limit)
@@ -633,10 +671,13 @@ def _assess(run: ModelRun) -> None:
     abs_tol, rel_tol = 1e-4, 1e-3
     tol = abs_tol + rel_tol * abs(opt)
 
-    if r.is_feasible and r.objective is not None:
-        beats_oracle = (
-            (run.minimize and r.objective < opt - tol)
-            or (not run.minimize and r.objective > opt + tol)
+    # ``is_feasible`` is OPTIMAL|FEASIBLE only, so a verified incumbent reported
+    # from a ``time_limit`` run would otherwise skip the impossible-incumbent test
+    # below — the single most dangerous check here. Reporting that incumbent
+    # without widening this gate would have created an unchecked path.
+    if (r.is_feasible or run.incumbent_verified) and r.objective is not None:
+        beats_oracle = (run.minimize and r.objective < opt - tol) or (
+            not run.minimize and r.objective > opt + tol
         )
         disagrees = abs(r.objective - opt) > tol
         if beats_oracle:
@@ -683,8 +724,26 @@ def run_suite(config: GDPLibSuiteConfig) -> tuple[BenchmarkResults, list[ModelRu
             results.add_result(run.discopt)
             runs.append(run)
             _print_run(run)
-    _print_summary(runs)
+    _print_summary(runs, oracle_enabled=config.oracle)
     return results, runs
+
+
+def sweep_is_vacuous(runs: list[ModelRun], oracle_enabled: bool) -> bool:
+    """True when a sweep that was *meant* to verify something verified nothing.
+
+    ``CLAUDE.md`` §6: every soundness check here is gated on ``oracle_objective is
+    not None`` (see :func:`_assess`, which returns early without it). If no run
+    acquires an oracle -- every model errored on build, every model was skipped by
+    ``--max-variables``, or no oracle backend is installed -- then zero comparisons
+    execute, ``violations`` is trivially 0, and the sweep reports "no soundness
+    violations" while having verified nothing. That is a no-op wearing a pass, so
+    the caller must fail on it instead.
+
+    ``--no-oracle`` is the one honest way to check nothing, so it is exempt.
+    """
+    if not oracle_enabled:
+        return False
+    return not any(r.oracle_objective is not None for r in runs)
 
 
 def _print_run(run: ModelRun) -> None:
@@ -708,7 +767,7 @@ def _print_run(run: ModelRun) -> None:
         print(f"      · {run.note}")
 
 
-def _print_summary(runs: list[ModelRun]) -> None:
+def _print_summary(runs: list[ModelRun], oracle_enabled: bool = True) -> None:
     n = len(runs)
     solved = sum(1 for r in runs if r.discopt.is_solved)
     feasible = sum(1 for r in runs if r.discopt.is_feasible)
@@ -721,8 +780,14 @@ def _print_summary(runs: list[ModelRun]) -> None:
     print(f"oracle-checked={checked} | INCORRECT={incorrect} | bound-crossings={bound_bad}")
     if incorrect or bound_bad:
         print("  ✗ SOUNDNESS VIOLATIONS — see flagged runs above (incorrect_count must be 0)")
+    elif sweep_is_vacuous(runs, oracle_enabled):
+        # Never let "verified nothing" print as "verified clean" (CLAUDE.md §6).
+        print("  ✗ VACUOUS SWEEP — oracle-checked=0: zero comparisons executed, so")
+        print("    'no violations' means 'nothing was checked', not 'nothing is wrong'.")
+    elif not oracle_enabled:
+        print("  — oracle disabled (--no-oracle): no soundness claim is made")
     else:
-        print("  ✓ no soundness violations among oracle-checked runs")
+        print(f"  ✓ no soundness violations across {checked} oracle-checked runs")
     print("=" * 68)
 
 
@@ -779,7 +844,18 @@ def main(argv: list[str] | None = None) -> int:
         print(f"wrote results to {args.output}")
     # Nonzero exit on any soundness violation so CI can gate on it.
     violations = sum(1 for r in runs if r.false_optimum or r.bound_crosses)
-    return 1 if violations else 0
+    if violations:
+        return 1
+    if sweep_is_vacuous(runs, config.oracle):
+        # §6: a sweep that executed zero comparisons must not exit green.
+        print(
+            "FAIL: oracle-checked=0 — this sweep verified nothing. Install an oracle "
+            "(highspy for the linear subset, GAMS/SCIP for the nonlinear one), widen "
+            "--max-variables, or pass --no-oracle to say so deliberately.",
+            file=sys.stderr,
+        )
+        return 3
+    return 0
 
 
 if __name__ == "__main__":

--- a/discopt_benchmarks/tests/test_gdplib.py
+++ b/discopt_benchmarks/tests/test_gdplib.py
@@ -315,11 +315,117 @@ def test_assess_feasible_worse_is_not_flagged():
     assert run.false_optimum is False
 
 
+def test_verified_time_limit_incumbent_still_faces_the_impossible_check():
+    """A reported time-limit incumbent must NOT bypass the false-primal check.
+
+    ``SolveResult.is_feasible`` is OPTIMAL|FEASIBLE only, so once a verified
+    incumbent from a ``time_limit`` run is reported, the impossible-incumbent
+    test — the most dangerous check in this file — would skip it unless the gate
+    widens too. Reporting without this is an unchecked path (``CLAUDE.md`` §1).
+    """
+    run = _make_run(SolveStatus.TIME_LIMIT, 9.0, minimize=True, oracle=10.0)
+    run.incumbent_verified = True
+    gr._assess(run)
+    assert run.false_optimum is True
+    assert "IMPOSSIBLE INCUMBENT" in run.note
+
+
+def test_unverified_time_limit_objective_is_not_assessed_as_an_incumbent():
+    """Without verification the run carries no objective, so nothing is claimed.
+
+    This pins the pairing: an objective is reported ONLY when verified, and
+    verification is exactly what subjects it to the oracle check above.
+    """
+    run = _make_run(SolveStatus.TIME_LIMIT, None, minimize=True, oracle=10.0)
+    assert run.incumbent_verified is False
+    gr._assess(run)
+    assert run.false_optimum is False
+
+
+def test_time_limit_incumbent_is_reported_only_when_it_verifies():
+    """The production reporting rule: verified -> reported, unverified -> withheld.
+
+    Measured motivation: on cstr discopt exits ``time_limit`` having found
+    3.3700327 with a scale-normalized violation of 1.6e-06 — inside this file's
+    own ``_ORACLE_FEAS_TOL`` — and the sweep recorded "no incumbent".
+    """
+    tl = SolveStatus.TIME_LIMIT
+
+    # cstr's real numbers: inside tolerance -> reported, and flagged for re-check.
+    assert gr._decide_objective(tl, 3.3700327, 1.6294483888765542e-06) == (3.3700327, True)
+    # Outside tolerance -> withheld, never reported as an incumbent.
+    assert gr._decide_objective(tl, 3.3700327, 1e-3) == (None, False)
+    # Unevaluable / incompletely loaded solution -> withheld, never treated as OK.
+    assert gr._decide_objective(tl, 3.37, None) == (None, False)
+    assert gr._decide_objective(tl, None, 0.0) == (None, False)
+    # A genuinely feasible run is untouched by all of this: reported, and not
+    # marked verified because ``is_feasible`` already arms every soundness check.
+    assert gr._decide_objective(SolveStatus.OPTIMAL, 3.06201, None) == (3.06201, False)
+    assert gr._decide_objective(SolveStatus.FEASIBLE, 3.06201, None) == (3.06201, False)
+
+
 def test_assess_flags_bound_crossing_min():
     """A min-sense dual bound above the optimum would fathom it -> crossing."""
     run = _make_run(SolveStatus.TIME_LIMIT, None, minimize=True, oracle=10.0, bound=10.5)
     gr._assess(run)
     assert run.bound_crosses is True
+
+
+def test_sweep_with_no_oracle_acquired_is_vacuous():
+    """§6: zero executed comparisons must not read as a clean sweep."""
+    runs = [_make_run(SolveStatus.TIME_LIMIT, None, oracle=None)]
+    assert gr.sweep_is_vacuous(runs, oracle_enabled=True) is True
+
+
+def test_sweep_with_one_oracle_is_not_vacuous():
+    """A single executed comparison is enough to make the verdict non-vacuous."""
+    runs = [
+        _make_run(SolveStatus.TIME_LIMIT, None, oracle=None),
+        _make_run(SolveStatus.OPTIMAL, 10.0, oracle=10.0),
+    ]
+    assert gr.sweep_is_vacuous(runs, oracle_enabled=True) is False
+
+
+def test_no_oracle_mode_is_exempt_from_vacuity():
+    """--no-oracle is an honest declaration that nothing is being checked."""
+    runs = [_make_run(SolveStatus.TIME_LIMIT, None, oracle=None)]
+    assert gr.sweep_is_vacuous(runs, oracle_enabled=False) is False
+
+
+def test_main_exits_nonzero_on_a_vacuous_sweep(monkeypatch, capsys):
+    """The CLI must fail, not pass, when it verified nothing (CLAUDE.md §6).
+
+    Before this guard, ``violations == 0`` was the only exit criterion, so a sweep
+    in which every model errored or was skipped exited 0 and printed a checkmark.
+    """
+    vacuous = [_make_run(SolveStatus.ERROR, None, oracle=None)]
+
+    def _fake_run_suite(config):
+        from benchmarks.metrics import BenchmarkResults
+
+        return BenchmarkResults(suite="gdplib", timestamp="now"), vacuous
+
+    monkeypatch.setattr(gr, "run_suite", _fake_run_suite)
+    monkeypatch.setattr(gr, "is_available", lambda: True)
+
+    rc = gr.main(["--models", "jobshop"])
+    assert rc == 3, "a sweep that executed zero oracle comparisons must not exit 0"
+    assert "oracle-checked=0" in capsys.readouterr().err
+
+
+def test_main_exits_zero_when_no_oracle_requested(monkeypatch):
+    """--no-oracle is deliberate, so it stays a clean exit."""
+    runs = [_make_run(SolveStatus.TIME_LIMIT, None, oracle=None)]
+
+    def _fake_run_suite(config):
+        from benchmarks.metrics import BenchmarkResults
+
+        return BenchmarkResults(suite="gdplib", timestamp="now"), runs
+
+    monkeypatch.setattr(gr, "run_suite", _fake_run_suite)
+    monkeypatch.setattr(gr, "is_available", lambda: True)
+
+    assert gr.main(["--models", "jobshop", "--no-oracle"]) == 0
 
 
 @pytest.mark.slow

--- a/docs/dev/gdplib-benchmarking.md
+++ b/docs/dev/gdplib-benchmarking.md
@@ -195,7 +195,16 @@ Re-run **2026-07-22** after the recent performance work. discopt and SCIP
 (`pyscipopt`) read the same big-M `.nl`; BARON is run via GAMS (`optcr=0`) as an
 independent third global solver. `reference optimum` is the value **both BARON and
 SCIP prove** (see the cstr correction below). Reproduce discopt/SCIP with
-`python scripts/reeval_gdplib.py`.
+
+```bash
+cd discopt_benchmarks
+python -m benchmarks.gdplib_runner --methods bigm --max-variables 500 --time-limit 60
+```
+
+(Earlier revisions of this page gave the reproduction command as
+`python scripts/reeval_gdplib.py`. **No such script has ever existed in the tree**,
+so the table was not reproducible as documented; the runner above is the real entry
+point.)
 
 Legend: **opt** = proven optimal (gap 0); *feas* = feasible incumbent, not proven;
 *inc* = incumbent only (time limit, gap open); — = no incumbent.
@@ -276,8 +285,10 @@ aliases (verified: the recycle indicators stay unset). What changed:
 
 1. Extend the SCIP-certified `reference_optima()` to the larger models with a longer
    budget; optionally add BARON/Couenne behind the same oracle hook for redundancy.
-2. Wire a curated `gdplib_small` suite into the nightly correctness lane (linear
-   models + short-limit nonlinear feasibility), gating on `incorrect_count == 0`.
+2. Curate a `gdplib_small` suite (linear models + short-limit nonlinear
+   feasibility) gating on `incorrect_count == 0`. **Not in a nightly lane** — the
+   owner's standing instruction is that there is no nightly run (CI-minute cost);
+   run it per-PR or on demand.
 3. Grow the native-discopt subset (`gdplib_native.py`) beyond the current three —
    `cstr`, `positioning`, and the larger process models — porting each from source
    with a certified-optimum test. The hand-ported route already exercises discopt's

--- a/python/discopt/_relax/primal_heuristics.py
+++ b/python/discopt/_relax/primal_heuristics.py
@@ -1405,6 +1405,277 @@ def enumerate_binary_seeds_subnlp(
     return results
 
 
+def _residual_assignments(
+    residual: list[int], x_relax: np.ndarray, limit: int
+) -> list[tuple[float, ...]]:
+    """Candidate 0/1 fixings for binaries outside every one-hot group.
+
+    Ordered by how much information backs them: three *anchors* first — the
+    relaxation's own nearest rounding, then the two homogeneous fixings (a big-M
+    indicator's "off" and "on" values) — and then the rest by increasing **Hamming
+    distance from an anchor**, one distance wave at a time. Deterministic in every
+    branch: a primal heuristic that varies run to run makes a node-count comparison
+    unreproducible.
+
+    The distance ordering is what makes the list usable, not just complete. Raw
+    ``itertools.product`` order is a *binary counter*, which has nothing to do with
+    plausibility: measured on cstr, every feasible residual assignment sat at index
+    **30 or 31 of 32** — one bit away from all-ones — so a budget that stopped
+    anywhere short of the full enumeration missed all of them, while under this
+    ordering those same fixings land in the first wave after the anchors. The
+    anchors are the informative points on a big-M GDP (an uncovered indicator is
+    usually at a bound), so "near an anchor" is where to spend the budget first.
+
+    Always returns at least one assignment (the empty tuple when there is no
+    residual), so the caller's cross product is never empty.
+    """
+    k = len(residual)
+    if k == 0:
+        return [()]
+
+    nearest = tuple(float(np.clip(np.round(x_relax[j]), 0.0, 1.0)) for j in residual)
+    anchors: list[tuple[float, ...]] = [nearest, (0.0,) * k, (1.0,) * k]
+    out: list[tuple[float, ...]] = []
+    seen: set[tuple[float, ...]] = set()
+    for cand in anchors:
+        if cand not in seen:
+            seen.add(cand)
+            out.append(cand)
+
+    # Wave d: everything exactly d flips from some anchor, anchors in order.
+    for dist in range(1, k + 1):
+        if len(out) >= limit:
+            break
+        for anchor in anchors:
+            for flips in itertools.combinations(range(k), dist):
+                if len(out) >= limit:
+                    break
+                bits = list(anchor)
+                for j in flips:
+                    bits[j] = 1.0 - bits[j]
+                cand = tuple(bits)
+                if cand not in seen:
+                    seen.add(cand)
+                    out.append(cand)
+            if len(out) >= limit:
+                break
+    return out[:limit]
+
+
+def one_hot_config_subnlp(
+    model: Model,
+    x_relax: np.ndarray,
+    backend: Optional[Callable] = None,
+    nlp_options: Optional[dict] = None,
+    evaluator: Optional[NLPEvaluator] = None,
+    max_configs: int = 256,
+    integer_tol: float = 1e-5,
+    deadline: Optional[float] = None,
+) -> list[tuple[np.ndarray, float]]:
+    """Root primal *constructor* for disjunctive (GDP) models: pick one disjunct
+    per disjunction, then solve the fixed-integer sub-NLP.
+
+    Motivation (#823). On a big-M reformulated GDP the indicator binaries are
+    partitioned by ``sum_k y_k == 1`` rows, one per disjunction. Two existing
+    paths both decline this structure:
+
+    * :func:`enumerate_binary_seeds_subnlp` enumerates *all* 0/1 assignments and
+      so self-gates off above ``max_binaries`` (4). Real GDPs carry one indicator
+      per disjunct — measured 6..138 binaries across the GDPlib small set — so the
+      root disjunct cover never runs on this class at all.
+    * Plain :func:`subnlp` rounds each binary independently to nearest. Independent
+      rounding does not respect ``sum_k y_k == 1``: a disjunction whose relaxed
+      indicators read ``(0.4, 0.35, 0.25)`` rounds to *all zeros*, and one reading
+      ``(0.6, 0.55)`` rounds to *two ones*. Either way the fixed sub-NLP is
+      infeasible on a constraint the model states outright, so the heuristic
+      returns nothing and the node contributes no incumbent.
+
+    This constructor instead selects, per group, the indicator with the largest
+    relaxed value (a valid configuration *by construction*), fixes the rest of the
+    group to 0, and solves one sub-NLP. It then tries a bounded number of
+    alternates by flipping the least-confident groups — those with the smallest
+    margin between their best and runner-up indicator — to their runner-up, since
+    those are where the relaxation's preference carries the least information.
+
+    Binaries outside every group are searched too, by
+    :func:`_residual_assignments` — measured, that is what separates a model this
+    helps from one it does not (see that function and the ``max_configs`` note).
+
+    Cost is bounded to ``max_configs`` sub-NLP solves in total across both
+    searches (not ``2**k``), so it scales to the 138-binary models the enumerator
+    skips, and the whole path is additionally deadline-bounded — in practice the
+    deadline, not ``max_configs``, is what stops it.
+
+    ``max_configs`` is deliberately large. Measured on cstr, a fixed-integer
+    sub-NLP here costs **0.018 s** (384 plans in 7 s), and the feasible plans sit
+    at ``ci + ri`` = 17, 23 and 33 in the configuration x residual grid — so a
+    32-solve budget cannot reach them under *any* ordering, and an earlier default
+    of 32 returned nothing on a model where three feasible plans exist (one at the
+    true optimum). A budget too small to reach the answer is not a cheap heuristic,
+    it is a heuristic that does not work.
+
+    Soundness: every returned point comes from :func:`subnlp`, which fixes the
+    integers and then verifies both integer- and constraint-feasibility before
+    returning. This proposes incumbents only; it never touches the dual bound, so
+    it cannot weaken the optimality certificate. Binaries outside any detected
+    group keep their nearest-rounded value from *x_relax* (subnlp's own rule).
+
+    Args:
+        model: The optimization model.
+        x_relax: Relaxation point at the node (drives the per-group argmax).
+        backend: ``solve_nlp(evaluator, x0, options=...)`` callable.
+        nlp_options: Options forwarded to the NLP backend.
+        evaluator: Pre-built evaluator; one is constructed if omitted.
+        max_configs: Maximum number of plans (sub-NLP solves) to try, across
+            both the configuration and residual searches combined.
+        integer_tol: Integrality tolerance forwarded to :func:`subnlp`.
+        deadline: Absolute ``perf_counter`` deadline; the loop stops before
+            starting a configuration that cannot finish inside it.
+
+    Returns:
+        Every feasible ``(x, obj)`` found (possibly empty). The caller injects
+        each as an incumbent candidate, so this is agnostic to objective sense.
+    """
+    int_mask = _get_integer_mask(model)
+    if not np.any(int_mask):
+        return []
+
+    lb, ub = _get_variable_bounds(model)
+    n_vars = int(int_mask.size)
+    x_relax = np.asarray(x_relax, dtype=np.float64)
+
+    groups = _scan_one_hot_rows(model, int_mask, n_vars)
+    if not groups:
+        return []
+
+    # Per group: the relaxation's preference order, and how strongly it prefers.
+    ranked: list[list[int]] = []
+    margins: list[float] = []
+    for g in groups:
+        order = sorted(g, key=lambda j: -float(x_relax[j]))
+        ranked.append(order)
+        top = float(x_relax[order[0]])
+        second = float(x_relax[order[1]]) if len(order) > 1 else 0.0
+        margins.append(top - second)
+
+    # Least-confident groups first: those are the flips most likely to matter.
+    flip_order = sorted(range(len(groups)), key=lambda gi: margins[gi])
+
+    # Configurations, by increasing number of demotions from the pure argmax and,
+    # within a wave, least-confident groups first. Same principle as the residual
+    # ordering: spend the budget near the informative anchor, outward.
+    #
+    # This has to be a distance enumeration, not a ladder. A cumulative chain
+    # (config k demotes the first k groups of ``flip_order``) reaches |groups|+1 of
+    # the 2**|groups| configurations, and never demotes group g alone unless g is
+    # first in that order. Measured on cstr against the real in-solve relaxation
+    # point, an exhaustive scan of the rank-0/rank-1 space found 6 feasible
+    # configurations — best 3.0620146, the true optimum — at multi-flip positions
+    # (configs 1, 17, 32, 33, 48, 49 of 64). Not one of them lies on the chain.
+    flippable = [gi for gi in flip_order if len(ranked[gi]) >= 2]
+    configs: list[dict[int, int]] = []
+    for dist in range(len(flippable) + 1):
+        if len(configs) >= max_configs:
+            break
+        for combo in itertools.combinations(flippable, dist):
+            if len(configs) >= max_configs:
+                break
+            configs.append({gi: 1 for gi in combo})
+
+    # Binaries that sit outside EVERY disjunction still have to be fixed, and
+    # nearest-rounding them can be invalid on its own. Measured on the GDPlib
+    # small set this is decisive, not a detail: valid disjunct selection alone
+    # gives a feasible sub-NLP on batch_processing (one-hot rows cover 138/138
+    # binaries) but not on cstr (15/20) — and on cstr, searching the 5 uncovered
+    # binaries turns "no point at all" into a feasible 3.13020 against a true
+    # optimum of 3.06201. So the residual gets its own bounded search.
+    covered = {j for g in groups for j in g}
+    residual = [
+        j
+        for j in np.nonzero(int_mask)[0].tolist()
+        if j not in covered and lb[j] >= -1e-9 and ub[j] <= 1.0 + 1e-9
+    ]
+    residual_assigns = _residual_assignments(residual, x_relax, max_configs)
+
+    # A zero-continuous start: inactive disaggregated variables begin at their
+    # feasible 0, leaving only the active disjunct to solve. Same reasoning as
+    # ``enumerate_binary_seeds_subnlp`` — a relaxation point carries the settled
+    # disjunct's values, an ill-conditioned start for any other configuration.
+    cont = ~int_mask
+    zero_start = x_relax.copy()
+    zero_start[cont] = np.clip(0.0, lb, ub)[cont]
+
+    # Interleave the two searches DIAGONALLY, so neither can starve the other.
+    # Concatenating them (all residual variants, then all group demotions) does not
+    # interleave: it merely orders. Measured on cstr — 6 groups, 5 uncovered
+    # binaries — the residual enumeration is 2**5 = 32 assignments, which exactly
+    # fills ``max_configs``, so every slot went to a residual variant of
+    # configuration 0 and NO alternative disjunct configuration was ever tried. With
+    # the relaxation's argmax configuration infeasible there (0/32 feasible), the
+    # search could not reach the demoted configuration that IS feasible at 3.0620146
+    # — the true optimum — and returned nothing.
+    #
+    # Enumerating by increasing ``ci + ri`` keeps the most-informed fixing first
+    # ((0,0) = argmax configuration with the relaxation's own residual rounding) and
+    # thereafter spends the budget on both axes, whatever their relative sizes.
+    plans: list[tuple[int, int]] = []
+    for total in range(len(configs) + len(residual_assigns) - 1):
+        for ci in range(min(total, len(configs) - 1), -1, -1):
+            ri = total - ci
+            if ri < len(residual_assigns):
+                plans.append((ci, ri))
+        if len(plans) >= max_configs:
+            break
+
+    results: list[tuple[np.ndarray, float]] = []
+    attempted = 0
+    stop = "exhausted"
+    for ci, ri in plans[:max_configs]:
+        if deadline is not None and _now() >= deadline:
+            stop = "deadline"
+            break
+        seed = zero_start.copy()
+        choice = configs[ci]
+        for gi, g in enumerate(groups):
+            pick = ranked[gi][choice.get(gi, 0)]
+            for j in g:
+                seed[j] = 0.0
+            seed[pick] = 1.0
+        for j, v in zip(residual, residual_assigns[ri]):
+            seed[j] = v
+        budget = None if deadline is None else max(0.0, deadline - _now())
+        if budget is not None and budget <= 0.0:
+            stop = "deadline"
+            break
+        attempted += 1
+        found = subnlp(
+            model,
+            seed,
+            backend=backend,
+            nlp_options=nlp_options,
+            evaluator=evaluator,
+            integer_tol=integer_tol,
+            time_budget=budget,
+        )
+        if found is not None:
+            results.append(found)
+    # An empty return has several distinct causes — no sub-NLP was even started,
+    # the deadline cut the search short, or every fixing was genuinely infeasible.
+    # Reporting the count and the stop reason is what makes those distinguishable
+    # after the fact; without it "found nothing" is unfalsifiable (CLAUDE.md §6).
+    logger.debug(
+        "one_hot_config_subnlp: %d group(s), %d residual binaries, %d/%d sub-NLP(s) "
+        "attempted (%s), %d feasible",
+        len(groups),
+        len(residual),
+        attempted,
+        len(plans[:max_configs]),
+        stop,
+        len(results),
+    )
+    return results
+
+
 # ─────────────────────────────────────────────────────────────────────────────
 # Improvement heuristics: diving, RINS, local branching
 #
@@ -2099,20 +2370,22 @@ def local_branching(
     return best
 
 
-def _detect_one_hot_groups(model: Model, binary_mask: np.ndarray, n_vars: int) -> list[list[int]]:
-    """Detect disjoint, equal-size one-hot groups (``sum of binaries == 1``).
+def _scan_one_hot_rows(model: Model, binary_mask: np.ndarray, n_vars: int) -> list[list[int]]:
+    """Scan for disjoint ``sum(binaries) == 1`` rows, of any sizes.
 
-    Scans the model's ``==`` constraints for the assignment / set-partition
-    pattern ``sum_k x[i,k] == 1`` (each *item* i assigned to exactly one *slot*
-    k). A row qualifies only when its affine form is ``sum(x_g) - 1`` with unit
-    coefficients over an all-binary support; per-slot cardinality/balance rows
-    (``sum == c`` with ``c != 1``) are naturally excluded (their constant is
-    ``-c``). Overlapping or unequal-size groups are rejected — the swap move pairs
-    members by sorted position, which is only well defined for a clean partition
-    into equal-size groups.
+    This is the raw structural scan shared by two consumers with *different*
+    requirements:
 
-    Returns the list of groups (each a sorted list of flat binary indices, one
-    entry per slot), or ``[]`` when no such structure is present.
+    * :func:`_detect_one_hot_groups` (the #280 swap move) additionally demands at
+      least two groups, all of equal size — the swap pairs members by sorted
+      position, which is only well defined for a clean equal-size partition.
+    * :func:`one_hot_config_subnlp` (disjunct selection) has no such need: picking
+      one indicator per disjunction is well defined for groups of any sizes, and
+      for a single group. Requiring equal sizes there would discard exactly the
+      GDP models whose disjunctions have differing numbers of disjuncts.
+
+    Returns the disjoint groups in scan order (each a sorted list of flat binary
+    indices), or ``[]`` when the model has no such rows.
     """
     from discopt._relax.milp_relaxation import _linearize_affine_expr_sparse
 
@@ -2146,6 +2419,25 @@ def _detect_one_hot_groups(model: Model, binary_mask: np.ndarray, n_vars: int) -
             continue  # overlapping groups: not a clean partition
         seen.update(g)
         groups.append(sorted(g))
+    return groups
+
+
+def _detect_one_hot_groups(model: Model, binary_mask: np.ndarray, n_vars: int) -> list[list[int]]:
+    """Detect disjoint, equal-size one-hot groups (``sum of binaries == 1``).
+
+    Scans the model's ``==`` constraints for the assignment / set-partition
+    pattern ``sum_k x[i,k] == 1`` (each *item* i assigned to exactly one *slot*
+    k). A row qualifies only when its affine form is ``sum(x_g) - 1`` with unit
+    coefficients over an all-binary support; per-slot cardinality/balance rows
+    (``sum == c`` with ``c != 1``) are naturally excluded (their constant is
+    ``-c``). Overlapping or unequal-size groups are rejected — the swap move pairs
+    members by sorted position, which is only well defined for a clean partition
+    into equal-size groups.
+
+    Returns the list of groups (each a sorted list of flat binary indices, one
+    entry per slot), or ``[]`` when no such structure is present.
+    """
+    groups = _scan_one_hot_rows(model, binary_mask, n_vars)
 
     if len(groups) < 2:
         return []

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -439,6 +439,58 @@ def _trivial_primal_enabled() -> bool:
     )
 
 
+def _gdp_config_primal_enabled() -> bool:
+    """Whether the #823 disjunct-configuration primal is on (env flag, **default
+    OFF** pending the §5 differential panel).
+
+    On a big-M reformulated GDP the indicator binaries are partitioned by
+    ``sum_k y_k == 1`` rows, one per disjunction, and no existing constructor
+    respects that partition: ``enumerate_binary_seeds_subnlp`` self-gates off
+    above 4 binaries (measured 6..138 across the GDPlib small set, so it never
+    runs on this class), while plain ``subnlp`` rounds each indicator
+    independently and can therefore fix a disjunction to zero-or-two active
+    disjuncts — an assignment the model forbids outright, making the fixed
+    sub-NLP infeasible and yielding no incumbent.
+
+    When ON, the root selects one disjunct per disjunction (per-group argmax of
+    the relaxation, plus a bounded set of least-confident flips) and solves the
+    fixed-integer sub-NLP for each. Primal-only: every candidate is verified
+    integer- and constraint-feasible by ``subnlp`` before injection, and the dual
+    bound is untouched, so the certificate cannot weaken."""
+    return os.environ.get("DISCOPT_GDP_CONFIG_PRIMAL", "").strip().lower() in (
+        "1",
+        "true",
+        "yes",
+        "on",
+    )
+
+
+#: Share of the remaining wall-clock budget the #823 constructor may spend, and the
+#: absolute cap on that share. A root constructor must be *cheap when it fails*: it
+#: runs before the tree does any work, so every second it spends is a second B&B does
+#: not get. Measured un-bounded (deadline = the whole remaining budget), the search
+#: cost batch_processing 71% of its nodes at 60 s — 307 nodes OFF, 89 ON — while
+#: finding nothing there, i.e. it charged the models it cannot help for the one it
+#: can. The cap is sized from the measured per-attempt cost of 0.018 s on cstr: 15 s
+#: buys ~800 fixed-integer sub-NLPs, comfortably more than the ``max_configs=256``
+#: plan budget can consume, so bounding the clock does not shorten the search that
+#: actually succeeds.
+_GDP_CONFIG_BUDGET_FRACTION = 0.15
+_GDP_CONFIG_BUDGET_CAP_S = 15.0
+
+
+def _gdp_config_deadline(outer_deadline: float, now: float) -> float:
+    """Deadline for the #823 constructor: a bounded share of what is left.
+
+    Never returns a time past ``outer_deadline`` — the caller's budget still binds.
+    """
+    remaining = outer_deadline - now
+    if remaining <= 0.0:
+        return outer_deadline
+    share = min(remaining * _GDP_CONFIG_BUDGET_FRACTION, _GDP_CONFIG_BUDGET_CAP_S)
+    return now + min(remaining, share)
+
+
 def _qubo_primal_enabled() -> bool:
     """Whether the #843 QUBO local-search primal is on (env flag, **default ON** —
     graduated per the §5 panel recorded in
@@ -969,21 +1021,58 @@ def _native_kernel_seed_candidates(model, lb, ub, n_orig, deadline):
                     cand = None
                 if cand is not None and cand[0] is not None:
                     yield np.asarray(cand[0], dtype=np.float64)
-        elif xr is not None and time.perf_counter() < deadline:
-            # Too many free binaries to enumerate: one nearest-rounding sub-NLP.
-            try:
-                cand = subnlp(
-                    model,
-                    xr,
-                    evaluator=ev,
-                    backend=backend,
-                    time_budget=max(1e-3, min(4.0, deadline - time.perf_counter())),
-                )
-            except Exception as exc:  # pragma: no cover - defensive
-                logger.debug("native seed subnlp raised: %s", exc)
-                cand = None
-            if cand is not None and cand[0] is not None:
-                yield np.asarray(cand[0], dtype=np.float64)
+        elif time.perf_counter() < deadline:
+            # Too many free integers to enumerate. The legacy fallback is a single
+            # nearest-rounding sub-NLP — and on a disjunctive (GDP) model that is
+            # precisely the wrong move (#823). Indicators partitioned by
+            # ``sum_k y_k == 1`` do not survive independent rounding: (0.4, 0.35,
+            # 0.25) rounds to all zeros and (0.6, 0.55) to two ones, both of which
+            # contradict a constraint the model states outright, so the sub-NLP is
+            # infeasible and the kernel gets NO seed at all. This is the path the
+            # class actually takes — the GDPlib big-M models carry 20/61/138 free
+            # binaries against a cap of 10 — so disjunct selection is tried first.
+            #
+            # Sound by construction: these are only CANDIDATES, and every one is
+            # rigorously re-verified against the original model by
+            # ``_native_kernel_verify_point`` before it may seed anything.
+            if _gdp_config_primal_enabled():
+                # Both markers are INFO on purpose: without an *entering* marker a
+                # differential arm showing no change cannot distinguish "searched and
+                # found nothing" from "the gate never opened" (CLAUDE.md §6). The
+                # count is emitted from ``finally`` so it is reported even when the
+                # consumer abandons this generator after the first candidate.
+                logger.info("GDP config subNLP (native): entering disjunct selection")
+                _cf_n = 0
+                try:
+                    from discopt._relax.primal_heuristics import one_hot_config_subnlp
+
+                    for _cf_x, _ in one_hot_config_subnlp(
+                        model,
+                        xr if xr is not None else base,
+                        backend=backend,
+                        evaluator=ev,
+                        deadline=_gdp_config_deadline(deadline, time.perf_counter()),
+                    ):
+                        _cf_n += 1
+                        yield np.asarray(_cf_x, dtype=np.float64)
+                except Exception as exc:  # pragma: no cover - defensive
+                    logger.debug("native seed one-hot config raised: %s", exc)
+                finally:
+                    logger.info("GDP config subNLP: %d feasible point(s)", _cf_n)
+            if xr is not None and time.perf_counter() < deadline:
+                try:
+                    cand = subnlp(
+                        model,
+                        xr,
+                        evaluator=ev,
+                        backend=backend,
+                        time_budget=max(1e-3, min(4.0, deadline - time.perf_counter())),
+                    )
+                except Exception as exc:  # pragma: no cover - defensive
+                    logger.debug("native seed subnlp raised: %s", exc)
+                    cand = None
+                if cand is not None and cand[0] is not None:
+                    yield np.asarray(cand[0], dtype=np.float64)
     except Exception as exc:  # pragma: no cover - defensive
         logger.debug("native seed subnlp import/setup failed: %s", exc)
 
@@ -11525,6 +11614,64 @@ def solve_model(
                 _record_improver(_HEUR_COST["enumerate"], _enum_improved)
                 _heuristic_governor.record("enumerate", _enum_improved)
 
+        # --- Root disjunct-configuration primal (#823, flag-gated, default OFF) ---
+        # The enumeration above self-gates off above 4 binaries, so on a big-M GDP
+        # (6..138 indicators across the GDPlib small set) the root disjunct cover
+        # never runs; and plain rounding can fix a disjunction to zero-or-two
+        # active disjuncts, which the model forbids, so its sub-NLP is infeasible.
+        # This selects one disjunct per ``sum_k y_k == 1`` row instead. Runs only
+        # while NO incumbent exists — it is a constructor, not an improver.
+        if (
+            iteration == 0
+            and _gdp_config_primal_enabled()
+            and _subnlp_backend_fn is not None
+            and tree.incumbent() is None
+            and not _root_optimum_proven()
+            and _root_heur_nlp_entry_ok(evaluator)
+        ):
+            from discopt._relax.primal_heuristics import one_hot_config_subnlp
+
+            logger.info("GDP config subNLP (root): entering disjunct selection")
+
+            # Seed from the best root relaxation point when one produced a usable
+            # bound, else the bound midpoint. Computed here rather than reused from
+            # the enumeration above, which may not have run at all.
+            _cfg_cands = [
+                (i, float(result_lbs[i]))
+                for i in range(n_batch)
+                if result_lbs[i] < _SENTINEL_THRESHOLD and np.isfinite(result_lbs[i])
+            ]
+            _cfg_cands.sort(key=lambda t: t[1])
+            _cfg_seed = (
+                result_sols[_cfg_cands[0][0]]
+                if _cfg_cands
+                else 0.5 * (np.clip(lb, -_SPC, _SPC) + np.clip(ub, -_SPC, _SPC))
+            )
+            try:
+                _cfg_results = one_hot_config_subnlp(
+                    model,
+                    _cfg_seed,
+                    backend=_subnlp_backend_fn,
+                    nlp_options=subnlp_options,
+                    evaluator=evaluator,
+                    deadline=_gdp_config_deadline(_deadline, time.perf_counter()),
+                )
+            except Exception as _e:
+                logger.debug("one_hot_config_subnlp raised: %s", _e)
+                _cfg_results = []
+            # Log unconditionally, including the zero case. Without this, a run
+            # showing no change is ambiguous between "the constructor ran and
+            # found nothing" and "the gate never opened" — the §6 vacuity trap,
+            # where an instrument that measured nothing reads as a clean result.
+            logger.info("GDP config subNLP: %d feasible point(s)", len(_cfg_results))
+            _subnlp_calls += len(_cfg_results)
+            for _x_cf, _obj_cf in _cfg_results:
+                _subnlp_feasible += 1
+                if np.isfinite(_obj_cf) and _obj_cf < _SENTINEL_THRESHOLD:
+                    _inject_incumbent(np.asarray(_x_cf).copy(), float(_obj_cf))
+                    _subnlp_incumbent_updates += 1
+                    logger.info("GDP config subNLP incumbent: obj=%.6g", _obj_cf)
+
         # --- Incumbent integer-neighbourhood search (general-integer LB) ---
         # A feasible incumbent of a nonconvex general-integer model can sit next
         # to a far better feasible integer assignment that no unit (1-opt/2-opt)
@@ -14044,6 +14191,52 @@ def _solve_nlp_bb(
                     best_root_idx = i
             if best_root_idx is not None:
                 _root_incumbent = False
+
+                # --- Root disjunct-configuration primal (#823, flag-gated) ---
+                # The THIRD call site, and the one this class needs: a convex GDP
+                # (batch_processing) routes here, not to the spatial kernel or the
+                # Python B&B loop, so wiring only those two left the constructor
+                # unreachable on it — a dead flag on the very subclass it targets
+                # (CLAUDE.md §3). RENS and the pump below both round the relaxation,
+                # which cannot respect ``sum_k y_k == 1``; this selects one disjunct
+                # per row instead. Constructor only: it runs while NO incumbent
+                # exists and never touches the dual bound.
+                if _gdp_config_primal_enabled() and tree.incumbent() is None:
+                    logger.info("GDP config subNLP (nlp-bb): entering disjunct selection")
+                    _cfg_found = []
+                    try:
+                        from discopt._relax.primal_heuristics import one_hot_config_subnlp
+
+                        _cfg_found = one_hot_config_subnlp(
+                            model,
+                            result_sols[best_root_idx],
+                            evaluator=evaluator,
+                            deadline=_gdp_config_deadline(
+                                t_start + time_limit, time.perf_counter()
+                            ),
+                        )
+                    except Exception as _e:  # pragma: no cover - defensive
+                        logger.debug("nlp-bb one_hot_config_subnlp raised: %s", _e)
+                    logger.info("GDP config subNLP: %d feasible point(s)", len(_cfg_found))
+                    for _cfg_x, _ in _cfg_found:
+                        # Re-verified here by this path's own standard, exactly as
+                        # RENS and diving results are, rather than trusted because
+                        # the heuristic said so.
+                        _cfg_sol = np.asarray(_cfg_x, dtype=np.float64).copy()
+                        _cfg_obj = float(evaluator.evaluate_objective(_cfg_sol))
+                        _cfg_feas = not cl_list or _check_constraint_feasibility(
+                            evaluator, _cfg_sol, cl_list, cu_list
+                        )
+                        if (
+                            np.isfinite(_cfg_obj)
+                            and _cfg_obj < _SENTINEL_THRESHOLD
+                            and _cfg_feas
+                            and _is_integer_feasible_solution(_cfg_sol, int_offsets, int_sizes)
+                        ):
+                            tree.inject_incumbent(_cfg_sol, _cfg_obj)
+                            _root_incumbent = True
+                            logger.info("GDP config subNLP incumbent: obj=%.6g", _cfg_obj)
+
                 # --- RENS (Relaxation Enforced Neighborhood Search), primary ---
                 # Solve the relaxation's rounding neighbourhood EXACTLY (fix the
                 # integers already integral in the relaxation; restrict each

--- a/python/tests/test_issue823_gdp_config_primal.py
+++ b/python/tests/test_issue823_gdp_config_primal.py
@@ -1,0 +1,224 @@
+"""Regression tests for issue #823 — the disjunctive (GDP) primal-constructor gap.
+
+On a big-M reformulated GDP the indicator binaries are partitioned by
+``sum_k y_k == 1`` rows, one per disjunction. Two existing constructors both
+decline that structure, so the class returns *no incumbent at all*:
+
+* ``enumerate_binary_seeds_subnlp`` enumerates every 0/1 assignment and therefore
+  self-gates off above ``max_binaries=4``. Measured on the GDPlib small set, the
+  big-M models carry 6..138 binaries, so the root disjunct cover never runs.
+* plain ``subnlp`` rounds each binary independently to nearest, which does not
+  respect ``sum_k y_k == 1``: indicators reading ``(0.4, 0.35, 0.25)`` round to
+  *all zeros* and ``(0.6, 0.55)`` rounds to *two ones*. Either fixing contradicts
+  a constraint the model states outright, so the sub-NLP is infeasible.
+
+``one_hot_config_subnlp`` selects one disjunct per row instead (per-group argmax
+plus bounded least-confident flips), which is valid by construction.
+
+These tests pin the structure detection and the constructor directly — fast and
+deterministic, gated on detected structure rather than on any problem name.
+"""
+
+from __future__ import annotations
+
+import discopt.modeling as dm
+import numpy as np
+import pytest
+from discopt._relax.primal_heuristics import (
+    _detect_one_hot_groups,
+    _residual_assignments,
+    _scan_one_hot_rows,
+    one_hot_config_subnlp,
+    subnlp,
+)
+
+
+def _uneven_disjunction_model():
+    """Two disjunctions of *different* sizes (3-way and 2-way) over one binary vec.
+
+    y[0..2] is one disjunction, y[3..4] another. The continuous x is driven to a
+    value determined by which disjunct is active, and the objective prefers the
+    third disjunct of the first group.
+    """
+    m = dm.Model("uneven")
+    y = m.binary("y", 5)
+    x = m.continuous("x", lb=0.0, ub=10.0)
+    m.subject_to(y[0] + y[1] + y[2] == 1, name="d1")
+    m.subject_to(y[3] + y[4] == 1, name="d2")
+    # x is pushed up unless the 3rd disjunct of the first group is active.
+    m.subject_to(x >= 5.0 - 4.0 * y[2], name="lo")
+    m.minimize(x + y[3])
+    return m, y, x
+
+
+def _equal_size_model():
+    """Two disjunctions of the SAME size — what the #280 swap detector accepts."""
+    m = dm.Model("even")
+    y = m.binary("y", 4)
+    m.subject_to(y[0] + y[1] == 1, name="d1")
+    m.subject_to(y[2] + y[3] == 1, name="d2")
+    m.minimize(y[0] + y[2])
+    return m
+
+
+@pytest.mark.smoke
+def test_scan_finds_unequal_size_groups_the_swap_detector_rejects():
+    """The #823 structural gap: unequal-size disjunctions detect as zero groups.
+
+    ``_detect_one_hot_groups`` requires every group be the same size (the swap
+    move pairs members by sorted position). A GDP whose disjunctions have
+    differing numbers of disjuncts therefore reads as "no one-hot structure",
+    which is correct for the swap move and wrong for disjunct selection.
+    """
+    m, _, _ = _uneven_disjunction_model()
+    mask = np.zeros(6, dtype=bool)
+    mask[:5] = True  # y[0..4] binary, x continuous
+
+    scanned = _scan_one_hot_rows(m, mask, mask.size)
+    assert [len(g) for g in scanned] == [3, 2], scanned
+
+    # The swap-move detector rejects the very same model.
+    assert _detect_one_hot_groups(m, mask, mask.size) == []
+
+
+@pytest.mark.smoke
+def test_equal_size_detection_is_unchanged():
+    """The refactor must not alter #280's swap-move detection."""
+    m = _equal_size_model()
+    mask = np.ones(4, dtype=bool)
+    groups = _detect_one_hot_groups(m, mask, mask.size)
+    assert len(groups) == 2
+    assert all(len(g) == 2 for g in groups)
+    assert groups == _scan_one_hot_rows(m, mask, mask.size)
+
+
+@pytest.mark.smoke
+def test_independent_rounding_produces_an_invalid_configuration():
+    """Pin the mechanism: nearest-rounding a flat disjunction sets NO indicator.
+
+    This is why the class returns no incumbent — the fixing contradicts
+    ``sum_k y_k == 1`` before the NLP is even consulted.
+    """
+    x_relax = np.array([0.4, 0.35, 0.25, 0.5, 0.5, 3.0])
+    rounded = np.round(x_relax[:3])
+    assert rounded.sum() == 0.0, "expected an all-zero rounding of the 3-way disjunction"
+
+    # And the constructor's rule picks exactly one, by construction.
+    m, _, _ = _uneven_disjunction_model()
+    mask = np.zeros(6, dtype=bool)
+    mask[:5] = True
+    for g in _scan_one_hot_rows(m, mask, mask.size):
+        pick = max(g, key=lambda j: x_relax[j])
+        assert sum(1 for j in g if j == pick) == 1
+
+
+@pytest.mark.smoke
+def test_config_subnlp_finds_a_point_where_plain_subnlp_cannot():
+    """The regression: valid disjunct selection yields an incumbent, rounding does not."""
+    m, _, _ = _uneven_disjunction_model()
+    # Indicators deliberately fractional so nearest-rounding zeroes both groups.
+    x_relax = np.array([0.4, 0.35, 0.25, 0.45, 0.4, 3.0])
+
+    assert subnlp(m, x_relax) is None, "plain rounding should fix an invalid configuration"
+
+    found = one_hot_config_subnlp(m, x_relax)
+    assert found, "disjunct selection should produce at least one feasible point"
+    for x, obj in found:
+        assert np.isfinite(obj)
+        # Every returned point satisfies both one-hot rows exactly.
+        assert abs(x[0] + x[1] + x[2] - 1.0) < 1e-6
+        assert abs(x[3] + x[4] - 1.0) < 1e-6
+
+
+@pytest.mark.smoke
+def test_config_subnlp_is_a_noop_without_one_hot_structure():
+    """Generality: gated on detected structure, never on a name."""
+    m = dm.Model("plain")
+    z = m.binary("z", 3)
+    m.subject_to(z[0] + z[1] + z[2] <= 2, name="c")
+    m.minimize(z[0] + z[1] + z[2])
+    assert one_hot_config_subnlp(m, np.array([0.4, 0.4, 0.4])) == []
+
+
+@pytest.mark.smoke
+def test_config_subnlp_respects_an_expired_deadline():
+    """A past deadline must stop it before the first sub-NLP solve."""
+    import time
+
+    m, _, _ = _uneven_disjunction_model()
+    x_relax = np.array([0.4, 0.35, 0.25, 0.45, 0.4, 3.0])
+    assert one_hot_config_subnlp(m, x_relax, deadline=time.perf_counter() - 1.0) == []
+
+
+@pytest.mark.smoke
+def test_residual_assignments_are_ordered_bounded_and_deterministic():
+    """Binaries outside every disjunction get their own bounded, ordered search.
+
+    Measured on GDPlib, this is what separates a model the constructor helps from
+    one it does not: valid disjunct selection alone suffices on batch_processing
+    (one-hot rows cover 138/138 binaries) but not on cstr (15/20) — where
+    searching the 5 uncovered binaries turns "no incumbent at all" into a feasible
+    3.13020 against a true optimum of 3.06201.
+    """
+    x_relax = np.array([0.9, 0.2, 0.6])
+    got = _residual_assignments([0, 1, 2], x_relax, limit=16)
+
+    # Most-informed first: the relaxation's own nearest rounding.
+    assert got[0] == (1.0, 0.0, 1.0)
+    # Then the two homogeneous fixings — a big-M indicator's off/on values.
+    assert (0.0, 0.0, 0.0) in got[:3] and (1.0, 1.0, 1.0) in got[:3]
+    # Exhaustive for a small residual, no duplicates, and bounded by the limit.
+    assert len(got) == len(set(got)) == 8
+    # Deterministic: a heuristic that varies run to run makes node counts
+    # unreproducible, which would break the §5 bound-neutral comparison.
+    assert got == _residual_assignments([0, 1, 2], x_relax, limit=16)
+
+    # No residual is still one (empty) assignment, so the cross product is never
+    # empty and the group search still runs.
+    assert _residual_assignments([], x_relax, limit=16) == [()]
+
+    # A large residual samples instead of enumerating, and still respects limit.
+    big = _residual_assignments(list(range(12)), np.zeros(12), limit=10)
+    assert len(big) == len(set(big)) == 10
+
+
+@pytest.mark.smoke
+def test_flag_is_default_off():
+    """§5: the constructor ships default-OFF pending its differential panel."""
+    import os
+
+    from discopt.solver import _gdp_config_primal_enabled
+
+    os.environ.pop("DISCOPT_GDP_CONFIG_PRIMAL", None)
+    assert _gdp_config_primal_enabled() is False
+    os.environ["DISCOPT_GDP_CONFIG_PRIMAL"] = "1"
+    try:
+        assert _gdp_config_primal_enabled() is True
+    finally:
+        os.environ.pop("DISCOPT_GDP_CONFIG_PRIMAL", None)
+
+
+def test_constructor_gets_a_bounded_share_of_the_budget():
+    """A root constructor must be cheap when it fails.
+
+    Handed the whole remaining budget, the search cost batch_processing 71 % of
+    its nodes (307 OFF -> 89 ON) while finding nothing on it: the models it
+    cannot help paid for the one it can. The deadline it receives is a bounded
+    share of what is left, never past the caller's own deadline.
+    """
+    from discopt.solver import (
+        _GDP_CONFIG_BUDGET_CAP_S,
+        _GDP_CONFIG_BUDGET_FRACTION,
+        _gdp_config_deadline,
+    )
+
+    # A share of the remaining budget, not all of it.
+    assert _gdp_config_deadline(100.0, 0.0) == pytest.approx(
+        min(100.0 * _GDP_CONFIG_BUDGET_FRACTION, _GDP_CONFIG_BUDGET_CAP_S)
+    )
+    # The absolute cap binds on a long budget.
+    assert _gdp_config_deadline(10_000.0, 0.0) == pytest.approx(_GDP_CONFIG_BUDGET_CAP_S)
+    # Never past the caller's deadline, however short it is.
+    assert _gdp_config_deadline(1.0, 0.0) <= 1.0
+    # An already-expired budget stays expired rather than being extended.
+    assert _gdp_config_deadline(5.0, 9.0) == 5.0


### PR DESCRIPTION
Contributes to #823 — the "discopt returns no incumbent on nonlinear GDPs that
SCIP/BARON solve easily" checklist item.

## What was actually wrong

On a big-M reformulated GDP the indicator binaries are partitioned by
`sum_k y_k == 1` rows, one per disjunction. Nothing in the primal stack respects
that partition:

- `enumerate_binary_seeds_subnlp` enumerates every 0/1 assignment, so it self-gates
  off above `max_binaries=4`. These models carry 6/20/60/61/138 binaries — the root
  disjunct cover never ran on any of them.
- plain `subnlp` rounds each binary independently, which *breaks* the one-hot rows:
  `(0.4, 0.35, 0.25)` rounds to all zeros, `(0.6, 0.55)` to two ones. Either fixing
  contradicts a constraint the model states outright, so the sub-NLP is infeasible
  before the NLP is consulted.
- `_detect_one_hot_groups` additionally requires all groups be the same size. That
  is a #280 **swap-move** requirement (it pairs members by sorted position), not a
  disjunct-selection one, so unequal-size disjunctions read as "no one-hot structure
  at all". The raw scan is factored out as `_scan_one_hot_rows`; #280's detector
  keeps its equal-size filter unchanged.

New `one_hot_config_subnlp` selects one disjunct per row and solves the fixed
sub-NLP — valid by construction. One-hot rows do not always *cover* every binary
(cstr: 15/20), so the uncovered ones get their own bounded search, interleaved with
the group configurations under a single budget.

## Search ordering turned out to be the whole result

The first working version found points offline and nothing in-solve. Three
ordering/budget defects, each caught by measurement rather than by reasoning:

- the config ladder was *cumulative* (config k demoted the first k groups of a fixed
  order), reaching |groups|+1 of 2^|groups| configurations and never demoting group
  g alone unless g was first → distance-ordered flips.
- `plans` was concatenated (all residual variants, then all group demotions), so with
  5 residual binaries 2^5 = 32 exactly filled `max_configs=32` and **no alternative
  disjunct configuration was ever tried** → diagonal interleave.
- `_residual_assignments` used raw `itertools.product` order. Measured exhaustively
  on cstr, *every* feasible residual assignment sat at index 30 or 31 of 32 — one bit
  from all-ones, i.e. dead last under a binary counter → Hamming-distance waves from
  three anchors (relaxation rounding, all-zeros, all-ones). The RNG sampling branch is
  gone.
- `max_configs` 32 → 256, from the measured 0.018 s per fixed-integer sub-NLP (384
  plans in 7 s) with feasible plans at diagonals 17/23/33. A budget too small to reach
  the answer is not a cheap heuristic; it is one that does not work.

## Three call sites

A GDP can take three paths, and wiring fewer than all three leaves a dead flag on the
subclass it targets (CLAUDE.md §3): the Python B&B root loop, the native Rust spatial
kernel (#764) — whose `_native_kernel_seed_candidates` enumerates only below 10 free
integers and otherwise falls back to exactly the broken nearest rounding — and
`_solve_nlp_bb` ("Convex MINLP detected, using NLP-BB"), where batch_processing goes.
The ON arm's entry counter confirms all three fire: `{'root': 1, 'native': 1, 'nlp-bb': 1}`.

Each site passes `_gdp_config_deadline(...)` — 15 % of the remaining budget, capped at
15 s — rather than the whole clock. Un-bounded, the search cost batch_processing 71 %
of its nodes (307 → 89 at 60 s) while finding nothing there: the models it cannot help
were paying for the one it can. At 0.018 s per attempt the cap still buys ~800 sub-NLPs,
more than `max_configs` can spend.

## Measurement (big-M, 60 s, `--max-variables 500`, oracle on)

| model | OFF | ON |
|---|---|---|
| cstr | 3.370033, 11615 nodes | **3.0620146**, 9970 nodes (reference optimum 3.0620073) |
| batch_processing | no incumbent, 307 nodes | no incumbent, 243 nodes |
| syngas | no incumbent, 31 nodes | no incumbent, 31 nodes |

Both arms: `oracle-checked=3 | INCORRECT=0 | bound-crossings=0`.

One decisive win; two models pay ~15-20 % of their nodes for nothing, on a 3-model
sample. **That does not meet the §5 net-positive bar, so the flag ships default-OFF
behind `DISCOPT_GDP_CONFIG_PRIMAL` and no graduation is claimed.**

## Soundness

Every candidate flows through `subnlp` (integer- and constraint-feasibility); the
native path re-verifies via `_native_kernel_verify_point`, and the NLP-BB site
re-verifies with `evaluate_objective` + `_check_constraint_feasibility` +
`_is_integer_feasible_solution` before `inject_incumbent` — by that path's own
standard, not because the heuristic said so. The constructor only proposes
incumbents and never touches the dual bound, so the certificate cannot weaken.
Gated on detected structure, never on a problem name (§2).

## Recorded negative result (§4)

syngas resists **all 132 valid integer fixings** tried across three probes. Its blocker
is the *continuous* subproblem, not the disjunct configuration, so no integer-side
constructor will fix it. Do not re-attempt one there.

## Reporting bug found while measuring this

`gdplib_runner.solve_model` read the objective only for `OPTIMAL|FEASIBLE`, while the
pyomo bridge loads the solution whenever `result.x` is set. On cstr discopt exits
`time_limit` carrying 3.3700327 at a scale-normalized violation of 1.6e-06 — inside
the harness's own `_ORACLE_FEAS_TOL = 1e-5` — and the sweep printed "no incumbent".
Extracted as `_decide_objective`, which reports such a point *only* if it verifies
feasible in the real pyomo model and marks it `incumbent_verified`. That flag widens
the soundness gate in `_assess`, because `is_feasible` is `OPTIMAL|FEASIBLE` only and
a newly-reported time-limit incumbent would otherwise bypass the impossible-incumbent
check — an unchecked path (§1). The incumbent is genuinely absent, not merely
unreported, on syngas and batch_processing.

## Docs

`docs/dev/gdplib-benchmarking.md` gave its reproduction command as
`python scripts/reeval_gdplib.py`. **That script has never existed in the tree** (no
git history for the path), so the published 2026-07-22 table was not reproducible as
documented; replaced with the real `python -m benchmarks.gdplib_runner ...` invocation
and a note. Its "wire a curated `gdplib_small` suite into the **nightly** correctness
lane" next-step is reworded — the owner's standing instruction is that there is no
nightly run (CI-minute cost); the suite is still worth curating, per-PR or on demand.

## Tests run

- `pytest -m smoke` — 951 passed, 1 skipped, 2 xpassed
- `pytest -m slow python/tests/test_adversarial_recent_fixes.py` — 10 passed
- `pytest python/tests/test_issue823_gdp_config_primal.py discopt_benchmarks/tests/test_gdplib.py` — 35 passed
- No Rust touched, so no `cargo test`.

New: `python/tests/test_issue823_gdp_config_primal.py` (9 tests — the structural gap,
the constructor, residual ordering/determinism, the deadline share, the default-OFF
flag) and four tests in `discopt_benchmarks/tests/test_gdplib.py` covering the
reporting rule and its soundness gate. The impossible-incumbent test fails with the
gate narrowed to `is_feasible` and passes with it widened.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017PQaiDVuY5Rs3tga98tnNo
