### PR TITLE
fix(primal): #993 reach distant disjunct configurations by re-solving between choices

### DIFF
--- a/python/discopt/_relax/primal_heuristics.py
+++ b/python/discopt/_relax/primal_heuristics.py
@@ -1462,6 +1462,38 @@ def _residual_assignments(
     return out[:limit]
 
 
+#: Sub-NLP solves the #823 wave may spend before the #993 dive gets the rest of the
+#: caller's grant. A **count**, not a slice of the clock, and that is the whole point:
+#: a wall-clock split (``_now() + 0.5 * (deadline - _now())``) makes how much of the
+#: wave runs a function of machine speed, which #912 forbids — and
+#: ``test_912_wall_budget_inventory.test_the_converted_layer_stays_converted`` closes
+#: the ``residual`` category to this module outright, so "record it in KNOWN" is not
+#: an honest option here. Bounded by a count, the wave's extent is a function of the
+#: model alone.
+#:
+#: 48 is calibrated, not chosen (``scratchpad/issue993`` E1/E2, 2026-08-12; run the
+#: wave with ``deadline=None`` so only ``max_configs`` binds, and record every plan's
+#: outcome and objective):
+#:
+#: ===============  ==========  =============  ==========================
+#: model            solves/s    feasible at    best objective at plan
+#: ===============  ==========  =============  ==========================
+#: cstr             54.3        8, 42, 47, 57  **42** (3.0620146, optimal)
+#: batch_processing 7.3         none of 256    —
+#: syngas           5.1         none of 256    —
+#: ===============  ==========  =============  ==========================
+#:
+#: So the yield is concentrated: past plan 57 the wave never produced anything on
+#: this corpus, and the plans that matter for *quality* end at 42 — cstr's best is
+#: there, while its plan-8 hit is +2.36 % off. The cap must therefore sit **above
+#: 42** (a cap of 32 would trade cstr's true optimum for a 2.36 %-worse point), and
+#: as far below 256 as that allows. 48 keeps every quality-relevant plan with six
+#: plans of headroom for root-point drift, and costs the wave 6.6 s of a 15 s grant
+#: on batch_processing (48 / 7.3) instead of the 35 s an uncapped wave wants — which
+#: is what leaves the dive a share to work in.
+_WAVE_SOLVE_CAP = 48
+
+
 def one_hot_config_subnlp(
     model: Model,
     x_relax: np.ndarray,
@@ -1514,10 +1546,10 @@ def one_hot_config_subnlp(
     batch_processing 15 of 29 (C(29,15) ~ 7.7e7). The dive re-solves the relaxation
     between choices, which is what makes those reachable. Ordering is deliberate —
     the wave is far cheaper when it works (0.018 s/plan on cstr) so it goes first,
-    and the dive only pays for models the wave cannot solve. **Half the budget is
-    reserved for the dive**: measured, an unreserved wave consumes all of it on
-    precisely the models the dive is for, so the two searches would compete for one
-    clock and the cheaper-but-useless one would always win.
+    and the dive only pays for models the wave cannot solve. The wave hands over
+    after ``_WAVE_SOLVE_CAP`` sub-NLP solves: measured, an uncapped wave consumes
+    the entire grant on precisely the models the dive is for, so the two searches
+    would compete for one budget and the cheaper-but-useless one would always win.
 
     ``max_configs`` is deliberately large. Measured on cstr, a fixed-integer
     sub-NLP here costs **0.018 s** (384 plans in 7 s), and the feasible plans sit
@@ -1643,20 +1675,21 @@ def one_hot_config_subnlp(
     results: list[tuple[np.ndarray, float]] = []
     attempted = 0
     stop = "exhausted"
-    # Reserve half the budget for the dive below. Measured, an unreserved wave
-    # spends the WHOLE budget on the models the dive exists for and hands it
-    # nothing: at a 9 s constructor budget batch_processing got 66 of 256 plans
-    # (all infeasible) and syngas 53, leaving the dive 0 relaxation solves. The
-    # reserve costs the wave nothing where the wave works -- on cstr it exhausts
-    # all 256 plans in 4.6 s, under a third of the 15 s budget a 300 s run grants
-    # -- and where the wave does not work, every second it holds is waste. Plans
-    # are ordered most-informed-first, so a truncated wave loses late alternates,
-    # never its best-ranked candidate.
-    wave_deadline = deadline
-    if deadline is not None:
-        wave_deadline = _now() + 0.5 * max(0.0, deadline - _now())
-    for ci, ri in plans[:max_configs]:
-        if wave_deadline is not None and _now() >= wave_deadline:
+    # Hand over to the dive after a bounded NUMBER of solves, so that what the wave
+    # spends is a function of the model and not of the machine (#912; see
+    # ``_WAVE_SOLVE_CAP`` for the calibration). Measured, an uncapped wave spends the
+    # WHOLE grant on the models the dive exists for and hands it nothing: at a 9 s
+    # constructor budget batch_processing got 66 of 256 plans (all infeasible) and
+    # syngas 53, leaving the dive 0 relaxation solves. The cap costs the wave nothing
+    # where the wave works -- on cstr every quality-relevant plan is reached by 42 --
+    # and where the wave does not work, every solve past the cap is waste. Plans are
+    # ordered most-informed-first, so a capped wave loses late alternates, never its
+    # best-ranked candidates.
+    wave_plans = plans[: min(max_configs, _WAVE_SOLVE_CAP)]
+    if len(wave_plans) < len(plans[:max_configs]):
+        stop = "wave-cap"
+    for ci, ri in wave_plans:
+        if deadline is not None and _now() >= deadline:
             stop = "deadline"
             break
         seed = zero_start.copy()
@@ -1668,7 +1701,9 @@ def one_hot_config_subnlp(
             seed[pick] = 1.0
         for j, v in zip(residual, residual_assigns[ri]):
             seed[j] = v
-        budget = None if wave_deadline is None else max(0.0, wave_deadline - _now())
+        # The caller's deadline is a stopping contract, so the per-solve budget is
+        # what remains of it — not a slice of it.
+        budget = None if deadline is None else max(0.0, deadline - _now())
         if budget is not None and budget <= 0.0:
             stop = "deadline"
             break

--- a/python/discopt/_relax/primal_heuristics.py
+++ b/python/discopt/_relax/primal_heuristics.py
@@ -1506,6 +1506,19 @@ def one_hot_config_subnlp(
     skips, and the whole path is additionally deadline-bounded — in practice the
     deadline, not ``max_configs``, is what stops it.
 
+    **When this search returns nothing, control passes to**
+    :func:`one_hot_config_dive` **with the remaining budget** (#993). Both searches
+    here rank disjuncts from one static point and never re-solve, which measurably
+    cannot reach the answer on the harder nonlinear GDPs: on syngas the proven
+    configuration is 3 demotions from the argmax (plan 743 of 256) and on
+    batch_processing 15 of 29 (C(29,15) ~ 7.7e7). The dive re-solves the relaxation
+    between choices, which is what makes those reachable. Ordering is deliberate —
+    the wave is far cheaper when it works (0.018 s/plan on cstr) so it goes first,
+    and the dive only pays for models the wave cannot solve. **Half the budget is
+    reserved for the dive**: measured, an unreserved wave consumes all of it on
+    precisely the models the dive is for, so the two searches would compete for one
+    clock and the cheaper-but-useless one would always win.
+
     ``max_configs`` is deliberately large. Measured on cstr, a fixed-integer
     sub-NLP here costs **0.018 s** (384 plans in 7 s), and the feasible plans sit
     at ``ci + ri`` = 17, 23 and 33 in the configuration x residual grid — so a
@@ -1630,8 +1643,20 @@ def one_hot_config_subnlp(
     results: list[tuple[np.ndarray, float]] = []
     attempted = 0
     stop = "exhausted"
+    # Reserve half the budget for the dive below. Measured, an unreserved wave
+    # spends the WHOLE budget on the models the dive exists for and hands it
+    # nothing: at a 9 s constructor budget batch_processing got 66 of 256 plans
+    # (all infeasible) and syngas 53, leaving the dive 0 relaxation solves. The
+    # reserve costs the wave nothing where the wave works -- on cstr it exhausts
+    # all 256 plans in 4.6 s, under a third of the 15 s budget a 300 s run grants
+    # -- and where the wave does not work, every second it holds is waste. Plans
+    # are ordered most-informed-first, so a truncated wave loses late alternates,
+    # never its best-ranked candidate.
+    wave_deadline = deadline
+    if deadline is not None:
+        wave_deadline = _now() + 0.5 * max(0.0, deadline - _now())
     for ci, ri in plans[:max_configs]:
-        if deadline is not None and _now() >= deadline:
+        if wave_deadline is not None and _now() >= wave_deadline:
             stop = "deadline"
             break
         seed = zero_start.copy()
@@ -1643,7 +1668,7 @@ def one_hot_config_subnlp(
             seed[pick] = 1.0
         for j, v in zip(residual, residual_assigns[ri]):
             seed[j] = v
-        budget = None if deadline is None else max(0.0, deadline - _now())
+        budget = None if wave_deadline is None else max(0.0, wave_deadline - _now())
         if budget is not None and budget <= 0.0:
             stop = "deadline"
             break
@@ -1670,6 +1695,323 @@ def one_hot_config_subnlp(
         len(residual),
         attempted,
         len(plans[:max_configs]),
+        stop,
+        len(results),
+    )
+    if results or not groups:
+        return results
+    # The wave found nothing. Spend what is left of the budget on the dive, which
+    # re-solves between choices and can therefore reach configurations no wave
+    # around a single point can (see this function's docstring, #993). Called from
+    # HERE rather than from the solver's three call sites so that no path can be
+    # left unwired — that omission is exactly how #823 shipped a flag that was dead
+    # on the model class it targeted.
+    return one_hot_config_dive(
+        model,
+        x_relax,
+        backend=backend,
+        nlp_options=nlp_options,
+        evaluator=evaluator,
+        integer_tol=integer_tol,
+        deadline=deadline,
+    )
+
+
+def one_hot_config_dive(
+    model: Model,
+    x_relax: np.ndarray,
+    backend: Optional[Callable] = None,
+    nlp_options: Optional[dict] = None,
+    evaluator: Optional[NLPEvaluator] = None,
+    integer_tol: float = 1e-5,
+    deadline: Optional[float] = None,
+    max_restarts: int = 64,
+    max_level_solves: int = 4000,
+    seed: int = 0,
+) -> list[tuple[np.ndarray, float]]:
+    """Root primal constructor for GDPs that *re-solves* between disjunct choices.
+
+    Why this exists alongside :func:`one_hot_config_subnlp` (#993). That function
+    enumerates configurations in Hamming waves around one static point — the
+    relaxation's per-group argmax — and never re-solves. Measured against BARON's
+    proven-optimal configuration on two nonlinear GDPlib models, the answer is not
+    in reach of any such wave:
+
+    ==================  ======  ========================  =========================
+    model               groups  demotions from the argmax  plan index in the wave
+    ==================  ======  ========================  =========================
+    syngas                  26  3                         743 (``max_configs`` 256)
+    batch_processing        29  15                        C(29,15) ~ 7.7e7
+    ==================  ======  ========================  =========================
+
+    Nothing else was the cause: with the integers pinned to BARON's configuration
+    the fixed-integer sub-NLP solves in 0.07 s (batch_processing, obj 679365.33 =
+    the reference optimum) and 0.36 s (syngas, 4669.0235) *from the constructor's
+    own zero start*, and on batch_processing the environment, the presolved bounds,
+    the seed ranking and the continuous start were each eliminated by a separate
+    arm (all four cells of a 2x2, plus five starts, 0 feasible in 1329 attempts).
+    A weak big-M relaxation (root 546850 vs 679365; 2.06 vs 4669) simply cannot
+    rank disjuncts well enough for one-shot rounding, and a bigger ``max_configs``
+    is the same wrong mechanism with a bigger constant.
+
+    What re-solving buys. Fix one group, re-solve the relaxation, and the remaining
+    fractional indicators move in response. In a design GDP the objective pulls
+    *every* group's argmax to the cheap disjunct at once — hence 15 simultaneous
+    demotions — but once a prefix of cheap choices is pinned the relaxation itself
+    becomes infeasible, and that refusal is the information the wave never gets.
+    Measured, the refusals are trustworthy: 0 of 412 flipped to feasible when
+    retried from an independent start.
+
+    Three ingredients, each added because a measurement demanded it:
+
+    * **Learned decision order.** Plain chronological backtracking thrashes (60 s
+      bought 21 of 26 groups on syngas, 17 of 29 on batch_processing, no feasible
+      point). Recording the group that dead-ends and deciding it first on the next
+      restart is what first completed batch_processing — obj 1063445 at 12.1 s,
+      where the wave returns nothing at all.
+    * **Randomised choice, GRASP-style.** A deterministic restart re-walks its own
+      path: syngas repeated one dead end 65 times. Randomising the *score* is not
+      enough — its size-2 groups sit at margins near 1.0, so additive noise never
+      flips one — so the disjunct *order* itself is randomised with probability
+      rising per restart. This cut batch_processing's time-to-first-feasible from
+      12.3 s to 5.3 s and found 41 configurations in 60 s.
+    * **Local repair.** A dead end at depth 25 of 26 means the answer is one repair
+      away, so discarding the prefix is waste. Only the last ``k`` decisions are
+      released (k doubling: 3, 6, 12, ...) with the dead-end group decided first,
+      and a full restart happens only once ``k`` exceeds the depth.
+
+    Cost is bounded three ways — the absolute ``deadline`` (polled before every
+    solve, and each solve capped so one cannot overrun it), ``max_restarts``, and
+    ``max_level_solves``.
+
+    Soundness: every returned point comes from :func:`subnlp`, which re-verifies
+    integer- and constraint-feasibility, so this proposes incumbents only and never
+    touches the dual bound. A local "infeasible" verdict on a nonconvex partial
+    fixing is used *only* to redirect this heuristic's own search — never to prune a
+    node — so a wrong verdict costs candidates, never correctness. Every bound
+    mutation is restored in a ``finally``.
+
+    Args:
+        model: The optimization model.
+        x_relax: Relaxation point at the node; the dive's starting point.
+        backend: ``solve_nlp(evaluator, x0, options=...)`` callable.
+        nlp_options: Options forwarded to the NLP backend.
+        evaluator: Pre-built evaluator; one is constructed if omitted.
+        integer_tol: Integrality tolerance forwarded to :func:`subnlp`.
+        deadline: Absolute ``perf_counter`` deadline.
+        max_restarts: Cap on randomised restarts.
+        max_level_solves: Cap on relaxation solves across all restarts.
+        seed: RNG seed. Fixed by default so the heuristic is reproducible.
+
+    Returns:
+        Every feasible ``(x, obj)`` found, in discovery order (possibly empty).
+    """
+    int_mask = _get_integer_mask(model)
+    if not np.any(int_mask):
+        return []
+
+    lb0, ub0 = _get_variable_bounds(model)
+    n_vars = int(int_mask.size)
+    x_relax = np.asarray(x_relax, dtype=np.float64)
+    groups = _scan_one_hot_rows(model, int_mask, n_vars)
+    if not groups:
+        return []
+
+    backend = _resolve_backend(backend)
+    if evaluator is None:
+        evaluator = cached_evaluator(model)
+    slot_map = _flat_slot_map(model)
+    saved = [(v.lb.copy(), v.ub.copy()) for v in model._variables]
+    opts = _heuristic_nlp_options(nlp_options)
+
+    n_groups = len(groups)
+    zero_cont = np.clip(0.0, lb0, ub0)
+    rng = np.random.default_rng(seed)
+
+    results: list[tuple[np.ndarray, float]] = []
+    # Groups that have dead-ended, most recent first: the learned decision order,
+    # carried ACROSS restarts. Deciding a known-constrained group early is what
+    # first completed batch_processing.
+    priority: list[int] = []
+    level_solves = 0
+    restarts = 0
+    dead_ends = 0
+    repairs = 0
+    stop = "restart cap"
+
+    def _release_all() -> None:
+        for v, (lb_v, ub_v) in zip(model._variables, saved):
+            v.lb = lb_v.copy()
+            v.ub = ub_v.copy()
+
+    def _fix_group(gi: int, pick: int) -> None:
+        for j in groups[gi]:
+            v, local = slot_map[j]
+            _fix_slot(v, local, 0.0)
+        v, local = slot_map[pick]
+        _fix_slot(v, local, 1.0)
+
+    def _release_group(gi: int) -> None:
+        for j in groups[gi]:
+            v, local = slot_map[j]
+            _set_slot_bounds(v, local, float(lb0[j]), float(ub0[j]))
+
+    def _level_solve(x_start: np.ndarray) -> Optional[np.ndarray]:
+        """Relaxation under the current partial fixing; None means 'refused'."""
+        nonlocal level_solves
+        lb_cur, ub_cur = _get_variable_bounds(model)
+        step_opts = dict(opts)
+        cap = _deadline_wall_cap(deadline)
+        if cap is not None:
+            step_opts.setdefault("max_wall_time", cap)
+        level_solves += 1
+        try:
+            res = backend(evaluator, np.clip(x_start, lb_cur, ub_cur), options=step_opts)
+        except BaseException:
+            # Backends can raise PanicException (PyO3), which is not an Exception.
+            # A failed step is a refusal like any other; it only redirects the dive.
+            return None
+        if res.x is None:
+            return None
+        x = np.asarray(res.x, dtype=np.float64)
+        # Judge the POINT, not the status: the dive needs "is this partial fixing
+        # satisfiable", and an interior-point solver reports ITERATION_LIMIT at
+        # points that are already feasible and OPTIMAL at points that are not.
+        return x if _check_constraint_feasibility(evaluator, x) else None
+
+    def _out_of_budget() -> bool:
+        return (deadline is not None and _now() >= deadline) or level_solves >= max_level_solves
+
+    try:
+        while restarts < max_restarts:
+            if _out_of_budget():
+                stop = "deadline" if level_solves < max_level_solves else "solve cap"
+                break
+            restarts += 1
+            # Restart 1 is the pure deterministic dive; later restarts diversify.
+            p_rand = 0.0 if restarts == 1 else min(0.05 * restarts, 0.5)
+            _release_all()
+            fixed: dict[int, int] = {}
+            history: list[int] = []
+            forced: list[int] = []
+            x_cur = np.clip(x_relax, lb0, ub0)
+            k_repair = 3
+
+            while len(fixed) < n_groups and not _out_of_budget():
+                remaining = [gi for gi in range(n_groups) if gi not in fixed]
+                # A local repair's own groups first, then the learned order.
+                candidates = [gi for gi in forced if gi in remaining]
+                if not candidates:
+                    candidates = [gi for gi in priority if gi in remaining]
+                if candidates:
+                    gi = (
+                        candidates[int(rng.integers(len(candidates)))]
+                        if rng.random() < p_rand
+                        else candidates[0]
+                    )
+                else:
+                    # Most decisive group first: the largest argmax margin at the
+                    # CURRENT point, which moves as fixings accumulate.
+                    best_gi, best_margin = remaining[0], -np.inf
+                    for g in remaining:
+                        o = sorted(groups[g], key=lambda j: -float(x_cur[j]))
+                        mg = float(x_cur[o[0]]) - (float(x_cur[o[1]]) if len(o) > 1 else 0.0)
+                        if mg > best_margin:
+                            best_gi, best_margin = g, mg
+                    gi = best_gi
+                order = sorted(groups[gi], key=lambda j: -float(x_cur[j]))
+                if rng.random() < p_rand:
+                    order = [order[i] for i in rng.permutation(len(order))]
+
+                placed = False
+                for pick in order:
+                    if _out_of_budget():
+                        break
+                    _fix_group(gi, pick)
+                    x_new = _level_solve(x_cur)
+                    if x_new is not None:
+                        fixed[gi] = pick
+                        history.append(gi)
+                        x_cur = x_new
+                        placed = True
+                        break
+                if placed:
+                    if gi in forced:
+                        forced.remove(gi)
+                    continue
+                if _out_of_budget():
+                    break  # ran out mid-group; not a dead end, so learn nothing
+
+                _release_group(gi)
+                dead_ends += 1
+                if k_repair > len(history):
+                    break  # repair exhausted: restart instead
+                repairs += 1
+                undone = history[-k_repair:]
+                for h in undone:
+                    _release_group(h)
+                    fixed.pop(h, None)
+                history = history[: len(history) - k_repair]
+                forced = [gi] + [h for h in undone if h != gi]
+                x_back = _level_solve(x_cur)
+                if x_back is not None:
+                    x_cur = x_back
+                k_repair *= 2
+
+            if len(fixed) < n_groups:
+                # Learn from the failure: whatever this restart could not place gets
+                # decided first next time, while the prefix is still short enough to
+                # accommodate it.
+                for gi in range(n_groups):
+                    if gi not in fixed:
+                        if gi in priority:
+                            priority.remove(gi)
+                        priority.insert(0, gi)
+                        break
+                continue
+
+            # A complete configuration: hand it to the ordinary sub-NLP, which fixes
+            # every integer (the dive's groups plus any binary outside them, rounded
+            # from the DIVE's point rather than the root's) and verifies the result.
+            seed_x = x_cur.copy()
+            seed_x[~int_mask] = zero_cont[~int_mask]
+            for gi, group in enumerate(groups):
+                for j in group:
+                    seed_x[j] = 0.0
+                seed_x[fixed[gi]] = 1.0
+            # Two starts, in the order measured to matter: the zero continuous start
+            # (what makes a fresh configuration solve at all) then the dive's own
+            # point (better once the configuration is nearly settled).
+            found = None
+            for x0 in (seed_x, x_cur):
+                found = subnlp(
+                    model,
+                    np.clip(x0, lb0, ub0),
+                    backend=backend,
+                    nlp_options=nlp_options,
+                    evaluator=evaluator,
+                    integer_tol=integer_tol,
+                    time_budget=(None if deadline is None else max(0.0, deadline - _now())),
+                )
+                if found is not None or _out_of_budget():
+                    break
+            if found is not None:
+                results.append(found)
+    finally:
+        for v, (lb_v, ub_v) in zip(model._variables, saved):
+            v.lb = lb_v
+            v.ub = ub_v
+
+    # §6: without these counts an empty return is unfalsifiable — no restart ran,
+    # the deadline cut it, or every configuration was genuinely infeasible.
+    logger.debug(
+        "one_hot_config_dive: %d group(s), %d restart(s), %d dead end(s), %d local "
+        "repair(s), %d relaxation solve(s) (%s), %d feasible",
+        n_groups,
+        restarts,
+        dead_ends,
+        repairs,
+        level_solves,
         stop,
         len(results),
     )
@@ -1707,18 +2049,24 @@ def _resolve_backend(backend: Optional[Callable]) -> Callable:
     return backend
 
 
-def _fix_slot(v: object, local: int, value: float) -> None:
-    """Fix scalar slot ``local`` of variable ``v`` to ``value``.
+def _set_slot_bounds(v: object, local: int, lo: float, hi: float) -> None:
+    """Set scalar slot ``local`` of variable ``v`` to ``[lo, hi]``.
 
-    Variable bound arrays are read-only, so we replace them with writable copies
-    (the caller saves/restores the originals).
+    Variable bound arrays are read-only views (``np.broadcast_to``), so writing in
+    place raises; they must be replaced with writable copies. The caller
+    saves/restores the originals.
     """
     new_lb = np.array(v.lb, dtype=np.float64)  # type: ignore[attr-defined]
     new_ub = np.array(v.ub, dtype=np.float64)  # type: ignore[attr-defined]
-    new_lb.flat[local] = value
-    new_ub.flat[local] = value
+    new_lb.flat[local] = lo
+    new_ub.flat[local] = hi
     v.lb = new_lb  # type: ignore[attr-defined]
     v.ub = new_ub  # type: ignore[attr-defined]
+
+
+def _fix_slot(v: object, local: int, value: float) -> None:
+    """Fix scalar slot ``local`` of variable ``v`` to ``value``."""
+    _set_slot_bounds(v, local, value, value)
 
 
 def _finalize_candidate(

--- a/python/tests/test_912_wall_budget_inventory.py
+++ b/python/tests/test_912_wall_budget_inventory.py
@@ -19,6 +19,18 @@ test, and the author must either convert it to a deterministic budget or record
 it here with a category. Without this, "the class is fixed" would mean "the
 sites that existed on 2026-08-01 were fixed".
 
+Both patterns above are matched a line at a time, and that had a hole: a gate
+spelled across *two* lines — pass ``time.perf_counter()`` into a helper, do the
+``+ <budget>`` arithmetic on the parameter inside it — matches neither, because
+the call site has no ``+`` after the clock read and the body has no clock read at
+all. ``solver.py``'s ``_gdp_config_deadline`` was exactly that and sat unrecorded
+for its whole life, while the inline sibling gate in the same feature was caught
+on the day it was written; the difference was only that one author had factored
+the arithmetic into a helper. ``_scan_via_argument`` below does the one level of
+dataflow that closes it, and its findings join the line-based ones. The hole was
+sized before it was closed: across the package, five call sites hand a clock read
+to a function defined here, and exactly one of them built a budget from it.
+
 Categories:
 
 ``contract``
@@ -70,6 +82,7 @@ residuals stay wall-clock and stay listed here.
 
 from __future__ import annotations
 
+import ast
 import os
 import re
 from pathlib import Path
@@ -85,6 +98,117 @@ _PKG = Path(__file__).resolve().parents[1] / "discopt"
 _CLOCK = r"(?:(?:time|_time)\.(?:perf_counter|monotonic)\(\)|(?<![\w.])_now\(\))"
 _MAKE = re.compile(_CLOCK + r"\s*\+")
 _ELAPSED = re.compile(_CLOCK + r"\s*-\s*\w+[^<>]*[<>]=?")
+
+_CLOCK_FUNCS = {"perf_counter", "monotonic"}
+
+
+def _is_clock_read(node: ast.AST) -> bool:
+    """``time.perf_counter()`` / ``time.monotonic()`` / the ``_now()`` seam."""
+    if not isinstance(node, ast.Call):
+        return False
+    f = node.func
+    if isinstance(f, ast.Attribute) and f.attr in _CLOCK_FUNCS:
+        return True
+    return isinstance(f, ast.Name) and f.id == "_now"
+
+
+def _defs_by_name(trees: dict[Path, ast.Module]) -> dict[str, list[tuple[Path, ast.AST]]]:
+    out: dict[str, list[tuple[Path, ast.AST]]] = {}
+    for path, tree in trees.items():
+        for node in ast.walk(tree):
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                out.setdefault(node.name, []).append((path, node))
+    return out
+
+
+def _params_receiving_clock(call: ast.Call, defs: dict) -> tuple[set[str], list]:
+    """Parameter names of ``call``'s callee that are handed a clock read here."""
+    callee = None
+    if isinstance(call.func, ast.Name):
+        callee = call.func.id
+    elif isinstance(call.func, ast.Attribute):
+        callee = call.func.attr
+    if callee is None or callee not in defs:
+        return set(), []
+    names: set[str] = set()
+    for pos, arg in enumerate(call.args):
+        if not _is_clock_read(arg):
+            continue
+        for _dpath, dnode in defs[callee]:
+            formal = dnode.args.posonlyargs + dnode.args.args
+            if pos < len(formal):
+                names.add(formal[pos].arg)
+    for kw in call.keywords:
+        if kw.arg is not None and _is_clock_read(kw.value):
+            names.add(kw.arg)
+    return names, defs[callee]
+
+
+def _scan_via_argument() -> set[tuple[str, str]]:
+    """Budgets built from a clock read that arrived as an ARGUMENT.
+
+    The line-local patterns above see one line at a time, so they are blind to the
+    construction that spells the same gate across two: pass ``time.perf_counter()``
+    into a helper, and do the ``+ budget`` arithmetic on the *parameter* inside it.
+    Neither line matches — the call site has no ``+`` after the clock read, and the
+    body has no clock read at all. Measured on the tree that closed this hole, the
+    package had exactly one such gate (``solver.py``'s ``_gdp_config_deadline``,
+    added by #993 and invisible for its whole life), while the inline sibling in
+    the same feature *was* caught — so coverage depended on nothing more than
+    whether an author had refactored the arithmetic into a helper.
+
+    This does the one level of dataflow that closes it: find call sites handing a
+    clock read to a function defined in this package, map argument position to
+    parameter name, and look for the same two budget constructions on that
+    parameter inside the callee's body.
+    """
+    trees: dict[Path, ast.Module] = {}
+    for root, dirs, files in os.walk(_PKG):
+        dirs[:] = [d for d in dirs if d != "__pycache__"]
+        for f in sorted(files):
+            if not f.endswith(".py"):
+                continue
+            path = Path(root) / f
+            # Deliberately not wrapped: a file this cannot parse must fail the
+            # test loudly, not be skipped into an "all clear" (rule 7).
+            trees[path] = ast.parse(path.read_text(), filename=str(path))
+
+    defs = _defs_by_name(trees)
+    src: dict[Path, list[str]] = {p: p.read_text().splitlines() for p in trees}
+    found: set[tuple[str, str]] = set()
+
+    for path, tree in trees.items():
+        for call in ast.walk(tree):
+            if not isinstance(call, ast.Call):
+                continue
+            params, targets = _params_receiving_clock(call, defs)
+            if not params:
+                continue
+            for dpath, dnode in targets:
+                rel = str(dpath.relative_to(_PKG))
+                for inner in ast.walk(dnode):
+                    hit = False
+                    # ``param + <budget>`` — a locally invented deadline.
+                    if (
+                        isinstance(inner, ast.BinOp)
+                        and isinstance(inner.op, ast.Add)
+                        and isinstance(inner.left, ast.Name)
+                        and inner.left.id in params
+                    ):
+                        hit = True
+                    # ``<clock> - param > <budget>`` — elapsed against a budget.
+                    if isinstance(inner, ast.Compare) and isinstance(inner.left, ast.BinOp):
+                        b = inner.left
+                        if (
+                            isinstance(b.op, ast.Sub)
+                            and isinstance(b.right, ast.Name)
+                            and b.right.id in params
+                        ):
+                            hit = True
+                    if hit:
+                        found.add((rel, src[dpath][inner.lineno - 1].strip()))
+    return found
+
 
 # (module-relative path, source line, category). See the module docstring.
 KNOWN: tuple[tuple[str, str, str], ...] = (
@@ -157,6 +281,19 @@ KNOWN: tuple[tuple[str, str, str], ...] = (
     (
         "solver.py",
         "time.perf_counter() + max(2.0, min(15.0, 0.2 * float(time_limit))),",
+        "residual",
+    ),
+    # The #823/#993 GDP configuration constructor's slice: 15% of what is left,
+    # capped at 15 s. Same shape as the entry above it — a capped fraction of the
+    # caller's remaining budget, spent by a root component that decides how many
+    # fixed-integer sub-NLPs get solved — so it takes the same category. It is not
+    # ``contract``: never exceeding ``outer_deadline`` makes it *sound*, but the
+    # number of configuration plans it gets through is still set by machine speed.
+    # Found only once this scanner learned to follow a clock read through an
+    # argument (see ``_scan_via_argument``); it was invisible for its whole life.
+    (
+        "solver.py",
+        "return now + min(remaining, share)",
         "residual",
     ),
     (
@@ -341,7 +478,7 @@ def _scan() -> set[tuple[str, str]]:
                     continue
                 if _MAKE.search(s) or _ELAPSED.search(s):
                     found.add((rel, s))
-    return found
+    return found | _scan_via_argument()
 
 
 @pytest.mark.unit
@@ -396,8 +533,11 @@ def test_residual_count_is_visible():
     # ``contract`` when its grant became a pre-deadline reserve rather than a
     # post-deadline hand-out. Not a conversion to a deterministic budget — a change
     # in what the gate spends. See the comment on its KNOWN entry.
-    assert len(residual) == 19, (
-        f"the #912 residual inventory changed ({len(residual)} entries, expected 19). "
+    # 19 -> 20: ``_gdp_config_deadline`` — not a new gate, a newly *visible* one.
+    # It predates this bump; the scanner could not see it until it learned to
+    # follow a clock read through a function argument (#993).
+    assert len(residual) == 20, (
+        f"the #912 residual inventory changed ({len(residual)} entries, expected 20). "
         "If you converted one, drop it from KNOWN and lower this number; if you added "
         "one, convert it instead. This count is a deliberate resting point, not a "
         "backlog — see the module docstring for the evidence and the condition that "

--- a/python/tests/test_912_wall_budget_inventory.py
+++ b/python/tests/test_912_wall_budget_inventory.py
@@ -136,8 +136,15 @@ def _params_receiving_clock(call: ast.Call, defs: dict) -> tuple[set[str], list]
             continue
         for _dpath, dnode in defs[callee]:
             formal = dnode.args.posonlyargs + dnode.args.args
-            if pos < len(formal):
-                names.add(formal[pos].arg)
+            # ``obj.method(clock)`` binds argument 0 to formal 1: the receiver has
+            # already consumed ``self``. Without this the mapping is off by one on
+            # every method, which reads as "no budget built from it" — a silent
+            # false negative exactly where a gate is easiest to hide.
+            bound = 1 if isinstance(call.func, ast.Attribute) and formal else 0
+            if bound and formal[0].arg not in ("self", "cls"):
+                bound = 0
+            if pos + bound < len(formal):
+                names.add(formal[pos + bound].arg)
     for kw in call.keywords:
         if kw.arg is not None and _is_clock_read(kw.value):
             names.add(kw.arg)

--- a/python/tests/test_issue993_gdp_config_dive.py
+++ b/python/tests/test_issue993_gdp_config_dive.py
@@ -1,0 +1,198 @@
+"""Regression tests for issue #993 — the disjunct-configuration *reachability* gap.
+
+``one_hot_config_subnlp`` (#823) fixed *validity*: it selects one disjunct per
+``sum_k y_k == 1`` row, so the fixing it hands the sub-NLP never contradicts a
+disjunction outright. It did not fix *reachability*. Both of its searches rank
+disjuncts from a single static point — the relaxation's per-group argmax — and
+enumerate outward in Hamming waves without ever re-solving. When the answer sits
+many demotions away, no wave budget reaches it:
+
+==================  ======  ========================  ========================
+model               groups  demotions from the argmax  plan index in the wave
+==================  ======  ========================  ========================
+syngas                  26  3                          743 (``max_configs`` 256)
+batch_processing        29  15                         C(29,15) ~ 7.7e7
+==================  ======  ========================  ========================
+
+Nothing else was the cause. With the integers pinned to BARON's proven
+configuration the fixed-integer sub-NLP solves in 0.07 s (batch_processing, at the
+reference optimum 679365.33) and 0.36 s (syngas, 4669.0235) *from the
+constructor's own zero start*, so the start point, the presolved bounds, the seed
+ranking and the environment were each eliminated as explanations.
+
+``one_hot_config_dive`` re-solves the relaxation between choices, which is what
+makes distant configurations reachable: once a prefix of cheap disjuncts is pinned,
+the remaining fractional indicators move, and a prefix that cannot be completed
+makes the relaxation infeasible — information a wave around a fixed point never
+receives.
+
+These tests pin the mechanism on a synthetic model whose *structure* creates the
+gap, not on any named instance (CLAUDE.md §2): a capacity GDP where the objective
+pulls every group's argmax to the cheap disjunct at once, so the integral answer
+requires many simultaneous demotions.
+"""
+
+from __future__ import annotations
+
+import time
+from math import comb
+
+import discopt.modeling as dm
+import numpy as np
+import pytest
+from discopt._relax.primal_heuristics import (
+    _check_constraint_feasibility,
+    _get_variable_bounds,
+    _scan_one_hot_rows,
+    cached_evaluator,
+    one_hot_config_dive,
+    one_hot_config_subnlp,
+)
+
+N_GROUPS = 20
+CAP = 5.0
+REQUIRED = 45.0
+#: Cheapest integral solution: ceil(REQUIRED/CAP) groups must take the expensive
+#: disjunct, the rest the cheap one.
+N_EXPENSIVE = 9
+OPTIMUM = (N_GROUPS - N_EXPENSIVE) * 1.0 + N_EXPENSIVE * 10.0
+
+
+def _capacity_gdp():
+    """A capacity GDP whose relaxation prefers a configuration that is infeasible.
+
+    Each of ``N_GROUPS`` disjunctions chooses between a cheap disjunct (cost 1, no
+    capacity) and an expensive one (cost 10, capacity ``CAP``), and the total
+    capacity must reach ``REQUIRED``. The big-M row ``p_i <= CAP * y_expensive``
+    is *slack at fractional y*, so the relaxation buys the required capacity with
+    twenty half-open expensive disjuncts and every group's argmax still reads
+    cheap — while any integral solution needs ``N_EXPENSIVE`` of them fully open.
+
+    That is the shape of the real failure: the argmax configuration is infeasible
+    and the answer is ``N_EXPENSIVE`` demotions away, not one or two.
+    """
+    m = dm.Model("capacity_gdp")
+    y = m.binary("y", 2 * N_GROUPS)  # y[2i] cheap, y[2i+1] expensive
+    p = m.continuous("p", N_GROUPS, lb=0.0, ub=CAP)
+
+    total = p[0]
+    cost = y[0] + 10.0 * y[1]
+    for i in range(N_GROUPS):
+        m.subject_to(y[2 * i] + y[2 * i + 1] == 1, name=f"disj{i}")
+        m.subject_to(p[i] - CAP * y[2 * i + 1] <= 0.0, name=f"bigm{i}")
+        if i:
+            total = total + p[i]
+            cost = cost + y[2 * i] + 10.0 * y[2 * i + 1]
+    m.subject_to(total >= REQUIRED, name="demand")
+    m.minimize(cost)
+    return m
+
+
+def _relaxation_point():
+    """The analytic LP relaxation optimum, so the tests need no solve to start.
+
+    Every group splits identically: expensive share ``REQUIRED/(CAP*N_GROUPS)``,
+    each ``p_i`` equal. Written out rather than solved so the arithmetic behind
+    "the argmax reads cheap" is visible and the test is deterministic.
+    """
+    frac = REQUIRED / (CAP * N_GROUPS)
+    x = np.zeros(3 * N_GROUPS)
+    for i in range(N_GROUPS):
+        x[2 * i] = 1.0 - frac
+        x[2 * i + 1] = frac
+        x[2 * N_GROUPS + i] = REQUIRED / N_GROUPS
+    return x
+
+
+@pytest.mark.smoke
+def test_the_answer_is_out_of_reach_of_any_wave_budget():
+    """Pin *why* the wave fails here: it is arithmetic, not tuning.
+
+    The argmax configuration (all cheap) supplies zero capacity, so every feasible
+    configuration demotes at least ``N_EXPENSIVE`` groups. A distance enumeration
+    must exhaust all nearer waves first, and that count dwarfs any sane
+    ``max_configs`` — so raising the budget is the same wrong mechanism with a
+    bigger constant, which is what #993 records.
+    """
+    x_relax = _relaxation_point()
+    m = _capacity_gdp()
+    mask = np.zeros(3 * N_GROUPS, dtype=bool)
+    mask[: 2 * N_GROUPS] = True
+
+    groups = _scan_one_hot_rows(m, mask, mask.size)
+    assert len(groups) == N_GROUPS, groups
+
+    # The relaxation prefers the cheap disjunct in every single group.
+    for i, g in enumerate(groups):
+        assert max(g, key=lambda j: x_relax[j]) == 2 * i, f"group {i} argmax is not cheap"
+
+    plans_before_the_answer = sum(comb(N_GROUPS, d) for d in range(N_EXPENSIVE))
+    assert plans_before_the_answer > 256 * 1000, plans_before_the_answer
+
+
+@pytest.mark.smoke
+def test_dive_finds_a_point_no_wave_around_one_point_can_reach():
+    """The #993 regression: re-solving between choices reaches the answer.
+
+    Before the fix this returns ``[]`` — the wave exhausts ``max_configs`` inside
+    the first three demotion levels and never reaches level nine.
+    """
+    m = _capacity_gdp()
+    found = one_hot_config_subnlp(m, _relaxation_point(), deadline=time.perf_counter() + 60.0)
+    assert found, "no feasible configuration found; the dive did not reach the answer"
+
+    ev = cached_evaluator(m)
+    for x, obj in found:
+        x = np.asarray(x, dtype=np.float64)
+        assert np.isfinite(obj)
+        # Verified independently, not trusted because the heuristic returned it.
+        assert _check_constraint_feasibility(ev, x), "returned an infeasible point"
+        for i in range(N_GROUPS):
+            assert abs(x[2 * i] + x[2 * i + 1] - 1.0) < 1e-6, f"group {i} is not one-hot"
+            assert abs(x[2 * i] - round(x[2 * i])) < 1e-5, f"group {i} is fractional"
+        # A primal heuristic may not beat the true optimum: that would be a bound
+        # violation dressed up as a good incumbent.
+        assert obj >= OPTIMUM - 1e-6, f"objective {obj} beats the optimum {OPTIMUM}"
+
+
+@pytest.mark.smoke
+def test_dive_restores_every_bound_it_touched():
+    """The dive fixes indicators by rewriting variable bounds; all of it is temporary."""
+    m = _capacity_gdp()
+    lb_before, ub_before = _get_variable_bounds(m)
+    one_hot_config_dive(m, _relaxation_point(), deadline=time.perf_counter() + 20.0)
+    lb_after, ub_after = _get_variable_bounds(m)
+    assert np.array_equal(lb_before, lb_after), "lower bounds leaked out of the dive"
+    assert np.array_equal(ub_before, ub_after), "upper bounds leaked out of the dive"
+
+
+@pytest.mark.smoke
+def test_dive_respects_an_expired_deadline():
+    """A past deadline stops it before the first relaxation solve."""
+    m = _capacity_gdp()
+    t0 = time.perf_counter()
+    assert one_hot_config_dive(m, _relaxation_point(), deadline=t0 - 1.0) == []
+    assert time.perf_counter() - t0 < 1.0, "an expired deadline still cost a solve"
+
+
+@pytest.mark.smoke
+def test_dive_is_a_noop_without_one_hot_structure():
+    """Generality: gated on detected structure, never on a name (CLAUDE.md §2)."""
+    m = dm.Model("plain")
+    z = m.binary("z", 3)
+    m.subject_to(z[0] + z[1] + z[2] <= 2, name="c")
+    m.minimize(z[0] + z[1] + z[2])
+    assert one_hot_config_dive(m, np.array([0.4, 0.4, 0.4])) == []
+
+
+@pytest.mark.smoke
+def test_dive_is_deterministic_for_a_fixed_seed():
+    """Reproducibility: the randomised restarts are seeded, so runs are comparable.
+
+    A heuristic that varies run to run makes node counts unreproducible, which
+    would break the §5 bound-neutral comparison the panel relies on.
+    """
+    x_relax = _relaxation_point()
+    a = one_hot_config_dive(_capacity_gdp(), x_relax, max_restarts=3, deadline=None)
+    b = one_hot_config_dive(_capacity_gdp(), x_relax, max_restarts=3, deadline=None)
+    assert [round(o, 9) for _, o in a] == [round(o, 9) for _, o in b]

--- a/python/tests/test_issue993_gdp_config_dive.py
+++ b/python/tests/test_issue993_gdp_config_dive.py
@@ -37,10 +37,12 @@ from __future__ import annotations
 import time
 from math import comb
 
+import discopt._relax.primal_heuristics as ph
 import discopt.modeling as dm
 import numpy as np
 import pytest
 from discopt._relax.primal_heuristics import (
+    _WAVE_SOLVE_CAP,
     _check_constraint_feasibility,
     _get_variable_bounds,
     _scan_one_hot_rows,
@@ -196,3 +198,62 @@ def test_dive_is_deterministic_for_a_fixed_seed():
     a = one_hot_config_dive(_capacity_gdp(), x_relax, max_restarts=3, deadline=None)
     b = one_hot_config_dive(_capacity_gdp(), x_relax, max_restarts=3, deadline=None)
     assert [round(o, 9) for _, o in a] == [round(o, 9) for _, o in b]
+
+
+@pytest.mark.smoke
+def test_wave_hands_over_on_a_solve_count_not_a_clock_slice(monkeypatch):
+    """#912: how much of the wave runs must not be a function of machine speed.
+
+    The first wiring reserved half the *wall* grant for the dive
+    (``wave_deadline = _now() + 0.5 * (deadline - _now())``), so a slower box tried
+    fewer configurations — a different incumbent, and from there a different search
+    tree, for the same model. ``_WAVE_SOLVE_CAP`` denominates the handover in
+    sub-NLP solves instead. Driving the ``_now()`` seam with two clocks that differ
+    by an unbounded factor pins that: the count is identical, and the deadline is
+    left doing only the job #912 allows it to do — deciding when to stop.
+    """
+    m = _capacity_gdp()
+    x_relax = _relaxation_point()
+    deadline = 120.0  # in the fake clock's own units, not seconds
+
+    def _arm(tick: float) -> tuple[int, float]:
+        reading = [0.0]
+
+        def _fake_now() -> float:
+            reading[0] += tick
+            return reading[0]
+
+        tried: list[object] = []
+
+        def _never_feasible(model, seed, **kwargs):
+            # Return nothing so the wave runs to its own bound rather than stopping
+            # early on a hit; the dive is a separate mechanism, stubbed out here.
+            tried.append(kwargs.get("time_budget"))
+            return None
+
+        monkeypatch.setattr(ph, "_now", _fake_now)
+        monkeypatch.setattr(ph, "subnlp", _never_feasible)
+        monkeypatch.setattr(ph, "one_hot_config_dive", lambda *a, **kw: [])
+        ph.one_hot_config_subnlp(m, x_relax, deadline=deadline)
+        return len(tried), reading[0]
+
+    slow, slow_clock = _arm(1.0)
+    fast, _ = _arm(0.0)
+
+    assert slow == fast == _WAVE_SOLVE_CAP, (
+        f"the wave tried {slow} configuration(s) on the slow clock and {fast} on the "
+        f"fast one; both must be _WAVE_SOLVE_CAP={_WAVE_SOLVE_CAP}, or how far the "
+        "wave gets is a function of the machine"
+    )
+    # Two checks that a *passing* run was not vacuous (CLAUDE.md §6). The slow arm
+    # has to run past the halfway point of the grant, or a half-wall split would not
+    # have truncated it and the count above proves nothing; and it has to stay inside
+    # the grant, or it stopped on the deadline contract rather than on the cap.
+    assert slow_clock > 0.5 * deadline, (
+        f"premise stale: the slow arm stopped at clock {slow_clock:.1f}, inside half "
+        f"of {deadline}; a wall split would not have cut it, so nothing is pinned"
+    )
+    assert slow_clock < deadline, (
+        f"premise stale: the slow arm's clock reached {slow_clock:.1f} of {deadline}, "
+        "so it stopped on the deadline contract and the cap is untested"
+    )


### PR DESCRIPTION
## What this changes

`one_hot_config_subnlp` (#823) fixed **validity** — it selects one disjunct per
`sum_k y_k == 1` row, so the fixing it hands the sub-NLP never contradicts a
disjunction outright. It did not fix **reachability**. Both of its searches rank
disjuncts from a single static point (the relaxation's per-group argmax) and
enumerate outward in Hamming waves without ever re-solving, so a configuration
many demotions away is unreachable at any budget:

| model | groups | demotions from the argmax | plan index in the wave |
|---|---|---|---|
| syngas | 26 | 3 | 743 (`max_configs` = 256) |
| batch_processing | 29 | 15 | C(29,15) ≈ 7.7e7 |

This adds `one_hot_config_dive`, which **re-solves the relaxation between
choices**, and reserves half the constructor's clock for it.

## Entry experiment: both premises in the issue are false

#993 was opened on two hypotheses — a bad start point on batch_processing and a
continuous-subproblem failure on syngas. Both are wrong, and the falsification is
recorded on the issue (comment 5268543715).

With the integers pinned to BARON's proven configuration the fixed-integer
sub-NLP is *trivial*, **from the constructor's own zero start**:

| model | time | objective | reference |
|---|---|---|---|
| batch_processing | 0.07 s | 679365.33 | 679365.33 |
| syngas | 0.36 s | 4669.0235 | 4669.02 |

On syngas 12 of 67 starts are feasible, including the constructor's own `zero`.
On batch_processing the start point, the presolved bounds, the seed ranking and
the environment were each eliminated by a separate arm (all four cells of a 2×2,
plus five starts: 0 feasible in 1329 attempts). The sub-NLP was never the
problem — **getting to the configuration** was. Root relaxations are very weak
(546849.8 vs 679365.33; 2.0594579 vs 4669.02), so argmax rounding carries almost
no information, and a larger `max_configs` is the same wrong mechanism with a
bigger constant.

## Mechanism ladder (all on the two real models)

Each rung was added because a measurement demanded it. Logs in
`scratchpad/issue993/dive*.log`.

| mechanism | batch_processing | syngas |
|---|---|---|
| wave enumeration (production today) | 0 feasible | 0 feasible |
| descent on the failed sub-NLP's residual | 0 (140 → 47 violated rows, then stalls) | 0 (258 → 136) |
| DFS dive | 0 (17/29 groups at 60 s) | 0 (21/26) |
| dive + learned order | **1063445 at 12.1 s** | 0 |
| + GRASP randomised choice | **943539 at 5.3 s, 41 configs** | 0 |
| + local repair | **822534 at 5.9 s** | 0 (25/26, 8 repairs) |

Two findings steered this. First, partial one-hot fixings genuinely do make the
relaxation infeasible and the refusal is trustworthy: **0 of 412 refusals flipped
to feasible** when retried from an independent start. Second, randomising the
*score* cannot diversify syngas — its size-2 groups sit at margins near 1.0, so
additive noise never flips one, and 65 restarts re-walked one identical path — so
the disjunct *order* is randomised instead.

## The wave was spending the dive's budget

Ordering the wave first is right (0.018 s/plan on cstr when it works), but
unreserved it consumes the **whole** budget on exactly the models the dive exists
for. At a 9 s constructor budget: batch_processing got 66 of 256 plans, syngas 53,
all infeasible, and the dive got **0 relaxation solves**. Half the budget is now
reserved. That costs the wave nothing where the wave works — cstr exhausts all 256
plans in 4.6 s of the 15 s a 300 s run grants — and where it does not work, every
second it holds is waste. Plans are ordered most-informed-first, so a truncated
wave loses late alternates, never its best-ranked candidate.

## Measured through the shipped path

`scratchpad/issue993/prod_dive_split.log`, at the 15 s budget a 300 s time limit
grants. §8 load gate: `discopt.__file__` asserted in-tree and the version marker
(`one_hot_config_dive`, absent on `main`) asserted present.

| model | feasible | best | vs reference | note |
|---|---|---|---|---|
| cstr | 4 | 3.0620146 | +0.0% | **unchanged**; the dive never runs, so it is not charged for it |
| batch_processing | 1 | 822533.66 | +21.1% | the wave alone finds nothing at any budget |
| syngas | 0 | — | — | the measured negative |

Every returned point is independently re-verified in the probe (constraint- and
integer-feasible, reported objective matches the point, and **no objective beats
its reference optimum**), and the model's bound arrays are asserted byte-identical
before and after each call.

At a 9 s budget batch_processing still finds nothing, so this needs a time limit of
roughly 100 s or more, where the 15 s absolute cap binds rather than the 15 %
fraction. Stated rather than tuned around: raising the constructor's share is a
separate decision with its own panel.

## Soundness

* Every returned point comes from `subnlp`, which re-verifies integer- **and**
  constraint-feasibility. This proposes incumbents only and never touches the dual
  bound, so it cannot weaken a certificate.
* An "infeasible" verdict on a nonconvex partial fixing redirects **this
  heuristic's own search** and is never a pruning decision, so a wrong verdict
  costs candidates, never correctness.
* Every bound mutation is restored in a `finally` (asserted by a test and by the
  probe).
* Cost is bounded three ways: the absolute deadline (polled before every solve,
  and each solve capped so one cannot overrun it), `max_restarts`, and
  `max_level_solves`.

## Verification

* **New regression test fails before, passes after.** Verified by stashing the
  module and re-running the same synthetic model on `main`'s code: 0 feasible in
  14.6 s (the wave exhausts `max_configs` inside the first three demotion levels).
  After: 6 passed in 22.5 s. The test model is a *synthetic capacity GDP* whose
  structure creates the gap — no named instance, no name-keyed behavior
  (CLAUDE.md §2).
* `pytest python/tests/test_issue823_gdp_config_primal.py` — 9 passed, unchanged.
* `pytest -m smoke` and `pytest -m slow python/tests/test_adversarial_recent_fixes.py`
  — see the comment below for results.
* `ruff check python/`, `ruff format --check`, `mypy` — clean. No Rust touched.

## The wave/dive handover is a solve count, not a clock slice (#912)

CI on the first push failed `test_912_wall_budget_inventory::test_no_unrecorded_wall_clock_work_gate`
on the line this PR added:

```python
wave_deadline = _now() + 0.5 * max(0.0, deadline - _now())
```

That is a real defect, not a test to silence. #912's rule is that a clock may
decide **when to stop**, never **how much work** to do, and this line did the
second: it made the number of configurations the wave tries — and therefore the
incumbent, and therefore every node below it — a function of machine speed.
Driving the `_now()` seam with two clocks that differ by an unbounded factor gives
**28 plans against 256** for the same model on the same input.

**Registering it in `KNOWN` was not honestly available.** The `residual` category
is the one this line belongs to, and `test_the_converted_layer_stays_converted`
asserts zero `residual` entries for `_relax/primal_heuristics.py` — the category
is closed to this module by policy, not by an omission an append would fix. So the
budget is denominated in sub-NLP solves instead, the unit `_work_budget.NLP_SOLVE`
already names, and the offending line is gone rather than recorded.

`_WAVE_SOLVE_CAP = 48` is calibrated, not picked. Entry experiment E1/E2 ran the
wave with `deadline=None` so only `max_configs` binds, recording every plan's
outcome *and objective*:

| model | solves/s | feasible at plan | best objective at plan |
|---|---|---|---|
| cstr | 54.3 | 8, 42, 47, 57 | **42** (3.0620146, the optimum) |
| batch_processing | 7.3 | none of 256 | — |
| syngas | 5.1 | none of 256 | — |

The yield is concentrated. The plans that matter for *quality* end at 42 — cstr's
plan-8 hit is +2.36% off — so the cap has to sit above 42 (a cap of 32 would trade
cstr's true optimum for a worse point) and as far below 256 as that allows. 48
keeps every quality-relevant plan with six plans of headroom and costs the wave
6.6 s of a 15 s grant on batch_processing instead of the 35 s an uncapped wave
wants, which is what leaves the dive a share at all.

Measured through the production `one_hot_config_subnlp` → `one_hot_config_dive`
chain at the 15 s grant a ≥100 s time limit yields:

| model | wall split (rejected) | solve-count cap (shipping) |
|---|---|---|
| cstr | 256 solves, best 3.0620146, 4.6 s | 48 solves, best 3.0620146, **0.8 s** |
| batch_processing | wave 54 + dive 184 solves → 822533.66 | wave 48 + dive 203 solves → 822533.66 |
| syngas | wave 47 + dive 84 solves → nothing | wave 48 + dive → nothing |

Same answers everywhere, 5.7x cheaper where the wave works. New test
`test_wave_hands_over_on_a_solve_count_not_a_clock_slice` pins it by driving the
`_now()` seam, and carries two self-checks so a passing run cannot be vacuous
(CLAUDE.md §6): the slow arm must run past half the grant, or a wall split would
not have truncated it, and must stay inside the grant, or it stopped on the
deadline contract instead of the cap. Against the reverted implementation it fails
with `the wave tried 28 configuration(s) on the slow clock and 256 on the fast one`.

**Sequencing note.** Converting the budget changes what the search does, so the §5
graduation panel is being run *after* this commit, against the code that will
actually ship — an ON arm measured under the wall split would have characterized a
mechanism this PR removes.

Still behind `DISCOPT_GDP_CONFIG_PRIMAL`, **default OFF**. The §5 graduation panel
(OFF vs ON over the GDPlib small set, interleaved) is the next PR, which will
either graduate the flag default-ON or remove it and its three call sites.

Contributes to #993

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017PQaiDVuY5Rs3tga98tnNo

