### PR TITLE
fix(test): #832 prove the byte-identity test's premise instead of assuming it

### DIFF
--- a/python/tests/test_832_root_build_deadline.py
+++ b/python/tests/test_832_root_build_deadline.py
@@ -94,10 +94,29 @@ def test_832_flag_byte_identical_on_normal_instance(monkeypatch, inst):
     p = _INREPO / f"{inst}.nl"
     if not p.exists():
         pytest.skip(f"{inst}.nl absent")
+    # The premise — "the base build finishes before the deadline" — has to be
+    # PROVEN, not assumed. With the default 3 s grant it silently stopped holding
+    # for casctanks under the `--cov` job (coverage instruments every Python
+    # bytecode, and the base build is Python-bound): the grant bound, the ON arm
+    # truncated to a weaker-but-sound relaxation, and the arms diverged legitimately
+    # (`None` vs `0.0`) on a test whose whole point is that they must not. That is a
+    # broken premise reported as a soundness failure. Verified on the identical
+    # commit: a rerun of run 31563343233's failed coverage job passed.
+    #
+    # So: a grant far larger than the build, and an assertion that it did not bind.
+    # If a build ever does exceed it, this fails loudly with the measured time
+    # rather than silently comparing two different code paths.
+    grant = 60.0
     monkeypatch.setenv("DISCOPT_ROOT_BUILD_DEADLINE", "0")
-    val_off, _ = _fallback(p)
+    val_off, dt_off = _fallback(p, budget=grant)
     monkeypatch.setenv("DISCOPT_ROOT_BUILD_DEADLINE", "1")
-    val_on, _ = _fallback(p)
+    val_on, dt_on = _fallback(p, budget=grant)
+    assert max(dt_off, dt_on) < grant, (
+        f"{inst}: premise broken — a build took {max(dt_off, dt_on):.1f}s of its "
+        f"{grant:.0f}s grant, so the deadline BOUND and the two arms are no longer "
+        "comparing the same relaxation. This test cannot say anything about "
+        "byte-identity here; raise the grant or drop the instance."
+    )
     if val_off is None or val_on is None:
         assert val_off is val_on, f"{inst}: one side None, other not ({val_off} vs {val_on})"
     else:


### PR DESCRIPTION
Fixes the red CI on `main`.

## The failure

Run [31563343233](https://github.com/jkitchin/discopt/actions/runs/31563343233)
(push to `main`, the #992 merge):

```
FAILED python/tests/test_832_root_build_deadline.py::test_832_flag_byte_identical_on_normal_instance[casctanks]
AssertionError: casctanks: one side None, other not (None vs 0.0)
```

## Why it is not a #992 regression

- #992's `solver.py` hunks are at lines 439 / 1021 / 11614 / 14191;
  `_root_relaxation_lower_bound` is at 4588. Its only edit to *existing*
  `primal_heuristics.py` code is the `_detect_one_hot_groups` refactor, used by the
  #280 swap move, which the root relaxation never calls.
- **A rerun of the failed job on the identical commit passed.**

## The actual defect — an unverified premise

The test compares the `=0` opt-out against the graduated-ON default on "an
instance whose base build finishes before the deadline", and never checks that it
does; it ran both arms on a 3 s grant.

The failing job is **`Python coverage`, which is `skipped` on `pull_request` and
runs only on push to `main`** — so no PR gate exercises it. Coverage instruments
every bytecode and the base build is Python-bound, so the 3 s grant binds there
where it does not locally. The ON arm then truncates to a weaker-but-sound
relaxation while the OFF arm builds the whole one, and the arms diverge
legitimately (`None` vs `0.0`, both sound) — on a test whose entire point is that
they must not. A broken premise was being reported as a soundness failure.

## The fix

A grant far larger than the build (60 s) plus an assertion that it did **not**
bind. If a build ever exceeds it, the test fails loudly with the measured time
instead of silently comparing two different relaxations — CLAUDE.md §6, an
instrument must prove it measured what it claims.

## Verification

`pytest python/tests/test_832_root_build_deadline.py` — 3 passed, 3 deselected, in
4.19 s, so the new grant is ~14x the slowest observed build. Test-only change.
