### PR TITLE
fix(correctness): C-42 strip fabricated dual bound on the opaque CustomCall local path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -163,6 +163,18 @@ The release procedure that produces these entries is documented in
   `CustomCall` path are unaffected. Regression tests:
   `python/tests/test_customcall_local_bound.py`.
 
+  **Behaviour change (both uncertified local-NLP paths).** `_solve_continuous`
+  reported `status="optimal"` on the same basis it reported the bound — the NLP
+  converged — which on an unproven-convex model is the same unearned claim. Both
+  the opaque-`CustomCall` path and the pure-continuous convexity-unknown path
+  (`skip_convex_check`, or the convexity classifier abstained) now report
+  `status="feasible"`: a feasible point was found, global optimality was not
+  proved. This is already the convention the spatial path uses when its gap does
+  not close. `"unknown"` is reported when the incumbent itself was withheld. Code
+  that gated on `status == "optimal"` from these paths should check for
+  `"feasible"` too — or, better, read `gap_certified`. The convex fast path,
+  MCBox-relaxable `CustomCall` models, and every certified path are unchanged.
+
 - **`solve(time_limit=T)` overran `T` because heuristic sub-NLPs were polled but
   never capped** (`fix(heuristics)`, contributes to #966). Every deadline guard in
   `_relax/primal_heuristics.py` gated whether a sub-NLP *starts*; none bounded how

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -145,6 +145,24 @@ The release procedure that produces these entries is documented in
 
 ### Fixed
 
+- **Opaque `dm.custom` models reported a fabricated (invalid) dual bound**
+  (`fix(correctness)`, C-42, closes #998). A `CustomCall` body that is not
+  MCBox-reducible falls back to a single local NLP; that caller cleared
+  `gap_certified` but left the *local* objective in `bound` / `gap` /
+  `root_bound` / `root_gap`. On a nonconvex body the local optimum is routinely
+  above the true global minimum, so the reported "dual bound" was not a bound at
+  all — 2-D Ackley behind `dm.custom` on `[-25.768, 39.768]` returned
+  `bound=15.06, gap=0.0` against a true global minimum of `0.0`, while the
+  algebraic twin of the same mathematics correctly returned `bound=None`. This is
+  the C-33/SC-1 defect, whose strip was never applied to this caller; an opaque
+  body cannot be inspected at all, so convexity can never be established for it
+  and the strip applies a fortiori. The fix keeps the feasible incumbent and
+  strips the bound/gap on any non-`infeasible` result — it only ever removes a
+  claim, so it can neither introduce a false optimum nor loosen a valid bound.
+  Rigorous `status="infeasible"` and the MCBox-reducible (global reduced-space)
+  `CustomCall` path are unaffected. Regression tests:
+  `python/tests/test_customcall_local_bound.py`.
+
 - **`solve(time_limit=T)` overran `T` because heuristic sub-NLPs were polled but
   never capped** (`fix(heuristics)`, contributes to #966). Every deadline guard in
   `_relax/primal_heuristics.py` gated whether a sub-NLP *starts*; none bounded how

--- a/docs/dev/correctness-issues.md
+++ b/docs/dev/correctness-issues.md
@@ -126,6 +126,7 @@ in non-default configs; loud ingestion gaps. **P3** = hygiene.
 | C-35 | P1 | oa.py / gdpopt_loa | non-rigorous NLP failure → unconditional no-good cut → possible false infeasible/optimal (= OA-1, opt-in OA/LOA path) | fixed |
 | C-36 | P3 | convexity/interval.py | Python `interval_mul` yields NaN on 0·∞ (`RuntimeWarning: invalid value encountered in multiply`), same 0·∞ class as C-22 but a SEPARATE Python code path (`python/discopt/_relax/convexity/interval.py:171`); lost tightening, not unsound | fixed |
 | C-37 | P2 | solver.py callback API | `CallbackContext.best_bound` surfaced the raw tree `global_lower_bound` with no sense-negation and no taint gate → **over-reported** the certified global bound on a non-rigorously-fathomed tree (nvs05: callback 5.32 vs the rigorous `SolveResult.bound` 1.35) and reported a wrong-signed bound for MAXIMIZE; API-surface soundness (the reported `SolveResult.bound` was already correct) | fixed (A1) |
+| C-42 | P1 | solver.py CustomCall local path | the non-MCBox-reducible `dm.custom`/`CustomCall` local-NLP fallback cleared `gap_certified` only, leaving the local NLP objective in `bound`/`gap`/`root_bound`/`root_gap` → an **invalid dual bound above the optimum** on the DEFAULT path (2-D Ackley behind `dm.custom`: `bound=15.06, gap=0.0` against a true global minimum of 0). Same defect as C-33/SC-1, whose strip was never applied to this caller; the algebraic twin of the same model correctly reports `bound=None` (= issue #998) | fixed |
 
 ---
 
@@ -2785,3 +2786,82 @@ fails on `main` (bound 1072.96) and passes after. MBQCP/MIQCP/QCP-class scan
 (12 instances) shows no false optima. Note: the 144-vs-145 repr length is a latent
 `model_to_repr` layout divergence; the fix soundly guards around it — a follow-up
 to *restore* the tightening by aligning the repr layout is tracked in the fix doc.
+
+---
+
+## C-42 (P1, FIXED — issue #998) — opaque `CustomCall` local path emits a fabricated (invalid) dual bound
+
+**Origin:** issue #998 (found while running the entry experiment for a proposed
+derivative-free `solver="direct"` backend, whose panel wraps multimodal test
+functions in `dm.custom`).
+**Area:** `python/discopt/solver.py` — the `CustomCall` local-NLP fallback in
+`solve_model` (the `if not _cc_admissible:` / pure-continuous arm), which calls
+`_solve_continuous` and returns its result.
+**Reachability:** DEFAULT path — any continuous model whose `dm.custom` body is
+*not* MCBox-reducible (raw `jnp` intrinsics, a non-affine hidden division, a
+non-scalar leaf, a non-finite box). No opt-in flag required.
+
+**Mechanism:** `_solve_continuous` sets `bound` / `gap` / `root_bound` /
+`root_gap` from the NLP's own convergence status, which for a local solver means
+"a KKT point was reached", not "this is the global optimum". The `CustomCall`
+caller cleared `gap_certified` only, so the *local* objective survived in
+`result.bound` as a purported dual bound. On a nonconvex opaque body that value
+is routinely **above** the true global minimum — not a valid bound at all. This
+is the identical defect fixed for the convexity-unknown local path as C-33/SC-1;
+that fix strips the bound, and the `CustomCall` caller was never updated to
+match. An opaque body is a *strictly weaker* epistemic position than "convexity
+unknown" — it cannot be inspected at all, so convexity can never be established —
+which makes it the one caller that most needs the strip.
+
+**Severity (P1, not P0):** `gap_certified=False` was set correctly, so a consumer
+that checks the flag was never misled into accepting a false certificate. But
+`result.bound` is read directly by reports, notebooks, and comparison harnesses,
+and a dual bound above the optimum violates the certificate invariant of
+CLAUDE.md §1.
+
+**Reproduce/confirm (VERIFIED, fail-before/pass-after):** 2-D Ackley on
+`[-25.768, 39.768]` (true global minimum 0.0 at the origin) expressed two ways.
+Behind `dm.custom` the pre-fix solver returned `status=optimal,
+objective=15.06351400512647, bound=15.06351400512647, root_bound=15.0635…,
+gap=0.0, gap_certified=False` — a lower bound of 15.06 on a problem whose optimum
+is 0, reported with a zero gap. The algebraic twin of the same mathematics
+(`skip_convex_check=True`, the C-33 path) correctly returned `bound=None,
+gap=None`.
+
+**Fix:** mirror the accepted C-33/SC-1 code at the `CustomCall` caller rather
+than invent a second convention — on any non-`infeasible` result, keep the
+feasible incumbent (`objective`, `x`, `status`) and set `gap_certified=False`,
+`bound=None`, `root_bound=None`, `gap=None`, `root_gap=None`. This only ever
+*removes* a claim, so it can neither introduce a false optimum nor loosen a valid
+bound (the same soundness argument the C-33 site carries). Genuine
+`status="infeasible"` from `_solve_continuous` is a rigorous
+nonlinear-tightening / NLP-infeasibility claim, not a gap, so it is left
+untouched. The MCBox-reducible `CustomCall` path (reduced-space global engine) is
+not reached by this branch and keeps its valid certificate.
+
+**Regression test** (`python/tests/test_customcall_local_bound.py`, all
+`@pytest.mark.smoke`; fail-before/pass-after verified by stashing the fix — 2
+failed / 2 passed before, 4 passed after):
+`test_customcall_local_path_strips_fabricated_bound` (the opaque Ackley repro:
+incumbent kept, all four bound/gap fields `None`, and the invariant that a
+*reported* bound must satisfy `bound <= true_optimum + tol`),
+`test_algebraic_twin_control_agrees` (the C-33 path on the same mathematics),
+`test_customcall_and_algebraic_paths_agree` (the two spellings of one problem
+must report the same kind of answer — this is the assertion that pins the
+divergence), and `test_mcbox_traceable_customcall_still_certifies` (control
+against over-correction: an MCBox-relaxable `dm.custom` still certifies with a
+valid bound).
+
+**Not changed (deliberate, per #998):** both local paths still report
+`status="optimal"` for what is only a local solution. That is the existing
+convention C-33 chose to keep; with `gap` now `None` on both, the output no
+longer reads as a solved problem. Changing it belongs in its own issue covering
+both callers.
+
+**Gates:** new test 4 passed; `pytest -m smoke` 958 passed / 15 skipped /
+2 xpassed; adversarial `test_adversarial_recent_fixes.py -m slow` 10 passed;
+`test_customcall_reduced.py` + `test_custom_udf.py` +
+`test_c33_nonconvex_fallback_cert.py` 35 passed; `ruff check` / `ruff format
+--check` clean; `mypy python/discopt/solver.py` clean. No Rust touched.
+
+**Status:** confirmed → fixed.

--- a/docs/dev/correctness-issues.md
+++ b/docs/dev/correctness-issues.md
@@ -2828,16 +2828,31 @@ is 0, reported with a zero gap. The algebraic twin of the same mathematics
 (`skip_convex_check=True`, the C-33 path) correctly returned `bound=None,
 gap=None`.
 
-**Fix:** mirror the accepted C-33/SC-1 code at the `CustomCall` caller rather
-than invent a second convention — on any non-`infeasible` result, keep the
-feasible incumbent (`objective`, `x`, `status`) and set `gap_certified=False`,
-`bound=None`, `root_bound=None`, `gap=None`, `root_gap=None`. This only ever
-*removes* a claim, so it can neither introduce a false optimum nor loosen a valid
-bound (the same soundness argument the C-33 site carries). Genuine
+**Fix:** both uncertified-local-NLP callers now route through one shared helper,
+`_withhold_local_optimality_certificate`, rather than each carrying its own copy
+of the treatment — the duplication is precisely how this happened (C-33 fixed one
+site; the other kept emitting the fabricated bound 470 lines away). On any
+non-`infeasible` result it keeps the feasible incumbent (`objective`, `x`) and
+sets `gap_certified=False`, `bound=None`, `root_bound=None`, `gap=None`,
+`root_gap=None`, and downgrades `status="optimal"` to `"feasible"` (see below).
+This only ever *removes* a claim, so it can neither introduce a false optimum nor
+loosen a valid bound (the same soundness argument the C-33 site carries). Genuine
 `status="infeasible"` from `_solve_continuous` is a rigorous
 nonlinear-tightening / NLP-infeasibility claim, not a gap, so it is left
 untouched. The MCBox-reducible `CustomCall` path (reduced-space global engine) is
 not reached by this branch and keeps its valid certificate.
+
+**Status downgrade (the issue's "secondary question", decided in favour of
+changing it):** `_solve_continuous` reports `status="optimal"` on the same basis
+it reported the bound — the NLP converged — so on an unproven-convex model that
+verdict is the same unearned claim. Both local paths now report the honest
+`status="feasible"`: a feasible point was found, global optimality was not
+proved. That is already the codebase's convention for an uncertified incumbent
+(the spatial path returns `"feasible"` when its gap does not close). When the
+incumbent itself was withheld (the #815 feasibility check rejected the NLP's
+point) the verdict is `"unknown"`, since `"feasible"` would assert a feasible
+point that is not in hand. The change is applied to **both** callers together, as
+#998 required of any change to this convention.
 
 **Regression test** (`python/tests/test_customcall_local_bound.py`, all
 `@pytest.mark.smoke`; fail-before/pass-after verified by stashing the fix — 2
@@ -2852,11 +2867,11 @@ divergence), and `test_mcbox_traceable_customcall_still_certifies` (control
 against over-correction: an MCBox-relaxable `dm.custom` still certifies with a
 valid bound).
 
-**Not changed (deliberate, per #998):** both local paths still report
-`status="optimal"` for what is only a local solution. That is the existing
-convention C-33 chose to keep; with `gap` now `None` on both, the output no
-longer reads as a solved problem. Changing it belongs in its own issue covering
-both callers.
+**Call-site updates for the downgraded status:** `test_custom_udf.py`'s two
+local-path cases (`test_vector_custom_solves`, `test_custom_mixed_with_primitives`)
+asserted `status == "optimal"` alongside `gap_certified is False` — they now
+assert `"feasible"` and no bound/gap. The user-facing docstrings for `dm.custom`,
+`CustomCall`, and the implicit-node module state the reported status.
 
 **Gates:** new test 4 passed; `pytest -m smoke` 958 passed / 15 skipped /
 2 xpassed; adversarial `test_adversarial_recent_fixes.py -m slow` 10 passed;

--- a/python/discopt/modeling/core.py
+++ b/python/discopt/modeling/core.py
@@ -937,8 +937,11 @@ class CustomCall(Expression):
       (MAiNGO-parity plan P3.1, #713). A body that uses raw ``jnp`` intrinsics on
       its arguments (e.g. ``jnp.exp(x)`` rather than an ``MCBox``-aware op), a
       non-affine hidden division, a non-scalar leaf, or an unbounded box is **not**
-      reduced-relaxable and falls back to the **local NLP path only** (no global
-      certificate, ``gap_certified`` is ``False``) -- sound-or-refuse.
+      reduced-relaxable and falls back to the **local NLP path only** -- sound-or-
+      refuse. That path proves a feasible point, not a global optimum, so it
+      reports ``status="feasible"`` with ``gap_certified=False`` and
+      ``bound``/``gap``/``root_bound``/``root_gap`` all ``None``: a local NLP's
+      objective is not a valid dual bound on a nonconvex body (#998).
     - Integer/binary variables are supported **when the body is MCBox-relaxable**
       (plan P3.2): the model is branched over the integer + continuous DOF with
       reduced-space node bounds and certified globally. A **non**-MCBox-relaxable
@@ -1532,9 +1535,10 @@ def custom(fn: Callable, *, name: Optional[str] = None) -> Callable:
 
     Because the body is opaque to the relaxation machinery, a model that uses a
     ``dm.custom`` function is solved on the **local NLP path only** -- there is
-    no global optimality certificate -- and the solver raises if integer/binary
-    variables are present (global branch-and-bound cannot bound an opaque
-    callable). See :class:`CustomCall`.
+    no global optimality certificate, so the result reports
+    ``status="feasible"`` with no ``bound``/``gap`` -- and the solver raises if
+    integer/binary variables are present (global branch-and-bound cannot bound an
+    opaque callable). See :class:`CustomCall`.
 
     Parameters
     ----------

--- a/python/discopt/modeling/implicit.py
+++ b/python/discopt/modeling/implicit.py
@@ -10,11 +10,12 @@ so we never differentiate through the Newton iterations.
 
 This rides entirely on :class:`~discopt.modeling.core.CustomCall`: the returned
 node is opaque and AD-only, so a model containing an implicit node is solved on
-the **local NLP path only** (no global optimality certificate) and the solver
-raises if integer/binary variables are present -- exactly the CustomCall
-contract.  It is the core-side primitive that lets reduced-space / variable
-aggregation eliminate an irreducible *cyclic* block ``g_B(u, v_B) = 0`` instead
-of leaving its variables in the reduced model.
+the **local NLP path only** (no global optimality certificate: ``status``
+``"feasible"``, no ``bound``/``gap``) and the solver raises if integer/binary
+variables are present -- exactly the CustomCall contract.  It is the core-side
+primitive that lets reduced-space / variable aggregation eliminate an irreducible
+*cyclic* block ``g_B(u, v_B) = 0`` instead of leaving its variables in the
+reduced model.
 
 Prototype for #379 -- API and scope may still change.
 """

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -7257,7 +7257,28 @@ def solve_model(
                 nlp_solver,
                 initial_point=initial_point,
             )
-            result.gap_certified = False
+            # C-33/SC-1 (#998) applies here a fortiori: an opaque dm.custom body
+            # cannot be inspected at all, so convexity can never be established
+            # for it — the single NLP's objective is a LOCAL optimum only.
+            # `_solve_continuous` sets bound/gap/root_bound/root_gap from the NLP's
+            # own convergence status ("a KKT point was reached"), which on a
+            # nonconvex body is routinely ABOVE the true global minimum, i.e. not a
+            # valid dual bound at all (2-D Ackley on [-25.768, 39.768] stalls at
+            # ~15.06 against a true optimum of 0, reported as bound=15.06, gap=0).
+            # Clearing gap_certified alone is not enough: `result.bound` is read
+            # directly by reports/notebooks/comparison harnesses. Keep the feasible
+            # incumbent (objective, x); strip the fabricated dual bound and gap.
+            # This only ever REMOVES a claim, so it can neither create a false
+            # optimum nor loosen a valid bound. Genuine infeasibility from
+            # `_solve_continuous` is a rigorous nonlinear-tightening / NLP-
+            # infeasibility claim, not a gap, so leave that case alone — same
+            # convention as the convexity-unknown caller below.
+            if result.status != "infeasible":
+                result.gap_certified = False
+                result.bound = None
+                result.root_bound = None
+                result.gap = None
+                result.root_gap = None
             return result
         logger.info(
             "Model contains a dm.custom(...) function that traces soundly through "

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -5133,6 +5133,56 @@ _BACKEND_PASSTHROUGH_KWARGS: frozenset[str] = frozenset(
 )
 
 
+def _withhold_local_optimality_certificate(result: SolveResult) -> SolveResult:
+    """Downgrade an UNCERTIFIED single-NLP result in place (C-33/SC-1, C-42, #998).
+
+    Two callers in :func:`solve_model` route a model to one local NLP without any
+    proof of convexity: the opaque ``dm.custom``/``CustomCall`` fallback (the body
+    cannot be inspected at all, so convexity can never be established) and the
+    pure-continuous convexity-unknown fallback (``skip_convex_check``, or the
+    classifier abstained). Both need the identical treatment, so it lives here
+    rather than being written twice and drifting — the drift is exactly how #998
+    happened: C-33 fixed one site, the other kept emitting the fabricated bound
+    for 470 lines' worth of distance.
+
+    :func:`_solve_continuous` fills ``bound``/``gap``/``root_bound``/``root_gap``
+    from the NLP's own convergence status, which for a local solver means "a KKT
+    point was reached", not "this is the global optimum" — and reports
+    ``status="optimal"`` on that same basis. On a nonconvex model the local
+    optimum is not global (a nonconvex double-well returned obj=-50 while the true
+    min was -78; 2-D Ackley behind ``dm.custom`` returned bound=15.06 on a problem
+    whose optimum is 0), so every one of those fields is a claim the solve did not
+    earn.
+
+    What survives is the *incumbent* — ``objective`` and ``x`` are a genuine
+    feasible point (``_solve_continuous`` verifies feasibility at the source,
+    #815). So the honest report is ``status="feasible"``: a feasible solution was
+    found, global optimality was not proved. That is the same verdict the spatial
+    path already uses when its gap does not close.
+
+    This only ever REMOVES a claim — it can neither introduce a false optimum nor
+    loosen a valid bound. Do NOT weaken it into "trust the NLP": refuse to certify
+    (CLAUDE.md §1, §3).
+
+    A rigorous ``status="infeasible"`` (nonlinear tightening / NLP infeasibility)
+    is a proof, not a gap, and is returned untouched.
+    """
+    if result.status == "infeasible":
+        return result
+    result.gap_certified = False
+    result.bound = None
+    result.root_bound = None
+    result.gap = None
+    result.root_gap = None
+    if result.status == "optimal":
+        # "optimal" here means only "the NLP converged". Downgrade to the honest
+        # verdict — "feasible" when an incumbent survives, "unknown" when the
+        # point was withheld (e.g. the #815 feasibility check rejected it), since
+        # "feasible" would then assert a feasible point we do not have.
+        result.status = "feasible" if result.objective is not None and result.x else "unknown"
+    return result
+
+
 @functools.lru_cache(maxsize=1)
 def solve_model_accepted_kwargs() -> frozenset[str]:
     """The complete set of keyword names ``Model.solve`` may forward to the solver.
@@ -7259,27 +7309,14 @@ def solve_model(
             )
             # C-33/SC-1 (#998) applies here a fortiori: an opaque dm.custom body
             # cannot be inspected at all, so convexity can never be established
-            # for it — the single NLP's objective is a LOCAL optimum only.
-            # `_solve_continuous` sets bound/gap/root_bound/root_gap from the NLP's
-            # own convergence status ("a KKT point was reached"), which on a
-            # nonconvex body is routinely ABOVE the true global minimum, i.e. not a
-            # valid dual bound at all (2-D Ackley on [-25.768, 39.768] stalls at
-            # ~15.06 against a true optimum of 0, reported as bound=15.06, gap=0).
-            # Clearing gap_certified alone is not enough: `result.bound` is read
-            # directly by reports/notebooks/comparison harnesses. Keep the feasible
-            # incumbent (objective, x); strip the fabricated dual bound and gap.
-            # This only ever REMOVES a claim, so it can neither create a false
-            # optimum nor loosen a valid bound. Genuine infeasibility from
-            # `_solve_continuous` is a rigorous nonlinear-tightening / NLP-
-            # infeasibility claim, not a gap, so leave that case alone — same
-            # convention as the convexity-unknown caller below.
-            if result.status != "infeasible":
-                result.gap_certified = False
-                result.bound = None
-                result.root_bound = None
-                result.gap = None
-                result.root_gap = None
-            return result
+            # for it — the single NLP's objective is a LOCAL optimum only, and
+            # `_solve_continuous`'s bound/gap/status describe NLP convergence, not
+            # global optimality (2-D Ackley on [-25.768, 39.768] stalls at ~15.06
+            # against a true optimum of 0, reported as bound=15.06, gap=0,
+            # status="optimal"). Clearing gap_certified alone is not enough:
+            # `result.bound` is read directly by reports/notebooks/comparison
+            # harnesses. Keep the feasible incumbent, withhold the certificate.
+            return _withhold_local_optimality_certificate(result)
         logger.info(
             "Model contains a dm.custom(...) function that traces soundly through "
             "MCBox — solving GLOBALLY via the reduced-space engine (branching on the "
@@ -7771,17 +7808,12 @@ def solve_model(
             # the local objective) is a FALSE optimality certificate (a nonconvex
             # double-well returned obj=-50 certified while the true min was -78).
             # Withhold the certificate: keep the feasible incumbent (objective, x)
-            # but strip the fabricated dual bound/gap and mark it uncertified. Do
-            # NOT weaken this into "trust the NLP" — refuse to certify (CLAUDE.md
-            # §1, §3). Genuine infeasibility from _solve_continuous is a rigorous
+            # but strip the fabricated dual bound/gap, downgrade the NLP-convergence
+            # "optimal" to the honest "feasible", and mark it uncertified. Do NOT
+            # weaken this into "trust the NLP" — refuse to certify (CLAUDE.md §1,
+            # §3). Genuine infeasibility from _solve_continuous is a rigorous
             # nonlinear-tightening / NLP-infeasibility claim, not a gap, so leave it.
-            if _cont_result.status != "infeasible":
-                _cont_result.gap_certified = False
-                _cont_result.bound = None
-                _cont_result.root_bound = None
-                _cont_result.gap = None
-                _cont_result.root_gap = None
-            return _cont_result
+            return _withhold_local_optimality_certificate(_cont_result)
         logger.info(
             "Local NLP on convexity-unknown continuous model returned error; "
             "falling back to spatial Branch-and-Bound (issue #266)"

--- a/python/tests/test_convex_fast_path.py
+++ b/python/tests/test_convex_fast_path.py
@@ -187,9 +187,16 @@ class TestConvexFastPathOptOut:
         m.minimize(dm.exp(x))
 
         result = m.solve(skip_convex_check=True)
-        assert result.status == "optimal"
         # With skip_convex_check, the fast path is not used
         assert result.convex_fast_path is False
+        # ...and convexity is therefore never established, so the single local NLP
+        # proves a feasible point, not a global optimum: no certificate, no bound,
+        # and the honest "feasible" rather than the NLP's own "optimal" (#998).
+        # The objective is still exp(-10) — the true minimum here — it is only the
+        # *claim* about it that is withheld.
+        assert result.status == "feasible"
+        assert result.gap_certified is False
+        assert result.bound is None and result.gap is None
 
 
 class TestConvexFastPathSolutions:

--- a/python/tests/test_custom_udf.py
+++ b/python/tests/test_custom_udf.py
@@ -109,7 +109,10 @@ class TestLocalSolve:
         m.minimize(f(x))
 
         result = m.solve()
-        assert result.status == "optimal"
+        # The local NLP proves a feasible point, not a global optimum (#998), so
+        # the honest verdict is "feasible" with no bound/gap.
+        assert result.status == "feasible"
+        assert result.bound is None and result.gap is None
         np.testing.assert_allclose(result.x["x"], np.asarray(target), atol=1e-4)
         assert result.gap_certified is False
 
@@ -152,7 +155,9 @@ class TestLocalSolve:
         m.minimize(opaque(x) + (x - 1.0) ** 2)
 
         result = m.solve()
-        assert result.status == "optimal"
+        # Local NLP path ⇒ feasible point, no global certificate (#998).
+        assert result.status == "feasible"
+        assert result.bound is None and result.gap is None
         # Verify the reported point is a stationary point of the true objective:
         # d/dx [sin^2(x) + (x-1)^2] = sin(2x) + 2(x-1) = 0.
         xv = float(result.x["x"])

--- a/python/tests/test_customcall_local_bound.py
+++ b/python/tests/test_customcall_local_bound.py
@@ -78,6 +78,10 @@ def _assert_no_fabricated_bound(r, label):
     assert r.root_bound is None, f"{label}: fabricated root bound {r.root_bound!r}"
     assert r.gap is None, f"{label}: fabricated gap {r.gap!r}"
     assert r.root_gap is None, f"{label}: fabricated root gap {r.root_gap!r}"
+    # "optimal" from a local NLP means only "the NLP converged". With an
+    # incumbent in hand the honest verdict is "feasible": a feasible point was
+    # found, global optimality was not proved.
+    assert r.status == "feasible", f"{label}: local solution reported as {r.status!r}"
 
 
 def _assert_bound_is_valid(r, label):
@@ -132,6 +136,7 @@ def test_customcall_and_algebraic_paths_agree():
     assert (r_opaque.root_bound is None) == (r_algebraic.root_bound is None)
     assert (r_opaque.root_gap is None) == (r_algebraic.root_gap is None)
     assert r_opaque.gap_certified == r_algebraic.gap_certified
+    assert r_opaque.status == r_algebraic.status
 
 
 @pytest.mark.smoke

--- a/python/tests/test_customcall_local_bound.py
+++ b/python/tests/test_customcall_local_bound.py
@@ -1,0 +1,150 @@
+"""#998 — the opaque ``CustomCall`` local-NLP path must not emit a fabricated bound.
+
+A ``dm.custom`` body that does NOT trace soundly through MCBox (raw ``jnp``
+intrinsics, a non-affine hidden division, …) has no valid node relaxation, so
+``solve_model`` falls back to a single local NLP. ``_solve_continuous`` fills
+``bound`` / ``gap`` / ``root_bound`` / ``root_gap`` from the NLP's own
+convergence status — which for a local solver means "a KKT point was reached",
+not "this is the global optimum". On a nonconvex opaque body that value is
+routinely *above* the true global minimum, i.e. not a valid dual bound at all.
+
+That is exactly the C-33/SC-1 defect already fixed for the convexity-unknown
+local path; the ``CustomCall`` caller cleared ``gap_certified`` only, leaving the
+fabricated bound/gap in place. An opaque body is a strictly weaker epistemic
+position than "convexity unknown" — it cannot be inspected at all — so the strip
+applies a fortiori.
+
+Fails-before / passes-after: 2-D Ackley on the asymmetric box
+``[-25.768, 39.768]`` has its global minimum 0.0 at the origin, but the default
+start stalls at ≈ 15.06. Before the fix the opaque arm reported
+``bound = 15.06`` with ``gap = 0.0`` on a problem whose optimum is 0.
+
+The algebraic twin (same mathematics, inspectable AST → the convexity-unknown
+path) is the control: the two paths must agree.
+"""
+
+import os
+
+os.environ.setdefault("JAX_PLATFORMS", "cpu")
+os.environ.setdefault("JAX_ENABLE_X64", "1")
+
+import math  # noqa: E402
+
+import discopt.modeling as dm  # noqa: E402
+import jax.numpy as jnp  # noqa: E402
+import pytest  # noqa: E402
+
+# Ackley's global minimum on any box containing the origin.
+TRUE_GLOBAL = 0.0
+LB, UB = -25.768, 39.768
+
+
+def _ackley(v):
+    """2-D Ackley written with raw ``jnp`` intrinsics (NOT MCBox-traceable)."""
+    n = v.shape[0]
+    return (
+        -20 * jnp.exp(-0.2 * jnp.sqrt(jnp.sum(v**2) / n))
+        - jnp.exp(jnp.sum(jnp.cos(2 * math.pi * v)) / n)
+        + 20
+        + math.e
+    )
+
+
+def _opaque_model():
+    """Ackley behind ``dm.custom`` — routes to the CustomCall local-NLP path."""
+    m = dm.Model("ackley_customcall")
+    x = m.continuous("x", shape=2, lb=LB, ub=UB)
+    m.minimize(dm.custom(_ackley, name="ackley")(x))
+    return m
+
+
+def _algebraic_model():
+    """The same mathematics as an inspectable AST — the convexity-unknown path."""
+    m = dm.Model("ackley_algebraic")
+    y = m.continuous("y", shape=2, lb=LB, ub=UB)
+    m.minimize(
+        -20 * dm.exp(-0.2 * dm.sqrt((y[0] ** 2 + y[1] ** 2) / 2))
+        - dm.exp((dm.cos(2 * math.pi * y[0]) + dm.cos(2 * math.pi * y[1])) / 2)
+        + 20
+        + math.e
+    )
+    return m
+
+
+def _assert_no_fabricated_bound(r, label):
+    """No dual-bound claim may survive an uncertified local solve."""
+    assert r.gap_certified is False, f"{label}: local NLP result certified as global"
+    assert r.bound is None, f"{label}: fabricated dual bound {r.bound!r}"
+    assert r.root_bound is None, f"{label}: fabricated root bound {r.root_bound!r}"
+    assert r.gap is None, f"{label}: fabricated gap {r.gap!r}"
+    assert r.root_gap is None, f"{label}: fabricated root gap {r.root_gap!r}"
+
+
+def _assert_bound_is_valid(r, label):
+    """The property that actually matters (min sense): a *reported* dual bound
+    must never exceed the true global optimum. Vacuous while the bound is
+    stripped; it is the pin that survives if a future change ever routes this
+    path to a genuine bound."""
+    for field in ("bound", "root_bound"):
+        val = getattr(r, field)
+        if val is not None:
+            assert val <= TRUE_GLOBAL + 1e-6, (
+                f"{label}: {field}={val} exceeds the true global optimum "
+                f"{TRUE_GLOBAL} — invalid dual bound"
+            )
+
+
+@pytest.mark.smoke
+def test_customcall_local_path_strips_fabricated_bound():
+    """Opaque ``dm.custom`` body: keep the incumbent, strip the bound/gap."""
+    r = _opaque_model().solve(time_limit=60)
+
+    # The feasible incumbent is kept — only the *claim* about it is withheld.
+    assert r.objective is not None
+    assert r.objective >= TRUE_GLOBAL - 1e-6
+
+    _assert_no_fabricated_bound(r, "customcall")
+    _assert_bound_is_valid(r, "customcall")
+
+
+@pytest.mark.smoke
+def test_algebraic_twin_control_agrees():
+    """Control: the same mathematics on the convexity-unknown path (C-33/SC-1)."""
+    r = _algebraic_model().solve(time_limit=60, skip_convex_check=True)
+
+    _assert_no_fabricated_bound(r, "algebraic")
+    _assert_bound_is_valid(r, "algebraic")
+
+
+@pytest.mark.smoke
+def test_customcall_and_algebraic_paths_agree():
+    """The two spellings of one problem must report the same kind of answer.
+
+    Before the fix the opaque arm reported ``bound=15.06, gap=0.0`` while the
+    algebraic arm reported ``bound=None, gap=None`` — the same mathematics,
+    two different soundness stories.
+    """
+    r_opaque = _opaque_model().solve(time_limit=60)
+    r_algebraic = _algebraic_model().solve(time_limit=60, skip_convex_check=True)
+
+    assert (r_opaque.bound is None) == (r_algebraic.bound is None)
+    assert (r_opaque.gap is None) == (r_algebraic.gap is None)
+    assert (r_opaque.root_bound is None) == (r_algebraic.root_bound is None)
+    assert (r_opaque.root_gap is None) == (r_algebraic.root_gap is None)
+    assert r_opaque.gap_certified == r_algebraic.gap_certified
+
+
+@pytest.mark.smoke
+def test_mcbox_traceable_customcall_still_certifies():
+    """Control against over-correction: a CustomCall that DOES trace through
+    MCBox goes to the global reduced-space engine and must keep its valid
+    certificate — the strip above must not reach that path."""
+    m = dm.Model("customcall_mcbox_convex")
+    x = m.continuous("x", lb=-2.0, ub=3.0)
+    m.minimize(dm.custom(lambda v: v * v, name="sq")(x))
+    r = m.solve(time_limit=60)
+
+    assert r.status == "optimal"
+    assert r.gap_certified, "MCBox-relaxable CustomCall lost its valid certificate"
+    assert r.bound is not None
+    assert r.bound <= r.objective + 1e-6

--- a/python/tests/test_implicit_full_space.py
+++ b/python/tests/test_implicit_full_space.py
@@ -99,7 +99,11 @@ def test_full_space_lowering_solves_without_jax():
     # Vacuity control: the SAME problem through the opaque node must import JAX,
     # or "0" above is measuring an environment without JAX rather than the change.
     opaque = _run_raw(_SQRT_BLOCK + _OPAQUE_TAIL.format(x0=1.0) + _REPORT)
-    assert opaque["STATUS"] == "optimal", opaque
+    # The opaque node runs the local-NLP path, which proves a feasible point and
+    # not a global optimum, so it reports "feasible" (#998) — the status half of
+    # the same forfeit that the next test pins as CERTIFIED == "False". The
+    # lowered arm above keeps its genuine "optimal".
+    assert opaque["STATUS"] == "feasible", opaque
     assert int(opaque["JAXMODS"]) > 0, (
         f"control did not import JAX, so the test is vacuous: {opaque}"
     )


### PR DESCRIPTION
## Summary

A `dm.custom` / `CustomCall` body that is **not** MCBox-reducible has no valid node
relaxation, so `solve_model` falls back to a single local NLP. That caller cleared
`gap_certified` but left `bound` / `gap` / `root_bound` / `root_gap` populated with the
**local** NLP objective — which `_solve_continuous` sets from the NLP's own convergence
status ("a KKT point was reached", not "this is the global optimum"). On a nonconvex
opaque body that value is routinely *above* the true global minimum, i.e. not a valid
dual bound at all.

This is the C-33/SC-1 defect already fixed for the convexity-unknown local path 470
lines later in the same function; the `CustomCall` caller was never updated to match.
An opaque body is a *strictly weaker* epistemic position than "convexity unknown" — it
cannot be inspected at all, so convexity can never be established — which makes it the
one caller that most needs the strip.

Reproduced on 2-D Ackley over `[-25.768, 39.768]`, whose true global minimum is `0.0`
at the origin:

| field | behind `dm.custom` (before) | algebraic twin | behind `dm.custom` (after) |
|---|---|---|---|
| `objective` | 15.06351400512647 | 15.06351400512647 | 15.06351400512647 |
| `bound` | **15.06351400512647** | `None` | `None` |
| `gap` | **0.0** | `None` | `None` |
| `root_bound` / `root_gap` | **15.0635… / 0.0** | `None` / `None` | `None` / `None` |
| `gap_certified` | `False` | `False` | `False` |
| `status` | `optimal` | `optimal` | **`feasible`** |

The fix routes **both** uncertified-local-NLP callers through one shared helper,
`_withhold_local_optimality_certificate`, instead of each carrying its own copy of the
treatment — the duplication is precisely how this happened (C-33 fixed one site; the
other kept emitting the fabricated bound 470 lines away). On any non-`infeasible`
result it keeps the feasible incumbent (`objective`, `x`) and sets
`gap_certified=False`, `bound=None`, `root_bound=None`, `gap=None`, `root_gap=None`.

### Status downgrade — the issue's "secondary question", decided in favour of changing it

`_solve_continuous` reports `status="optimal"` on the same basis it reported the bound:
the NLP converged, i.e. a KKT point was reached. On a model never proven convex that
verdict is the same unearned claim — a local optimum need not be global. Both callers
now report the honest **`status="feasible"`**: a feasible point was found, global
optimality was not proved. That is already this codebase's convention for an
uncertified incumbent (the spatial path returns `"feasible"` when its gap does not
close). `"unknown"` is reported when the incumbent itself was withheld — the #815
feasibility check rejected the NLP's point — since `"feasible"` would then assert a
feasible point we do not have.

Per #998's requirement that any change to this convention cover both callers, this is
applied to the opaque-`CustomCall` path *and* the pure-continuous convexity-unknown
path (`skip_convex_check`, or the classifier abstained) together.

**Behaviour change for callers:** code gating on `status == "optimal"` from these two
paths should now also accept `"feasible"` — or better, read `gap_certified`. The convex
fast path, MCBox-relaxable `CustomCall` models, rigorous `status="infeasible"`, and
every certified path are unchanged. Two existing tests in `test_custom_udf.py`
(`test_vector_custom_solves`, `test_custom_mixed_with_primitives`) asserted
`status == "optimal"` alongside `gap_certified is False` and now assert `"feasible"`
with no bound/gap; the user-facing docstrings for `dm.custom`, `CustomCall`, and the
implicit-node module state the reported status.

Also documents the defect as **C-42** in `docs/dev/correctness-issues.md` (table row +
full section) and adds a CHANGELOG entry.

Closes #998

## Correctness

The change only ever **removes** a claim — it strips a dual bound and a gap, and never
adds, tightens, or relaxes one. So it cannot introduce a false optimal, a false
infeasible, or a looser-but-asserted bound; it can only turn an unsound claim into no
claim. This is the same soundness argument the C-33 site already carries.

Two cases are deliberately left untouched, both verified by controls in the new test
file:

- Rigorous `status="infeasible"` from `_solve_continuous` is a nonlinear-tightening /
  NLP-infeasibility claim, not a gap — same convention as the C-33 caller.
- The MCBox-reducible `CustomCall` path routes to the global reduced-space engine and
  never reaches this branch, so its valid certificate is intact
  (`test_mcbox_traceable_customcall_still_certifies`).

Checked rather than assumed: the convexity classifier runs *after* this branch, so an
opaque `CustomCall` cannot reach the `certify_convex=True` convex fast path — there is
no sibling defect there.

- [x] Cannot produce a false certificate — the change only withholds a claim
- [x] No validation, fallback, or safety guard was weakened to make a check pass (the
      gate was made stricter)

## Tests run (state the result — numbers, not adjectives)

- [x] `pytest -m smoke` → 958 passed, 15 skipped, 8412 deselected, 2 xpassed (388.97s)
      — run before the status downgrade; a full `pytest python/tests/` run over the
      final state is in flight and its result will be posted in a comment
- [x] `pytest -m slow python/tests/test_adversarial_recent_fixes.py` → 10 passed (154.98s)
- [x] `cargo test -p discopt-core` → N/A (no Rust touched)
- [x] `ruff check` / `ruff format --check` clean; `mypy` clean on the three touched modules
- Also: `test_customcall_reduced.py` + `test_custom_udf.py` +
  `test_c33_nonconvex_fallback_cert.py` → 35 passed

## Regression test

`python/tests/test_customcall_local_bound.py`, 4 tests, all `@pytest.mark.smoke`
(each also pins the `feasible` status):

- `test_customcall_local_path_strips_fabricated_bound` — the opaque Ackley repro:
  incumbent kept, all four bound/gap fields `None`, plus the invariant that a *reported*
  bound must satisfy `bound <= true_optimum + tol` (vacuous now; it is the pin that
  survives if a future change ever routes this path to a genuine bound).
- `test_algebraic_twin_control_agrees` — the C-33 path on the same mathematics.
- `test_customcall_and_algebraic_paths_agree` — the two spellings of one problem must
  report the same kind of answer; this is the assertion that pins the divergence.
- `test_mcbox_traceable_customcall_still_certifies` — control against over-correction.

The issue suggested the `correctness` marker; `smoke` is used instead because `addopts`
deselects `correctness` by default, which would keep these out of ordinary runs. They
are sub-second local NLPs, matching the C-33 test's precedent.

- [x] Fail-before / pass-after **verified** by stashing only the solver change: **2
      failed / 2 passed before** (`AssertionError: customcall: fabricated dual bound
      15.06351400512647`), **4 passed after**.

## Bound-changing / performance change?

N/A — no bound, cut, or relaxation is computed differently. The only behavioural deltas
are that an unsound dual-bound claim is no longer reported, and that the status on those
same paths now says `feasible` instead of `optimal`. Both paths were already
`gap_certified=False`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dbj9SYmJEVQY9jv8uSkngK)_