### PR TITLE
test(1009): measure and cover the kernel node-LP deadline

### DIFF
--- a/docs/dev/1009-kernel-lp-deadline-measurement-2026-08-13.md
+++ b/docs/dev/1009-kernel-lp-deadline-measurement-2026-08-13.md
@@ -1,0 +1,104 @@
+# What the #1009 kernel node-LP deadline is worth — measurement + coverage (2026-08-13)
+
+**Status.** Measurement-and-coverage only; no behavior change. #1014 already threaded
+the tree's live deadline into the node LP (`node_lp_opts`) and #1015 fixed the
+incremental McCormick fast path, closing #1009. This records what the kernel-side
+change actually bounds, and closes a coverage gap it left.
+
+## 0. Correcting the attribution first
+
+#1009 was opened against `spatial_bindings.rs` with QPLIB_1157 (240.83 s against a
+20 s `time_limit`, 11.9×) as evidence. **That attribution was wrong**, and #1014
+retracted it: threading the deadline did not shorten that repro (419.74 s, 21.0×,
+nodes=1), and `faulthandler` sampling put the wall clock in
+`_root_relaxation_lower_bound` → `MccormickLPRelaxer.solve_at_node` →
+`solve_lp_warm_std` — the Python-side root relaxation computed *before* the kernel
+tree is entered. #1015 fixed that. Any reading of the numbers below as "this is what
+caused the QPLIB_1157 overrun" is the same error; they are about a different,
+genuinely present defect that #1009 correctly identified by inspection.
+
+## 1. The quantity
+
+`solve_spatial_tree` checks its clock only BETWEEN nodes. Without a per-LP deadline
+the wall-clock floor of any kernel solve is therefore the cost of **one node LP**,
+however small the caller's budget — unbounded in the size of the relaxation, and not
+a property of any corpus instance.
+
+#1014 shipped on a soundness-by-construction argument with no measurement
+("Sound by construction, not by measurement"), so this is the missing half.
+
+## 2. Method
+
+Both arms run against the **same fixed code**, so this reproduces on `main` with no
+flag and no revert (`scripts/spatial_kernel_lp_deadline_scaling.py`):
+
+* **uncapped** — `time_limit_s=None, max_nodes=1`: one node LP run to completion.
+  This is exactly what the pre-#1014 path spent on node 1 regardless of the budget,
+  i.e. the floor the fix removes.
+* **capped** — `time_limit_s=BUDGET`: the same LP under the deadline.
+
+> x86-64 Linux, 4 cores, Python 3.11, **release** build (`pip install -e .` → maturin
+> release). Load gate: `uptime` load average 0.24–0.63. Arm order alternates per rep
+> (CLAUDE.md §9); medians of 3 with sd. Driver is a general dense-bilinear model
+> (`min Σ_{i<j} x_i x_j s.t. Σx ≥ n/2, x ∈ [0,1]^n`), not a named instance
+> (CLAUDE.md §2), whose global optimum `C(n/2, 2)` is closed-form and is asserted as a
+> soundness oracle on every solve.
+
+## 3. Result — budget fixed at 1 s
+
+| n | lifted terms | cols | uncapped (one node LP) | capped | bound ≤ optimum |
+|---:|---:|---:|---:|---:|:--:|
+| 50 | 1 225 | 1 275 | 0.81 s (sd 0.03) — 0.8× | 1.02 s (sd 0.02) — 1.0× | ok |
+| 70 | 2 415 | 2 485 | 2.68 s (sd 0.04) — 2.7× | 1.20 s (sd 0.02) — 1.2× | ok |
+| 90 | 4 005 | 4 095 | 7.69 s (sd 0.09) — 7.7× | 1.23 s (sd 0.01) — 1.2× | ok |
+| 120 | 7 140 | 7 260 | 25.90 s (sd 0.39) — **25.9×** | 1.05 s (sd 0.01) — 1.0× | ok |
+
+The uncapped column is the floor, and it grows without limit; the capped column
+tracks the budget. At n = 50 the capped run is *longer* than the uncapped one — the LP
+is cheaper than the budget there, so the tree keeps branching until the clock runs
+out. That is the expected shape: the deadline bounds the overshoot, it does not
+shorten solves that were already inside their budget.
+
+## 4. Corpus check — the change is inert where the budget does not bind
+
+A 20-instance differential panel (in-repo `minlplib_nl` + `qplib`, the instances the
+producer accepts) at 0.05 / 0.25 / 1.0 / 3.0 s kernel budgets, run at the binding with
+both arms interleaved in one process, was **cert-clean at every budget**: no dual
+bound past its reference optimum (sense-aware, from `qplib.solu` and
+`known_optima.toml`), no incumbent invented, and no instance losing a finite bound at
+a budget ≥ 1 s. Bounds and node counts are unchanged on every instance that finishes
+inside its budget; worst corpus overshoot went from +0.20 s to +0.01 s.
+
+**The one cost, stated plainly.** At a budget *smaller than a single LP*, a bound is
+traded for compliance: `QPLIB_3815` at ≤ 0.25 s goes from `-96` — obtained by
+overrunning — to no bound at all. That is not avoidable; you cannot both stop on time
+and finish an LP that costs more than the whole budget. It is also the case #933
+exists for (the caller withholds a root-relaxation reserve precisely for a bound-less
+time-limited kernel exit), and measured end-to-end through `Model.solve` on that
+instance at 0.5 / 1 / 2 s both arms are identical (`bound=None`, inside budget,
+sd ≤ 0.03 s), so it does not propagate to the reported result there.
+
+Soundness is structural, not statistical: a cut LP bails as `IterLimit`,
+`solve_spatial_node` certifies a Neumaier–Shcherbina safe bound only on `Optimal`, and
+`verdict_for` routes `IterLimit` to `Undecided` — branched with the parent's valid
+bound, never fathomed. It can only loosen a bound, never lift one.
+
+## 5. The coverage gap this closes
+
+`spatial_tree.rs` unit-tests `node_lp_opts` in isolation and pins the
+`IterLimit → Undecided` verdict, but nothing tested that the tree's deadline **reaches
+the LP at all**. Measured, not assumed: mutating the call site to
+`node_lp_opts(opts, None)` — a full revert of #1014's effect, leaving the
+unit-tested helper correct — leaves `cargo test -p discopt-core --lib` at
+**602 passed, 0 failed**.
+
+(The neighbouring `extension_is_taken_only_with_an_incumbent_in_hand` does catch a
+*too-early* deadline: mutating the call site to freeze `config.deadline` instead of
+the live value fails it. It cannot catch a *missing* one, because an LP with no
+deadline solves fine and reports a finite bound.)
+
+`python/tests/test_1009_kernel_lp_deadline.py` closes that: two of its three tests
+fail on the `None` mutant and pass on `main`. They exercise a real LP cut mid-flight
+across the PyO3 boundary, calibrated against the uncapped single-node cost on the
+same build, and skip rather than pass vacuously if one LP is already cheaper than the
+budget on the host.

--- a/python/tests/test_1009_kernel_lp_deadline.py
+++ b/python/tests/test_1009_kernel_lp_deadline.py
@@ -1,0 +1,197 @@
+"""#1009 / #1014 — the spatial kernel's node LP honors the tree's wall-clock deadline.
+
+`solve_spatial_tree` checks its clock only BETWEEN nodes, so before #1014 the
+wall-clock floor of any kernel solve was the cost of **one node LP**, however small
+the caller's budget: `spatial_bindings.rs` built `SimplexOptions` with no `deadline`
+and the pivot loops polled nothing. #1014's `node_lp_opts` composes the tree's live
+deadline into the LP's options.
+
+That fix shipped "sound by construction, not by measurement" — and the instance #1009
+was opened for turned out to overrun for an unrelated reason (the Python incremental
+McCormick fast path, fixed separately in #1015), so the kernel-side change has no
+end-to-end coverage. `crates/discopt-core/src/bnb/spatial_tree.rs` unit-tests the
+composition and the `IterLimit -> Undecided` verdict; nothing exercises an LP that
+genuinely outlives its budget and is cut *mid-solve*, through the PyO3 boundary,
+where the wall-clock behavior either materializes or does not.
+
+These tests close that gap. They are calibrated against an **uncapped single-node
+run** on the same build rather than against a reverted binary: that time is precisely
+what the pre-#1014 path spent on node 1 regardless of the budget, so it is the floor
+the fix removes. `scripts/spatial_kernel_lp_deadline_scaling.py` runs the same
+comparison across sizes; at a fixed 1 s budget it measures a floor of 2.7x the budget
+at 2 415 lifted terms, 7.7x at 4 005 and **25.9x** at 7 140, against 1.0-1.2x capped.
+
+Soundness rides along on every assertion: an interrupted LP bails as `IterLimit`,
+`solve_spatial_node` certifies a Neumaier-Shcherbina safe bound only on `Optimal`, so
+the node contributes no bound and is branched rather than fathomed. A partial simplex
+iterate must never be readable as a dual bound.
+"""
+
+from __future__ import annotations
+
+import time
+
+import discopt.modeling as dm
+import pytest
+from discopt._relax.spatial_producer import build_spatial_kernel_spec
+
+_rust = pytest.importorskip("discopt._rust")
+
+# Big enough that one node LP costs several times the budget below on ordinary CI
+# hardware (4 005 lifted terms), small enough to keep the file under ~15 s.
+_N = 90
+_BUDGET = 1.0
+
+
+def _dense_bilinear(n: int):
+    """``min sum_{i<j} x_i x_j  s.t.  sum x >= n/2,  x in [0,1]^n``.
+
+    ``n(n-1)/2`` lifted bilinear terms over a trivial box, so the *node LP* is large
+    while the search is a single root node — which isolates the cost of one LP, the
+    quantity the overshoot is bounded by. Deliberately a general model rather than a
+    named instance (CLAUDE.md §2): the defect is a property of LP size, not of any
+    corpus entry.
+
+    Its global minimum is available in closed form, so the soundness assertions have a
+    real oracle: ``sum_{i<j} x_i x_j = ((sum x)^2 - sum x^2) / 2``, and for
+    ``s = sum x >= n/2`` that is minimized by maximizing ``sum x^2``, i.e. at
+    ``s = n/2`` with ``n/2`` variables at 1 — giving ``C(n/2, 2)``.
+    """
+    m = dm.Model()
+    xs = [m.continuous(f"x{i}", lb=0.0, ub=1.0) for i in range(n)]
+    m.constraint(dm.RangeSet(1), lambda _k: sum(xs) >= n / 2.0, name="half", fast=False)
+    terms = [xs[i] * xs[j] for i in range(n) for j in range(i + 1, n)]
+    # Balanced reduction: a left-deep `sum()` chain exceeds the canonicalizer's
+    # recursion limit long before the LP is big enough to matter here.
+    while len(terms) > 1:
+        terms = [
+            terms[k] + terms[k + 1] if k + 1 < len(terms) else terms[k]
+            for k in range(0, len(terms), 2)
+        ]
+    m.minimize(terms[0])
+    return m
+
+
+def _tiny_bilinear():
+    """``min x*y  s.t.  x + y >= 3,  x,y in [0,2]`` — global minimum 2.0.
+
+    Converges by *proof* in milliseconds, which is what the neutrality test needs: a
+    solve that stops on the clock has a legitimately run-dependent bound and could not
+    be compared exactly against anything.
+    """
+    m = dm.Model()
+    x = m.continuous("x", lb=0.0, ub=2.0)
+    y = m.continuous("y", lb=0.0, ub=2.0)
+    m.constraint(dm.RangeSet(1), lambda _k: x + y >= 3.0, name="sum", fast=False)
+    m.minimize(x * y)
+    return m
+
+
+def _optimum(n: int) -> float:
+    half = n // 2
+    return half * (half - 1) / 2.0
+
+
+def _spec(model):
+    spec = build_spatial_kernel_spec(model)
+    assert spec is not None, "the producer declined the model these tests are built on"
+    for key in [k for k in spec if k.startswith("meta_")]:
+        spec.pop(key)
+    return spec
+
+
+def _solve(spec, **kwargs):
+    t0 = time.perf_counter()
+    res = _rust.solve_spatial_tree_py(**spec, **kwargs)
+    return res, time.perf_counter() - t0
+
+
+def _one_node_lp_cost(spec):
+    """Wall time of a single node LP run to completion — the floor the pre-#1014 path
+    could not go below, measured on this machine and this build."""
+    _, wall = _solve(spec, time_limit_s=None, max_nodes=1)
+    return wall
+
+
+@pytest.mark.slow
+def test_a_node_lp_costlier_than_the_budget_does_not_set_the_wall_clock_floor():
+    """The defect itself, end to end through the binding.
+
+    Self-calibrating: the uncapped single-node run measures what one LP costs *here*,
+    so the assertion is a ratio rather than a wall-clock threshold. If one LP is
+    already cheaper than the budget on this machine there is no floor to remove, and
+    the test skips instead of passing vacuously (CLAUDE.md §6).
+    """
+    spec = _spec(_dense_bilinear(_N))
+    floor = _one_node_lp_cost(spec)
+    if floor < 2.5 * _BUDGET:
+        pytest.skip(
+            f"one node LP costs {floor:.2f}s here, under 2.5x the {_BUDGET}s budget — "
+            "no wall-clock floor for the deadline to remove"
+        )
+
+    res, wall = _solve(spec, time_limit_s=_BUDGET, max_nodes=10**9)
+
+    assert wall < 0.5 * floor, (
+        f"the budget did not bound the node LP: {wall:.2f}s against a {_BUDGET}s "
+        f"budget, with one uninterrupted LP costing {floor:.2f}s"
+    )
+    assert res["status"] == "time_limit", f"expected a clock-limited exit, got {res['status']}"
+    opt = _optimum(_N)
+    assert res["bound"] <= opt + 1e-6 * (1.0 + abs(opt)), (
+        f"bound {res['bound']} exceeds the true optimum {opt}"
+    )
+
+
+@pytest.mark.slow
+def test_an_interrupted_node_lp_contributes_no_bound_and_no_fathom():
+    """What a deadline-cut LP is allowed to say.
+
+    A budget far below the cost of the root LP cuts it mid-solve. The kernel must then
+    report ``time_limit`` with NO dual bound (``-inf``) and NO incumbent: an
+    interrupted simplex iterate is not a certified dual value, and reading one as a
+    bound is the shape of bug that yields a certified-``optimal`` false bound. The
+    node must also be recorded as *undecided* — branched, never fathomed.
+
+    The core's `an_interrupted_node_lp_is_undecided_never_fathomed` pins the same
+    contract with a deadline that expired before pivot 0; this one cuts a real LP in
+    flight, across the PyO3 boundary.
+    """
+    spec = _spec(_dense_bilinear(_N))
+    res, wall = _solve(spec, time_limit_s=0.05, max_nodes=10**9)
+
+    assert res["status"] == "time_limit"
+    assert res["bound"] == float("-inf"), (
+        f"a cut root LP produced a bound ({res['bound']}) it never certified"
+    )
+    assert res["incumbent"] is None, "a cut root LP invented an incumbent"
+    assert res["n_undecided"] >= 1, (
+        "the interrupted LP was not recorded as undecided — it was either never cut "
+        "(the probe did not fire) or it was fathomed, which would be unsound"
+    )
+    assert wall < 1.0, f"a 0.05s budget took {wall:.2f}s"
+
+
+def test_a_non_binding_budget_matches_the_uncapped_search():
+    """A deadline with time to spare must not perturb the search.
+
+    The per-LP cap fires only on an LP that outlives the tree's deadline, so on
+    everything else a budgeted solve must agree exactly with an unbudgeted one —
+    status, bound, incumbent, node count, LP count. This is the bound-neutral half of
+    the CLAUDE.md §5 regime made observable at the binding.
+    """
+    spec = _spec(_tiny_bilinear())
+    uncapped, _ = _solve(spec, time_limit_s=None, max_nodes=10**9)
+    capped, _ = _solve(spec, time_limit_s=30.0, max_nodes=10**9)
+
+    # Non-vacuity: a clock-limited solve has a legitimately run-dependent bound, so the
+    # exact comparison is only meaningful once the search terminates by proof.
+    assert uncapped["status"] == "optimal", (
+        f"the control instance did not solve: {uncapped['status']}"
+    )
+    for key in ("status", "bound", "incumbent", "node_count", "n_lp_solves", "n_undecided"):
+        assert uncapped[key] == capped[key], (
+            f"{key} drifted under a non-binding budget: {uncapped[key]!r} != {capped[key]!r}"
+        )
+    assert uncapped["bound"] <= 2.0 + 1e-6, f"bound {uncapped['bound']} above the optimum 2.0"
+    assert capped["incumbent"] is not None and abs(capped["incumbent"] - 2.0) < 1e-3

--- a/scripts/spatial_kernel_lp_deadline_scaling.py
+++ b/scripts/spatial_kernel_lp_deadline_scaling.py
@@ -1,0 +1,141 @@
+"""What the #1009 node-LP deadline is worth, as a function of node-LP size.
+
+#1014 threaded the tree's live deadline into the node LP (`node_lp_opts`) on the
+argument that it is sound by construction. It shipped without a measurement, and the
+instance the issue was opened for turned out to overrun for an unrelated reason (the
+Python incremental fast path, fixed separately in #1015), so nothing on record says
+what the kernel-side fix actually bounds.
+
+This measures it. The quantity that matters is the *overshoot*: the tree checks its
+clock only BETWEEN nodes, so without a per-LP deadline the wall-clock floor of any
+solve is the cost of one node LP, however small the budget.
+
+Both arms run against the SAME (fixed) code, so this is reproducible on `main` with
+no flag and no revert:
+
+* **uncapped** — `time_limit_s=None, max_nodes=1`: one node LP, run to completion.
+  This is exactly what the pre-#1014 path spent on node 1 regardless of the budget.
+* **capped** — `time_limit_s=BUDGET`: the same LP under the deadline.
+
+The uncapped time is therefore the wall the legacy path could not go below; the
+capped time is what it costs now. Holding BUDGET fixed and growing the relaxation
+shows the overshoot is unbounded in LP size rather than a property of one instance
+(CLAUDE.md §2 — the driver is a general dense-bilinear model, not a named instance).
+
+Usage:  python -u scripts/spatial_kernel_lp_deadline_scaling.py [n ...]
+        SCALE_BUDGET=1.0 SCALE_REPS=3 python -u scripts/... 50 70 90 120
+
+Prints per-size progress unbuffered (§10) and an executed-comparison count, exiting
+non-zero if it is zero (§6).
+"""
+
+from __future__ import annotations
+
+import os
+import statistics
+import sys
+import time
+
+import discopt
+import discopt.modeling as dm
+from discopt import _rust
+from discopt._relax.spatial_producer import build_spatial_kernel_spec
+
+BUDGET = float(os.environ.get("SCALE_BUDGET", "1.0"))
+REPS = int(os.environ.get("SCALE_REPS", "3"))
+
+
+def dense_bilinear(n: int):
+    """``min sum_{i<j} x_i x_j  s.t.  sum x >= n/2,  x in [0,1]^n``.
+
+    ``n(n-1)/2`` lifted bilinear terms over a trivial box: the node LP grows
+    quadratically while the search stays a single root node, which isolates the cost
+    of one LP — the quantity the overshoot is bounded by. Global minimum ``C(n/2, 2)``
+    in closed form (``sum_{i<j} x_i x_j = ((sum x)^2 - sum x^2)/2``, minimized at
+    ``sum x = n/2`` with ``n/2`` variables at 1), so the soundness check has an oracle.
+    """
+    m = dm.Model()
+    xs = [m.continuous(f"x{i}", lb=0.0, ub=1.0) for i in range(n)]
+    m.constraint(dm.RangeSet(1), lambda _k: sum(xs) >= n / 2.0, name="half", fast=False)
+    terms = [xs[i] * xs[j] for i in range(n) for j in range(i + 1, n)]
+    # Balanced reduction: a left-deep `sum()` chain exceeds the canonicalizer's
+    # recursion limit long before the LP is big enough to matter here.
+    while len(terms) > 1:
+        terms = [
+            terms[k] + terms[k + 1] if k + 1 < len(terms) else terms[k]
+            for k in range(0, len(terms), 2)
+        ]
+    m.minimize(terms[0])
+    return m
+
+
+def optimum(n: int) -> float:
+    half = n // 2
+    return half * (half - 1) / 2.0
+
+
+def main(sizes: list[int]) -> int:
+    # §8: say which code produced these numbers.
+    print(f"# discopt.__file__ = {discopt.__file__}", flush=True)
+    print(f"# _rust.__file__   = {_rust.__file__}", flush=True)
+    print(f"# budget={BUDGET}s reps={REPS}", flush=True)
+    print(
+        f"{'n':>4} {'terms':>6} {'cols':>6} | {'uncapped (1 node)':>22} | "
+        f"{'capped':>22} | bound <= opt",
+        flush=True,
+    )
+
+    compared = 0
+    for size in sizes:
+        spec = build_spatial_kernel_spec(dense_bilinear(size))
+        if spec is None:
+            print(f"{size:>4} SKIP (producer declined)", flush=True)
+            continue
+        for key in [k for k in spec if k.startswith("meta_")]:
+            spec.pop(key)
+
+        uncapped, capped = [], []
+        sound = True
+        for rep in range(REPS):
+            # Alternate the order so a first-run penalty cannot land on one arm
+            # (CLAUDE.md §9 — interleaved, not sequential).
+            order = ("uncapped", "capped") if rep % 2 == 0 else ("capped", "uncapped")
+            for arm in order:
+                t0 = time.perf_counter()
+                if arm == "uncapped":
+                    res = _rust.solve_spatial_tree_py(**spec, time_limit_s=None, max_nodes=1)
+                    uncapped.append(time.perf_counter() - t0)
+                else:
+                    res = _rust.solve_spatial_tree_py(**spec, time_limit_s=BUDGET, max_nodes=10**9)
+                    capped.append(time.perf_counter() - t0)
+                compared += 1
+                # Soundness rides along on every solve: a cut LP must never lift the
+                # dual bound above the true optimum.
+                if res["bound"] > optimum(size) + 1e-6 * (1.0 + optimum(size)):
+                    sound = False
+                    print(
+                        f"!! UNSOUND: n={size} {arm} bound={res['bound']} "
+                        f"> optimum {optimum(size)}",
+                        flush=True,
+                    )
+
+        u_med, c_med = statistics.median(uncapped), statistics.median(capped)
+        u_sd = statistics.stdev(uncapped) if REPS > 1 else 0.0
+        c_sd = statistics.stdev(capped) if REPS > 1 else 0.0
+        print(
+            f"{size:>4} {size * (size - 1) // 2:>6} {spec['n_cols']:>6} | "
+            f"{u_med:7.2f}s sd {u_sd:4.2f} {u_med / BUDGET:5.1f}x | "
+            f"{c_med:7.2f}s sd {c_sd:4.2f} {c_med / BUDGET:5.1f}x | "
+            f"{'ok' if sound else 'VIOLATED'}",
+            flush=True,
+        )
+
+    print(f"# executed kernel solves: {compared}", flush=True)
+    if compared == 0:
+        print("PROBE FIRED ZERO SOLVES", flush=True)
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main([int(a) for a in sys.argv[1:]] or [50, 70, 90, 120]))


### PR DESCRIPTION
## Summary

Rewritten. This PR originally duplicated the fix that landed as #1014 — see [the comment above](https://github.com/jkitchin/discopt/pull/1011#issuecomment-5279809237) for the retraction of its misattributed framing. What is left is the part `main` does not have: **the measurement #1014 shipped without, and the coverage it left open**. Rebased onto `main`; no Rust, no solver source, no behavior change.

`git diff --stat origin/main`: 3 files, +442, 0 deletions — one test file, one measurement script, one record.

Follows up #1009 (closed by #1015). Deliberately no closing keyword.

## Correctness

- [x] N/A — no solver-math change. Nothing outside `python/tests/`, `scripts/` and `docs/dev/` is touched.
- [x] No validation, fallback, or safety guard was weakened

The tests *assert* a soundness property rather than changing one: an interrupted LP must report no bound and no incumbent, and be recorded undecided (branched, never fathomed), so a partial simplex iterate can never be read as a dual bound. The scaling script asserts a closed-form optimum oracle on every solve it makes.

## The coverage gap, measured rather than asserted

`spatial_tree.rs` unit-tests `node_lp_opts` in isolation and pins the `IterLimit → Undecided` verdict — but nothing tested that the tree's deadline **reaches the LP at all**. Mutating the call site to `node_lp_opts(opts, None)` — a full revert of #1014's effect, leaving the unit-tested helper correct — leaves `cargo test -p discopt-core --lib` at **602 passed, 0 failed**.

The neighbouring `extension_is_taken_only_with_an_incumbent_in_hand` *does* catch a too-**early** deadline (I checked: mutating the call site to freeze `config.deadline` fails it). It cannot catch a **missing** one, because an LP with no deadline solves fine and reports a finite bound.

`python/tests/test_1009_kernel_lp_deadline.py` closes that gap — two of its three tests fail on the `None` mutant and pass on `main`:

| test | on `main` | on the `node_lp_opts(opts, None)` mutant |
| --- | --- | --- |
| `test_a_node_lp_costlier_than_the_budget_does_not_set_the_wall_clock_floor` | PASSED | FAILED |
| `test_an_interrupted_node_lp_contributes_no_bound_and_no_fathom` | PASSED | FAILED |
| `test_a_non_binding_budget_matches_the_uncapped_search` | PASSED | PASSED (neutrality guard — passes in both by design) |

They cut a real LP mid-flight across the PyO3 boundary, where the wall-clock behaviour either materialises or does not; the core's test cuts at pivot 0 with an already-expired deadline, which proves the semantics but not the plumbing. Calibration is against an **uncapped single-node run on the same build** — that time is what the pre-#1014 path spent on node 1 regardless of the budget — so the assertions are ratios, not wall-clock thresholds, and the test **skips rather than passing vacuously** when one LP is already cheaper than the budget on the host.

## The measurement

`scripts/spatial_kernel_lp_deadline_scaling.py` runs both arms against the same fixed code, so it reproduces on `main` with no flag and no revert: *uncapped* = `time_limit_s=None, max_nodes=1` (one LP to completion — the floor the fix removes), *capped* = the same LP under the budget. Driver is a general dense-bilinear model, **not a named instance** (CLAUDE.md §2), with closed-form optimum `C(n/2, 2)` asserted as an oracle on every solve.

Budget fixed at 1 s; medians of 3 interleaved reps, arm order alternating, load gate checked:

| n | lifted terms | uncapped (one node LP) | capped |
| ---: | ---: | ---: | ---: |
| 50 | 1 225 | 0.81 s (sd 0.03) — 0.8× | 1.02 s (sd 0.02) — 1.0× |
| 70 | 2 415 | 2.68 s (sd 0.04) — 2.7× | 1.20 s (sd 0.02) — 1.2× |
| 90 | 4 005 | 7.69 s (sd 0.09) — 7.7× | 1.23 s (sd 0.01) — 1.2× |
| 120 | 7 140 | 25.90 s (sd 0.39) — **25.9×** | 1.05 s (sd 0.01) — 1.0× |

The floor grows without limit; the capped column tracks the budget. At n = 50 the capped run is *longer* — the LP is cheaper than the budget there, so the tree keeps branching until the clock runs out. That is the expected shape: the deadline bounds the overshoot, it does not shorten solves already inside their budget.

`docs/dev/1009-kernel-lp-deadline-measurement-2026-08-13.md` records the above plus the 20-instance × 4-budget corpus panel (cert-clean at every budget — no bound past its reference optimum, no incumbent invented; bounds and node counts unchanged wherever the budget does not bind; worst overshoot +0.20 s → +0.01 s) and the one honest cost: at a budget smaller than a single LP, `QPLIB_3815` trades a `-96` bound *obtained by overrunning* for no bound. Its §0 restates #1014's retraction up front, so these numbers cannot be misread as explaining the QPLIB_1157 report.

## Tests run

- [x] `pytest -m smoke` → 1008 passed, 15 skipped, 2 xpassed (458.70s)
- [x] `python/tests/test_1009_kernel_lp_deadline.py` → 3 passed (14.16s)
- [x] `cargo test -p discopt-core --lib` → 602 passed (unchanged; no Rust touched — run only to establish the mutant baseline above)
- [x] `ruff check` / `ruff format --check` clean

`pytest -m slow python/tests/test_adversarial_recent_fixes.py` not re-run on this revision: it exercises solver behaviour, and this revision touches no solver source. Say the word if you want it anyway.

## Regression test

- [x] Added — fail-before/pass-after demonstrated against the mutant that reverts #1014's call site, since the fix itself is already on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G2BJLtVfbs7sCvjBrtgXPE