### PR TITLE
feat(relax,lp): equality-factor RLT + cold dual start for nonconvex QP dual bounds

### DIFF
--- a/crates/discopt-core/examples/feral_update_cost.rs
+++ b/crates/discopt-core/examples/feral_update_cost.rs
@@ -172,6 +172,7 @@ fn main() {
             warm_stall_cap_override: None,
             expel_zero_artificials: false,
             bank_deadline_duals: false,
+            cold_dual_start: false,
         };
         let sol = solve_lp(&lp, &b, &opts);
         let basis = &sol.basis.basic_vars;

--- a/crates/discopt-core/examples/milp_bench.rs
+++ b/crates/discopt-core/examples/milp_bench.rs
@@ -168,6 +168,7 @@ fn opts(n_struct: usize, integer_cols: Vec<usize>, tl: f64) -> MilpOptions {
             warm_stall_cap_override: None,
             expel_zero_artificials: false,
             bank_deadline_duals: false,
+            cold_dual_start: false,
         },
     }
 }

--- a/crates/discopt-core/examples/par_bench.rs
+++ b/crates/discopt-core/examples/par_bench.rs
@@ -132,6 +132,7 @@ fn opts(inst: &Instance) -> MilpOptions {
             warm_stall_cap_override: None,
             expel_zero_artificials: false,
             bank_deadline_duals: false,
+            cold_dual_start: false,
         },
     }
 }

--- a/crates/discopt-core/src/bin/e0_warm_bench.rs
+++ b/crates/discopt-core/src/bin/e0_warm_bench.rs
@@ -160,6 +160,7 @@ fn main() -> ExitCode {
         warm_stall_cap_override: None,
         expel_zero_artificials: true,
         bank_deadline_duals: false,
+        cold_dual_start: false,
     };
 
     let mut l = lp_data.l.clone();

--- a/crates/discopt-core/src/bnb/spatial_kernel.rs
+++ b/crates/discopt-core/src/bnb/spatial_kernel.rs
@@ -24,7 +24,9 @@ use crate::bnb::mccormick_patch as mc;
 use crate::bnb::obbt_sweep::{obbt_probe_sweep, ObbtSweepResult};
 use crate::lp::simplex::refine::ns_safe_bound_csc;
 use crate::lp::simplex::sparse::SparseCols;
-use crate::lp::simplex::{primal::solve_lp_cols_scaled, LpStatus, SimplexOptions};
+use crate::lp::simplex::{
+    dual::solve_lp_warm_csc, primal::solve_lp_cols_scaled, LpStatus, SimplexOptions,
+};
 
 /// A box-independent linear constraint row `sum(coeffs[k] * x[cols[k]]) <= rhs`
 /// (senses are normalized to `<=` by the Python producer; an `==` row is two `<=`).
@@ -376,6 +378,51 @@ pub fn assemble_node_lp(spec: &SpatialKernelSpec, lo: &[f64], hi: &[f64]) -> Ass
     }
 }
 
+/// The sign-matched slack start basis for a node LP in the kernel's standard form
+/// `[A | I] z = b`, or `None` when it would not be dual-feasible.
+///
+/// Slacks (`n_cols..n_total`) basic, so `B = I`; the objective is zero over them,
+/// hence `y = B⁻ᵀc_B = 0` and each reduced cost is just `c_j`. Putting structural
+/// column `j` at its lower bound when `c_j > 0` and its upper when `c_j < 0` then
+/// makes every reduced cost point the right way — dual feasibility — provided the
+/// selected side is finite. `INF` here is the layer's `1e20` sentinel, never
+/// `f64::INFINITY`, so the test is on the magnitude of the bound itself.
+///
+/// This is the Rust twin of `_dual_start_slack_basis` in `solvers/milp_simplex.py`,
+/// which does the same job for the Python pure-LP entry.
+fn cold_dual_start_basis(
+    c: &[f64],
+    l: &[f64],
+    u: &[f64],
+    m: usize,
+    n_total: usize,
+) -> Option<crate::lp::basis::Basis> {
+    use crate::lp::basis::{Basis, AT_LOWER, AT_UPPER, BASIC};
+    const INF: f64 = 1e20;
+    if m == 0 || n_total != l.len() || n_total != u.len() || c.len() != n_total {
+        return None;
+    }
+    let n_struct = n_total - m;
+    let mut col_status = vec![AT_LOWER; n_total];
+    for (j, status) in col_status.iter_mut().enumerate().take(n_struct) {
+        if c[j] < 0.0 {
+            if u[j] >= INF {
+                return None; // selected side open → dual-infeasible
+            }
+            *status = AT_UPPER;
+        } else if l[j] <= -INF {
+            return None;
+        }
+    }
+    for status in col_status.iter_mut().skip(n_struct) {
+        *status = BASIC;
+    }
+    Some(Basis {
+        col_status,
+        basic_vars: (n_struct..n_total).collect(),
+    })
+}
+
 /// Run one native spatial node over the box `(lo, hi)` (length `n_cols`): assemble,
 /// solve the relaxation, and — if `run_obbt` and candidates exist — run the in-kernel
 /// OBBT sweep warm-started from the node's optimal basis.
@@ -399,16 +446,41 @@ pub fn solve_spatial_node(
     // trusted path uses and unscales x/dual/ray back to the original space, so the
     // safe-bound evaluation sees well-conditioned certificates against the
     // original system.
-    let sol = solve_lp_cols_scaled(
-        lp.sp.clone(),
-        lp.m,
-        lp.n_total,
-        &c,
-        &lp.l,
-        &lp.u,
-        &lp.b,
-        opts,
-    );
+    //
+    // `cold_dual_start` (default OFF) routes the same equilibrated solve through
+    // the DUAL simplex started from the sign-matched slack basis instead. Same LP,
+    // same scaling, same certificates — only the algorithm that reaches the
+    // optimum changes, and `solve_lp_warm_csc` cold-falls-back whenever the basis
+    // is unusable. See `SimplexOptions::cold_dual_start` for why: the cold primal
+    // grinds to `max_iter` on equality-rich (hence primal-degenerate) relaxations.
+    let start = if opts.cold_dual_start {
+        cold_dual_start_basis(&c, &lp.l, &lp.u, lp.m, lp.n_total)
+    } else {
+        None
+    };
+    let sol = match start {
+        Some(ref basis) => solve_lp_warm_csc(
+            lp.sp.clone(),
+            lp.m,
+            lp.n_total,
+            &c,
+            &lp.l,
+            &lp.u,
+            &lp.b,
+            Some(basis),
+            opts,
+        ),
+        None => solve_lp_cols_scaled(
+            lp.sp.clone(),
+            lp.m,
+            lp.n_total,
+            &c,
+            &lp.l,
+            &lp.u,
+            &lp.b,
+            opts,
+        ),
+    };
     let mut n_lp_solves = 1usize;
 
     // Rigorous safe lower bound from the row duals — NEVER the raw simplex objective
@@ -497,6 +569,87 @@ mod tests {
         // 4 envelope rows -> m=4, n_total = 3 + 4.
         assert_eq!(lp.m, 4);
         assert_eq!(lp.n_total, 7);
+    }
+
+    /// A spec with a linear EQUALITY (as the two opposing `<=` rows the producer
+    /// emits) over a bilinear term — the primal-degenerate shape `cold_dual_start`
+    /// exists for. Generic structure, not a named instance.
+    fn equality_spec() -> SpatialKernelSpec {
+        // x + y == 2, minimize w = x*y, x,y in [0,2].
+        SpatialKernelSpec {
+            n_cols: 3,
+            n_orig: 2,
+            c: vec![0.0, 0.0, 1.0],
+            integrality: vec![false, false, false],
+            global_lo: vec![0.0, 0.0, -1e20],
+            global_hi: vec![2.0, 2.0, 1e20],
+            fixed_rows: vec![
+                FixedRow {
+                    cols: vec![0, 1],
+                    coeffs: vec![1.0, 1.0],
+                    rhs: 2.0,
+                },
+                FixedRow {
+                    cols: vec![0, 1],
+                    coeffs: vec![-1.0, -1.0],
+                    rhs: -2.0,
+                },
+            ],
+            terms: vec![EnvTerm::Bilinear { i: 0, j: 1, w: 2 }],
+            blf_terms: vec![],
+            obbt_candidates: vec![0, 1],
+        }
+    }
+
+    #[test]
+    fn cold_dual_start_reaches_the_same_node_bound() {
+        // The flag chooses the ALGORITHM, never the answer: the dual start and the
+        // cold primal must certify the same safe bound on the same node LP.
+        let spec = equality_spec();
+        let lo = vec![0.0, 0.0, -1e20];
+        let hi = vec![2.0, 2.0, 1e20];
+        let off = solve_spatial_node(&spec, &lo, &hi, false, &SimplexOptions::default());
+        let on = solve_spatial_node(
+            &spec,
+            &lo,
+            &hi,
+            false,
+            &SimplexOptions {
+                cold_dual_start: true,
+                ..SimplexOptions::default()
+            },
+        );
+        assert_eq!(off.status, LpStatus::Optimal);
+        assert_eq!(on.status, LpStatus::Optimal);
+        assert!(
+            (on.bound - off.bound).abs() < 1e-7,
+            "start basis moved the bound: {} vs {}",
+            on.bound,
+            off.bound
+        );
+        // Both are sound: min x*y on x+y==2, x,y in [0,2] is 0 (at a corner).
+        assert!(
+            on.bound <= 1e-9,
+            "safe bound {} above the optimum",
+            on.bound
+        );
+    }
+
+    #[test]
+    fn cold_dual_start_basis_is_dual_feasible_or_refused() {
+        // Slacks basic; each structural at the side its objective sign selects.
+        let c = [1.0, -1.0, 0.0, 0.0, 0.0]; // 3 structural + 2 slack columns
+        let l = [0.0, 0.0, 0.0, 0.0, 0.0];
+        let u = [1.0, 1.0, 1.0, 1e20, 1e20];
+        let b = cold_dual_start_basis(&c, &l, &u, 2, 5).expect("eligible");
+        assert_eq!(b.col_status, vec![0, 2, 0, 1, 1]); // AT_LOWER, AT_UPPER, AT_LOWER, BASIC, BASIC
+        assert_eq!(b.basic_vars, vec![3, 4]);
+
+        // An OPEN selected side is refused rather than handed over dual-infeasible.
+        let u_open = [1.0, 1e20, 1.0, 1e20, 1e20];
+        assert!(cold_dual_start_basis(&c, &l, &u_open, 2, 5).is_none());
+        let l_open = [-1e20, 0.0, 0.0, 0.0, 0.0];
+        assert!(cold_dual_start_basis(&c, &l_open, &u, 2, 5).is_none());
     }
 
     #[test]

--- a/crates/discopt-core/src/lp/simplex/dual.rs
+++ b/crates/discopt-core/src/lp/simplex/dual.rs
@@ -1356,6 +1356,7 @@ mod tests {
         let expired = SimplexOptions {
             deadline: Some(std::time::Instant::now() - std::time::Duration::from_millis(1)),
             bank_deadline_duals: true,
+            cold_dual_start: false,
             ..opts()
         };
         let cut = solve_lp_warm(&lp2, &b, &cold.basis, &expired);

--- a/crates/discopt-core/src/lp/simplex/mod.rs
+++ b/crates/discopt-core/src/lp/simplex/mod.rs
@@ -134,6 +134,34 @@ pub struct SimplexOptions {
     /// sets it, and only when its caller passed a `time_limit` — i.e. exactly the
     /// `DISCOPT_LP_WARM_DEADLINE` path whose graduation panel judges it.
     pub bank_deadline_duals: bool,
+    /// Start a COLD spatial-kernel node LP from the sign-matched dual-feasible
+    /// slack basis instead of the cold two-phase primal.
+    ///
+    /// The kernel's node LP (`bnb::spatial_kernel::solve_spatial_node`) has always
+    /// gone straight to `solve_lp_cols_scaled`, i.e. the cold PRIMAL loop — the
+    /// one whose own comment reads "a dense, degenerate lifted-McCormick LP can
+    /// otherwise grind toward `max_iter` and run uninterruptibly for minutes". It
+    /// does exactly that on relaxations rich in linear *equalities*: an equality
+    /// reaches the LP layer as two opposing `<=` rows, both tight at every
+    /// feasible point, so the LP is massively primal-degenerate. Measured on the
+    /// constraint-factor-RLT root relaxation of a continuous nonconvex QP
+    /// (QPLIB_1157, 3937 rows): the cold primal exhausted `max_iter` after >150 s
+    /// and returned no bound; the dual start returns the same optimum (to 5e-13
+    /// against HiGHS) in ~6 s.
+    ///
+    /// With slacks basic and each structural column nonbasic at the bound its
+    /// objective sign selects, `y = B⁻ᵀc_B = 0` and every reduced cost is `c_j`,
+    /// so the basis is dual-feasible whenever each selected side is finite.
+    /// `PreparedDual::prepare` re-verifies that precondition independently and
+    /// falls back to the cold path when it fails, so an accepted basis can never
+    /// make the engine converge wrong — this only changes *which* algorithm
+    /// reaches the same LP optimum.
+    ///
+    /// Default `false`: a different optimal basis on a degenerate LP means a
+    /// different (still rigorous) safe bound and can move downstream branching,
+    /// which is bound-changing under the §5 regime. Set from Python by
+    /// `DISCOPT_LP_COLD_DUAL_START`, pending its graduation panel.
+    pub cold_dual_start: bool,
 }
 
 impl SimplexOptions {
@@ -174,6 +202,7 @@ impl Default for SimplexOptions {
             warm_stall_cap_override: None,
             expel_zero_artificials: false,
             bank_deadline_duals: false,
+            cold_dual_start: false,
         }
     }
 }

--- a/crates/discopt-python/src/lp_bindings.rs
+++ b/crates/discopt-python/src/lp_bindings.rs
@@ -373,6 +373,7 @@ pub fn solve_lp_py<'py>(
         warm_stall_cap_override: None,
         expel_zero_artificials: false,
         bank_deadline_duals: false,
+        cold_dual_start: false,
     };
     let sol = simplex_solve_lp(&lp, b.as_slice()?, &opts);
     let status = match sol.status {
@@ -505,6 +506,7 @@ pub fn solve_lp_warm_py<'py>(
         warm_stall_cap_override: None,
         expel_zero_artificials: false,
         bank_deadline_duals: false,
+        cold_dual_start: false,
     };
     let b_slice = b.as_slice()?;
 
@@ -611,6 +613,7 @@ pub fn solve_lp_warm_csc_py<'py>(
         // driver's own deadline route keeps the default `false`, so the default
         // B&B pivot path is untouched.
         bank_deadline_duals: deadline.is_some(),
+        cold_dual_start: false,
     };
     let start = match (start_col_status, start_basic_vars) {
         (Some(cs), Some(bv)) => build_extended_basis(cs.as_slice()?, bv.as_slice()?, n, m),
@@ -741,6 +744,7 @@ pub fn solve_lp_batch_py<'py>(
         warm_stall_cap_override: None,
         expel_zero_artificials: false,
         bank_deadline_duals: false,
+        cold_dual_start: false,
     };
     // The solve touches no Python objects, so release the GIL to let the core's
     // rayon workers run the batch concurrently without contending on it.
@@ -1113,6 +1117,7 @@ fn run_milp_hooked<'py>(
             warm_stall_cap_override: None,
             expel_zero_artificials: false,
             bank_deadline_duals: false,
+            cold_dual_start: false,
         },
     };
     // Wrap an attached Python debugger (if any) as a core hook. It is created

--- a/crates/discopt-python/src/spatial_bindings.rs
+++ b/crates/discopt-python/src/spatial_bindings.rs
@@ -42,6 +42,7 @@ use std::time::{Duration, Instant};
     min_box_width=1e-9, run_obbt=false, run_propagation=true,
     propagation_rounds=15, initial_incumbent=None, time_limit_s=None,
     incumbent_time_extension_s=None, bound_time_extension_s=None,
+    cold_dual_start=false,
 ))]
 pub fn solve_spatial_tree_py<'py>(
     py: Python<'py>,
@@ -84,6 +85,7 @@ pub fn solve_spatial_tree_py<'py>(
     time_limit_s: Option<f64>,
     incumbent_time_extension_s: Option<f64>,
     bound_time_extension_s: Option<f64>,
+    cold_dual_start: bool,
 ) -> PyResult<Bound<'py, PyDict>> {
     let c = c.as_slice()?;
     let integrality = integrality.as_slice()?;
@@ -312,7 +314,14 @@ pub fn solve_spatial_tree_py<'py>(
         incumbent_time_extension,
         bound_time_extension,
     };
-    let opts = SimplexOptions::default();
+    // The node LP's start basis (`SimplexOptions::cold_dual_start`, default OFF,
+    // set from `DISCOPT_LP_COLD_DUAL_START`). Everything else is the default; note
+    // that `deadline` deliberately stays `None` here — see the tree loop, which
+    // enforces `cfg.deadline` between nodes.
+    let opts = SimplexOptions {
+        cold_dual_start,
+        ..SimplexOptions::default()
+    };
 
     // Release the GIL for the (potentially long) solve.
     let res = py.allow_threads(|| solve_spatial_tree(&spec, &cfg, &opts));

--- a/python/discopt/_relax/milp_relaxation.py
+++ b/python/discopt/_relax/milp_relaxation.py
@@ -2315,10 +2315,16 @@ def _uniform_relaxation_delegate(
     # engaged level-1 RLT AND ``DISCOPT_RLT_QUAD`` is on (default on). Off => the
     # base build is byte-identical to before.
     rlt_quad = bool(rlt_level1 and _tuning().rlt_quad)
+    # Linear-equality RLT is NOT gated on ``rlt_level1``: its rows are box-free
+    # equalities that are sound and cheap on every model with a linear equality,
+    # and the class they fix (continuous nonconvex QPs) does not otherwise trip
+    # the RLT auto-engage policy. Its own flag is the gate.
+    rlt_lineq = bool(_tuning().rlt_lineq)
     rel = build_uniform_relaxation(
         model,
         box=(flat_lb, flat_ub),
         rlt_quad=rlt_quad,
+        rlt_lineq=rlt_lineq,
         skip_separable_floor=skip_separable_floor,
         skip_convex_lift=skip_convex_lift,
         disc_state=disc_state,

--- a/python/discopt/_relax/spatial_producer.py
+++ b/python/discopt/_relax/spatial_producer.py
@@ -55,6 +55,7 @@ def build_spatial_kernel_spec(model, bounds: Optional[tuple] = None) -> Optional
     to the kernel; :func:`solve_with_native_kernel` strips them automatically."""
     from discopt._relax.uniform_relax import build_uniform_relaxation
     from discopt.modeling.core import VarType
+    from discopt.solver_tuning import current as _tuning
 
     # Scalar-variable models only: the relaxation's column 0..n_orig-1 maps to the n
     # variable objects one-to-one only when each has size 1. Vector variables shift
@@ -80,8 +81,17 @@ def build_spatial_kernel_spec(model, bounds: Optional[tuple] = None) -> Optional
         # relaxation (a valid lower bound dropped, never invented) and makes each
         # term's envelope match the kernel's regeneration row-for-row. Mirrors the
         # incremental engine's ``_full_build``.
+        # Linear-equality RLT rows carry no box data, so they land in the
+        # box-INDEPENDENT fixed-row set below and the kernel's per-node patcher
+        # (which regenerates only per-term envelope rows) leaves them correct at
+        # every node. The bound-factor RLT families are excluded for exactly the
+        # opposite reason.
         return build_uniform_relaxation(
-            model, box=(box_lb, box_ub), skip_separable_floor=True, skip_convex_lift=True
+            model,
+            box=(box_lb, box_ub),
+            rlt_lineq=bool(_tuning().rlt_lineq),
+            skip_separable_floor=True,
+            skip_convex_lift=True,
         )
 
     # STRUCTURE is identified on a PROBE box with distinct, strictly sign-matched

--- a/python/discopt/_relax/uniform_relax.py
+++ b/python/discopt/_relax/uniform_relax.py
@@ -2881,6 +2881,139 @@ def _emit_quadratic_rlt(
                 ctx.add_row({int(j): float(coeffs[j]) for j in nz}, float(rhs))
 
 
+def _emit_linear_equality_rlt(ctx: _Builder, model: Model) -> None:
+    """Add level-1 RLT rows from the model's *linear equality* constraints.
+
+    For an equality body ``a'x + c == 0`` and any variable ``x_j``, the product
+
+        ``(a'x + c) * x_j == 0``
+
+    is an identity on the feasible region. Linearized over the lifted product
+    columns it becomes ``sum_i a_i X_ij + c x_j == 0`` — the Sherali–Adams
+    constraint-factor row. It holds with *equality* at every feasible point
+    (``X_ij = x_i x_j`` there), so it cannot remove one: sound by construction,
+    tightening only the lifted McCormick polytope where ``X`` is free to drift
+    from ``x x'``.
+
+    Two properties distinguish this family from the bound-factor RLT passes
+    (:func:`_emit_quadratic_rlt` and the per-node ``rlt_constraint_bound_cut``
+    separator), and they are why it is worth having as its own pass:
+
+    * **No binary requirement.** ``_relax/rlt.py``'s exhaustive RLT-1 LP is gated
+      to binary variables because its ``X_ii = x_i`` diagonal and bound-factor
+      rows need them. This row needs neither, so it applies to *continuous*
+      nonconvex QPs — the class where the McCormick root bound is weakest.
+    * **No box data.** Every coefficient comes from the constraint, not from
+      ``[l, u]``, so the row is identical at every node of the tree. It is
+      therefore a box-independent *fixed* row, which is what lets it flow through
+      ``spatial_producer`` into the native Rust spatial kernel unchanged — the
+      bound-factor families cannot, since the kernel regenerates only the
+      per-term envelope rows when it patches a node box.
+
+    Multipliers ``x_j`` are restricted to variables that already participate in
+    some registered nonlinear product: elsewhere the row would tighten nothing
+    and every ``X_ij`` it names would have to be lifted from scratch. Products
+    the base decomposition did not register are lifted on demand (McCormick), up
+    to ``DISCOPT_RLT_LINEQ_MAX`` new columns.
+    """
+    from discopt._relax.milp_relaxation import _linear_form_terms
+    from discopt.solver_tuning import current as _tuning
+
+    n_orig = ctx.n_orig
+
+    # ``body == 0`` rows in sparse original-column form. A body the affine
+    # linearizer refuses (nonlinear, non-finite coefficient) is simply not a
+    # linear factor and is skipped; the quadratic pass owns those.
+    rows: list[tuple[dict[int, float], float]] = []
+    for constraint in model._constraints:
+        if constraint.sense != "==":
+            continue
+        form = _linear_form_terms(constraint.body, model, n_orig)
+        if form is None:
+            continue
+        terms, const = form
+        terms = {int(i): float(a) for i, a in terms.items() if a != 0.0}
+        # The stored constraint is ``body == rhs`` and the linearizer describes the
+        # BODY only, so the zero-form constant is ``const - rhs`` — the same shift
+        # the base constraint-row loop applies. Dropping ``rhs`` here would emit
+        # ``(a'x + const) x_j == 0`` for a constraint that never said that, which
+        # for a nonzero rhs is a WRONG row, not merely a weak one.
+        if terms:
+            rows.append((terms, float(const) - float(constraint.rhs)))
+    if not rows:
+        return
+
+    # Multiplier candidates: original variables inside some registered product.
+    multipliers: set[int] = set()
+    for a, b in ctx.bilinear_map:
+        multipliers.update((a, b))
+    for i, _p in ctx.monomial_map:
+        multipliers.add(i)
+    for tri in ctx.trilinear_map:
+        multipliers.update(tri)
+    for multi in ctx.multilinear_map:
+        multipliers.update(multi)
+    multipliers = {j for j in multipliers if 0 <= j < n_orig}
+    if not multipliers:
+        return
+
+    prod: dict[tuple[int, int], int] = {}
+    for (a, b), col in ctx.bilinear_map.items():
+        prod[(min(a, b), max(a, b))] = col
+    for (i, p), col in ctx.monomial_map.items():
+        if p == 2:
+            prod[(i, i)] = col
+
+    cap = int(_tuning().rlt_lineq_max)
+    start_cols = len(ctx.col_lb)
+
+    def _pair_col(i: int, j: int) -> Optional[int]:
+        """Lifted column for ``x_i x_j``, lifting it if the base build had no need
+        for it. ``None`` when it cannot be lifted soundly (infinite box) or the
+        new-column budget is spent — the caller then drops the whole row."""
+        key = (min(i, j), max(i, j))
+        hit = prod.get(key)
+        if hit is not None:
+            return hit
+        if len(ctx.col_lb) - start_cols >= cap:
+            return None
+        a, b = key
+        ba = (ctx.col_lb[a], ctx.col_ub[a])
+        bb = (ctx.col_lb[b], ctx.col_ub[b])
+        if not (_finite(*ba) and _finite(*bb)):
+            return None
+        tb = _interval_mul(ba, bb)
+        w = ctx.new_aux(tb[0], tb[1])
+        _emit_mccormick(ctx, w, LinForm.col(a), ba, LinForm.col(b), bb)
+        prod[key] = w
+        if a == b:
+            ctx.register_power(a, 2, w)
+        else:
+            ctx.register_product([a, b], w)
+        return w
+
+    for terms, const in rows:
+        for j in sorted(multipliers):
+            row: dict[int, float] = {}
+            ok = True
+            for i, coef in terms.items():
+                pair_col = _pair_col(i, j)
+                if pair_col is None:
+                    ok = False
+                    break
+                row[pair_col] = row.get(pair_col, 0.0) + coef
+            if not ok:
+                continue
+            if const != 0.0:
+                row[j] = row.get(j, 0.0) + const
+            row = {c: v for c, v in row.items() if v != 0.0}
+            if not row:
+                continue
+            # ``row · z == 0`` as the two inequalities the LP layer takes.
+            ctx.add_row(row, 0.0)
+            ctx.add_row({c: -v for c, v in row.items()}, 0.0)
+
+
 def _clamped_breakpoints(
     raw: "np.ndarray", lo: float, hi: float, min_intervals: int = 2
 ) -> Optional[list[float]]:
@@ -3242,6 +3375,7 @@ def build_uniform_relaxation(
     box: Optional[tuple[np.ndarray, np.ndarray]] = None,
     *,
     rlt_quad: bool = False,
+    rlt_lineq: bool = False,
     skip_separable_floor: bool = False,
     skip_convex_lift: bool = False,
     disc_state: object = None,
@@ -3277,6 +3411,14 @@ def build_uniform_relaxation(
         lifting the resulting degree-3 monomials on demand, and add the valid RLT
         product rows. Sound (only tightens); the caller gates it on the
         ``rlt_level1`` build option AND ``DISCOPT_RLT_QUAD``.
+    rlt_lineq : bool, default False
+        Enable the linear-equality constraint-factor RLT pass: multiply each
+        linear equality by each product-participating variable and add the
+        resulting ``sum_i a_i X_ij + c x_j == 0`` rows (see
+        :func:`_emit_linear_equality_rlt`). Sound (an identity at every feasible
+        point) and box-independent, so unlike ``rlt_quad`` its rows survive the
+        native spatial kernel's per-node box patching. Callers gate it on
+        ``DISCOPT_RLT_LINEQ``.
 
     Returns
     -------
@@ -3366,6 +3508,10 @@ def build_uniform_relaxation(
     # keeps the truncation honoring the deadline.
     if rlt_quad and not build_truncated:
         _emit_quadratic_rlt(ctx, model, flat_lb, flat_ub)
+    # Linear-equality constraint-factor RLT, gated the same way and for the same
+    # reasons (adds rows only, so skipping a truncated build stays sound).
+    if rlt_lineq and not build_truncated:
+        _emit_linear_equality_rlt(ctx, model)
 
     obj_offset = obj_lin.const
 

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -1271,6 +1271,11 @@ def _try_native_spatial_kernel(
             max_nodes=int(max_nodes),
             gap_tol=float(gap_tolerance),
             time_limit_s=remaining,
+            # Node-LP start basis (default OFF). The kernel's cold two-phase primal
+            # grinds to `max_iter` on equality-rich, hence primal-degenerate,
+            # relaxations — the constraint-factor-RLT class above all. See
+            # ``SolverTuning.lp_cold_dual_start``.
+            cold_dual_start=bool(_tuning().lp_cold_dual_start),
         )
         if _bound_reserve > 0.0:
             solve_kwargs["bound_time_extension_s"] = float(_bound_reserve)

--- a/python/discopt/solver_tuning.py
+++ b/python/discopt/solver_tuning.py
@@ -305,6 +305,41 @@ class SolverTuning:
     rlt_quad_max: int = field(default_factory=lambda: _env_int("DISCOPT_RLT_QUAD_MAX", 256))
     """Column cap for quadratic RLT (``DISCOPT_RLT_QUAD_MAX``, default 256)."""
 
+    rlt_lineq: bool = field(default_factory=lambda: _env_flag("DISCOPT_RLT_LINEQ", default=False))
+    """Build-time RLT products of *linear equality* constraints with the original
+    variables (``DISCOPT_RLT_LINEQ``, default **off** pending the graduation panel).
+
+    For a linear equality ``a'x + c == 0`` and a variable ``x_j``, the product
+    ``(a'x + c) * x_j == 0`` linearizes over the lifted product columns to
+    ``sum_i a_i X_ij + c x_j == 0`` — the Sherali–Adams level-1 constraint-factor
+    row. It holds with equality at every feasible point, so it never cuts one.
+
+    Unlike the bound-factor RLT families (``rlt``/``rlt_quad``), this row contains
+    **no box data**: it is identical at every node, which is why it can be emitted
+    once as a fixed row and carried into the native spatial kernel unchanged.
+
+    Motivation (measured, QPLIB continuous nonconvex QPs, root LP bound vs the
+    published optimum): the McCormick-only root bound is hopeless on this class,
+    and *all* of the recoverable gap on the instances that respond comes from this
+    equality family — the bound-factor rows added nothing on top of it:
+
+    ==============  ===========  ================  ==========  ===========
+    instance        McCormick    +linear-eq RLT    optimum     gap closed
+    ==============  ===========  ================  ==========  ===========
+    QPLIB_1157        -14.8046          -11.7716    -10.9482        78.6 %
+    QPLIB_1493        -85.6492          -65.5915    -43.1604        47.2 %
+    QPLIB_1143       -140.3576         -114.7060    -57.2467        30.9 %
+    QPLIB_1423        -25.6777          -22.6093    -14.9675        28.6 %
+    QPLIB_1507        -18.1057          -15.8070     -8.3014        23.4 %
+    ==============  ===========  ================  ==========  ===========
+
+    No bound crossed its published optimum on any instance in the probe."""
+
+    rlt_lineq_max: int = field(default_factory=lambda: _env_int("DISCOPT_RLT_LINEQ_MAX", 4096))
+    """New-column cap for linear-equality RLT (``DISCOPT_RLT_LINEQ_MAX``, default
+    4096). Products already registered by the base decomposition are free; only
+    columns this pass has to lift itself count against the cap."""
+
     multilinear_rlt_max: int = field(
         default_factory=lambda: _env_int("DISCOPT_MULTILINEAR_RLT_MAX", 4)
     )
@@ -957,6 +992,58 @@ class SolverTuning:
     )
     """Warm-start the node LP from the parent basis (``DISCOPT_LP_WARMSTART``)."""
 
+    lp_cold_dual_start: bool = field(
+        default_factory=lambda: _env_flag("DISCOPT_LP_COLD_DUAL_START", default=False)
+    )
+    """Start a COLD pure-LP solve from the sign-matched dual-feasible slack basis
+    even with no deadline (``DISCOPT_LP_COLD_DUAL_START``).
+
+    ``solve_lp_warm_std`` already builds that basis (``_dual_start_slack_basis``),
+    but #928 engaged it only when the caller passed a finite ``time_limit``,
+    because #928's *motivation* was an anytime bankable floor rather than speed.
+    Since ``lp_warm_deadline`` is itself default-OFF, no deadline reaches the LP on
+    the default path, so in practice **every** cold node LP takes the Rust cold
+    PRIMAL loop — the loop whose own comment reads "a dense, degenerate
+    lifted-McCormick LP can otherwise grind toward ``max_iter`` and run
+    uninterruptibly for minutes" (``lp/simplex/primal.rs``).
+
+    It does. Measured on the QPLIB relaxation LPs, one variable changed (the start
+    basis) and **no deadline on either arm**, so both run to optimality and the LP
+    optimum is a control (``scratchpad/qplib_run/coldstart_ab.py``):
+
+    ==========  =====  ==================  =========================
+    instance    RLT    dual-slack start    cold primal (pre-flag)
+    ==========  =====  ==================  =========================
+    QPLIB_1157  off    0.27 s              0.18 s
+    QPLIB_1157  on     **6.17 s** optimal  **>150 s, iter-cap fail**
+    QPLIB_1493  off    0.34 s              0.30 s
+    QPLIB_1493  on     **2.91 s** optimal  **11.79 s, iter-cap fail**
+    QPLIB_1507  off    0.19 s              0.38 s
+    QPLIB_1507  on     0.56 s              0.88 s
+    QPLIB_1143  off    0.88 s              1.63 s
+    QPLIB_1143  on     5.17 s              14.59 s
+    ==========  =====  ==================  =========================
+
+    The dual start wins 6 of 8; both losses are under 0.1 s absolute. On 2 of 8 the
+    cold primal does not merely run long, it **fails** — ``max_iter`` exhausted,
+    ``None`` returned, which then cascades into the equilibrated retry and the
+    ~170x-slower cold ``solve_milp``. Wherever both arms returned, the objectives
+    agree to <=3e-12 (and to HiGHS likewise), so this is bound-neutral on those.
+
+    Why the degeneracy: an equality row reaches the LP layer as two opposing
+    ``<=`` rows, both tight at every feasible point. Relaxations rich in linear
+    equalities (constraint-factor RLT above all — see ``rlt_lineq``) are therefore
+    massively primal-degenerate, and the cold primal stalls where a dual simplex
+    started dual-feasible does not. That is a property of the row structure, not of
+    any instance.
+
+    Default **off** pending the graduation panel. It is not provably bound-neutral:
+    a different optimal basis can be returned on a degenerate LP, which can move
+    downstream branching, and the iter-cap cases change status ``None`` -> optimal
+    (a strict gain, but a change). Ineligible LPs — an open bound on the side the
+    objective sign selects — keep the primal path exactly as before.
+    """
+
     # --- branch-and-reduce (cert:T2.3 / T2.4) ---------------------------------
     root_fixpoint: bool = field(
         default_factory=lambda: _env_flag("DISCOPT_ROOT_FIXPOINT", default=True)
@@ -1161,6 +1248,8 @@ class SolverTuning:
     def __post_init__(self) -> None:
         if self.rlt_quad_max < 1:
             raise ValueError(f"rlt_quad_max must be >= 1, got {self.rlt_quad_max}")
+        if self.rlt_lineq_max < 0:
+            raise ValueError(f"rlt_lineq_max must be >= 0, got {self.rlt_lineq_max}")
         if self.rlt_sparse_max_vars < 1:
             raise ValueError(f"rlt_sparse_max_vars must be >= 1, got {self.rlt_sparse_max_vars}")
         if self.rlt_sparse_max_terms < 1:

--- a/python/discopt/solvers/milp_simplex.py
+++ b/python/discopt/solvers/milp_simplex.py
@@ -449,6 +449,14 @@ def _refined_safe_bound_regularized(
     return best
 
 
+def _cold_dual_start_enabled() -> bool:
+    """``DISCOPT_LP_COLD_DUAL_START`` — use the dual slack start on a cold,
+    deadline-free pure LP too. Resolved per call so a test can set the env var."""
+    from discopt.solver_tuning import current as _tuning_current
+
+    return bool(_tuning_current().lp_cold_dual_start)
+
+
 def _dual_start_slack_basis(
     c_arr: np.ndarray,
     lb: np.ndarray,
@@ -470,10 +478,15 @@ def _dual_start_slack_basis(
     was -141697 at *any* deadline fraction (15/40/75% of the full solve) against
     an optimum of -64473. The dual simplex maintains dual feasibility, so its
     dual objective is a monotone anytime lower bound and a deadline exit banks
-    the best bound proved so far. Only engaged when the caller set a finite
-    ``time_limit`` (i.e. it wants an interruptible solve with a bankable floor);
-    a solve without a deadline keeps the historical cold-primal path
-    bit-identical.
+    the best bound proved so far. That is why a finite ``time_limit`` engages it.
+
+    A cold solve with **no** deadline engages it only under
+    ``DISCOPT_LP_COLD_DUAL_START`` (default OFF, so the historical cold-primal
+    path stays bit-identical by default). The reason there is speed rather than
+    bankability: on equality-rich lifted relaxations — every equality reaching the
+    LP layer as two opposing, always-tight ``<=`` rows — the cold primal is
+    massively degenerate and stalls, exhausting ``max_iter`` on LPs this start
+    solves in seconds to the same optimum. See ``SolverTuning.lp_cold_dual_start``.
     """
     if m <= 0:
         return None
@@ -774,9 +787,17 @@ def solve_lp_warm_std(
     # the sign-matched slack basis when that basis is dual-feasible, because only
     # the dual loop has an anytime (monotone, bankable) lower bound to return when
     # the deadline fires — the cold primal proves nothing usable mid-run. An
-    # ineligible LP (an open bound on a selected side) keeps the primal path, and
-    # a solve with no deadline is bit-identical to before.
-    if in_basis is None and time_limit is not None and np.isfinite(time_limit):
+    # ineligible LP (an open bound on a selected side) keeps the primal path.
+    #
+    # ``lp_cold_dual_start`` (default OFF) extends the SAME start to a cold solve
+    # with no deadline, for a different reason: speed. On equality-rich lifted
+    # relaxations the cold primal grinds — on the RLT-on QPLIB_1157 root LP it
+    # exhausted ``max_iter`` after >150 s where this start returns the identical
+    # optimum in 6.2 s. See ``SolverTuning.lp_cold_dual_start`` for the 8-LP table.
+    # With the flag off, a deadline-free solve stays bit-identical to before.
+    if in_basis is None and (
+        (time_limit is not None and np.isfinite(time_limit)) or _cold_dual_start_enabled()
+    ):
         in_basis = _dual_start_slack_basis(c_arr, lb, ub, m)
 
     cs0 = None if in_basis is None else np.ascontiguousarray(in_basis[0], dtype=np.int8)

--- a/python/tests/test_lp_cold_dual_start.py
+++ b/python/tests/test_lp_cold_dual_start.py
@@ -1,0 +1,187 @@
+"""Cold dual start basis for deadline-free pure LPs (``DISCOPT_LP_COLD_DUAL_START``).
+
+``solve_lp_warm_std`` builds a sign-matched, dual-feasible slack start basis
+(:func:`_dual_start_slack_basis`, #928) but engaged it only when the caller
+passed a finite ``time_limit`` — #928 wanted a bankable anytime floor, not speed.
+Since the deadline itself is default-OFF, every cold node LP on the default path
+took the Rust cold PRIMAL loop, which stalls on the equality-rich lifted
+relaxations this solver produces: an equality reaches the LP layer as two
+opposing ``<=`` rows, both tight at every feasible point, so such an LP is
+massively primal-degenerate. Measured on the RLT-on QPLIB_1157 root LP the cold
+primal exhausted ``max_iter`` after >150 s; the dual start returned the same
+optimum in 6.2 s.
+
+These tests lock what the flag may and may not change:
+
+1. it flips the start basis on a cold, deadline-free solve, and only then;
+2. the LP optimum is unchanged — the flag is a start-basis choice, not a
+   relaxation change, so ON and OFF must agree with each other and with SciPy;
+3. an LP whose selected side is open stays on the primal path (the basis would
+   not be dual-feasible), flag or not;
+4. a solve that carries a finite deadline is unaffected — that path already used
+   the dual start and must keep doing so with the flag OFF.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+import scipy.sparse as sp
+from discopt.solvers import SolveStatus
+from discopt.solvers.milp_simplex import (
+    _cold_dual_start_enabled,
+    _dual_start_slack_basis,
+    solve_lp_warm_std,
+)
+from scipy.optimize import linprog
+
+pytestmark = [pytest.mark.correctness]
+
+
+def _degenerate_lp(n: int = 8, seed: int = 0):
+    """A small stand-in for the pathology: a lifted LP carrying linear equalities
+    encoded as opposing ``<=`` pairs, so every one of them is tight everywhere.
+
+    Generic construction (random equalities over a box), not a named instance.
+    """
+    rng = np.random.default_rng(seed)
+    c = rng.uniform(-1.0, 1.0, size=n)
+    rows: list[np.ndarray] = []
+    rhs: list[float] = []
+    x0 = rng.uniform(0.2, 0.8, size=n)  # a strictly interior feasible point
+    for _ in range(3):
+        a = rng.uniform(-1.0, 1.0, size=n)
+        r = float(a @ x0)
+        rows.append(a)
+        rhs.append(r)  # a'x <= r
+        rows.append(-a)
+        rhs.append(-r)  # -a'x <= -r  =>  together a'x == r
+    for _ in range(4):  # a few ordinary inequalities on top
+        a = rng.uniform(-1.0, 1.0, size=n)
+        rows.append(a)
+        rhs.append(float(a @ x0) + 0.5)
+    A = sp.csr_matrix(np.array(rows))
+    b = np.array(rhs, dtype=float)
+    bounds = [(0.0, 1.0)] * n
+    return c, A, b, bounds
+
+
+def _reference(c, A, b, bounds):
+    res = linprog(c, A_ub=A, b_ub=b, bounds=bounds, method="highs")
+    assert res.status == 0, res.message
+    return float(res.fun)
+
+
+def test_flag_controls_the_cold_deadline_free_start(monkeypatch):
+    """The flag is what decides whether a cold, deadline-free LP gets the basis."""
+    monkeypatch.delenv("DISCOPT_LP_COLD_DUAL_START", raising=False)
+    assert _cold_dual_start_enabled() is False
+    monkeypatch.setenv("DISCOPT_LP_COLD_DUAL_START", "1")
+    assert _cold_dual_start_enabled() is True
+
+
+def _record_start_basis(monkeypatch) -> list:
+    """Capture the ``(col_status, basic_vars)`` actually handed to Rust.
+
+    Without this the behavioural tests below cannot see the gate at all: both
+    arms converge to the same optimum by construction, so a gate that never
+    fires reads as a pass. ``solve_lp_warm_std`` imports the binding inside the
+    function body, so patching the module attribute is what intercepts it.
+    """
+    import discopt._rust as _rust
+
+    seen: list = []
+    real = _rust.solve_lp_warm_csc_py
+
+    def spy(*args, **kwargs):
+        seen.append(args[9])  # cs0, the start column-status vector (None = cold primal)
+        return real(*args, **kwargs)
+
+    monkeypatch.setattr(_rust, "solve_lp_warm_csc_py", spy)
+    return seen
+
+
+@pytest.mark.parametrize(
+    ("env", "deadline", "expect_basis"),
+    [
+        (None, None, False),  # today's default: cold primal
+        ("1", None, True),  # what the flag exists to change
+        (None, 30.0, True),  # #928's deadline path, unchanged
+        ("1", 30.0, True),
+    ],
+)
+def test_the_gate_is_wired(monkeypatch, env, deadline, expect_basis):
+    """The flag/deadline combination decides what reaches the Rust binding.
+
+    Reverting the gate to its pre-flag form (deadline only) fails the second row.
+    """
+    if env is None:
+        monkeypatch.delenv("DISCOPT_LP_COLD_DUAL_START", raising=False)
+    else:
+        monkeypatch.setenv("DISCOPT_LP_COLD_DUAL_START", env)
+    seen = _record_start_basis(monkeypatch)
+
+    c, A, b, bounds = _degenerate_lp(seed=5)
+    res, _basis = solve_lp_warm_std(c, A, b, bounds, in_basis=None, time_limit=deadline)
+    assert res is not None and res.status == SolveStatus.OPTIMAL
+
+    assert seen, "the Rust binding was never called -- the spy measured nothing"
+    got_basis = seen[0] is not None
+    assert got_basis is expect_basis, (
+        f"env={env} deadline={deadline}: start basis passed={got_basis}, want {expect_basis}"
+    )
+
+
+@pytest.mark.parametrize("seed", [0, 1, 2])
+def test_optimum_is_identical_with_and_without_the_flag(monkeypatch, seed):
+    """A start basis cannot move the LP optimum. Both arms are run with no
+    deadline, so both must converge, and both must match SciPy."""
+    c, A, b, bounds = _degenerate_lp(seed=seed)
+    ref = _reference(c, A, b, bounds)
+
+    got = {}
+    for arm in ("off", "on"):
+        if arm == "on":
+            monkeypatch.setenv("DISCOPT_LP_COLD_DUAL_START", "1")
+        else:
+            monkeypatch.delenv("DISCOPT_LP_COLD_DUAL_START", raising=False)
+        res, _basis = solve_lp_warm_std(c, A, b, bounds, in_basis=None, time_limit=None)
+        assert res is not None, f"arm {arm}: no result"
+        assert res.status == SolveStatus.OPTIMAL, f"arm {arm}: {res.status}"
+        got[arm] = float(res.objective)
+
+    assert got["on"] == pytest.approx(ref, abs=1e-9, rel=1e-9)
+    assert got["off"] == pytest.approx(ref, abs=1e-9, rel=1e-9)
+    assert got["on"] == pytest.approx(got["off"], abs=1e-9, rel=1e-9)
+
+
+def test_open_selected_side_keeps_the_primal_path():
+    """``_dual_start_slack_basis`` refuses when the side the objective sign picks
+    is unbounded — that basis would not be dual-feasible. The flag must not be
+    able to force it: this is the eligibility guard, not a preference."""
+    n = 3
+    m = 4
+    c = np.array([1.0, -1.0, 1.0])
+    lb = np.array([0.0, 0.0, 0.0])
+    ub = np.array([1.0, 1e20, 1.0])  # c[1] < 0 selects the OPEN upper bound
+    assert _dual_start_slack_basis(c, lb, ub, m) is None
+
+    ub_ok = np.array([1.0, 1.0, 1.0])
+    start = _dual_start_slack_basis(c, lb, ub_ok, m)
+    assert start is not None
+    col_status, basic_vars = start
+    # AT_LOWER=0, BASIC=1, AT_UPPER=2; slacks basic, structurals at the sign-picked side.
+    assert list(col_status[:n]) == [0, 2, 0]
+    assert list(col_status[n:]) == [1] * m
+    assert list(basic_vars) == list(range(n, n + m))
+
+
+def test_deadline_path_is_untouched_by_the_flag_being_off(monkeypatch):
+    """A finite deadline already engaged the dual start (#928) and still must,
+    with the flag OFF. Guards against the gate rewrite dropping that arm."""
+    monkeypatch.delenv("DISCOPT_LP_COLD_DUAL_START", raising=False)
+    c, A, b, bounds = _degenerate_lp(seed=3)
+    ref = _reference(c, A, b, bounds)
+    res, _basis = solve_lp_warm_std(c, A, b, bounds, in_basis=None, time_limit=30.0)
+    assert res is not None and res.status == SolveStatus.OPTIMAL
+    assert float(res.objective) == pytest.approx(ref, abs=1e-9, rel=1e-9)

--- a/python/tests/test_rlt_lineq.py
+++ b/python/tests/test_rlt_lineq.py
@@ -1,0 +1,209 @@
+"""Linear-equality constraint-factor RLT (``DISCOPT_RLT_LINEQ``).
+
+For a linear equality ``a'x + c == 0`` and any variable ``x_j``, the product
+``(a'x + c) * x_j == 0`` is an identity on the feasible region; linearized over
+the lifted product columns it is ``sum_i a_i X_ij + c x_j == 0``. That is
+Sherali–Adams level 1 restricted to the *equality* factors — the one RLT family
+that needs neither a binary variable (unlike ``_relax/rlt.py``'s exhaustive
+RLT-1 LP, whose ``X_ii = x_i`` diagonal forces binaries) nor the node box
+(unlike the bound-factor families).
+
+Why it matters: on continuous nonconvex QPs the McCormick-only root bound is
+hopeless, and this family is where the recoverable gap lives. Measured on QPLIB
+(root LP vs published optimum): QPLIB_1157 −13.874 → −11.245 against −10.948
+(89.9 % of the gap), QPLIB_1493 49.7 %, QPLIB_1143 32.2 %, QPLIB_1423 29.0 %,
+QPLIB_1507 27.5 %; the bound-factor rows added nothing on top.
+
+These tests lock the three properties the pass is built on:
+
+1. **Soundness** — no feasible point is cut. Checked directly at the lifted
+   point ``(x, X = x x')`` of sampled feasible ``x``, against every row of the
+   relaxation (not only the new ones).
+2. **Tightening, without crossing** — the ON bound is ``>=`` the OFF bound and
+   still ``<=`` the true optimum of the sampled/known problem.
+3. **Box-independence** — the rows the pass emits are byte-identical at two
+   different boxes. The native spatial kernel regenerates only per-term envelope
+   rows when it patches a node box and carries everything else forward
+   unchanged, so a box-dependent row here would go stale and unsound at depth.
+"""
+
+from __future__ import annotations
+
+import discopt.modeling as dm
+import numpy as np
+import pytest
+import scipy.sparse as sp
+from discopt._relax.uniform_relax import build_uniform_relaxation
+from scipy.optimize import linprog
+
+pytestmark = [pytest.mark.relaxation, pytest.mark.correctness]
+
+
+def _stqp(n: int, seed: int) -> tuple[dm.Model, np.ndarray]:
+    """Standard quadratic program ``min x'Qx  s.t.  sum(x) == 1, 0 <= x <= 1``.
+
+    Indefinite ``Q`` (a symmetric uniform draw), so the McCormick relaxation of
+    the objective is genuinely loose. Generic structure, not a named instance.
+    """
+    rng = np.random.default_rng(seed)
+    A = rng.uniform(-1.0, 1.0, size=(n, n))
+    Q = 0.5 * (A + A.T)
+    m = dm.Model()
+    x = [m.continuous(f"x{i}", lb=0.0, ub=1.0) for i in range(n)]
+    m.minimize(sum(Q[i, j] * x[i] * x[j] for i in range(n) for j in range(n)))
+    m.subject_to(sum(x) == 1.0)
+    return m, Q
+
+
+def _root_lp(model, lb, ub, *, rlt_lineq):
+    """Root LP bound of the uniform relaxation, plus the LP data itself.
+
+    Solved with HiGHS rather than the in-house simplex purely for test runtime;
+    the bound is a property of the relaxation, not of the LP engine.
+    """
+    rel = build_uniform_relaxation(model, box=(lb, ub), rlt_lineq=rlt_lineq)
+    M = rel.model
+    A = sp.csr_matrix(M._A_ub)
+    b = np.asarray(M._b_ub, dtype=float).ravel()
+    bnds = [
+        (float(lo) if np.isfinite(lo) else None, float(hi) if np.isfinite(hi) else None)
+        for lo, hi in np.asarray(M._bounds, dtype=float)
+    ]
+    res = linprog(
+        np.asarray(M._c, dtype=float).ravel(), A_ub=A, b_ub=b, bounds=bnds, method="highs"
+    )
+    assert res.status == 0, res.message
+    return float(res.fun), rel, A, b
+
+
+def _lifted_point(rel, x: np.ndarray) -> np.ndarray:
+    """The exact lifted point for a feasible ``x``: originals, then every
+    registered product column set to the true product of its factors.
+
+    Columns the maps do not name (other aux families) are left at 0 — such a
+    column is not touched by an RLT row, so it cannot mask a violation there.
+    """
+    z = np.zeros(len(rel.model._bounds), dtype=float)
+    z[: rel.n_orig] = x
+    for (a, b), col in rel.bilinear_map.items():
+        z[col] = x[a] * x[b]
+    for (i, p), col in rel.monomial_map.items():
+        z[col] = x[i] ** p
+    return z
+
+
+@pytest.mark.parametrize("seed", [0, 1, 2])
+def test_no_feasible_point_is_cut(seed):
+    """Every row of the RLT-on relaxation holds at the exact lifted image of a
+    feasible point. This is the soundness property; an RLT row derived wrongly
+    (e.g. dropping the constraint's ``rhs`` shift) fails here."""
+    n = 6
+    model, _Q = _stqp(n, seed)
+    lb = np.zeros(n)
+    ub = np.ones(n)
+    rel = build_uniform_relaxation(model, box=(lb, ub), rlt_lineq=True)
+    A = sp.csr_matrix(rel.model._A_ub)
+    b = np.asarray(rel.model._b_ub, dtype=float).ravel()
+
+    rng = np.random.default_rng(1000 + seed)
+    checked = 0
+    for _ in range(25):
+        w = rng.dirichlet(np.ones(n))  # feasible: w >= 0, sum(w) == 1
+        z = _lifted_point(rel, w)
+        resid = A @ z - b
+        assert np.max(resid) <= 1e-7, f"feasible point cut by {np.max(resid):.3e}"
+        checked += 1
+    assert checked == 25
+
+
+@pytest.mark.parametrize("seed", [0, 1, 2, 3])
+def test_bound_tightens_and_never_crosses_the_optimum(seed):
+    """ON is at least as tight as OFF, and neither crosses the true optimum.
+
+    The true optimum is bracketed from above by the best sampled feasible
+    objective; a bound above that would be a false certificate.
+    """
+    n = 6
+    model, Q = _stqp(n, seed)
+    lb = np.zeros(n)
+    ub = np.ones(n)
+
+    off, _rel_off, _A0, _b0 = _root_lp(model, lb, ub, rlt_lineq=False)
+    on, _rel_on, _A1, _b1 = _root_lp(model, lb, ub, rlt_lineq=True)
+
+    # Upper bound on the true optimum from sampled feasible points (vertices of
+    # the simplex included — an StQP optimum is often on a face).
+    rng = np.random.default_rng(seed)
+    best = min(
+        float(w @ Q @ w) for w in [*np.eye(n), *(rng.dirichlet(np.ones(n)) for _ in range(400))]
+    )
+
+    assert on >= off - 1e-7, f"RLT loosened the bound: {on} < {off}"
+    assert on <= best + 1e-7, f"FALSE BOUND: {on} > feasible objective {best}"
+    assert off <= best + 1e-7
+
+
+def test_rows_are_box_independent():
+    """The emitted RLT rows are identical at two different boxes.
+
+    ``spatial_producer`` reads structure off a probe box and fixed rows off the
+    real box, and the Rust kernel re-derives only per-term envelope rows at each
+    node. A box-dependent row would silently go stale down the tree.
+    """
+    n = 5
+    model, _Q = _stqp(n, seed=7)
+
+    def rlt_rows(lo, hi):
+        base = build_uniform_relaxation(model, box=(lo, hi), rlt_lineq=False)
+        full = build_uniform_relaxation(model, box=(lo, hi), rlt_lineq=True)
+        A_b = sp.csr_matrix(base.model._A_ub)
+        A_f = sp.csr_matrix(full.model._A_ub)
+        assert A_f.shape[0] > A_b.shape[0], "the RLT pass emitted no rows"
+        extra = A_f[A_b.shape[0] :].toarray()
+        return extra, np.asarray(full.model._b_ub, dtype=float).ravel()[A_b.shape[0] :]
+
+    a1, r1 = rlt_rows(np.zeros(n), np.ones(n))
+    a2, r2 = rlt_rows(np.full(n, 0.1), np.full(n, 0.8))
+    assert a1.shape == a2.shape
+    assert np.array_equal(a1, a2), "RLT rows changed with the box"
+    assert np.array_equal(r1, r2)
+
+
+def test_equality_with_a_nonzero_constant_is_shifted_correctly():
+    """``a'x == 3`` must give ``sum_i a_i X_ij - 3 x_j == 0``, not ``sum_i a_i X_ij == 0``.
+
+    Dropping the constant makes the row *wrong* rather than merely weak, and it
+    cuts the feasible region — caught here by evaluating every row at the exact
+    lifted image of feasible points.
+
+    Note where the constant lives: :class:`Constraint` normalizes to ``body == 0``
+    and *enforces* ``rhs == 0``, so the ``-3`` arrives inside the body's affine
+    constant, and that is the term under test. The pass also subtracts
+    ``constraint.rhs`` (mirroring the base constraint-row loop), which is a no-op
+    under that contract and is not what this test exercises.
+    """
+    m = dm.Model()
+    x = [m.continuous(f"x{i}", lb=0.0, ub=4.0) for i in range(3)]
+    m.minimize(x[0] * x[1] - x[1] * x[2] + x[0] * x[2])
+    m.subject_to(x[0] + 2.0 * x[1] + x[2] == 3.0)
+
+    lb = np.zeros(3)
+    ub = np.full(3, 4.0)
+    rel = build_uniform_relaxation(m, box=(lb, ub), rlt_lineq=True)
+    A = sp.csr_matrix(rel.model._A_ub)
+    b = np.asarray(rel.model._b_ub, dtype=float).ravel()
+
+    checked = 0
+    rng = np.random.default_rng(3)
+    for _ in range(50):
+        x0 = rng.uniform(0.0, 3.0)
+        x2 = rng.uniform(0.0, min(4.0, 3.0 - x0)) if x0 < 3.0 else 0.0
+        x1 = (3.0 - x0 - x2) / 2.0
+        w = np.array([x0, x1, x2])
+        assert abs(w[0] + 2 * w[1] + w[2] - 3.0) < 1e-12
+        if np.any(w < -1e-12) or np.any(w > 4.0 + 1e-12):
+            continue
+        resid = A @ _lifted_point(rel, w) - b
+        assert np.max(resid) <= 1e-7, f"feasible point cut by {np.max(resid):.3e}"
+        checked += 1
+    assert checked >= 40, f"only {checked} feasible samples exercised the rows"

--- a/python/tests/test_solver_tuning.py
+++ b/python/tests/test_solver_tuning.py
@@ -37,7 +37,10 @@ def test_defaults_match_legacy_env_defaults():
     # ILS-DEFAULT: the integer_local_search sub-NLP solve cap is ON by default (2).
     assert t.ils_solve_cap == 2
     assert t.lp_warmstart is True
+    assert t.lp_cold_dual_start is False
     assert t.rlt is False
+    assert t.rlt_lineq is False
+    assert t.rlt_lineq_max == 4096
     # lifted_fbbt was deprecated/removed in #581 (graduated-gate net-negative).
     assert not hasattr(t, "lifted_fbbt")
     assert t.trilinear_nested is False
@@ -69,11 +72,14 @@ def test_defaults_match_legacy_env_defaults():
         ("DISCOPT_ILS_SOLVE_CAP", "5", "ils_solve_cap", 5),
         ("DISCOPT_ILS_SOLVE_CAP", "0", "ils_solve_cap", 0),  # escape hatch = uncapped
         ("DISCOPT_RLT_QUAD_MAX", "64", "rlt_quad_max", 64),
+        ("DISCOPT_RLT_LINEQ", "1", "rlt_lineq", True),
+        ("DISCOPT_RLT_LINEQ_MAX", "32", "rlt_lineq_max", 32),
         ("DISCOPT_TRILINEAR", "nested", "trilinear_nested", True),
         ("DISCOPT_TRILINEAR", "meyer", "trilinear_meyer", True),
         ("DISCOPT_TRILINEAR", "exact", "trilinear_exact", True),
         ("DISCOPT_SQUARE_SEPARATE", "0", "square_separate", False),
         ("DISCOPT_LP_WARMSTART", "0", "lp_warmstart", False),
+        ("DISCOPT_LP_COLD_DUAL_START", "1", "lp_cold_dual_start", True),
         ("DISCOPT_PSD_COST_GATE", "1", "psd_cost_gate", True),
         # G1.3: graduated default-ON, so "0" is the escape hatch that restores OFF.
         ("DISCOPT_PSD_COST_GATE", "0", "psd_cost_gate", False),
@@ -107,6 +113,7 @@ def test_explicit_field_overrides_env(monkeypatch):
     "kwargs, match",
     [
         (dict(rlt_quad_max=0), "rlt_quad_max must be >= 1"),
+        (dict(rlt_lineq_max=-1), "rlt_lineq_max must be >= 0"),
         (dict(multilinear_rlt_max=0), "multilinear_rlt_max must be >= 1"),
         (dict(node_nlp_stride=0), "node_nlp_stride must be >= 1"),
         (dict(ils_solve_cap=-1), "ils_solve_cap must be >= 0"),


### PR DESCRIPTION
## What

Two default-OFF flags targeting the **dual bound** on continuous nonconvex QPs. The primal is already competitive on this class (QPLIB_1493 incumbent `-43.16043143` vs best-known `-43.16043152`); the bound is what stalls.

### `DISCOPT_RLT_LINEQ` — Sherali-Adams level-1 equality constraint factors

`_relax/rlt.py` gates RLT-1 to **binary** variables, so a continuous QP gets McCormick and nothing else. The general fix: for a linear equality `a'x + c == 0` and any variable `x_j`, the product `(a'x + c)*x_j == 0` linearizes to `sum_i a_i X_ij + c*x_j == 0`.

That row holds **with equality at every feasible point**, needs no binary variable and no box data. Being box-independent, its rows land in `spatial_producer.py`'s *fixed* row set and reach the native Rust kernel with no Rust changes on the relaxation side.

### `DISCOPT_LP_COLD_DUAL_START` — dual slack start on cold, deadline-free LPs

`MilpRelaxationModel` has no `A_eq`, so every equality reaches the LP layer as **two opposing `<=` rows, both tight at every feasible point**. Equality-rich lifted relaxations are therefore massively primal-degenerate, and that is what stalls the cold two-phase primal simplex. This is a property of the row structure, not of any instance.

The dual slack start (slacks basic, each structural column nonbasic at the bound its objective sign selects) is the right start for exactly that shape, and it already existed — but #928 gated it on a deadline for *bankability*, not speed. Since `lp_warm_deadline` is itself default-OFF, **every** cold node LP took the cold primal.

Wired through both entry points:
- Python: `solvers/milp_simplex.py`
- Rust kernel: `SimplexOptions::cold_dual_start` -> `spatial_kernel::cold_dual_start_basis`, threaded via `spatial_bindings.rs` and `solver.py`

The basis builder **refuses** (returns `None` -> cold primal fallback) whenever the objective-selected side of any column is unbounded, so it is dual-feasible by construction. `INF` is tested as the `1e20` sentinel per the house rule.

## Measurements

Entry experiment run **before** implementation, per CLAUDE.md section 4. Identical LP, only the start basis varies, **no deadline on either arm** so both must run to optimality and the objective acts as a control:

| instance | RLT | dual-slack start | cold primal (today) |
|---|---|---|---|
| QPLIB_1157 | off | 0.27 s | 0.18 s |
| QPLIB_1157 | **on** | **6.17 s OPTIMAL** | **>150 s -> iter-cap FAIL** |
| QPLIB_1493 | off | 0.34 s | 0.30 s |
| QPLIB_1493 | **on** | **2.91 s OPTIMAL** | **11.79 s -> iter-cap FAIL** |
| QPLIB_1507 | off | 0.19 s | 0.38 s |
| QPLIB_1507 | on | 0.56 s | 0.88 s |
| QPLIB_1143 | off | 0.88 s | 1.63 s |
| QPLIB_1143 | on | 5.17 s | 14.59 s |

Dual start wins 6 of 8 (both losses under 0.1 s absolute); the cold primal **fails outright** on 2 of 8, returning `None` into an equilibrated retry and a ~170x-slower cold `solve_milp`. On the isolated 1157 RLT-on run the cold primal took 391.46 s and still returned `status=None`. Objectives agree to <= 3e-12 wherever both arms returned.

End to end on QPLIB_1157 at a 20 s budget (reference optimum `-10.94820362`):

```
rlt=0 coldstart=0   wall= 20.21s  bound=-12.417862  nodes=104
rlt=1 coldstart=0   wall=240.83s  bound=None        nodes=1
rlt=1 coldstart=1   wall= 21.16s  bound=-11.146567  nodes=3
```

Gap to optimum **1.470 -> 0.198: 86.5% of the remaining dual gap closed at the same budget.** No bound above its published optimum on any instance in any arm.

## Verification

- `cargo test -p discopt-core` — 597 passed, 0 failed (+2 new kernel tests: `cold_dual_start_reaches_the_same_node_bound`, `cold_dual_start_basis_is_dual_feasible_or_refused`)
- `pytest -m smoke` — 969 passed, 1 skipped, 2 xpassed
- `pytest -m slow python/tests/test_adversarial_recent_fixes.py` — 10 passed
- `python/tests/test_rlt_lineq.py` (9) + `test_lp_cold_dual_start.py` (10) + `test_solver_tuning.py` (44) — 63 passed
- `ruff check` / `ruff format --check` / `mypy` clean

Both new suites were **mutation-tested**: reverting either fix makes them fail (`test_the_gate_is_wired[1-None-True]` catches the LP gate via a spy on the start basis actually handed to `solve_lp_warm_csc_py`, since both bases otherwise converge to the same optimum and a naive test passes either way).

## Scope / what this does not do

Both flags are **default-OFF** pending the corpus-wide graduation panel required by CLAUDE.md section 5 (cert-clean AND net-positive). This PR does not graduate either one.

Two findings filed separately rather than fixed here:
- the in-house simplex is 8.7x-29x slower than HiGHS on the *identical* LP, which is now the dominant cost on this class
- `spatial_bindings.rs` hands `SimplexOptions::default()` to the kernel, so node LPs receive no deadline

Contributes to the nonconvex-QP dual bound work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017PQaiDVuY5Rs3tga98tnNo
