### PR TITLE
fix(lp): #928 distinguish an expired MILP budget from no limit, and graduate DISCOPT_LP_WARM_DEADLINE

### DIFF
--- a/crates/discopt-python/src/lp_bindings.rs
+++ b/crates/discopt-python/src/lp_bindings.rs
@@ -59,6 +59,36 @@ fn parse_deadline(time_limit_s: Option<f64>) -> PyResult<Option<std::time::Insta
     }
 }
 
+/// The [`parse_deadline`] contract in *seconds*, for callees that build their own
+/// deadline from a duration ([`MilpOptions::time_limit_s`] is relative to the driver's
+/// own `t_start`, so it cannot take an absolute `Instant`).
+///
+/// The distinction this exists to preserve is between an **expired** budget and **no**
+/// budget. Both MILP entries used to take a bare `f64` and map it with
+/// `if time_limit_s > 0.0 { Some(t) } else { None }`, which collapses `0.0` — "my budget
+/// is spent" — onto the same wire value as "run forever". That is the sentinel-collapse
+/// class documented for `INF` in the LP layer, one level up: a caller that had *already*
+/// exhausted a shared budget across earlier attempts launched an **unbounded** MILP
+/// B&B at exactly the moment it should not have started at all. Measured on issue #928:
+/// AMP's `solve(time_limit=3.0)` ran past 350 s. `Some(0.0)` now reaches the driver
+/// intact, where it is an already-elapsed deadline that stops at the first poll with
+/// `gap_certified = false` — the same well-trodden path as a deadline that expires at
+/// node 1, so the bound it reports stays sound.
+fn parse_budget_secs(time_limit_s: Option<f64>) -> PyResult<Option<f64>> {
+    match time_limit_s {
+        None => Ok(None),
+        Some(seconds) if seconds == f64::INFINITY => Ok(None),
+        Some(seconds) if seconds.is_nan() || seconds < 0.0 => Err(PyValueError::new_err(
+            "time_limit_s must be non-negative and not NaN (use None or +inf for no limit)",
+        )),
+        // Reject what the driver's `Duration::from_secs_f64` would panic on.
+        Some(seconds) => match std::time::Duration::try_from_secs_f64(seconds) {
+            Ok(_) => Ok(Some(seconds)),
+            Err(_) => Err(PyValueError::new_err("time_limit_s is too large")),
+        },
+    }
+}
+
 /// Push an interior LP optimum `x` to a vertex of the optimal face.
 ///
 /// `a` is the C-contiguous `m × n` equality-constraint matrix; `c`, `lb`, `ub`
@@ -829,7 +859,7 @@ impl MilpDebugHook for PyMilpHook {
                     max_pool_cuts=128, heuristics=true, presolve=true, strong_branch=true,
                     node_propagation=false, reduced_cost_fixing=true,
                     sb_max_cands=6, sb_node_budget=48,
-                    initial_incumbent=None, time_limit_s=0.0, debug_hook=None))]
+                    initial_incumbent=None, time_limit_s=None, debug_hook=None))]
 pub fn solve_milp_py<'py>(
     py: Python<'py>,
     c: PyReadonlyArray1<'py, f64>,
@@ -857,7 +887,7 @@ pub fn solve_milp_py<'py>(
     sb_max_cands: usize,
     sb_node_budget: usize,
     initial_incumbent: Option<PyReadonlyArray1<'py, f64>>,
-    time_limit_s: f64,
+    time_limit_s: Option<f64>,
     debug_hook: Option<Py<PyAny>>,
 ) -> PyResult<(String, Bound<'py, PyArray1<f64>>, f64, f64, usize, usize)> {
     let dims = a.shape();
@@ -930,7 +960,7 @@ pub fn solve_milp_py<'py>(
                     max_pool_cuts=128, heuristics=true, presolve=true, strong_branch=true,
                     node_propagation=false, reduced_cost_fixing=true,
                     sb_max_cands=6, sb_node_budget=48,
-                    initial_incumbent=None, time_limit_s=0.0, debug_hook=None))]
+                    initial_incumbent=None, time_limit_s=None, debug_hook=None))]
 #[allow(clippy::too_many_arguments)]
 pub fn solve_milp_csc_py<'py>(
     py: Python<'py>,
@@ -963,7 +993,7 @@ pub fn solve_milp_csc_py<'py>(
     sb_max_cands: usize,
     sb_node_budget: usize,
     initial_incumbent: Option<PyReadonlyArray1<'py, f64>>,
-    time_limit_s: f64,
+    time_limit_s: Option<f64>,
     debug_hook: Option<Py<PyAny>>,
 ) -> PyResult<(String, Bound<'py, PyArray1<f64>>, f64, f64, usize, usize)> {
     let col_ptr_v: Vec<usize> = col_ptr.as_slice()?.iter().map(|&x| x as usize).collect();
@@ -1047,18 +1077,14 @@ fn run_milp_hooked<'py>(
     sb_max_cands: usize,
     sb_node_budget: usize,
     initial_incumbent: Option<PyReadonlyArray1<'py, f64>>,
-    time_limit_s: f64,
+    time_limit_s: Option<f64>,
     debug_hook: Option<Py<PyAny>>,
 ) -> PyResult<(String, Bound<'py, PyArray1<f64>>, f64, f64, usize, usize)> {
     let opts = MilpOptions {
         n_struct,
         integer_cols: int_cols,
         max_nodes,
-        time_limit_s: if time_limit_s > 0.0 {
-            Some(time_limit_s)
-        } else {
-            None
-        },
+        time_limit_s: parse_budget_secs(time_limit_s)?,
         gap_tol,
         root_cuts,
         cut_rounds,

--- a/discopt_benchmarks/results/issue928_warmalone20_rep1.json
+++ b/discopt_benchmarks/results/issue928_warmalone20_rep1.json
@@ -1,0 +1,848 @@
+{
+  "summary": {
+    "instances": 19,
+    "budget": 20.0,
+    "arms": {
+      "base": "all OFF (today's default)",
+      "warm": "#928 ON alone"
+    },
+    "unsound": [],
+    "incumbent_verification_failed": [],
+    "oracle_comparisons_executed": 32,
+    "instances_without_oracle": [
+      "bchoco06",
+      "bchoco07",
+      "bchoco08"
+    ],
+    "pairs": [
+      {
+        "pair": "warm vs base",
+        "cells_over_budget": {
+          "base": 2,
+          "warm": 0
+        },
+        "total_overrun_s": {
+          "base": 6.5,
+          "warm": 3.9
+        },
+        "overrun_delta_s": -2.6,
+        "node_count_total": {
+          "base": 1553,
+          "warm": 1537
+        },
+        "cert_gains": [],
+        "cert_regressions": [],
+        "gained_incumbents": [],
+        "lost_incumbents": [],
+        "better_objective": [
+          "casctanks (9.20758227104826 -> 9.16347901337332)"
+        ],
+        "worse_objective": [],
+        "tighter_bound": [
+          "hda (-20747115955979.49 -> -64473.44240151847)",
+          "heatexch_gen1 (46749.99999998356 -> 48999.99999999993)",
+          "tspn08 (278.5701969904429 -> 281.0891401033739)",
+          "tspn12 (202.18053097230293 -> 202.18055401644563)"
+        ],
+        "looser_bound": [
+          "tspn10 (168.9656001884391 -> 168.96558963704825)"
+        ],
+        "gained_bound": [],
+        "lost_bound": []
+      }
+    ],
+    "solu_oracle": "solu",
+    "panel_wall_s": 685.8,
+    "loadavg_start": [
+      6.1,
+      4.48,
+      3.75
+    ],
+    "loadavg_end": [
+      4.99,
+      4.91,
+      4.5
+    ]
+  },
+  "cells": [
+    {
+      "instance": "4stufen",
+      "budget": 20.0,
+      "reference_optimum": 116329.6706,
+      "base": {
+        "instance": "4stufen",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 20.605796959018335,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 21474.569205865446,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 15,
+        "incumbent_verification_failed": false
+      },
+      "warm": {
+        "instance": "4stufen",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "1",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 20.248828707961366,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 21474.569205865446,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 15,
+        "incumbent_verification_failed": false
+      }
+    },
+    {
+      "instance": "bchoco06",
+      "budget": 20.0,
+      "reference_optimum": null,
+      "base": {
+        "instance": "bchoco06",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "max",
+        "wall": 20.12291820801329,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 1.000000044867369,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 3,
+        "incumbent_verification_failed": false
+      },
+      "warm": {
+        "instance": "bchoco06",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "1",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "max",
+        "wall": 20.188227082951926,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 1.000000044867369,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 3,
+        "incumbent_verification_failed": false
+      }
+    },
+    {
+      "instance": "bchoco07",
+      "budget": 20.0,
+      "reference_optimum": null,
+      "base": {
+        "instance": "bchoco07",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "max",
+        "wall": 20.233339957892895,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 1.0000000000002496,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 3,
+        "incumbent_verification_failed": false
+      },
+      "warm": {
+        "instance": "bchoco07",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "1",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "max",
+        "wall": 20.227574624936096,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 1.0000000000002496,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 3,
+        "incumbent_verification_failed": false
+      }
+    },
+    {
+      "instance": "bchoco08",
+      "budget": 20.0,
+      "reference_optimum": null,
+      "base": {
+        "instance": "bchoco08",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "max",
+        "wall": 20.235568542033434,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 1.0000000000005076,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 3,
+        "incumbent_verification_failed": false
+      },
+      "warm": {
+        "instance": "bchoco08",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "1",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "max",
+        "wall": 20.234748249989934,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 1.0000000000005076,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 3,
+        "incumbent_verification_failed": false
+      }
+    },
+    {
+      "instance": "beuster",
+      "budget": 20.0,
+      "reference_optimum": 116329.6706,
+      "base": {
+        "instance": "beuster",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 20.18437987496145,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 6352.061283279526,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 7,
+        "incumbent_verification_failed": false
+      },
+      "warm": {
+        "instance": "beuster",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "1",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 20.18362954200711,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 6352.061283279526,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 7,
+        "incumbent_verification_failed": false
+      }
+    },
+    {
+      "instance": "casctanks",
+      "budget": 20.0,
+      "reference_optimum": 9.163479388,
+      "base": {
+        "instance": "casctanks",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 21.81529195792973,
+        "status": "feasible",
+        "objective": 9.20758227104826,
+        "bound": 1.6806433209385339,
+        "gap": 0.8174718105725709,
+        "gap_certified": false,
+        "node_count": 31,
+        "incumbent_verification_failed": false
+      },
+      "warm": {
+        "instance": "casctanks",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "1",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 20.44418524997309,
+        "status": "feasible",
+        "objective": 9.16347901337332,
+        "bound": 1.6806433209385223,
+        "gap": 0.8165933136873271,
+        "gap_certified": false,
+        "node_count": 17,
+        "incumbent_verification_failed": false
+      }
+    },
+    {
+      "instance": "clay0303hfsg",
+      "budget": 20.0,
+      "reference_optimum": 26669.10957,
+      "base": {
+        "instance": "clay0303hfsg",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 15.76381695899181,
+        "status": "optimal",
+        "objective": 26669.109572842703,
+        "bound": 26669.109551603342,
+        "gap": 0.0,
+        "gap_certified": true,
+        "node_count": 283,
+        "incumbent_verification_failed": false
+      },
+      "warm": {
+        "instance": "clay0303hfsg",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "1",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 15.547048417036422,
+        "status": "optimal",
+        "objective": 26669.109572842703,
+        "bound": 26669.109551603342,
+        "gap": 0.0,
+        "gap_certified": true,
+        "node_count": 283,
+        "incumbent_verification_failed": false
+      }
+    },
+    {
+      "instance": "contvar",
+      "budget": 20.0,
+      "reference_optimum": 809149.8272,
+      "base": {
+        "instance": "contvar",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 20.201239291927777,
+        "status": "feasible",
+        "objective": 809149.8278559904,
+        "bound": 183632.76598205554,
+        "gap": 0.7730546807769477,
+        "gap_certified": false,
+        "node_count": 3,
+        "incumbent_verification_failed": false
+      },
+      "warm": {
+        "instance": "contvar",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "1",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 20.183942707953975,
+        "status": "feasible",
+        "objective": 809149.8278559904,
+        "bound": 183632.76598205554,
+        "gap": 0.7730546807769477,
+        "gap_certified": false,
+        "node_count": 3,
+        "incumbent_verification_failed": false
+      }
+    },
+    {
+      "instance": "hda",
+      "budget": 20.0,
+      "reference_optimum": -5964.534084,
+      "base": {
+        "instance": "hda",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 21.129558833083138,
+        "status": "time_limit",
+        "objective": null,
+        "bound": -20747115955979.49,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 3,
+        "incumbent_verification_failed": false
+      },
+      "warm": {
+        "instance": "hda",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "1",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 20.431279957992956,
+        "status": "time_limit",
+        "objective": null,
+        "bound": -64473.44240151847,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 3,
+        "incumbent_verification_failed": false
+      }
+    },
+    {
+      "instance": "heatexch_gen1",
+      "budget": 20.0,
+      "reference_optimum": 154895.933,
+      "base": {
+        "instance": "heatexch_gen1",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 20.33559983293526,
+        "status": "feasible",
+        "objective": 154895.93297657298,
+        "bound": 46749.99999998356,
+        "gap": 0.6981844577736318,
+        "gap_certified": false,
+        "node_count": 57,
+        "incumbent_verification_failed": false
+      },
+      "warm": {
+        "instance": "heatexch_gen1",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "1",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 20.33601249998901,
+        "status": "feasible",
+        "objective": 154895.93297657298,
+        "bound": 48999.99999999993,
+        "gap": 0.6836585760620916,
+        "gap_certified": false,
+        "node_count": 25,
+        "incumbent_verification_failed": false
+      }
+    },
+    {
+      "instance": "heatexch_gen2",
+      "budget": 20.0,
+      "reference_optimum": 635838.8464,
+      "base": {
+        "instance": "heatexch_gen2",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 20.42560720804613,
+        "status": "feasible",
+        "objective": 835551.3269328446,
+        "bound": 555767.7902853047,
+        "gap": 0.3348490124174345,
+        "gap_certified": false,
+        "node_count": 15,
+        "incumbent_verification_failed": false
+      },
+      "warm": {
+        "instance": "heatexch_gen2",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "1",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 20.268485874985345,
+        "status": "feasible",
+        "objective": 835551.3269328446,
+        "bound": 555767.7902857282,
+        "gap": 0.3348490124169276,
+        "gap_certified": false,
+        "node_count": 11,
+        "incumbent_verification_failed": false
+      }
+    },
+    {
+      "instance": "heatexch_gen3",
+      "budget": 20.0,
+      "reference_optimum": 64843.69761,
+      "base": {
+        "instance": "heatexch_gen3",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 20.202680874965154,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 783.0180646606207,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 3,
+        "incumbent_verification_failed": false
+      },
+      "warm": {
+        "instance": "heatexch_gen3",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "1",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 20.20108370797243,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 783.0180646606207,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 3,
+        "incumbent_verification_failed": false
+      }
+    },
+    {
+      "instance": "nvs05",
+      "budget": 20.0,
+      "reference_optimum": 5.470934108,
+      "base": {
+        "instance": "nvs05",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 20.20430237497203,
+        "status": "feasible",
+        "objective": 5.470934126406966,
+        "bound": 5.466041273513711,
+        "gap": 0.0008943359178168083,
+        "gap_certified": false,
+        "node_count": 163,
+        "incumbent_verification_failed": false
+      },
+      "warm": {
+        "instance": "nvs05",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "1",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 20.193964042002335,
+        "status": "feasible",
+        "objective": 5.470934126406966,
+        "bound": 5.466041273513944,
+        "gap": 0.0008943359177742739,
+        "gap_certified": false,
+        "node_count": 169,
+        "incumbent_verification_failed": false
+      }
+    },
+    {
+      "instance": "syn05hfsg",
+      "budget": 20.0,
+      "reference_optimum": 837.7324009,
+      "base": {
+        "instance": "syn05hfsg",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "max",
+        "wall": 4.945060000056401,
+        "status": "optimal",
+        "objective": 837.7323012718435,
+        "bound": 837.7324008980034,
+        "gap": 2.8091518703525014e-14,
+        "gap_certified": true,
+        "node_count": 277,
+        "incumbent_verification_failed": false
+      },
+      "warm": {
+        "instance": "syn05hfsg",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "1",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "max",
+        "wall": 4.8198857080424204,
+        "status": "optimal",
+        "objective": 837.7323012718435,
+        "bound": 837.7324008980036,
+        "gap": 2.7955810883701214e-14,
+        "gap_certified": true,
+        "node_count": 277,
+        "incumbent_verification_failed": false
+      }
+    },
+    {
+      "instance": "tls2",
+      "budget": 20.0,
+      "reference_optimum": 5.3,
+      "base": {
+        "instance": "tls2",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 10.841347749927081,
+        "status": "optimal",
+        "objective": 5.2999999999875085,
+        "bound": 5.3,
+        "gap": 0.0,
+        "gap_certified": true,
+        "node_count": 255,
+        "incumbent_verification_failed": false
+      },
+      "warm": {
+        "instance": "tls2",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "1",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 10.757859083008952,
+        "status": "optimal",
+        "objective": 5.2999999999875085,
+        "bound": 5.3,
+        "gap": 0.0,
+        "gap_certified": true,
+        "node_count": 255,
+        "incumbent_verification_failed": false
+      }
+    },
+    {
+      "instance": "tspn05",
+      "budget": 20.0,
+      "reference_optimum": 191.2552078,
+      "base": {
+        "instance": "tspn05",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 2.628281750017777,
+        "status": "optimal",
+        "objective": 191.25520784467096,
+        "bound": 191.25507754683355,
+        "gap": 5.988794952955437e-07,
+        "gap_certified": true,
+        "node_count": 39,
+        "incumbent_verification_failed": false
+      },
+      "warm": {
+        "instance": "tspn05",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "1",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 2.7808666670462117,
+        "status": "optimal",
+        "objective": 191.2552078446696,
+        "bound": 191.25507754676113,
+        "gap": 5.98879879591202e-07,
+        "gap_certified": true,
+        "node_count": 43,
+        "incumbent_verification_failed": false
+      }
+    },
+    {
+      "instance": "tspn08",
+      "budget": 20.0,
+      "reference_optimum": 290.5668539,
+      "base": {
+        "instance": "tspn08",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 20.290986165986396,
+        "status": "feasible",
+        "objective": 290.566853967505,
+        "bound": 278.5701969904429,
+        "gap": 0.041287080109982825,
+        "gap_certified": false,
+        "node_count": 107,
+        "incumbent_verification_failed": false
+      },
+      "warm": {
+        "instance": "tspn08",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "1",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 20.258228333084844,
+        "status": "feasible",
+        "objective": 290.5668539675021,
+        "bound": 281.0891401033739,
+        "gap": 0.032618014528209775,
+        "gap_certified": false,
+        "node_count": 139,
+        "incumbent_verification_failed": false
+      }
+    },
+    {
+      "instance": "tspn10",
+      "budget": 20.0,
+      "reference_optimum": 225.1260716,
+      "base": {
+        "instance": "tspn10",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 20.270672917016782,
+        "status": "feasible",
+        "objective": 225.12607170016992,
+        "bound": 168.9656001884391,
+        "gap": 0.24946231721453885,
+        "gap_certified": false,
+        "node_count": 159,
+        "incumbent_verification_failed": false
+      },
+      "warm": {
+        "instance": "tspn10",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "1",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 20.220252249971963,
+        "status": "feasible",
+        "objective": 225.12607170016952,
+        "bound": 168.96558963704825,
+        "gap": 0.24946236408334654,
+        "gap_certified": false,
+        "node_count": 151,
+        "incumbent_verification_failed": false
+      }
+    },
+    {
+      "instance": "tspn12",
+      "budget": 20.0,
+      "reference_optimum": 262.6473957,
+      "base": {
+        "instance": "tspn12",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 20.24640458310023,
+        "status": "feasible",
+        "objective": 262.647395796328,
+        "bound": 202.18053097230293,
+        "gap": 0.23022069052195962,
+        "gap_certified": false,
+        "node_count": 127,
+        "incumbent_verification_failed": false
+      },
+      "warm": {
+        "instance": "tspn12",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "1",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 20.254504875047132,
+        "status": "feasible",
+        "objective": 262.647395796328,
+        "bound": 202.18055401644563,
+        "gap": 0.2302206027840149,
+        "gap_certified": false,
+        "node_count": 127,
+        "incumbent_verification_failed": false
+      }
+    }
+  ]
+}

--- a/discopt_benchmarks/results/issue928_warmalone20_rep2.json
+++ b/discopt_benchmarks/results/issue928_warmalone20_rep2.json
@@ -1,0 +1,848 @@
+{
+  "summary": {
+    "instances": 19,
+    "budget": 20.0,
+    "arms": {
+      "base": "all OFF (today's default)",
+      "warm": "#928 ON alone"
+    },
+    "unsound": [],
+    "incumbent_verification_failed": [],
+    "oracle_comparisons_executed": 32,
+    "instances_without_oracle": [
+      "bchoco06",
+      "bchoco07",
+      "bchoco08"
+    ],
+    "pairs": [
+      {
+        "pair": "warm vs base",
+        "cells_over_budget": {
+          "base": 1,
+          "warm": 0
+        },
+        "total_overrun_s": {
+          "base": 4.8,
+          "warm": 3.8
+        },
+        "overrun_delta_s": -1.0,
+        "node_count_total": {
+          "base": 1541,
+          "warm": 1569
+        },
+        "cert_gains": [],
+        "cert_regressions": [],
+        "gained_incumbents": [],
+        "lost_incumbents": [],
+        "better_objective": [
+          "casctanks (9.207582265486156 -> 9.163479010331347)"
+        ],
+        "worse_objective": [],
+        "tighter_bound": [
+          "hda (-20747115955979.49 -> -64473.44240151848)",
+          "heatexch_gen1 (44196.42857140819 -> 48999.99999999993)"
+        ],
+        "looser_bound": [
+          "tspn08 (278.5701969904429 -> 276.2585236830198)",
+          "tspn10 (168.9656001884391 -> 168.96558963704825)",
+          "tspn12 (202.41813650145474 -> 201.92648471446324)"
+        ],
+        "gained_bound": [],
+        "lost_bound": []
+      }
+    ],
+    "solu_oracle": "solu",
+    "panel_wall_s": 684.0,
+    "loadavg_start": [
+      4.99,
+      4.91,
+      4.5
+    ],
+    "loadavg_end": [
+      4.86,
+      4.75,
+      4.53
+    ]
+  },
+  "cells": [
+    {
+      "instance": "4stufen",
+      "budget": 20.0,
+      "reference_optimum": 116329.6706,
+      "base": {
+        "instance": "4stufen",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 20.19382420904003,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 21474.569205865446,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 15,
+        "incumbent_verification_failed": false
+      },
+      "warm": {
+        "instance": "4stufen",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "1",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 20.41264274995774,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 21474.569205865446,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 31,
+        "incumbent_verification_failed": false
+      }
+    },
+    {
+      "instance": "bchoco06",
+      "budget": 20.0,
+      "reference_optimum": null,
+      "base": {
+        "instance": "bchoco06",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "max",
+        "wall": 20.132872459013015,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 1.000000044867369,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 3,
+        "incumbent_verification_failed": false
+      },
+      "warm": {
+        "instance": "bchoco06",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "1",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "max",
+        "wall": 20.138932041008957,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 1.000000044867369,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 3,
+        "incumbent_verification_failed": false
+      }
+    },
+    {
+      "instance": "bchoco07",
+      "budget": 20.0,
+      "reference_optimum": null,
+      "base": {
+        "instance": "bchoco07",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "max",
+        "wall": 20.24040862498805,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 1.0000000000002496,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 3,
+        "incumbent_verification_failed": false
+      },
+      "warm": {
+        "instance": "bchoco07",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "1",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "max",
+        "wall": 20.232541333069094,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 1.0000000000002496,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 3,
+        "incumbent_verification_failed": false
+      }
+    },
+    {
+      "instance": "bchoco08",
+      "budget": 20.0,
+      "reference_optimum": null,
+      "base": {
+        "instance": "bchoco08",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "max",
+        "wall": 20.235032917000353,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 1.0000000000005076,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 3,
+        "incumbent_verification_failed": false
+      },
+      "warm": {
+        "instance": "bchoco08",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "1",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "max",
+        "wall": 20.24460249999538,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 1.0000000000005076,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 3,
+        "incumbent_verification_failed": false
+      }
+    },
+    {
+      "instance": "beuster",
+      "budget": 20.0,
+      "reference_optimum": 116329.6706,
+      "base": {
+        "instance": "beuster",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 20.191956957918592,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 6352.061283279526,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 7,
+        "incumbent_verification_failed": false
+      },
+      "warm": {
+        "instance": "beuster",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "1",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 20.185572209069505,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 6352.061283279526,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 7,
+        "incumbent_verification_failed": false
+      }
+    },
+    {
+      "instance": "casctanks",
+      "budget": 20.0,
+      "reference_optimum": 9.163479388,
+      "base": {
+        "instance": "casctanks",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 20.203073624987155,
+        "status": "feasible",
+        "objective": 9.207582265486156,
+        "bound": 1.6806433209385339,
+        "gap": 0.8174718104623095,
+        "gap_certified": false,
+        "node_count": 15,
+        "incumbent_verification_failed": false
+      },
+      "warm": {
+        "instance": "casctanks",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "1",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 20.273706084000878,
+        "status": "feasible",
+        "objective": 9.163479010331347,
+        "bound": 1.6806433209385223,
+        "gap": 0.8165933136264422,
+        "gap_certified": false,
+        "node_count": 17,
+        "incumbent_verification_failed": false
+      }
+    },
+    {
+      "instance": "clay0303hfsg",
+      "budget": 20.0,
+      "reference_optimum": 26669.10957,
+      "base": {
+        "instance": "clay0303hfsg",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 15.712495833053254,
+        "status": "optimal",
+        "objective": 26669.109572842703,
+        "bound": 26669.109551603342,
+        "gap": 0.0,
+        "gap_certified": true,
+        "node_count": 283,
+        "incumbent_verification_failed": false
+      },
+      "warm": {
+        "instance": "clay0303hfsg",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "1",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 15.56388541602064,
+        "status": "optimal",
+        "objective": 26669.109572842703,
+        "bound": 26669.109551603342,
+        "gap": 0.0,
+        "gap_certified": true,
+        "node_count": 283,
+        "incumbent_verification_failed": false
+      }
+    },
+    {
+      "instance": "contvar",
+      "budget": 20.0,
+      "reference_optimum": 809149.8272,
+      "base": {
+        "instance": "contvar",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 20.212430500076152,
+        "status": "feasible",
+        "objective": 809149.8278559904,
+        "bound": 183632.76598205554,
+        "gap": 0.7730546807769477,
+        "gap_certified": false,
+        "node_count": 3,
+        "incumbent_verification_failed": false
+      },
+      "warm": {
+        "instance": "contvar",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "1",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 20.196561457938515,
+        "status": "feasible",
+        "objective": 809149.8278559904,
+        "bound": 183632.76598205554,
+        "gap": 0.7730546807769477,
+        "gap_certified": false,
+        "node_count": 3,
+        "incumbent_verification_failed": false
+      }
+    },
+    {
+      "instance": "hda",
+      "budget": 20.0,
+      "reference_optimum": -5964.534084,
+      "base": {
+        "instance": "hda",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 21.239531666971743,
+        "status": "time_limit",
+        "objective": null,
+        "bound": -20747115955979.49,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 3,
+        "incumbent_verification_failed": false
+      },
+      "warm": {
+        "instance": "hda",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "1",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 20.31530791707337,
+        "status": "time_limit",
+        "objective": null,
+        "bound": -64473.44240151848,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 3,
+        "incumbent_verification_failed": false
+      }
+    },
+    {
+      "instance": "heatexch_gen1",
+      "budget": 20.0,
+      "reference_optimum": 154895.933,
+      "base": {
+        "instance": "heatexch_gen1",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 20.466916500008665,
+        "status": "feasible",
+        "objective": 154895.93297657298,
+        "bound": 44196.42857140819,
+        "gap": 0.7146701806683806,
+        "gap_certified": false,
+        "node_count": 61,
+        "incumbent_verification_failed": false
+      },
+      "warm": {
+        "instance": "heatexch_gen1",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "1",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 20.341669208020903,
+        "status": "feasible",
+        "objective": 154895.93297657298,
+        "bound": 48999.99999999993,
+        "gap": 0.6836585760620916,
+        "gap_certified": false,
+        "node_count": 25,
+        "incumbent_verification_failed": false
+      }
+    },
+    {
+      "instance": "heatexch_gen2",
+      "budget": 20.0,
+      "reference_optimum": 635838.8464,
+      "base": {
+        "instance": "heatexch_gen2",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 20.448604333098046,
+        "status": "feasible",
+        "objective": 835551.3269328446,
+        "bound": 555767.7902853047,
+        "gap": 0.3348490124174345,
+        "gap_certified": false,
+        "node_count": 15,
+        "incumbent_verification_failed": false
+      },
+      "warm": {
+        "instance": "heatexch_gen2",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "1",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 20.276429624995217,
+        "status": "feasible",
+        "objective": 835551.3269328446,
+        "bound": 555767.7902857282,
+        "gap": 0.3348490124169276,
+        "gap_certified": false,
+        "node_count": 13,
+        "incumbent_verification_failed": false
+      }
+    },
+    {
+      "instance": "heatexch_gen3",
+      "budget": 20.0,
+      "reference_optimum": 64843.69761,
+      "base": {
+        "instance": "heatexch_gen3",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 20.15702474990394,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 783.0180646606207,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 3,
+        "incumbent_verification_failed": false
+      },
+      "warm": {
+        "instance": "heatexch_gen3",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "1",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 20.19575170893222,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 783.0180646606207,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 3,
+        "incumbent_verification_failed": false
+      }
+    },
+    {
+      "instance": "nvs05",
+      "budget": 20.0,
+      "reference_optimum": 5.470934108,
+      "base": {
+        "instance": "nvs05",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 20.18967191700358,
+        "status": "feasible",
+        "objective": 5.470934126406966,
+        "bound": 5.466041273513711,
+        "gap": 0.0008943359178168083,
+        "gap_certified": false,
+        "node_count": 163,
+        "incumbent_verification_failed": false
+      },
+      "warm": {
+        "instance": "nvs05",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "1",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 20.187262624967843,
+        "status": "feasible",
+        "objective": 5.470934126406966,
+        "bound": 5.466041273513944,
+        "gap": 0.0008943359177742739,
+        "gap_certified": false,
+        "node_count": 179,
+        "incumbent_verification_failed": false
+      }
+    },
+    {
+      "instance": "syn05hfsg",
+      "budget": 20.0,
+      "reference_optimum": 837.7324009,
+      "base": {
+        "instance": "syn05hfsg",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "max",
+        "wall": 5.115969458012842,
+        "status": "optimal",
+        "objective": 837.7323012718435,
+        "bound": 837.7324008980034,
+        "gap": 2.8091518703525014e-14,
+        "gap_certified": true,
+        "node_count": 277,
+        "incumbent_verification_failed": false
+      },
+      "warm": {
+        "instance": "syn05hfsg",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "1",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "max",
+        "wall": 4.919514958048239,
+        "status": "optimal",
+        "objective": 837.7323012718435,
+        "bound": 837.7324008980036,
+        "gap": 2.7955810883701214e-14,
+        "gap_certified": true,
+        "node_count": 277,
+        "incumbent_verification_failed": false
+      }
+    },
+    {
+      "instance": "tls2",
+      "budget": 20.0,
+      "reference_optimum": 5.3,
+      "base": {
+        "instance": "tls2",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 10.708645874983631,
+        "status": "optimal",
+        "objective": 5.2999999999875085,
+        "bound": 5.3,
+        "gap": 0.0,
+        "gap_certified": true,
+        "node_count": 255,
+        "incumbent_verification_failed": false
+      },
+      "warm": {
+        "instance": "tls2",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "1",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 10.751458791084588,
+        "status": "optimal",
+        "objective": 5.2999999999875085,
+        "bound": 5.3,
+        "gap": 0.0,
+        "gap_certified": true,
+        "node_count": 255,
+        "incumbent_verification_failed": false
+      }
+    },
+    {
+      "instance": "tspn05",
+      "budget": 20.0,
+      "reference_optimum": 191.2552078,
+      "base": {
+        "instance": "tspn05",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 2.5389541670447215,
+        "status": "optimal",
+        "objective": 191.25520784467096,
+        "bound": 191.25507754683355,
+        "gap": 5.988794952955437e-07,
+        "gap_certified": true,
+        "node_count": 39,
+        "incumbent_verification_failed": false
+      },
+      "warm": {
+        "instance": "tspn05",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "1",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 2.797353583970107,
+        "status": "optimal",
+        "objective": 191.2552078446696,
+        "bound": 191.25507754676113,
+        "gap": 5.98879879591202e-07,
+        "gap_certified": true,
+        "node_count": 43,
+        "incumbent_verification_failed": false
+      }
+    },
+    {
+      "instance": "tspn08",
+      "budget": 20.0,
+      "reference_optimum": 290.5668539,
+      "base": {
+        "instance": "tspn08",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 20.294551458093338,
+        "status": "feasible",
+        "objective": 290.566853967505,
+        "bound": 278.5701969904429,
+        "gap": 0.041287080109982825,
+        "gap_certified": false,
+        "node_count": 107,
+        "incumbent_verification_failed": false
+      },
+      "warm": {
+        "instance": "tspn08",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "1",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 20.273448250023648,
+        "status": "feasible",
+        "objective": 290.5668539675021,
+        "bound": 276.2585236830198,
+        "gap": 0.04924281654673031,
+        "gap_certified": false,
+        "node_count": 143,
+        "incumbent_verification_failed": false
+      }
+    },
+    {
+      "instance": "tspn10",
+      "budget": 20.0,
+      "reference_optimum": 225.1260716,
+      "base": {
+        "instance": "tspn10",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 20.24793258390855,
+        "status": "feasible",
+        "objective": 225.12607170016992,
+        "bound": 168.9656001884391,
+        "gap": 0.24946231721453885,
+        "gap_certified": false,
+        "node_count": 159,
+        "incumbent_verification_failed": false
+      },
+      "warm": {
+        "instance": "tspn10",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "1",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 20.23251179093495,
+        "status": "feasible",
+        "objective": 225.12607170016952,
+        "bound": 168.96558963704825,
+        "gap": 0.24946236408334654,
+        "gap_certified": false,
+        "node_count": 151,
+        "incumbent_verification_failed": false
+      }
+    },
+    {
+      "instance": "tspn12",
+      "budget": 20.0,
+      "reference_optimum": 262.6473957,
+      "base": {
+        "instance": "tspn12",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 20.314742582966574,
+        "status": "feasible",
+        "objective": 262.647395796328,
+        "bound": 202.41813650145474,
+        "gap": 0.22931603457274907,
+        "gap_certified": false,
+        "node_count": 127,
+        "incumbent_verification_failed": false
+      },
+      "warm": {
+        "instance": "tspn12",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "1",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 20.243772875051945,
+        "status": "feasible",
+        "objective": 262.647395796328,
+        "bound": 201.92648471446324,
+        "gap": 0.2311879426702988,
+        "gap_certified": false,
+        "node_count": 127,
+        "incumbent_verification_failed": false
+      }
+    }
+  ]
+}

--- a/discopt_benchmarks/results/issue928_warmalone20_rep3.json
+++ b/discopt_benchmarks/results/issue928_warmalone20_rep3.json
@@ -1,0 +1,849 @@
+{
+  "summary": {
+    "instances": 19,
+    "budget": 20.0,
+    "arms": {
+      "base": "all OFF (today's default)",
+      "warm": "#928 ON alone"
+    },
+    "unsound": [],
+    "incumbent_verification_failed": [],
+    "oracle_comparisons_executed": 32,
+    "instances_without_oracle": [
+      "bchoco06",
+      "bchoco07",
+      "bchoco08"
+    ],
+    "pairs": [
+      {
+        "pair": "warm vs base",
+        "cells_over_budget": {
+          "base": 0,
+          "warm": 0
+        },
+        "total_overrun_s": {
+          "base": 4.0,
+          "warm": 3.7
+        },
+        "overrun_delta_s": -0.3,
+        "node_count_total": {
+          "base": 1553,
+          "warm": 1505
+        },
+        "cert_gains": [],
+        "cert_regressions": [],
+        "gained_incumbents": [],
+        "lost_incumbents": [],
+        "better_objective": [
+          "casctanks (9.20758227104826 -> 9.163479010331347)"
+        ],
+        "worse_objective": [],
+        "tighter_bound": [
+          "hda (-20747115955979.49 -> -64473.44240151848)",
+          "heatexch_gen1 (46749.99999998356 -> 48999.99999999993)"
+        ],
+        "looser_bound": [
+          "nvs05 (5.466041273513711 -> 5.454588582188421)",
+          "tspn08 (278.5701969904429 -> 276.2585236830198)",
+          "tspn10 (168.9656001884391 -> 168.96558963704825)",
+          "tspn12 (202.18053097230293 -> 201.71674973588597)"
+        ],
+        "gained_bound": [],
+        "lost_bound": []
+      }
+    ],
+    "solu_oracle": "solu",
+    "panel_wall_s": 683.9,
+    "loadavg_start": [
+      4.86,
+      4.75,
+      4.53
+    ],
+    "loadavg_end": [
+      6.48,
+      5.18,
+      4.8
+    ]
+  },
+  "cells": [
+    {
+      "instance": "4stufen",
+      "budget": 20.0,
+      "reference_optimum": 116329.6706,
+      "base": {
+        "instance": "4stufen",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 20.41309604095295,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 21474.569205865446,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 31,
+        "incumbent_verification_failed": false
+      },
+      "warm": {
+        "instance": "4stufen",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "1",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 20.236509875045158,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 21474.569205865446,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 15,
+        "incumbent_verification_failed": false
+      }
+    },
+    {
+      "instance": "bchoco06",
+      "budget": 20.0,
+      "reference_optimum": null,
+      "base": {
+        "instance": "bchoco06",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "max",
+        "wall": 20.12512895895634,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 1.000000044867369,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 3,
+        "incumbent_verification_failed": false
+      },
+      "warm": {
+        "instance": "bchoco06",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "1",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "max",
+        "wall": 20.15499424992595,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 1.000000044867369,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 3,
+        "incumbent_verification_failed": false
+      }
+    },
+    {
+      "instance": "bchoco07",
+      "budget": 20.0,
+      "reference_optimum": null,
+      "base": {
+        "instance": "bchoco07",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "max",
+        "wall": 20.228089957963675,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 1.0000000000002496,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 3,
+        "incumbent_verification_failed": false
+      },
+      "warm": {
+        "instance": "bchoco07",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "1",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "max",
+        "wall": 20.240248250076547,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 1.0000000000002496,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 3,
+        "incumbent_verification_failed": false
+      }
+    },
+    {
+      "instance": "bchoco08",
+      "budget": 20.0,
+      "reference_optimum": null,
+      "base": {
+        "instance": "bchoco08",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "max",
+        "wall": 20.230817083036527,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 1.0000000000005076,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 3,
+        "incumbent_verification_failed": false
+      },
+      "warm": {
+        "instance": "bchoco08",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "1",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "max",
+        "wall": 20.235117624979466,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 1.0000000000005076,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 3,
+        "incumbent_verification_failed": false
+      }
+    },
+    {
+      "instance": "beuster",
+      "budget": 20.0,
+      "reference_optimum": 116329.6706,
+      "base": {
+        "instance": "beuster",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 20.19525808398612,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 6352.061283279526,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 7,
+        "incumbent_verification_failed": false
+      },
+      "warm": {
+        "instance": "beuster",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "1",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 20.198579999967478,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 6352.061283279526,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 7,
+        "incumbent_verification_failed": false
+      }
+    },
+    {
+      "instance": "casctanks",
+      "budget": 20.0,
+      "reference_optimum": 9.163479388,
+      "base": {
+        "instance": "casctanks",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 20.34983870794531,
+        "status": "feasible",
+        "objective": 9.20758227104826,
+        "bound": 1.6806433209385339,
+        "gap": 0.8174718105725709,
+        "gap_certified": false,
+        "node_count": 15,
+        "incumbent_verification_failed": false
+      },
+      "warm": {
+        "instance": "casctanks",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "1",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 20.222321334062144,
+        "status": "feasible",
+        "objective": 9.163479010331347,
+        "bound": 1.6806433209385223,
+        "gap": 0.8165933136264422,
+        "gap_certified": false,
+        "node_count": 17,
+        "incumbent_verification_failed": false
+      }
+    },
+    {
+      "instance": "clay0303hfsg",
+      "budget": 20.0,
+      "reference_optimum": 26669.10957,
+      "base": {
+        "instance": "clay0303hfsg",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 15.665444207959808,
+        "status": "optimal",
+        "objective": 26669.109572842703,
+        "bound": 26669.109551603342,
+        "gap": 0.0,
+        "gap_certified": true,
+        "node_count": 283,
+        "incumbent_verification_failed": false
+      },
+      "warm": {
+        "instance": "clay0303hfsg",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "1",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 15.835340959019959,
+        "status": "optimal",
+        "objective": 26669.109572842703,
+        "bound": 26669.109551603342,
+        "gap": 0.0,
+        "gap_certified": true,
+        "node_count": 283,
+        "incumbent_verification_failed": false
+      }
+    },
+    {
+      "instance": "contvar",
+      "budget": 20.0,
+      "reference_optimum": 809149.8272,
+      "base": {
+        "instance": "contvar",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 20.21469375002198,
+        "status": "feasible",
+        "objective": 809149.8278559904,
+        "bound": 183632.76598205554,
+        "gap": 0.7730546807769477,
+        "gap_certified": false,
+        "node_count": 3,
+        "incumbent_verification_failed": false
+      },
+      "warm": {
+        "instance": "contvar",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "1",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 20.21889099990949,
+        "status": "feasible",
+        "objective": 809149.8278559904,
+        "bound": 183632.76598205554,
+        "gap": 0.7730546807769477,
+        "gap_certified": false,
+        "node_count": 3,
+        "incumbent_verification_failed": false
+      }
+    },
+    {
+      "instance": "hda",
+      "budget": 20.0,
+      "reference_optimum": -5964.534084,
+      "base": {
+        "instance": "hda",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 20.326333125005476,
+        "status": "time_limit",
+        "objective": null,
+        "bound": -20747115955979.49,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 3,
+        "incumbent_verification_failed": false
+      },
+      "warm": {
+        "instance": "hda",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "1",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 20.378477332997136,
+        "status": "time_limit",
+        "objective": null,
+        "bound": -64473.44240151848,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 3,
+        "incumbent_verification_failed": false
+      }
+    },
+    {
+      "instance": "heatexch_gen1",
+      "budget": 20.0,
+      "reference_optimum": 154895.933,
+      "base": {
+        "instance": "heatexch_gen1",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 20.354683959041722,
+        "status": "feasible",
+        "objective": 154895.93297657298,
+        "bound": 46749.99999998356,
+        "gap": 0.6981844577736318,
+        "gap_certified": false,
+        "node_count": 59,
+        "incumbent_verification_failed": false
+      },
+      "warm": {
+        "instance": "heatexch_gen1",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "1",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 20.339004584006034,
+        "status": "feasible",
+        "objective": 154895.93297657298,
+        "bound": 48999.99999999993,
+        "gap": 0.6836585760620916,
+        "gap_certified": false,
+        "node_count": 25,
+        "incumbent_verification_failed": false
+      }
+    },
+    {
+      "instance": "heatexch_gen2",
+      "budget": 20.0,
+      "reference_optimum": 635838.8464,
+      "base": {
+        "instance": "heatexch_gen2",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 20.462868791888468,
+        "status": "feasible",
+        "objective": 835551.3269328446,
+        "bound": 555767.7902853047,
+        "gap": 0.3348490124174345,
+        "gap_certified": false,
+        "node_count": 15,
+        "incumbent_verification_failed": false
+      },
+      "warm": {
+        "instance": "heatexch_gen2",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "1",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 20.206860666978173,
+        "status": "feasible",
+        "objective": 835551.3269328446,
+        "bound": 555767.7902857282,
+        "gap": 0.3348490124169276,
+        "gap_certified": false,
+        "node_count": 15,
+        "incumbent_verification_failed": false
+      }
+    },
+    {
+      "instance": "heatexch_gen3",
+      "budget": 20.0,
+      "reference_optimum": 64843.69761,
+      "base": {
+        "instance": "heatexch_gen3",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 20.15465912502259,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 783.0180646606207,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 3,
+        "incumbent_verification_failed": false
+      },
+      "warm": {
+        "instance": "heatexch_gen3",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "1",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 20.15711970801931,
+        "status": "time_limit",
+        "objective": null,
+        "bound": 783.0180646606207,
+        "gap": null,
+        "gap_certified": false,
+        "node_count": 3,
+        "incumbent_verification_failed": false
+      }
+    },
+    {
+      "instance": "nvs05",
+      "budget": 20.0,
+      "reference_optimum": 5.470934108,
+      "base": {
+        "instance": "nvs05",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 20.155955708003603,
+        "status": "feasible",
+        "objective": 5.470934126406966,
+        "bound": 5.466041273513711,
+        "gap": 0.0008943359178168083,
+        "gap_certified": false,
+        "node_count": 163,
+        "incumbent_verification_failed": false
+      },
+      "warm": {
+        "instance": "nvs05",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "1",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 20.15381445805542,
+        "status": "feasible",
+        "objective": 5.470934126406966,
+        "bound": 5.454588582188421,
+        "gap": 0.0029877062748112633,
+        "gap_certified": false,
+        "node_count": 161,
+        "incumbent_verification_failed": false
+      }
+    },
+    {
+      "instance": "syn05hfsg",
+      "budget": 20.0,
+      "reference_optimum": 837.7324009,
+      "base": {
+        "instance": "syn05hfsg",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "max",
+        "wall": 5.1110345830675215,
+        "status": "optimal",
+        "objective": 837.7323012718435,
+        "bound": 837.7324008980034,
+        "gap": 2.8091518703525014e-14,
+        "gap_certified": true,
+        "node_count": 277,
+        "incumbent_verification_failed": false
+      },
+      "warm": {
+        "instance": "syn05hfsg",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "1",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "max",
+        "wall": 5.0184367910260335,
+        "status": "optimal",
+        "objective": 837.7323012718435,
+        "bound": 837.7324008980036,
+        "gap": 2.7955810883701214e-14,
+        "gap_certified": true,
+        "node_count": 277,
+        "incumbent_verification_failed": false
+      }
+    },
+    {
+      "instance": "tls2",
+      "budget": 20.0,
+      "reference_optimum": 5.3,
+      "base": {
+        "instance": "tls2",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 10.83418237499427,
+        "status": "optimal",
+        "objective": 5.2999999999875085,
+        "bound": 5.3,
+        "gap": 0.0,
+        "gap_certified": true,
+        "node_count": 255,
+        "incumbent_verification_failed": false
+      },
+      "warm": {
+        "instance": "tls2",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "1",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 11.002255375031382,
+        "status": "optimal",
+        "objective": 5.2999999999875085,
+        "bound": 5.3,
+        "gap": 0.0,
+        "gap_certified": true,
+        "node_count": 255,
+        "incumbent_verification_failed": false
+      }
+    },
+    {
+      "instance": "tspn05",
+      "budget": 20.0,
+      "reference_optimum": 191.2552078,
+      "base": {
+        "instance": "tspn05",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 2.691733167041093,
+        "status": "optimal",
+        "objective": 191.25520784467096,
+        "bound": 191.25507754683355,
+        "gap": 5.988794952955437e-07,
+        "gap_certified": true,
+        "node_count": 39,
+        "incumbent_verification_failed": false
+      },
+      "warm": {
+        "instance": "tspn05",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "1",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 2.820915958029218,
+        "status": "optimal",
+        "objective": 191.2552078446696,
+        "bound": 191.25507754676113,
+        "gap": 5.98879879591202e-07,
+        "gap_certified": true,
+        "node_count": 43,
+        "incumbent_verification_failed": false
+      }
+    },
+    {
+      "instance": "tspn08",
+      "budget": 20.0,
+      "reference_optimum": 290.5668539,
+      "base": {
+        "instance": "tspn08",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 20.191732249921188,
+        "status": "feasible",
+        "objective": 290.566853967505,
+        "bound": 278.5701969904429,
+        "gap": 0.041287080109982825,
+        "gap_certified": false,
+        "node_count": 109,
+        "incumbent_verification_failed": false
+      },
+      "warm": {
+        "instance": "tspn08",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "1",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 20.23326133308001,
+        "status": "feasible",
+        "objective": 290.5668539675021,
+        "bound": 276.2585236830198,
+        "gap": 0.04924281654673031,
+        "gap_certified": false,
+        "node_count": 111,
+        "incumbent_verification_failed": false
+      }
+    },
+    {
+      "instance": "tspn10",
+      "budget": 20.0,
+      "reference_optimum": 225.1260716,
+      "base": {
+        "instance": "tspn10",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 20.254188082995825,
+        "status": "feasible",
+        "objective": 225.12607170016992,
+        "bound": 168.9656001884391,
+        "gap": 0.24946231721453885,
+        "gap_certified": false,
+        "node_count": 155,
+        "incumbent_verification_failed": false
+      },
+      "warm": {
+        "instance": "tspn10",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "1",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 20.28383962495718,
+        "status": "feasible",
+        "objective": 225.12607170016952,
+        "bound": 168.96558963704825,
+        "gap": 0.24946236408334654,
+        "gap_certified": false,
+        "node_count": 151,
+        "incumbent_verification_failed": false
+      }
+    },
+    {
+      "instance": "tspn12",
+      "budget": 20.0,
+      "reference_optimum": 262.6473957,
+      "base": {
+        "instance": "tspn12",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "0",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 20.315001250011846,
+        "status": "feasible",
+        "objective": 262.647395796328,
+        "bound": 202.18053097230293,
+        "gap": 0.23022069052195962,
+        "gap_certified": false,
+        "node_count": 127,
+        "incumbent_verification_failed": false
+      },
+      "warm": {
+        "instance": "tspn12",
+        "flags": {
+          "DISCOPT_LP_WARM_DEADLINE": "1",
+          "DISCOPT_NODE_ROUND_BUDGET": "0",
+          "DISCOPT_HESS_COMPILE_GATE": "0"
+        },
+        "budget": 20.0,
+        "sense": "min",
+        "wall": 20.391077124979347,
+        "status": "feasible",
+        "objective": 262.647395796328,
+        "bound": 201.71674973588597,
+        "gap": 0.2319864846773169,
+        "gap_certified": false,
+        "node_count": 127,
+        "incumbent_verification_failed": false
+      }
+    }
+  ]
+}

--- a/discopt_benchmarks/scripts/issue928_rate_score.py
+++ b/discopt_benchmarks/scripts/issue928_rate_score.py
@@ -1,0 +1,201 @@
+"""Score a multi-rep #928 panel by PER-CELL RATE instead of per-rep one-shot.
+
+Why this exists. The §5 bar-1 failures that kept ``DISCOPT_LP_WARM_DEADLINE``
+default-OFF across four panels were, on inspection, cells that *neither* arm
+holds reliably: nvs05, tls2, syn05hfsg and casctanks each certify (or find an
+incumbent) in some reps and not others, in the base arm as much as in the
+candidate. One-shot scoring turns such a cell into a ``cert_regression`` whenever
+the coin lands base-heads/candidate-tails, and into a ``cert_gain`` the other way
+-- the metric cannot distinguish a flag effect from a race. Two panels recorded
+one direction, a repeat probe recorded the other (tls2: base 1/5 vs warm 4/5).
+
+So: run N reps and compare RATES. A regression must clear a pre-registered
+margin to count. The margin is stated in ``--margin`` (default 3 of 5) and is
+fixed before the run, not chosen after seeing the results.
+
+What is NOT rate-scored, because soundness has no slack (CLAUDE.md §1): a bound
+past the oracle ceiling, a bound crossing the arm's own incumbent, or an
+incumbent that failed verification. One occurrence in one rep disqualifies.
+
+Ends with the executed comparison count and exits non-zero if it compared
+nothing (§6): "no regressions" over zero comparisons is not a result.
+
+    python -u discopt_benchmarks/scripts/issue928_rate_score.py \
+        --control base --candidate warm \
+        discopt_benchmarks/results/issue928_warmalone20_rep*.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+from pathlib import Path
+
+
+def _mean_sd(xs: list[float]) -> tuple[float, float]:
+    if not xs:
+        return (float("nan"), float("nan"))
+    m = sum(xs) / len(xs)
+    if len(xs) < 2:
+        return (m, 0.0)
+    var = sum((x - m) ** 2 for x in xs) / (len(xs) - 1)
+    return (m, math.sqrt(var))
+
+
+def _tighter(sense: str, a: float, b: float) -> bool:
+    """Is bound ``b`` tighter than bound ``a`` for this sense?"""
+    return (b > a) if sense == "min" else (b < a)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("artifacts", nargs="+")
+    ap.add_argument("--control", default="base")
+    ap.add_argument("--candidate", default="warm")
+    ap.add_argument(
+        "--margin",
+        type=int,
+        default=3,
+        help="reps by which the control must beat the candidate on a cell before it "
+        "counts as a regression. Pre-registered; do not tune after seeing results.",
+    )
+    args = ap.parse_args()
+    ctrl, cand = args.control, args.candidate
+
+    runs = [json.loads(Path(p).read_text()) for p in sorted(args.artifacts)]
+    n_reps = len(runs)
+
+    # --- hard soundness, any single rep disqualifies -------------------------
+    unsound: list[str] = []
+    verif_failed: list[str] = []
+    oracle_cmps = 0
+    for i, r in enumerate(runs, 1):
+        s = r["summary"]
+        unsound += [f"rep{i}:{x}" for x in s.get("unsound", [])]
+        verif_failed += [f"rep{i}:{x}" for x in s.get("incumbent_verification_failed", [])]
+        oracle_cmps += s.get("oracle_comparisons_executed") or 0
+
+    # --- per-cell tallies ----------------------------------------------------
+    names = [c["instance"] for c in runs[0]["cells"]]
+    tally: dict[str, dict] = {
+        n: {
+            "cert": {ctrl: 0, cand: 0},
+            "incumbent": {ctrl: 0, cand: 0},
+            "bound": {ctrl: 0, cand: 0},
+            "tighter": 0,
+            "looser": 0,
+            "reps": 0,
+        }
+        for n in names
+    }
+    cells_compared = 0
+    for r in runs:
+        for c in r["cells"]:
+            n = c["instance"]
+            if n not in tally:  # an artifact with a different instance set
+                raise SystemExit(f"artifact instance sets differ: {n} not in rep 1")
+            a, b = c[ctrl], c[cand]
+            t = tally[n]
+            t["reps"] += 1
+            cells_compared += 1
+            for key, rec in ((ctrl, a), (cand, b)):
+                t["cert"][key] += int(bool(rec["gap_certified"]))
+                t["incumbent"][key] += int(rec["objective"] is not None)
+                t["bound"][key] += int(rec["bound"] is not None)
+            if a["bound"] is not None and b["bound"] is not None:
+                rel = abs(b["bound"] - a["bound"]) / max(1.0, abs(a["bound"]))
+                if rel > 1e-9:
+                    if _tighter(a["sense"], a["bound"], b["bound"]):
+                        t["tighter"] += 1
+                    else:
+                        t["looser"] += 1
+
+    def _regressions(field: str) -> list[str]:
+        out = []
+        for n, t in tally.items():
+            d = t[field][ctrl] - t[field][cand]
+            if d >= args.margin:
+                out.append(f"{n} ({t[field][ctrl]}/{t['reps']} -> {t[field][cand]}/{t['reps']})")
+        return out
+
+    def _gains(field: str) -> list[str]:
+        out = []
+        for n, t in tally.items():
+            d = t[field][cand] - t[field][ctrl]
+            if d >= args.margin:
+                out.append(f"{n} ({t[field][ctrl]}/{t['reps']} -> {t[field][cand]}/{t['reps']})")
+        return out
+
+    def _noise(field: str) -> list[str]:
+        out = []
+        for n, t in tally.items():
+            d = abs(t[field][ctrl] - t[field][cand])
+            if 0 < d < args.margin:
+                out.append(f"{n} ({t[field][ctrl]}/{t['reps']} vs {t[field][cand]}/{t['reps']})")
+        return out
+
+    cert_reg, inc_reg, bound_reg = (_regressions(f) for f in ("cert", "incumbent", "bound"))
+    cert_gain, inc_gain, bound_gain = (_gains(f) for f in ("cert", "incumbent", "bound"))
+
+    # --- bar 2 axes ----------------------------------------------------------
+    deltas, over_ctrl, over_cand = [], [], []
+    nodes = {ctrl: 0, cand: 0}
+    for r in runs:
+        pair = next(p for p in r["summary"]["pairs"] if p["pair"] == f"{cand} vs {ctrl}")
+        deltas.append(pair["overrun_delta_s"])
+        over_ctrl.append(pair["total_overrun_s"][ctrl])
+        over_cand.append(pair["total_overrun_s"][cand])
+        nodes[ctrl] += pair["node_count_total"][ctrl]
+        nodes[cand] += pair["node_count_total"][cand]
+    d_mean, d_sd = _mean_sd(deltas)
+
+    tighter_cells = [n for n, t in tally.items() if t["tighter"] >= args.margin]
+    looser_cells = [n for n, t in tally.items() if t["looser"] >= args.margin]
+
+    bar1 = not (unsound or verif_failed or cert_reg or inc_reg or bound_reg)
+
+    report = {
+        "reps": n_reps,
+        "instances": len(names),
+        "control": ctrl,
+        "candidate": cand,
+        "margin_reps": args.margin,
+        "hard_unsound": unsound,
+        "hard_incumbent_verification_failed": verif_failed,
+        "cert_regressions": cert_reg,
+        "cert_gains": cert_gain,
+        "cert_noise_cells": _noise("cert"),
+        "incumbent_regressions": inc_reg,
+        "incumbent_gains": inc_gain,
+        "incumbent_noise_cells": _noise("incumbent"),
+        "bound_lost": bound_reg,
+        "bound_gained": bound_gain,
+        "bound_noise_cells": _noise("bound"),
+        "overrun_delta_s_per_rep": deltas,
+        "overrun_delta_s_mean": round(d_mean, 2),
+        "overrun_delta_s_sd": round(d_sd, 2),
+        "total_overrun_s": {ctrl: over_ctrl, cand: over_cand},
+        "node_count_total": nodes,
+        "bound_tighter_cells": sorted(tighter_cells),
+        "bound_looser_cells": sorted(looser_cells),
+    }
+    print(json.dumps(report, indent=2))
+    print(f"\nBAR1_CERT_CLEAN={bar1}")
+    print(f"OVERRUN_DELTA_S={d_mean:.2f} +/- {d_sd:.2f}")
+    print(f"BOUND_LEDGER tighter={len(tighter_cells)} looser={len(looser_cells)}")
+    print(f"CELLS_COMPARED={cells_compared}")
+    print(f"ORACLE_COMPARISONS_EXECUTED={oracle_cmps}")
+    if cells_compared == 0:
+        print("SCORER COMPARED NOTHING", flush=True)
+        return 1
+    if oracle_cmps == 0:
+        # Same rule the panel itself enforces: no oracle reached means the
+        # soundness line is a formatting artifact, not a measurement.
+        print("NO ORACLE COMPARISONS -- soundness unproven", flush=True)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/discopt_benchmarks/scripts/issue966_coupled_graduation_panel.py
+++ b/discopt_benchmarks/scripts/issue966_coupled_graduation_panel.py
@@ -47,11 +47,18 @@ ROUND = "DISCOPT_NODE_ROUND_BUDGET"
 HESS = "DISCOPT_HESS_COMPILE_GATE"
 
 # (key, label, env). Every flag is named in every arm: an arm must never inherit.
-ARMS = (
-    ("base", "all OFF (today's default)", {WARM: "0", ROUND: "0", HESS: "0"}),
-    ("seam", "#966 ON, #928 OFF", {WARM: "0", ROUND: "1", HESS: "1"}),
-    ("cand", "all three ON", {WARM: "1", ROUND: "1", HESS: "1"}),
-)
+ALL_ARMS = {
+    "base": ("all OFF (today's default)", {WARM: "0", ROUND: "0", HESS: "0"}),
+    "seam": ("#966 ON, #928 OFF", {WARM: "0", ROUND: "1", HESS: "1"}),
+    "cand": ("all three ON", {WARM: "1", ROUND: "1", HESS: "1"}),
+    # #928's flag ALONE. The three-arm default cannot answer "does
+    # DISCOPT_LP_WARM_DEADLINE graduate", because every arm carrying it also
+    # carries #966's two, and #966's own panel (issue #966, f2565241) kept those
+    # OFF. ``cand - seam`` isolates it only under the counterfactual that the
+    # other two are ON, which is not the state of the tree.
+    "warm": ("#928 ON alone", {WARM: "1", ROUND: "0", HESS: "0"}),
+}
+ARMS = tuple((k, ALL_ARMS[k][0], ALL_ARMS[k][1]) for k in ("base", "seam", "cand"))
 
 
 def loadavg() -> list[float]:
@@ -260,10 +267,23 @@ def compare(cells: list[dict], a_key: str, b_key: str) -> dict:
 
 
 def main() -> int:
+    global ARMS
     ap = argparse.ArgumentParser()
     ap.add_argument("--budget", type=float, default=20.0)
     ap.add_argument("--instances", default=None)
     ap.add_argument("--out", default=None)
+    ap.add_argument(
+        "--arms",
+        default="base,seam,cand",
+        help=f"comma-separated arm keys to run, from {sorted(ALL_ARMS)}. Each arm sets "
+        "EVERY flag explicitly, so a two-arm run is as controlled as the three-arm one.",
+    )
+    ap.add_argument(
+        "--pair",
+        default=None,
+        help="graduation pair as 'control,candidate' (default: first,last of --arms). "
+        "CERT_CLEAN is scored on this pair.",
+    )
     ap.add_argument(
         "--rescore",
         default=None,
@@ -273,8 +293,25 @@ def main() -> int:
     )
     args = ap.parse_args()
 
+    keys = [k for k in args.arms.split(",") if k]
+    unknown = [k for k in keys if k not in ALL_ARMS]
+    if unknown:
+        raise SystemExit(f"unknown arm(s) {unknown}; known: {sorted(ALL_ARMS)}")
+    if len(keys) < 2:
+        raise SystemExit("need at least two arms to compare")
+    ARMS = tuple((k, ALL_ARMS[k][0], ALL_ARMS[k][1]) for k in keys)
+    ctrl, cand_key = args.pair.split(",") if args.pair else (keys[0], keys[-1])
+    if ctrl not in keys or cand_key not in keys:
+        raise SystemExit(f"--pair {ctrl},{cand_key} names an arm not in --arms {keys}")
+
     if args.rescore:
         saved = json.loads(Path(args.rescore).read_text())["cells"]
+        # Score the arms the artifact actually holds, not the ones --arms defaults
+        # to: rescoring a two-arm panel under the three-arm default would KeyError,
+        # and rescoring a three-arm panel under a two-arm run would silently skip
+        # an arm's soundness.
+        saved_keys = [k for k in ALL_ARMS if saved and k in saved[0]]
+        ARMS = tuple((k, ALL_ARMS[k][0], ALL_ARMS[k][1]) for k in saved_keys)
         for c in saved:
             c["reference_optimum"] = reference_optimum(c["instance"])
         snd = soundness(saved)
@@ -307,11 +344,13 @@ def main() -> int:
         print(f"[{idx}/{len(names)}] {name:22s} {parts}", flush=True)
 
     snd = soundness(cells)
-    pairs = [
-        compare(cells, "base", "cand"),
-        compare(cells, "seam", "cand"),
-        compare(cells, "base", "seam"),
+    others = [
+        (a, b)
+        for i, a in enumerate(keys)
+        for b in keys[i + 1 :]
+        if (a, b) != (ctrl, cand_key)
     ]
+    pairs = [compare(cells, ctrl, cand_key)] + [compare(cells, a, b) for a, b in others]
     grad = pairs[0]
     cert_clean = not (
         snd["unsound"]
@@ -334,8 +373,8 @@ def main() -> int:
 
     print()
     print(json.dumps(summary, indent=2))
-    print(f"\nCERT_CLEAN={cert_clean}  (graduation pair: cand vs base)")
-    print(f"OVERRUN_DELTA_S_CAND_VS_BASE={grad['overrun_delta_s']}")
+    print(f"\nCERT_CLEAN={cert_clean}  (graduation pair: {cand_key} vs {ctrl})")
+    print(f"OVERRUN_DELTA_S_{cand_key.upper()}_VS_{ctrl.upper()}={grad['overrun_delta_s']}")
     print(f"COMPARISONS_EXECUTED={compared}")
     print(f"ORACLE_COMPARISONS_EXECUTED={snd['oracle_comparisons_executed']}")
     print(f"INSTANCES_WITHOUT_ORACLE={snd['instances_without_oracle']}")

--- a/python/discopt/_relax/milp_relaxation.py
+++ b/python/discopt/_relax/milp_relaxation.py
@@ -479,10 +479,48 @@ def _lp_warm_deadline_enabled() -> bool:
     ``discopt_benchmarks/results/issue928_*.json``). Fixing THAT is caller-side
     budget accounting — a different seam with its own issue; this flag stays OFF
     until it lands and a re-run panel passes both bars.
+
+    **Update 2026-08-12: GRADUATED to default-ON.** Every panel above shares one
+    defect: no arm ever carried this flag *alone*. ``f2565241``'s arms are ``base``
+    (all OFF) / ``seam`` (#966's two ON, this one OFF) / ``cand`` (all three), so
+    ``cand - seam`` isolates this flag only under the counterfactual that #966's two
+    are ON — and #966's own panel kept them OFF. The §14d bar-1 failure was already
+    attributed to the ROUND budget rather than to here (``seam vs base`` loses tspn12's
+    incumbent too, ``cand vs seam`` loses none), which is a hypothesis the three-arm
+    design cannot itself test. The missing arm was run: ``base`` vs ``warm``
+    (``DISCOPT_LP_WARM_DEADLINE=1``, the other two explicitly ``0``), 19 binding
+    instances, 20 s, arms interleaved per instance in isolated subprocesses
+    (``issue928_rate_score.py``, ``results/issue928_warmalone20_rep{1,2,3}.json``).
+
+    *Bar 1 — PASS.* 0 unsound / 0 incumbent-verification failures / 0 certification
+    regressions / 0 lost incumbents / 0 lost bounds, in 3/3 reps, over **96 executed
+    oracle comparisons** against ``minlplib.solu`` (the earlier container runs reached
+    1 of 19 instances via the narrow ``_optima`` fallback, so their soundness line
+    rested on almost nothing). The §14d tspn12 incumbent loss does NOT recur without
+    the round budget, which confirms that attribution.
+
+    *Bar 2 — PASS.* Wall: overrun delta -2.6 / -1.0 / -0.3 s, negative in 3/3 (total
+    overrun 6.5/4.8/4.0 s -> 3.9/3.8/3.7 s); the sign no longer flips with budget.
+    Nodes: 4647 -> 4611, neutral. Bound: the two cells that move are both stable
+    GAINS — hda ``-2.07e13 -> -64473.44`` in 3/3 (identical to 8 digits; the base
+    arm's value is not a usable bound at all) and heatexch_gen1 ``46750/44196 ->
+    49000``, where the ON arm is also the reproducible one. The three cells scored
+    "looser" are the known timing-nondeterministic class: tspn10 by 6e-8 relative,
+    and tspn08/tspn12 flip direction between reps *in both arms* (the base arm alone
+    reports tspn12 as 202.181 in two reps and 202.418 in the third) — the
+    nvs05/clay0303hfsg signature recorded above, not a flag effect.
+
+    Scored by per-cell RATE over reps, not one-shot: the bar-1 failures that kept this
+    flag OFF in earlier panels (nvs05, tls2, syn05hfsg, casctanks) are cells *neither*
+    arm holds reliably, and one-shot scoring cannot separate a flag effect from a race.
+    Deviation from the pre-registration, recorded per §11: it fixed 5 reps and 3 were
+    run (the run was cut short); the regression margin is 2 of 3, proportionally at or
+    above the pre-registered 3 of 5. The ``=0`` opt-out and the legacy no-deadline path
+    are unchanged.
     """
     import os as _os
 
-    return _os.environ.get("DISCOPT_LP_WARM_DEADLINE", "0") not in (
+    return _os.environ.get("DISCOPT_LP_WARM_DEADLINE", "1") not in (
         "0",
         "",
         "false",

--- a/python/discopt/_relax/milp_relaxation.py
+++ b/python/discopt/_relax/milp_relaxation.py
@@ -521,9 +521,9 @@ def _lp_warm_deadline_enabled() -> bool:
     run (the run was cut short); the regression margin is 2 of 3, proportionally at or
     above the pre-registered 3 of 5.
 
-    **THE BLOCKER — an exhausted budget is indistinguishable from "no limit".** The
-    default was flipped ON on the strength of the panel above and immediately
-    retracted (§11): ``pytest -m smoke`` failed
+    **THE BLOCKER (now fixed) — an exhausted budget was indistinguishable from "no
+    limit".** The default was flipped ON on the strength of the panel above and
+    immediately retracted (§11): ``pytest -m smoke`` failed
     ``test_amp_integration.py::TestAmpConvergenceProperties::test_time_limit_respected``,
     which asserts ``solve(solver="amp", time_limit=3.0)`` returns within 8 s. A/B on
     that single test, same tree: ``DISCOPT_LP_WARM_DEADLINE=0`` **passes in 3.43 s**,
@@ -551,13 +551,27 @@ def _lp_warm_deadline_enabled() -> bool:
     500.6 s, bchoco08 80.9 s against a 20 s budget): those are the same unbounded
     MILP launch, not a diffuse budget-accounting problem.
 
-    So graduation is blocked on fixing that seam — ``solve_milp`` must be able to tell
-    "expired" from "unlimited" — not on another panel. Until then the flag is OFF and
-    the ``=0`` opt-out and legacy no-deadline path are unchanged.
+    **The seam is fixed and this flag is now ON by default.** ``solve_milp_py`` /
+    ``solve_milp_csc_py`` take ``Option<f64>``; ``None``/``+inf`` mean no limit and
+    ``Some(0.0)`` is an already-elapsed deadline that stops at the first poll with
+    ``gap_certified = false``. See ``parse_budget_secs`` in ``lp_bindings.rs`` and
+    ``python/tests/test_928_expired_budget_not_unlimited.py``. Re-verified with the
+    flag ON after that fix: the AMP case that forced the retraction passes in 3.39 s
+    (was >350 s), ``pytest -m smoke`` is 958 passed / 1 skipped / 2 xpassed — byte-
+    identical to the OFF arm — the adversarial suite is 10 passed, and
+    ``test_time_limit_contract.py`` is 3 passed + 1 XPASS, the xpass being the
+    ``hda`` 10 s case this flag exists to fix.
+
+    One caveat on the panel above, in the conservative direction: it was run with the
+    seam still present, so the ON arm's wall times *included* those unbounded MILP
+    launches. Bar 2 passed carrying that handicap, so the fix can only have improved
+    the margin it was graduated on.
+
+    The ``=0`` opt-out and the legacy no-deadline path are unchanged.
     """
     import os as _os
 
-    return _os.environ.get("DISCOPT_LP_WARM_DEADLINE", "0") not in (
+    return _os.environ.get("DISCOPT_LP_WARM_DEADLINE", "1") not in (
         "0",
         "",
         "false",

--- a/python/discopt/_relax/milp_relaxation.py
+++ b/python/discopt/_relax/milp_relaxation.py
@@ -480,8 +480,12 @@ def _lp_warm_deadline_enabled() -> bool:
     budget accounting — a different seam with its own issue; this flag stays OFF
     until it lands and a re-run panel passes both bars.
 
-    **Update 2026-08-12: GRADUATED to default-ON.** Every panel above shares one
-    defect: no arm ever carried this flag *alone*. ``f2565241``'s arms are ``base``
+    **Update 2026-08-12: the isolating panel PASSES both bars, and the flag STILL
+    stays OFF — blocked by a defect the panel cannot see.** Read the panel result
+    below, then the blocker at the end; the blocker is what decides it.
+
+    Every panel above shares one defect: no arm ever carried this flag *alone*.
+    ``f2565241``'s arms are ``base``
     (all OFF) / ``seam`` (#966's two ON, this one OFF) / ``cand`` (all three), so
     ``cand - seam`` isolates this flag only under the counterfactual that #966's two
     are ON — and #966's own panel kept them OFF. The §14d bar-1 failure was already
@@ -515,12 +519,45 @@ def _lp_warm_deadline_enabled() -> bool:
     arm holds reliably, and one-shot scoring cannot separate a flag effect from a race.
     Deviation from the pre-registration, recorded per §11: it fixed 5 reps and 3 were
     run (the run was cut short); the regression margin is 2 of 3, proportionally at or
-    above the pre-registered 3 of 5. The ``=0`` opt-out and the legacy no-deadline path
-    are unchanged.
+    above the pre-registered 3 of 5.
+
+    **THE BLOCKER — an exhausted budget is indistinguishable from "no limit".** The
+    default was flipped ON on the strength of the panel above and immediately
+    retracted (§11): ``pytest -m smoke`` failed
+    ``test_amp_integration.py::TestAmpConvergenceProperties::test_time_limit_respected``,
+    which asserts ``solve(solver="amp", time_limit=3.0)`` returns within 8 s. A/B on
+    that single test, same tree: ``DISCOPT_LP_WARM_DEADLINE=0`` **passes in 3.43 s**,
+    ``=1`` **runs past 350 s** (killed) — a >100x regression on a *time-limit* test,
+    the exact inverse of this flag's purpose.
+
+    Faulthandler puts the hang in the MILP branch, not the pure-LP path this flag
+    gates: ``_solve_amp_impl`` -> ``_solve_milp_with_oa_recovery`` ->
+    :meth:`MilpRelaxationModel.solve` -> ``milp_simplex.solve_milp``. The mechanism is
+    the shared-budget seam above. With the flag ON, ``solve_milp`` is handed
+    ``time_limit=_remaining()``; once the warm and equilibrated attempts have spent the
+    caller's budget, ``_remaining()`` is exactly ``0.0``. And ``milp_simplex.py``'s call
+    site reads::
+
+        time_limit_s=0.0 if time_limit is None else max(0.0, float(time_limit))
+
+    ``None`` (no limit) and ``0.0`` (budget gone) collapse onto the SAME wire value, so
+    the Rust MILP B&B launches unbounded precisely when it should not start at all.
+    Flag OFF never reaches it because each attempt gets a fresh copy of the duration
+    and ``_remaining()`` is never 0. This is the same sentinel trap as ``INF = 1e20``
+    in the LP layer, one level up, and it is general — AMP only reaches it reliably
+    because it solves with a tight limit after other attempts have run.
+
+    It also retro-explains the "sporadic severe modes" recorded in §14b (contvar
+    500.6 s, bchoco08 80.9 s against a 20 s budget): those are the same unbounded
+    MILP launch, not a diffuse budget-accounting problem.
+
+    So graduation is blocked on fixing that seam — ``solve_milp`` must be able to tell
+    "expired" from "unlimited" — not on another panel. Until then the flag is OFF and
+    the ``=0`` opt-out and legacy no-deadline path are unchanged.
     """
     import os as _os
 
-    return _os.environ.get("DISCOPT_LP_WARM_DEADLINE", "1") not in (
+    return _os.environ.get("DISCOPT_LP_WARM_DEADLINE", "0") not in (
         "0",
         "",
         "false",

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -18282,7 +18282,7 @@ def _solve_milp_simplex(
     int_idx = [j for off, sz in zip(int_offsets, int_sizes) for j in range(off, off + int(sz))]
 
     # Pass the remaining wall-clock budget so the Rust B&B's deadline (loop-top,
-    # per-node and per-LP) fires. Without it ``time_limit_s`` defaults to 0.0 -> no
+    # per-node and per-LP) fires. Without it ``time_limit_s`` defaults to None -> no
     # deadline, so a single node whose simplex fails to converge (or a degenerate
     # cycle) runs unbounded, ignoring the user's ``time_limit`` entirely (issue
     # #291: nvs12's integer-bilinear reformulation hung > 40 s on a 15 s limit).

--- a/python/discopt/solvers/milp_simplex.py
+++ b/python/discopt/solvers/milp_simplex.py
@@ -650,7 +650,13 @@ def solve_milp(
         0.0,  # obj_const: caller (MilpRelaxationModel) applies its own offset
         int(max_nodes),
         float(gap_tolerance),
-        time_limit_s=0.0 if time_limit is None else max(0.0, float(time_limit)),
+        # #928: pass ``None`` for "no limit" and the number — INCLUDING an exact
+        # 0.0 — for a real budget. The previous ``0.0 if time_limit is None``
+        # spelling collapsed the two: the binding mapped 0.0 back to "no
+        # deadline", so a caller whose shared budget was already spent by earlier
+        # attempts (``MilpRelaxationModel.solve`` under ``DISCOPT_LP_WARM_DEADLINE``)
+        # launched an *unbounded* B&B at the one moment it must not start at all.
+        time_limit_s=None if time_limit is None else max(0.0, float(time_limit)),
         debug_hook=_debug.rust_hook(),
         **_lp_kwargs,
     )

--- a/python/tests/test_917_lp_warm_deadline.py
+++ b/python/tests/test_917_lp_warm_deadline.py
@@ -59,23 +59,28 @@ def _small_lp():
 # ── the flag ────────────────────────────────────────────────────────────────
 
 
-def test_flag_defaults_off(warm_dl):
-    """Still OFF — but as of 2026-08-12 for a NEW and specific reason (#928).
+def test_flag_defaults_on(warm_dl):
+    """ON by default as of 2026-08-12 (#928), after the seam that blocked it was fixed.
 
-    The isolating panel finally ran (this flag alone, 19 binding instances, 20 s,
-    3 reps, rate-scored) and passes BOTH §5 bars: 0 unsound / 0 cert_regressions /
-    0 lost_incumbents / 0 lost_bound in 3/3 over 96 executed oracle comparisons,
+    The isolating panel (this flag alone, 19 binding instances, 20 s, 3 reps,
+    rate-scored) passes BOTH §5 bars: 0 unsound / 0 cert_regressions / 0
+    lost_incumbents / 0 lost_bound in 3/3 over 96 executed oracle comparisons,
     overrun delta -2.6/-1.0/-0.3 s, hda's bound -2.07e13 -> -64473.44 in 3/3.
 
-    The default was flipped ON on that evidence and retracted the same hour: with
-    the flag ON, ``test_amp_integration`` 's ``test_time_limit_respected`` runs
-    past 350 s against an 8 s allowance, where ``=0`` passes in 3.43 s. The cause
-    is that ``solve_milp`` cannot tell an EXPIRED budget from NO limit — both
-    arrive as ``time_limit_s=0.0`` — so an exhausted shared budget launches the
-    MILP B&B unbounded. Graduation is blocked on that seam, not on more panels.
-    See ``_lp_warm_deadline_enabled``'s docstring."""
+    The default was flipped ON on that evidence, retracted the same hour, and is now
+    flipped again. The retraction was correct at the time: with the flag ON,
+    ``test_amp_integration``'s ``test_time_limit_respected`` ran past 350 s against an
+    8 s allowance because ``solve_milp`` could not tell an EXPIRED budget from NO
+    limit — both arrived as ``time_limit_s=0.0`` — so an exhausted shared budget
+    launched the MILP B&B unbounded. That seam is fixed (``parse_budget_secs`` in
+    ``lp_bindings.rs``; ``test_928_expired_budget_not_unlimited.py``), and with the fix
+    in place the same AMP test passes in 3.39 s, smoke is byte-identical between the
+    two arms, and the ``hda`` 10 s time-limit case XPASSes.
+
+    Keep the ``=0`` opt-out working (``test_flag_parses``): the legacy fresh-duration-
+    per-attempt path stays reachable."""
     warm_dl(None)
-    assert _lp_warm_deadline_enabled() is False
+    assert _lp_warm_deadline_enabled() is True
 
 
 @pytest.mark.parametrize("value,expected", [("1", True), ("0", False), ("off", False)])

--- a/python/tests/test_917_lp_warm_deadline.py
+++ b/python/tests/test_917_lp_warm_deadline.py
@@ -59,19 +59,23 @@ def _small_lp():
 # ── the flag ────────────────────────────────────────────────────────────────
 
 
-def test_flag_defaults_on(warm_dl):
-    """GRADUATED (#928, 2026-08-12): the caller's ``time_limit`` is honoured by default.
+def test_flag_defaults_off(warm_dl):
+    """Still OFF — but as of 2026-08-12 for a NEW and specific reason (#928).
 
-    It stayed OFF through several panels, but none of them ever ran this flag
-    *alone* — every arm carrying it also carried #966's two, whose own panel kept
-    them OFF, so the isolating arm did not exist. Run alone over the 19 binding
-    instances at 20 s, 3 reps, rate-scored: bar 1 clean in 3/3 (0 unsound / 0
-    cert_regressions / 0 lost_incumbents / 0 lost_bound over 96 executed oracle
-    comparisons) and bar 2 positive (overrun delta -2.6/-1.0/-0.3 s, negative in
-    3/3; nodes 4647 -> 4611; hda's bound -2.07e13 -> -64473.44 in 3/3). See
-    ``_lp_warm_deadline_enabled``'s docstring for the full ledger."""
+    The isolating panel finally ran (this flag alone, 19 binding instances, 20 s,
+    3 reps, rate-scored) and passes BOTH §5 bars: 0 unsound / 0 cert_regressions /
+    0 lost_incumbents / 0 lost_bound in 3/3 over 96 executed oracle comparisons,
+    overrun delta -2.6/-1.0/-0.3 s, hda's bound -2.07e13 -> -64473.44 in 3/3.
+
+    The default was flipped ON on that evidence and retracted the same hour: with
+    the flag ON, ``test_amp_integration`` 's ``test_time_limit_respected`` runs
+    past 350 s against an 8 s allowance, where ``=0`` passes in 3.43 s. The cause
+    is that ``solve_milp`` cannot tell an EXPIRED budget from NO limit — both
+    arrive as ``time_limit_s=0.0`` — so an exhausted shared budget launches the
+    MILP B&B unbounded. Graduation is blocked on that seam, not on more panels.
+    See ``_lp_warm_deadline_enabled``'s docstring."""
     warm_dl(None)
-    assert _lp_warm_deadline_enabled() is True
+    assert _lp_warm_deadline_enabled() is False
 
 
 @pytest.mark.parametrize("value,expected", [("1", True), ("0", False), ("off", False)])

--- a/python/tests/test_917_lp_warm_deadline.py
+++ b/python/tests/test_917_lp_warm_deadline.py
@@ -59,16 +59,19 @@ def _small_lp():
 # ── the flag ────────────────────────────────────────────────────────────────
 
 
-def test_flag_defaults_off(warm_dl):
-    """Bound-changing, so panel-gated; ships OFF until net-positive is demonstrated.
+def test_flag_defaults_on(warm_dl):
+    """GRADUATED (#928, 2026-08-12): the caller's ``time_limit`` is honoured by default.
 
-    66 in-repo instances at a 15 s budget, OFF/ON interleaved: cert-clean
-    (``cert_regressions=0  lost_incumbents=0  lost_bound=0  unsound=0``; bounds 3
-    tighter / 2 looser), but the wall benefit — total overrun 82.1 s -> 70.9 s — sits
-    inside the metric's own noise (three OFF-arm runs gave 82.1 / 79.2 / 175.6 s).
-    Cert-clean is necessary, not sufficient: the ``DISCOPT_CUT_INHERIT`` rule."""
+    It stayed OFF through several panels, but none of them ever ran this flag
+    *alone* — every arm carrying it also carried #966's two, whose own panel kept
+    them OFF, so the isolating arm did not exist. Run alone over the 19 binding
+    instances at 20 s, 3 reps, rate-scored: bar 1 clean in 3/3 (0 unsound / 0
+    cert_regressions / 0 lost_incumbents / 0 lost_bound over 96 executed oracle
+    comparisons) and bar 2 positive (overrun delta -2.6/-1.0/-0.3 s, negative in
+    3/3; nodes 4647 -> 4611; hda's bound -2.07e13 -> -64473.44 in 3/3). See
+    ``_lp_warm_deadline_enabled``'s docstring for the full ledger."""
     warm_dl(None)
-    assert _lp_warm_deadline_enabled() is False
+    assert _lp_warm_deadline_enabled() is True
 
 
 @pytest.mark.parametrize("value,expected", [("1", True), ("0", False), ("off", False)])

--- a/python/tests/test_928_expired_budget_not_unlimited.py
+++ b/python/tests/test_928_expired_budget_not_unlimited.py
@@ -1,0 +1,190 @@
+"""An *expired* MILP budget must not be wire-identical to *no* budget (#928).
+
+Both MILP entry points in ``lp_bindings.rs`` used to take a bare ``f64`` and map it
+with ``if time_limit_s > 0.0 { Some(t) } else { None }``, while the Python side spelled
+"no limit" as ``0.0``. The two meanings therefore collapsed onto one wire value, and
+the collapse fell the *unsafe* way: a caller that had already spent a shared budget
+across earlier attempts — ``MilpRelaxationModel.solve`` under
+``DISCOPT_LP_WARM_DEADLINE=1``, whose ``_remaining()`` returns exactly ``0.0`` once the
+warm attempts drain it — asked for "stop now" and launched an **unbounded** B&B.
+
+Measured cost of the collapse: AMP's ``solve(solver="amp", time_limit=3.0)`` went from
+3.43 s with the flag off to >350 s with it on, and it is the mechanism behind the
+"sporadic severe modes" (contvar 500.6 s, bchoco08 80.9 s against a 20 s budget)
+previously attributed to diffuse budget accounting.
+
+This is the sentinel-collapse class already documented for ``INF = 1e20`` in the LP
+layer, one level up: a value that is *in range* for the parameter is also its own
+"absent" marker. The contract is now the one ``parse_deadline`` already applied to the
+LP entries — ``None``/``+inf`` mean no limit, negative/NaN are rejected loudly, and
+``Some(0.0)`` is an already-elapsed deadline.
+"""
+
+import time
+
+import numpy as np
+import pytest
+from discopt.solvers.milp_simplex import solve_milp
+
+# A knapsack-ish 0/1 MILP sized so the unlimited solve needs a real search (53 nodes)
+# while still finishing in milliseconds, which is what lets these live in the `smoke`
+# suite and run on every PR. The separation between "stopped at the deadline" and "ran
+# the tree" is therefore read off the NODE COUNT (1 vs 53), not the clock.
+_N = 34
+
+
+def _instance():
+    rng = np.random.default_rng(9280)
+    c = -rng.integers(10, 60, size=_N).astype(np.float64)  # maximize value (min -value)
+    w = rng.integers(10, 60, size=_N).astype(np.float64)
+    A = np.vstack([w, w[::-1].copy()])
+    b = np.array([0.5 * w.sum(), 0.5 * w.sum()], dtype=np.float64)
+    bounds = [(0.0, 1.0)] * _N
+    integrality = np.ones(_N, dtype=np.int64)
+    return c, A, b, bounds, integrality
+
+
+def _solve(time_limit):
+    c, A, b, bounds, integrality = _instance()
+    t0 = time.perf_counter()
+    res = solve_milp(
+        c,
+        A_ub=A,
+        b_ub=b,
+        bounds=bounds,
+        integrality=integrality,
+        time_limit=time_limit,
+    )
+    return res, time.perf_counter() - t0
+
+
+@pytest.mark.smoke
+def test_expired_budget_returns_immediately():
+    """``time_limit=0.0`` means "my budget is spent", not "run forever".
+
+    Before the fix, 0.0 was mapped back to "no deadline" and this call ran the whole
+    tree — verified by rebuilding the extension at the parent commit: this test fails
+    there with 53 nodes and ``status=OPTIMAL``.
+    """
+    res, wall = _solve(0.0)
+
+    # The DISCRIMINATOR is the node count, not the clock. This instance solves in
+    # milliseconds either way, so a wall-time threshold would pass even with the bug
+    # present and the test would be decorative. An expired budget must stop at the
+    # first deadline poll (1 node); the unlimited solve takes 53. See
+    # ``test_expired_and_unlimited_are_distinguishable`` for the paired assertion.
+    assert res.node_count <= 2, (
+        f"solve_milp(time_limit=0.0) explored {res.node_count} nodes: an exhausted "
+        "budget was treated as 'no limit' (the #928 sentinel collapse), so the B&B "
+        "launched unbounded"
+    )
+    # Whatever it reports must not be a certified answer — it did no search.
+    assert res.status.name != "OPTIMAL", (
+        f"solve_milp(time_limit=0.0) claimed {res.status} without spending any budget"
+    )
+    # Operational guard: on a larger instance the same bug is a hang, not a node count.
+    assert wall < 2.0, f"solve_milp(time_limit=0.0) ran {wall:.2f}s"
+
+
+@pytest.mark.smoke
+def test_no_limit_still_means_no_limit():
+    """The other half of the contract: ``None`` must still run to optimality.
+
+    Without this, "return immediately" could be satisfied by breaking every budget,
+    which would be the opposite defect and would silently uncertify the solver.
+    """
+    res, _ = _solve(None)
+
+    assert res.status.name == "OPTIMAL", (
+        f"solve_milp(time_limit=None) returned {res.status}; None must mean no limit"
+    )
+    assert res.objective is not None and np.isfinite(res.objective)
+
+
+@pytest.mark.smoke
+def test_expired_and_unlimited_are_distinguishable():
+    """The two must not be the same call. This is the collapse itself, asserted.
+
+    Stated as a *comparison* rather than two absolute thresholds so it keeps its
+    meaning on any machine: the unlimited solve does strictly more work than the
+    expired one, and the executed-comparison count is asserted so the test cannot
+    silently degrade to checking nothing.
+
+    Work is counted in NODES, deliberately. Wall time does not separate these two at
+    this size — measured 0.0031 s expired vs 0.0016 s unlimited, i.e. the *expired*
+    call is the slower one, because both pay the same fixed setup and neither runs
+    long enough for the search to dominate. An earlier draft asserted
+    ``wall_unlimited > wall_expired`` and passed only by scheduling luck.
+    """
+    comparisons = 0
+
+    expired, _ = _solve(0.0)
+    unlimited, _ = _solve(None)
+
+    assert unlimited.node_count > expired.node_count, (
+        f"expired budget explored {expired.node_count} nodes vs {unlimited.node_count} "
+        "unlimited — the two budgets are still the same wire value"
+    )
+    comparisons += 1
+    assert unlimited.status.name == "OPTIMAL" and expired.status.name != "OPTIMAL", (
+        f"expired={expired.status}, unlimited={unlimited.status} — the two budgets did "
+        "not lead to different outcomes"
+    )
+    comparisons += 1
+
+    assert comparisons == 2, "PROBE NEVER FIRED: expected 2 executed comparisons"
+
+
+@pytest.mark.smoke
+@pytest.mark.parametrize("bad", [-1.0, float("nan")])
+def test_invalid_budget_is_rejected_at_the_binding(bad):
+    """Negative/NaN are refused at the wire, not silently reinterpreted.
+
+    This is ``parse_deadline``'s rule, now applied to the MILP entries too. It matters
+    most for a *negative* budget: under the old ``> 0.0`` test it became "no limit" —
+    the single most dangerous possible reading of "you are already past your deadline".
+
+    Asserted against the binding rather than :func:`solve_milp` because the Python
+    wrapper clamps with ``max(0.0, ...)``, which sends both of these in as an *expired*
+    budget. That clamp fails closed (stop now) and is left alone; this test pins the
+    layer that must never again fail open.
+    """
+    from discopt._rust import solve_milp_py
+
+    # min -x  s.t.  x + s = 1, x binary. One structural column, one slack.
+    with pytest.raises(ValueError, match="non-negative and not NaN"):
+        solve_milp_py(
+            np.array([-1.0, 0.0]),
+            np.array([[1.0, 1.0]]),
+            np.array([1.0]),
+            np.array([0.0, 0.0]),
+            np.array([1.0, 1.0]),
+            np.array([0], dtype=np.int64),
+            1,
+            time_limit_s=bad,
+        )
+
+
+@pytest.mark.smoke
+def test_negative_budget_through_solve_milp_fails_closed():
+    """The wrapper's clamp must resolve a negative budget to *expired*, never unlimited."""
+    res, _ = _solve(-5.0)
+    assert res.node_count <= 2 and res.status.name != "OPTIMAL", (
+        f"solve_milp(time_limit=-5.0) explored {res.node_count} nodes -> {res.status}: "
+        "a budget already blown by 5 s was read as 'no limit'"
+    )
+
+
+@pytest.mark.smoke
+def test_infinite_budget_means_no_limit():
+    """``+inf`` is the natural spelling of an uncapped budget and must not raise.
+
+    Before the fix this did not merely mis-route — it **panicked** the driver.
+    ``inf > 0.0`` sent ``Some(inf)`` through to ``Duration::from_secs_f64`` in
+    ``milp_driver.rs``, which aborts with "cannot convert float seconds to Duration:
+    value is either too big or NaN" and surfaces in Python as ``PanicException``. Found
+    by running this file against the pre-fix extension; it is a second, independent
+    defect that the shared ``parse_budget_secs`` validation closes.
+    """
+    res, _ = _solve(float("inf"))
+    assert res.status.name == "OPTIMAL"

--- a/python/tests/test_time_limit_contract.py
+++ b/python/tests/test_time_limit_contract.py
@@ -79,18 +79,20 @@ _SLACK_FRAC = 0.10
 # §1. So this case is marked xfail non-strict rather than silenced or given a
 # wider slack: it keeps running, it keeps reporting, and it will xpass the moment
 # #917 is properly resolved.
-_XFAIL_LP_DEADLINE_DROP = pytest.mark.xfail(
-    reason="#928: warm pure-LP path drops the caller's time_limit, so the #138 "
-    "fallback's separated-relaxation phase overruns its grant by ~4s. Bimodal: "
-    "10.6-13.0s against 12.5s allowed. Not strict — it passes ~2/5 runs.",
-    strict=False,
-)
+# RESOLVED 2026-08-12 (#928): ``DISCOPT_LP_WARM_DEADLINE`` graduated to default-ON,
+# so the warm pure-LP path no longer discards the caller's ``time_limit`` and the
+# ``xfail`` above this case is retired. Measured on the graduated default,
+# ``hda`` at ``time_limit=10`` returns in 10.8 s against the 12.5 s allowed —
+# xpassing, which is why the marker had to go rather than stay as a non-strict
+# safety net: a permanent non-strict xfail on a passing case reports nothing.
+# The graduation ledger (both §5 bars, 3 reps, 96 oracle comparisons) is in
+# ``_lp_warm_deadline_enabled``'s docstring.
 
 # (instance, time_limit) pairs. Short limits are the discriminating cases —
 # a constant-overhead overrun is invisible at 60 s and catastrophic at 2 s.
 _CASES = [
     ("hda", 5.0),
-    pytest.param("hda", 10.0, marks=_XFAIL_LP_DEADLINE_DROP),
+    ("hda", 10.0),
     ("casctanks", 5.0),
 ]
 

--- a/python/tests/test_time_limit_contract.py
+++ b/python/tests/test_time_limit_contract.py
@@ -79,25 +79,20 @@ _SLACK_FRAC = 0.10
 # §1. So this case is marked xfail non-strict rather than silenced or given a
 # wider slack: it keeps running, it keeps reporting, and it will xpass the moment
 # #917 is properly resolved.
-# 2026-08-12 (#928): this xfail STAYS, and the reason is now sharper. Turning
-# ``DISCOPT_LP_WARM_DEADLINE=1`` makes this case xpass (measured 10.8 s against the
-# 12.5 s allowed), and its isolating panel passes both §5 bars — but the flag
-# cannot be the fix while it is ON-able only at the price of an unbounded MILP
-# launch: an exhausted shared budget reaches ``solve_milp`` as ``time_limit_s=0.0``,
-# the same wire value as "no limit", which takes AMP's 3 s budget past 350 s. The
-# blocker is that seam, not this case. See ``_lp_warm_deadline_enabled``.
-_XFAIL_LP_DEADLINE_DROP = pytest.mark.xfail(
-    reason="#928: warm pure-LP path drops the caller's time_limit, so the #138 "
-    "fallback's separated-relaxation phase overruns its grant by ~4s. Bimodal: "
-    "10.6-13.0s against 12.5s allowed. Not strict — it passes ~2/5 runs.",
-    strict=False,
-)
+# 2026-08-12 (#928): RESOLVED — the xfail is gone and this case is now a plain
+# assertion. ``DISCOPT_LP_WARM_DEADLINE`` is ON by default: the warm pure-LP path
+# honours the caller's ``time_limit``, so the #138 fallback's separated-relaxation
+# phase no longer overruns its grant. The flag's own blocker (an exhausted shared
+# budget reaching ``solve_milp`` as ``time_limit_s=0.0``, the same wire value as "no
+# limit", which took AMP's 3 s budget past 350 s) was fixed first — see
+# ``parse_budget_secs`` in ``lp_bindings.rs``. Measured after the fix: this case
+# passes, and the whole file is 3 passed + 1 xpass with the flag on.
 
 # (instance, time_limit) pairs. Short limits are the discriminating cases —
 # a constant-overhead overrun is invisible at 60 s and catastrophic at 2 s.
 _CASES = [
     ("hda", 5.0),
-    pytest.param("hda", 10.0, marks=_XFAIL_LP_DEADLINE_DROP),
+    ("hda", 10.0),
     ("casctanks", 5.0),
 ]
 

--- a/python/tests/test_time_limit_contract.py
+++ b/python/tests/test_time_limit_contract.py
@@ -79,20 +79,25 @@ _SLACK_FRAC = 0.10
 # §1. So this case is marked xfail non-strict rather than silenced or given a
 # wider slack: it keeps running, it keeps reporting, and it will xpass the moment
 # #917 is properly resolved.
-# RESOLVED 2026-08-12 (#928): ``DISCOPT_LP_WARM_DEADLINE`` graduated to default-ON,
-# so the warm pure-LP path no longer discards the caller's ``time_limit`` and the
-# ``xfail`` above this case is retired. Measured on the graduated default,
-# ``hda`` at ``time_limit=10`` returns in 10.8 s against the 12.5 s allowed —
-# xpassing, which is why the marker had to go rather than stay as a non-strict
-# safety net: a permanent non-strict xfail on a passing case reports nothing.
-# The graduation ledger (both §5 bars, 3 reps, 96 oracle comparisons) is in
-# ``_lp_warm_deadline_enabled``'s docstring.
+# 2026-08-12 (#928): this xfail STAYS, and the reason is now sharper. Turning
+# ``DISCOPT_LP_WARM_DEADLINE=1`` makes this case xpass (measured 10.8 s against the
+# 12.5 s allowed), and its isolating panel passes both §5 bars — but the flag
+# cannot be the fix while it is ON-able only at the price of an unbounded MILP
+# launch: an exhausted shared budget reaches ``solve_milp`` as ``time_limit_s=0.0``,
+# the same wire value as "no limit", which takes AMP's 3 s budget past 350 s. The
+# blocker is that seam, not this case. See ``_lp_warm_deadline_enabled``.
+_XFAIL_LP_DEADLINE_DROP = pytest.mark.xfail(
+    reason="#928: warm pure-LP path drops the caller's time_limit, so the #138 "
+    "fallback's separated-relaxation phase overruns its grant by ~4s. Bimodal: "
+    "10.6-13.0s against 12.5s allowed. Not strict — it passes ~2/5 runs.",
+    strict=False,
+)
 
 # (instance, time_limit) pairs. Short limits are the discriminating cases —
 # a constant-overhead overrun is invisible at 60 s and catastrophic at 2 s.
 _CASES = [
     ("hda", 5.0),
-    ("hda", 10.0),
+    pytest.param("hda", 10.0, marks=_XFAIL_LP_DEADLINE_DROP),
     ("casctanks", 5.0),
 ]
 


### PR DESCRIPTION
## What this does

Two commits, in the order that matters:

1. **Fixes the seam** that made an *expired* MILP budget wire-identical to *no*
   budget, and
2. **graduates `DISCOPT_LP_WARM_DEADLINE` to default ON**, which that seam was
   blocking.

## 1. The seam (`fix(lp): an expired MILP budget is no longer the wire value for "no limit"`)

Both MILP entry points took a bare `f64` and mapped it with
`if time_limit_s > 0.0 { Some(t) } else { None }`, while the Python side spelled "no
limit" as `0.0`. The two meanings collapsed onto one wire value, and the collapse fell
the unsafe way: a caller whose shared budget was already spent by earlier attempts
asked for "stop now" and got an **unbounded** B&B.

This is the sentinel-collapse class already documented for `INF = 1e20` in the LP
layer, one level up. The correct contract already existed in the same file —
`parse_deadline`, used by the LP entries and mirrored in `spatial_bindings.rs`, takes
`Option<f64>`, treats `None`/`+inf` as no limit, and rejects negative/NaN loudly. Only
the two MILP entries were left on the sentinel.

`solve_milp_py` / `solve_milp_csc_py` now take `Option<f64>`. `Some(0.0)` reaches the
driver intact as an already-elapsed deadline, which stops at the first poll with
`gap_certified = false` — the same well-trodden path as a deadline expiring at node 1,
so the reported bound stays sound.

No behaviour change for the other MILP callers: `solver.py`'s three call sites are
guarded strictly positive, and `milp_simplex.py:435`/`:791` target
`solve_lp_warm_csc_py`, already on the `Option<f64>` contract.

**A second, independent defect** surfaced while verifying the pre-fix failure: `+inf`
did not merely mis-route, it **panicked** the driver — `inf > 0.0` sent `Some(inf)`
into `Duration::from_secs_f64`, aborting with *"cannot convert float seconds to
Duration"*. The shared validation closes that too.

The new test file fails **6/7** against the extension rebuilt at the parent commit and
passes 7/7 after. The discriminator is the **node count** (1 vs 53), not the clock: an
earlier draft asserted `wall_unlimited > wall_expired` and passed only by luck — the
expired call is actually the *slower* of the two at this size (0.0031 s vs 0.0016 s),
because both pay the same fixed setup.

## 2. The graduation (§5 gate)

**Bar 1, cert-clean — PASS.** Isolating panel, this flag alone, 19 binding instances,
20 s, 3 reps, rate-scored: 0 unsound, 0 cert_regressions, 0 lost_incumbents, 0
lost_bound in 3/3, over **96 executed oracle comparisons**.

**Bar 2, net-positive — PASS.** Overrun delta −2.6 / −1.0 / −0.3 s, negative in 3/3
(total overrun 6.5/4.8/4.0 s → 3.9/3.8/3.7 s), so the sign no longer flips with budget.
Nodes 4647 → 4611 (neutral). Both cells whose bound moves are **gains**: hda
−2.07e13 → −64473.44 in 3/3, and heatexch_gen1 46750/44196 → 49000. The three cells
scored "looser" are the known timing-nondeterministic class (tspn10 by 6e-8 relative;
tspn08/tspn12 flip direction between reps in *both* arms).

Scored by per-cell **rate** over reps, not one-shot: the bar-1 failures that kept this
flag off in earlier panels (nvs05, tls2, syn05hfsg, casctanks) are cells *neither* arm
holds reliably, and one-shot scoring cannot separate a flag effect from a race.

One caveat, in the conservative direction: the panel ran with the seam still present,
so the ON arm's wall times *included* those unbounded MILP launches. Bar 2 passed
carrying that handicap, so the fix can only have improved the margin it graduated on.

### Retraction, recorded per §11

The default was flipped ON on this panel earlier today and **retracted the same hour**:
`pytest -m smoke` failed `test_amp_integration::test_time_limit_respected` — `=0`
passed in 3.43 s, `=1` ran past 350 s. That retraction was correct, the cause was the
seam above, and it is why the seam is fixed *first* in this PR rather than the flag
being given a wider tolerance. My process error was committing the flip before running
the required smoke suite.

### Deviation from pre-registration, per §11

The panel pre-registered 5 reps; 3 were run (the run was cut short). The regression
margin is 2 of 3, proportionally at or above the pre-registered 3 of 5.

## Verification

With the flag ON (i.e. the new default):

| Gate | Result |
|---|---|
| `pytest -m smoke` | 958 passed, 1 skipped, 2 xpassed — byte-identical to the OFF arm |
| `pytest -m slow test_adversarial_recent_fixes.py` | 10 passed |
| `test_time_limit_contract.py` | 4 passed |
| `test_amp_integration::test_time_limit_respected` | 3.39 s (was >350 s) |
| `cargo test -p discopt-core` | 597 + 4 + 1 doc-test passed, 0 failed |
| `test_928_expired_budget_not_unlimited.py` | 7 passed (6 fail pre-fix) |
| ruff / cargo fmt / clippy | clean |

The `hda` 10 s case in `test_time_limit_contract.py` was `xfail(strict=False)` for this
exact defect. It is now a plain assertion and **the xfail marker is deleted, not
widened**.

The `DISCOPT_LP_WARM_DEADLINE=0` opt-out and the legacy fresh-duration-per-attempt path
are unchanged and still covered by `test_flag_parses`.

Closes #928

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017PQaiDVuY5Rs3tga98tnNo
