### PR TITLE
chore(bench): #993 pin the GDPlib small panel as a named gdplib_small suite

### DIFF
--- a/discopt_benchmarks/benchmarks/gdplib_runner.py
+++ b/discopt_benchmarks/benchmarks/gdplib_runner.py
@@ -104,6 +104,38 @@ class GDPLibSuiteConfig:
     oracle: bool = True  # cross-check the linear subset against HiGHS
 
 
+#: The curated small set: every GDPlib model whose ``gdp.bigm`` reformulation fits
+#: under 500 variables, in increasing size. This is the panel the GDP work is
+#: scored on (#823, #993), so it is pinned by NAME rather than derived from
+#: ``--max-variables`` at run time. Two reasons, both learned here: the sizes are
+#: a property of the installed gdplib revision, so a size filter silently changes
+#: the population between installs and makes two panels incomparable; and a
+#: threshold quietly admits a model nothing has ever verified. Sizes are recorded
+#: in ``docs/dev/gdplib-benchmarking.md``.
+#:
+#: ``multiperiod_blending`` (474 vars) is deliberately absent: it fits the size
+#: bound but no in-repo oracle proves its optimum, so it can contribute a timing
+#: number and nothing to a soundness check. Add it here the day it has a verified
+#: reference.
+GDPLIB_SMALL: tuple[str, ...] = (
+    "jobshop",
+    "ex1_linan_2023",
+    "positioning",
+    "small_batch",
+    "cstr",
+    "spectralog",
+    "methanol",
+    "batch_processing",
+    "syngas",
+    "water_network",
+    "gdp_col",
+    "modprodnet",
+)
+
+#: Named model sets selectable with ``--suite``.
+SUITES: dict[str, tuple[str, ...]] = {"gdplib_small": GDPLIB_SMALL}
+
+
 def is_available() -> bool:
     """True if Pyomo and GDPlib are both importable."""
     try:
@@ -801,6 +833,13 @@ def main(argv: list[str] | None = None) -> int:
     )
     parser.add_argument("--exclude", nargs="*", default=None, help="model names to skip")
     parser.add_argument(
+        "--suite",
+        choices=sorted(SUITES),
+        default=None,
+        help="named model set, e.g. gdplib_small (the 12 models under 500 vars). "
+        "Mutually exclusive with --models.",
+    )
+    parser.add_argument(
         "--methods",
         nargs="+",
         default=["bigm"],
@@ -814,12 +853,33 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--output", default=None, help="write BenchmarkResults JSON to this path")
     args = parser.parse_args(argv)
 
+    if args.suite is not None:
+        if args.models:
+            parser.error("--suite and --models are mutually exclusive")
+        args.models = list(SUITES[args.suite])
+
     if not is_available():
         print(
             "GDPlib benchmark unavailable: install pyomo + gdplib "
             "(gdplib from source — the PyPI wheel omits data files)."
         )
         return 2
+
+    if args.suite is not None:
+        # `include` filtering in discover_models() drops a requested-but-absent
+        # model silently. For a preset pinned by name that is the §6 vacuity trap:
+        # a panel that ran 8 of 12 models and reported clean. Refuse loudly.
+        found = {s.name for s in discover_models(exclude=args.exclude)}
+        missing = [m for m in args.models if m not in found]
+        if missing:
+            print(
+                f"FAIL: suite '{args.suite}' names {len(missing)} model(s) this gdplib "
+                f"install does not provide: {', '.join(missing)}. A shrunken suite would "
+                "report clean while measuring less than it claims — install gdplib from "
+                "source, or run the models you do have via --models.",
+                file=sys.stderr,
+            )
+            return 4
 
     if args.list:
         specs = discover_models(include=args.models, exclude=args.exclude)

--- a/discopt_benchmarks/tests/test_gdplib.py
+++ b/discopt_benchmarks/tests/test_gdplib.py
@@ -440,3 +440,82 @@ def test_run_suite_jobshop_only_no_violation():
     # Results flow through the standard metrics pipeline.
     assert "jobshop/bigm" in results.instance_info
     assert results.get_results("discopt")
+
+
+# ── the gdplib_small named suite (#993 Phase D) ─────────────────────────────
+
+
+def test_gdplib_small_is_fully_discoverable():
+    """Every model the preset names must exist in this install.
+
+    This is the test that gives the preset its meaning: ``discover_models``
+    filters ``include`` by set intersection, so a preset naming a model this
+    gdplib revision does not ship would silently shrink to a smaller panel and
+    still report clean. If this fails, install gdplib from source.
+    """
+    found = {s.name for s in gr.discover_models()}
+    missing = sorted(set(gr.GDPLIB_SMALL) - found)
+    assert not missing, f"gdplib_small names undiscoverable models: {missing}"
+    assert len(gr.GDPLIB_SMALL) == len(set(gr.GDPLIB_SMALL)), "duplicate name in preset"
+
+
+def test_suite_expands_to_the_preset(monkeypatch):
+    seen = {}
+
+    def _fake_run_suite(config):
+        from benchmarks.metrics import BenchmarkResults
+
+        seen["include"] = list(config.include or [])
+        return BenchmarkResults(suite="gdplib", timestamp="now"), []
+
+    monkeypatch.setattr(gr, "run_suite", _fake_run_suite)
+    monkeypatch.setattr(gr, "is_available", lambda: True)
+    gr.main(["--suite", "gdplib_small", "--no-oracle"])
+    assert seen["include"] == list(gr.GDPLIB_SMALL)
+
+
+def test_suite_and_models_are_mutually_exclusive():
+    with pytest.raises(SystemExit) as exc:
+        gr.main(["--suite", "gdplib_small", "--models", "jobshop"])
+    assert exc.value.code == 2
+
+
+def test_suite_refuses_a_shrunken_preset(monkeypatch):
+    """A preset model absent from the install exits nonzero, never silently."""
+    # Resolve the spec BEFORE patching — _spec() calls discover_models() itself.
+    only = [_spec("jobshop")]
+    monkeypatch.setattr(gr, "is_available", lambda: True)
+    monkeypatch.setattr(gr, "discover_models", lambda include=None, exclude=None: only)
+
+    def _must_not_run(config):  # pragma: no cover - reached only on a bug
+        raise AssertionError("run_suite must not be reached with a shrunken preset")
+
+    monkeypatch.setattr(gr, "run_suite", _must_not_run)
+    assert gr.main(["--suite", "gdplib_small", "--no-oracle"]) == 4
+
+
+@pytest.mark.slow
+@pytest.mark.timeout(2400)
+def test_gdplib_small_suite_runs_clean():
+    """On-demand wrapper for the named suite: every model runs, nothing unsound.
+
+    Deliberately *not* a CI test — it is the reproducible entry point for the
+    GDP panel (``--suite gdplib_small``). The assertions are the two things a
+    panel must never get wrong: it ran every model it claims to cover (§6), and
+    no run produced a false optimum or a crossed bound (§1).
+    """
+    config = gr.GDPLibSuiteConfig(
+        include=list(gr.GDPLIB_SMALL),
+        methods=("bigm",),
+        time_limit_seconds=60,
+        oracle=True,
+    )
+    results, runs = gr.run_suite(config)
+    assert len(runs) == len(gr.GDPLIB_SMALL), (
+        f"suite ran {len(runs)} of {len(gr.GDPLIB_SMALL)} models — a shrunken panel"
+    )
+    bad = [r.name for r in runs if r.false_optimum or r.bound_crosses]
+    assert not bad, f"soundness violations on {bad}"
+    checked = sum(1 for r in runs if r.oracle_objective is not None)
+    assert checked > 0, "zero oracle-checked runs — this panel verified nothing"
+    assert results.get_results("discopt")

--- a/docs/dev/gdplib-benchmarking.md
+++ b/docs/dev/gdplib-benchmarking.md
@@ -83,6 +83,50 @@ python -m benchmarks.gdplib_runner --max-variables 500 --time-limit 120 --output
 
 The CLI exits nonzero if any run trips a soundness flag, so it can gate CI.
 
+## The `gdplib_small` named suite
+
+`--max-variables 500` was how the small panel used to be selected, and it is not
+reproducible: the variable count of a GDPlib model changes with the gdplib
+revision, so the same command silently covers a different set of models on a
+different checkout — and a panel that shrank is a panel that verified less than it
+claims. The set is therefore pinned **by name**, in
+`gdplib_runner.GDPLIB_SMALL`, and selected with `--suite`:
+
+```bash
+cd discopt_benchmarks
+python -m benchmarks.gdplib_runner --suite gdplib_small --methods bigm \
+    --time-limit 120 --output reports/gdplib_small.json
+```
+
+Twelve models: `jobshop`, `ex1_linan_2023`, `positioning`, `small_batch`, `cstr`,
+`spectralog`, `methanol`, `batch_processing`, `syngas`, `water_network`,
+`gdp_col`, `modprodnet`. `multiperiod_blending` (474 variables, so nominally in
+range) is **excluded** because no verified oracle value exists for it — an
+unverified oracle can mask a false primal rather than catch one, which is exactly
+the hole the cstr finding below came from.
+
+`--suite` and `--models` are mutually exclusive, and the suite path refuses (exit
+**4**) when the install does not provide every model the preset names. That guard
+is the point of the preset: `discover_models(include=…)` filters by set
+intersection, so without it a missing model would quietly drop out and the sweep
+would print "no soundness violations" over eleven models while claiming twelve.
+Exit codes: `1` soundness violation, `2` gdplib/pyomo unavailable, `3` vacuous
+sweep (zero oracle-checked runs), `4` incomplete suite.
+
+The on-demand pytest wrapper is
+`discopt_benchmarks/tests/test_gdplib.py::test_gdplib_small_suite_runs_clean`
+(`slow`-marked, 60 s per solve, not in CI):
+
+```bash
+pytest -m slow discopt_benchmarks/tests/test_gdplib.py -k gdplib_small_suite
+```
+
+It asserts the run count equals the preset size, that no run produced a false
+optimum or a crossed bound, and that at least one run was oracle-checked. There
+is deliberately **no nightly lane** — this is a panel you run when a change
+touches the GDP path (e.g. the `DISCOPT_GDP_CONFIG_PRIMAL` graduation panel in
+`docs/dev/data/`), not a continuous watch.
+
 ## Native discopt models
 
 `discopt_benchmarks/benchmarks/gdplib_native.py` rebuilds a curated subset of GDPlib


### PR DESCRIPTION
## Why

`--max-variables 500` is how the GDPlib small panel has been selected until now,
and it is not a reproducible selector. A model's variable count changes with the
gdplib revision, so the same command covers a different set of models on a
different checkout. A panel that silently shrank is a panel that verified less
than it claimed — the CLAUDE.md §6 vacuity failure mode, applied to a whole
benchmark set instead of a single probe.

This came out of the #993 GDP primal work, where the graduation panel needed a
model set that would still mean the same thing when someone re-ran it.

## What changed

- **`GDPLIB_SMALL` / `SUITES`** in `benchmarks/gdplib_runner.py` pin the 12-model
  set by name: `jobshop`, `ex1_linan_2023`, `positioning`, `small_batch`, `cstr`,
  `spectralog`, `methanol`, `batch_processing`, `syngas`, `water_network`,
  `gdp_col`, `modprodnet`. Selected with `--suite gdplib_small`, mutually
  exclusive with `--models`.
- **A loud refusal instead of a silent shrink.** `discover_models(include=...)`
  filters by set intersection, so a preset naming a model this install does not
  ship would quietly drop out and the sweep would print "no soundness violations"
  over 11 models while claiming 12. The suite path now exits **4** listing the
  missing models. Exit codes are now: `1` soundness violation, `2`
  gdplib/pyomo unavailable, `3` vacuous sweep (zero oracle-checked runs), `4`
  incomplete suite.
- **`multiperiod_blending` stays excluded** even though its 474 variables put it
  nominally in range: no verified oracle value exists for it. An unverified
  oracle masks a false primal rather than catching one — the exact hole that let
  the old pyscipopt path certify a below-true `cstr` optimum (#823).
- **Tests** (`discopt_benchmarks/tests/test_gdplib.py`): four unit tests —
  every preset name is discoverable in this install, `--suite` expands to the
  preset, `--suite`/`--models` conflict exits 2, and a shrunken preset exits 4
  without reaching `run_suite` — plus a `slow`-marked on-demand wrapper
  `test_gdplib_small_suite_runs_clean` asserting run count == preset size, zero
  false optima / crossed bounds, and at least one oracle-checked run.
- **Docs**: a `## The gdplib_small named suite` section in
  `docs/dev/gdplib-benchmarking.md` with the rationale, the command, and the
  exit-code table. Deliberately **no nightly lane** — this is a panel you run
  when a change touches the GDP path, not a continuous watch.

## Verification

- `pytest discopt_benchmarks/tests/test_gdplib.py -m "not slow" -k "suite or gdplib_small or discover"` — **7 passed**.
- `python -m benchmarks.gdplib_runner --suite gdplib_small --list` — lists all 12,
  exit 0, confirming the preset is fully discoverable in a source gdplib install.
- `ruff check` / `ruff format --check` clean on both changed Python files.
- `mypy benchmarks/gdplib_runner.py`: **25 errors, identical to the count on
  `main`** (all pre-existing `no-untyped-def` / `import-untyped`); none in the
  touched line ranges.
- No solver code and no Rust touched — this is benchmark harness plus docs, so
  `cargo test` is not applicable. `pytest -m smoke` and the adversarial suite are
  running after the #993 Phase C graduation panel completes (running one
  concurrently would put load on a live measurement, CLAUDE.md §9); CI runs both
  on this PR regardless.

Contributes to #993

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017PQaiDVuY5Rs3tga98tnNo
