### PR TITLE
fix(time-limit): #1009 budget the incremental McCormick node LPs

### DIFF
--- a/python/discopt/_relax/incremental_mccormick.py
+++ b/python/discopt/_relax/incremental_mccormick.py
@@ -1091,7 +1091,7 @@ class IncrementalMcCormickLP:
         return float(result.objective) + off, np.asarray(result.x, dtype=float), out_basis
 
     def solve_assembled_full(
-        self, A, b, bounds, in_basis=None, c_override=None, *, return_cert=False
+        self, A, b, bounds, in_basis=None, c_override=None, *, return_cert=False, time_limit=None
     ):
         """Like :meth:`solve_assembled`, but return the terminal *status* too so a
         caller can tell a (certified) ``infeasible`` apart from any other
@@ -1115,7 +1115,13 @@ class IncrementalMcCormickLP:
         ``(..., farkas_certified, cert)`` with the :class:`LpWarmCert` carrying the
         node LP's row duals / column status / safe bound (cert:T2.4a) -- a pure
         side-channel; ``bound``/``x`` are computed identically whether or not it is
-        requested."""
+        requested.
+
+        ``time_limit`` (seconds, ``None`` = unbounded) bounds this one LP; it reaches
+        ``SimplexOptions::deadline``, which the pivot loops poll. A spent budget exits
+        as ``iter_limit``, which this method reports as ``"other"`` — no certified
+        verdict, so the caller falls back rather than fathoming on it (issue #1009).
+        Passing ``None`` reproduces the historical unbounded behaviour exactly."""
         from discopt.solvers import SolveStatus
         from discopt.solvers.milp_simplex import LpWarmCert, solve_lp_warm_std
 
@@ -1130,7 +1136,13 @@ class IncrementalMcCormickLP:
 
         try:
             result, out_basis, cert = solve_lp_warm_std(
-                cobj, sp.csr_matrix(A), b, bounds, in_basis=in_basis, return_cert=True
+                cobj,
+                sp.csr_matrix(A),
+                b,
+                bounds,
+                in_basis=in_basis,
+                return_cert=True,
+                time_limit=time_limit,
             )
         except Exception:
             return _ret("other", None, None, None, False)

--- a/python/discopt/_relax/lp_spatial_bb.py
+++ b/python/discopt/_relax/lp_spatial_bb.py
@@ -612,6 +612,10 @@ def solve_lp_spatial_bb(
     # on the incremental path (needs the explicit row system).
     cut_enabled = _inc.ok
     _MAX_INHERITED_CUTS = 400
+    # No node LP is handed a zero/negative duration (the backend rejects one), so a
+    # node that starts with the engine's budget already spent still gets a floor and
+    # exits on it rather than erroring.
+    _NODE_LP_FLOOR_S = 0.05
 
     def node_relax(lb, ub, basis, inherited, rounds):
         """Solve the node LP with inherited cuts, then run ``rounds`` of cut
@@ -645,7 +649,18 @@ def solve_lp_spatial_bb(
             return b_, x_, bas, (), verdict, info_
         cuts = list(inherited)
         A, b, bounds = _inc.assemble(lb, ub, cuts)
-        _st, b_, x_, bas, _farkas = _inc.solve_assembled_full(A, b, bounds, in_basis=basis)
+        # #1009: budget this LP against the engine's own deadline. Without it a
+        # single warm solve on a large lift runs uninterruptibly past ``time_limit``
+        # (the top-of-loop poll at line ~958 only fires BETWEEN nodes). An expired
+        # budget exits as ``iter_limit`` -> ``b_ is None`` -> ``"unresolved"``, which
+        # the caller folds into ``unresolved_lb`` — never a fathom.
+        _st, b_, x_, bas, _farkas = _inc.solve_assembled_full(
+            A,
+            b,
+            bounds,
+            in_basis=basis,
+            time_limit=max(_own_deadline - time.perf_counter(), _NODE_LP_FLOOR_S),
+        )
         if b_ is None:
             _verdict = "fathom" if (_st == "infeasible" and _farkas) else "unresolved"
             return None, None, None, tuple(cuts), _verdict, info

--- a/python/discopt/_relax/mccormick_lp.py
+++ b/python/discopt/_relax/mccormick_lp.py
@@ -31,6 +31,7 @@ from discopt._relax.milp_relaxation import (
     _RELAX_NUMERIC_CAP,
     _any_linear_constraint_form,
     _collect_affine_powers,
+    _lp_warm_deadline_enabled,
     _quadratic_constraint_forms,
     build_milp_relaxation,
 )
@@ -683,6 +684,7 @@ class MccormickLPRelaxer:
         inherited_cuts: Optional[tuple],
         *,
         want_marginals: bool = False,
+        deadline: Optional[float] = None,
     ) -> Optional["MccormickLPResult"]:
         """Incremental McCormick node solve: patch the cached structure + warm-start,
         instead of a cold ``build_milp_relaxation`` + equilibration. Returns a
@@ -695,10 +697,33 @@ class MccormickLPRelaxer:
         When ``want_marginals`` is set, the returned result additionally carries the
         node LP's row duals, safe bound, and the ORIGINAL-column reduced costs
         (cert:T2.4a). Those are computed from the same solve — no extra LP — and
-        never change ``lower_bound``/``x``."""
+        never change ``lower_bound``/``x``.
+
+        ``deadline`` (absolute ``perf_counter`` time, ``None`` = unbounded) bounds the
+        LPs this path issues. Issue #1009: this path used to receive no budget at all
+        — ``_solve_at_node_impl`` anchors its deadline *after* the fast path has
+        already returned — on the assumption, written at the fast-path call site, that
+        "the incremental fast path is already cheap". That holds until the patched LP
+        is large: one warm solve at m=3937 ran 416 s against a caller's 20 s budget
+        with nothing able to interrupt it. A spent budget yields no certified verdict,
+        so this method returns ``None`` and the node falls back to the cold build —
+        the same decline as any other inconclusive LP, never a fathom."""
         inc = self._inc
         if inc is None:
             return None
+
+        # Per-LP slice of the caller's remaining budget. Gated on the SAME flag that
+        # already promises this exact guarantee elsewhere — ``DISCOPT_LP_WARM_DEADLINE``
+        # (#928), whose docstring is "honour the caller's ``time_limit`` on the warm
+        # pure-LP node path" and which is default-ON. This path was simply never
+        # covered by it; with ``=0`` the historical unbounded behaviour is unchanged.
+        _budget_on = _lp_warm_deadline_enabled()
+
+        def _lp_budget() -> Optional[float]:
+            if deadline is None or not _budget_on:
+                return None
+            return max(deadline - time.perf_counter(), _SOLVE_DEADLINE_FLOOR_S)
+
         lb = np.asarray(node_lb, dtype=np.float64).ravel()
         ub = np.asarray(node_ub, dtype=np.float64).ravel()
         if lb.size != inc.n or ub.size != inc.n:
@@ -783,7 +808,12 @@ class MccormickLPRelaxer:
                 else None
             )
             _solved = inc.solve_assembled_full(
-                A, b, bounds, in_basis=in_basis, return_cert=want_marginals
+                A,
+                b,
+                bounds,
+                in_basis=in_basis,
+                return_cert=want_marginals,
+                time_limit=_lp_budget(),
             )
             if want_marginals:
                 status, bound, x_full, basis, farkas_certified, cert = _solved
@@ -859,7 +889,9 @@ class MccormickLPRelaxer:
                         c_x,
                         _c_basis,
                         c_farkas,
-                    ) = inc.solve_assembled_full(A, b, bounds, in_basis=None)
+                    ) = inc.solve_assembled_full(
+                        A, b, bounds, in_basis=None, time_limit=_lp_budget()
+                    )
                 except Exception:
                     c_status = None
                     c_bound = None
@@ -876,14 +908,20 @@ class MccormickLPRelaxer:
             # the equilibration re-verify, which fathoms ONLY on a verified Farkas
             # ray and otherwise defers to the cold rebuild (never trusts an
             # uncertified infeasible — see :meth:`_reverify_incremental_infeasible`).
-            return self._reverify_incremental_infeasible(inc, A, b, bounds)
+            return self._reverify_incremental_infeasible(inc, A, b, bounds, time_limit=_lp_budget())
 
         # time_limit / unbounded / numerical error: no certified verdict — fall back
         # to the trusted cold build.
         return None
 
     def _reverify_incremental_infeasible(
-        self, inc, A: np.ndarray, b: np.ndarray, bounds: np.ndarray
+        self,
+        inc,
+        A: np.ndarray,
+        b: np.ndarray,
+        bounds: np.ndarray,
+        *,
+        time_limit: Optional[float] = None,
     ) -> Optional["MccormickLPResult"]:
         """Confirm an incremental ``infeasible`` verdict soundly, without a cold
         rebuild, when the simplex's Farkas ray did not already certify it. A node
@@ -923,7 +961,12 @@ class MccormickLPRelaxer:
             bl = [(float(bounds[i, 0]), float(bounds[i, 1])) for i in range(bounds.shape[0])]
             c2, a2, b2, bd2, col_scale = equilibrate_relaxation_lp(inc.c, a_csr, b, bl, None)
             status, bound, x_s, _, farkas = inc.solve_assembled_full(
-                a2, b2, np.asarray(bd2, dtype=np.float64), in_basis=None, c_override=c2
+                a2,
+                b2,
+                np.asarray(bd2, dtype=np.float64),
+                in_basis=None,
+                c_override=c2,
+                time_limit=time_limit,
             )
         except Exception:
             return None  # re-verify failed -> trusted cold rebuild
@@ -1285,8 +1328,24 @@ class MccormickLPRelaxer:
             and self._model_has_composite_lift()
         )
         if out_cuts is None:
+            # #1009: the fast path needs its OWN anchor. The node-wide ``_deadline``
+            # below is taken deliberately AFTER the cold build (see its comment), so
+            # it does not exist yet here — which is exactly why this path used to run
+            # unbudgeted. Anchoring now, from the same ``time_limit``/``round_deadline``
+            # pair, bounds the fast path without moving the cold path's anchor.
+            _fast_deadline = None if time_limit is None else time.perf_counter() + time_limit
+            if round_deadline is not None:
+                _fast_deadline = (
+                    round_deadline
+                    if _fast_deadline is None
+                    else min(_fast_deadline, round_deadline)
+                )
             _fast = self._try_incremental_node(
-                node_lb, node_ub, inherited_cuts, want_marginals=want_marginals
+                node_lb,
+                node_ub,
+                inherited_cuts,
+                want_marginals=want_marginals,
+                deadline=_fast_deadline,
             )
             if _fast is not None and not (_skip_fast_for_lift and _fast.status == "optimal"):
                 return _fast
@@ -1294,9 +1353,11 @@ class MccormickLPRelaxer:
         try:
             # Issue #694 anytime build: ``build_deadline`` (a ``perf_counter`` time,
             # default None) truncates the cold relaxation build's constraint loop
-            # once spent, yielding a valid weaker relaxation. The incremental fast
-            # path above is already cheap, so it ignores the deadline; only this
-            # cold, row-generating build (the ~16.8s sonet23v4 cost, #694) honors it.
+            # once spent, yielding a valid weaker relaxation. It truncates only this
+            # cold, row-generating build (the ~16.8s sonet23v4 cost, #694); the
+            # incremental fast path above generates no rows, and is bounded instead by
+            # its own ``_fast_deadline`` on the LP itself (#1009 — it is not always
+            # cheap: a large patched LP ran 416 s against a 20 s budget).
             # #966: a ``round_deadline`` clamps the build too (the round's grant
             # covers the build), min-combined with any caller ``build_deadline``.
             _eff_build_deadline = build_deadline

--- a/python/tests/test_912_wall_budget_inventory.py
+++ b/python/tests/test_912_wall_budget_inventory.py
@@ -414,6 +414,17 @@ KNOWN: tuple[tuple[str, str, str], ...] = (
         "_deadline = None if time_limit is None else time.perf_counter() + time_limit",
         "contract",
     ),
+    # #1009's sibling of the line above, and the same category for the same
+    # reason: it spends the caller's own ``time_limit``, answering "when do we
+    # stop?", never "how much work do we do?". It exists separately only because
+    # the node-wide anchor above is taken *after* the cold build, by which point
+    # the incremental fast path has already returned — which is how that path
+    # came to issue its LPs unbudgeted.
+    (
+        "_relax/mccormick_lp.py",
+        "_fast_deadline = None if time_limit is None else time.perf_counter() + time_limit",
+        "contract",
+    ),
     (
         "_relax/mccormick_lp.py",
         "and (time.perf_counter() - _psd_t0) > _gate_budget * _base_solve_wall",

--- a/python/tests/test_incremental_mccormick_node.py
+++ b/python/tests/test_incremental_mccormick_node.py
@@ -19,6 +19,7 @@ conservative rollout limit (#355), not a soundness boundary. Any uncovered term
 from __future__ import annotations
 
 import os
+import time
 
 os.environ.setdefault("JAX_PLATFORMS", "cpu")
 os.environ.setdefault("JAX_ENABLE_X64", "1")
@@ -374,6 +375,118 @@ def test_incremental_solve_bound_matches_cold_builder_with_constant():
     relax._integrality = None
     b_cold = relax.solve().bound
     assert b_inc == pytest.approx(b_cold, abs=1e-6)
+
+
+def _spy_warm_lp(monkeypatch):
+    """Record the ``time_limit`` every incremental-path LP is issued with.
+
+    ``incremental_mccormick.solve_assembled_full`` imports ``solve_lp_warm_std``
+    from ``discopt.solvers.milp_simplex`` *inside* the function body, so patching
+    the module attribute intercepts it. The real solver still runs — this only
+    reads the argument in flight.
+    """
+    from discopt.solvers import milp_simplex
+
+    real = milp_simplex.solve_lp_warm_std
+    seen: list = []
+
+    def _spy(*a, **kw):
+        seen.append(kw.get("time_limit", "ABSENT"))
+        return real(*a, **kw)
+
+    monkeypatch.setattr(milp_simplex, "solve_lp_warm_std", _spy)
+    return seen
+
+
+@pytest.mark.smoke
+def test_incremental_fast_path_receives_the_callers_time_limit(monkeypatch):
+    """#1009: ``solve_at_node(time_limit=T)`` must reach the fast path's LP.
+
+    Before the fix ``_try_incremental_node`` was called before the node-wide
+    deadline was even anchored and ``solve_assembled_full`` had no parameter to
+    carry one, so every LP on this path was issued unbounded — one such LP ran
+    416 s against a caller's 20 s budget. The LP-level ``time_limit`` is the only
+    thing that reaches ``SimplexOptions::deadline``.
+    """
+    monkeypatch.delenv("DISCOPT_LP_WARM_DEADLINE", raising=False)
+    m = _int_qcqp()
+    relaxer = MccormickLPRelaxer(m)
+    assert relaxer._inc is not None, "fast path must be active or this proves nothing"
+
+    seen = _spy_warm_lp(monkeypatch)
+    lb, ub = np.array([0.0, 0.0]), np.array([5.0, 5.0])
+    relaxer.solve_at_node(lb, ub, time_limit=7.0)
+
+    assert seen, "probe never fired: no warm LP was issued on the fast path"
+    checked = 0
+    for tl in seen:
+        assert tl != "ABSENT", "solve_lp_warm_std called without a time_limit kwarg"
+        assert tl is not None, "the caller's budget was dropped before the LP"
+        # A slice of the caller's duration, never more than it, never <= 0 (the
+        # backend rejects a nonpositive budget — hence the floor).
+        assert 0.0 < tl <= 7.0
+        checked += 1
+    assert checked == len(seen) and checked > 0, "probe fired on every LP"
+
+
+@pytest.mark.smoke
+def test_no_time_limit_leaves_the_fast_path_unbounded_as_before(monkeypatch):
+    """Bound-neutrality: with no caller budget the LP is issued exactly as it was
+    — unbounded. This is the arm that must not move."""
+    monkeypatch.delenv("DISCOPT_LP_WARM_DEADLINE", raising=False)
+    relaxer = MccormickLPRelaxer(_int_qcqp())
+    assert relaxer._inc is not None
+
+    seen = _spy_warm_lp(monkeypatch)
+    relaxer.solve_at_node(np.array([0.0, 0.0]), np.array([5.0, 5.0]))
+
+    assert seen, "probe never fired"
+    for tl in seen:
+        assert tl is None, f"an unbudgeted node LP acquired a deadline: {tl}"
+
+
+@pytest.mark.smoke
+def test_warm_deadline_opt_out_restores_the_unbounded_fast_path(monkeypatch):
+    """``DISCOPT_LP_WARM_DEADLINE=0`` is the documented escape hatch for exactly
+    this guarantee; it must cover this path too, or the opt-out is a lie."""
+    monkeypatch.setenv("DISCOPT_LP_WARM_DEADLINE", "0")
+    relaxer = MccormickLPRelaxer(_int_qcqp())
+    assert relaxer._inc is not None
+
+    seen = _spy_warm_lp(monkeypatch)
+    relaxer.solve_at_node(np.array([0.0, 0.0]), np.array([5.0, 5.0]), time_limit=7.0)
+
+    assert seen, "probe never fired"
+    for tl in seen:
+        assert tl is None, f"opt-out ignored: LP still budgeted at {tl}"
+
+
+@pytest.mark.smoke
+def test_an_exhausted_budget_still_hands_the_lp_a_positive_floor(monkeypatch):
+    """A node that starts with its budget already spent must not hand the backend
+    a zero/negative duration (it would reject it, turning a bounded solve into an
+    error). ``_SOLVE_DEADLINE_FLOOR_S`` is the guard."""
+    from discopt._relax.mccormick_lp import _SOLVE_DEADLINE_FLOOR_S
+
+    monkeypatch.delenv("DISCOPT_LP_WARM_DEADLINE", raising=False)
+    relaxer = MccormickLPRelaxer(_int_qcqp())
+    assert relaxer._inc is not None
+
+    seen = _spy_warm_lp(monkeypatch)
+    # An absolute round grant that expired in the past — the tightest possible case.
+    relaxer.solve_at_node(
+        np.array([0.0, 0.0]),
+        np.array([5.0, 5.0]),
+        time_limit=7.0,
+        round_deadline=time.perf_counter() - 100.0,
+    )
+
+    assert seen, "probe never fired"
+    for tl in seen:
+        # Every LP issued under an expired grant collapses to the floor, not to the
+        # caller's full 7 s. (The cold fallback re-slices the same floor against its
+        # own elapsed time, so this is an upper bound, not an equality.)
+        assert 0.0 < tl <= _SOLVE_DEADLINE_FLOOR_S + 1e-9, f"floor not applied: {tl}"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What was broken

The incremental McCormick fast path issued every LP **unbounded**. The caller's
`time_limit` reached the relaxer and then died two frames short of the solver:

- `_solve_at_node_impl` converts `time_limit` into a deadline at `mccormick_lp.py:1443`.
  The fast path is tried at line 1286 — *before* that — and returns directly on success.
- `solve_assembled_full` had no parameter to carry a budget.
- `solve_lp_warm_std` has accepted a working `time_limit` since #928 (it reaches
  `SimplexOptions::deadline`, polled by both pivot loops). Nobody on this path passed it.

The assumption is written down at the fast-path call site:

> *"The incremental fast path above is already cheap, so it ignores the deadline;
> only this cold, row-generating build honors it."*

True while the patched LP stays small. False once it is large: on QPLIB_1157 with
RLT rows on (m=3937) a **single** warm solve ran 415 s against a caller's 20 s
budget. `DISCOPT_PROFILE=1` confirms it is one LP, not many — `WarmVerdictOptimal 1`
for the entire run.

## What changed

Thread an absolute deadline through `_try_incremental_node` → `solve_assembled_full`
→ `solve_lp_warm_std`, anchored from the same `time_limit`/`round_deadline` pair the
cold path uses. The cold path's own anchor is deliberately **not** moved (its comment
explains why it is taken after the build); the fast path gets its own.

Two other unbudgeted LPs on the same path are closed with it (§2 — fix the class):

- `_reverify_incremental_infeasible` — the equilibration re-verify.
- `lp_spatial_bb.node_relax` — which already had `_own_deadline` in scope and ignored
  it; its top-of-loop budget poll only fires *between* nodes.

## Soundness

A spent budget exits `iter_limit`, which `solve_assembled_full` already maps to
`"other"` — no certified verdict — so `_try_incremental_node` returns `None` and the
node falls back to the cold build. In `lp_spatial_bb` it maps to `"unresolved"`, which
the caller folds into `unresolved_lb`. **Neither path can fathom on a timeout**, so a
shortened LP can only loosen a bound, never invalidate one. This is the same decline
any other inconclusive LP already takes.

Gated on `DISCOPT_LP_WARM_DEADLINE` (#928, **default-ON**), whose docstring already
promises exactly this guarantee — *"honour the caller's `time_limit` on the warm
pure-LP node path"* — and which simply never covered this path. `=0` restores the
unbounded behaviour unchanged, and a test asserts that.

## Regime (CLAUDE.md §5)

**Bound-neutral when no `time_limit` is set** — `_lp_budget()` returns `None` and the
LP is issued exactly as before (asserted by
`test_no_time_limit_leaves_the_fast_path_unbounded_as_before`).

**Bound-changing when one is set**, in two ways, both disclosed:

1. An LP that would have run past the budget now yields, so the node falls back and
   the reported bound can differ. It can only be looser or absent, never falsely
   tighter — a yielded LP produces no verdict to fathom on.
2. `solve_lp_warm_std` turns on `_dual_start_slack_basis` for a *cold* solve whenever
   a finite `time_limit` is present (`milp_simplex.py:798` — pre-existing, documented
   behaviour of that parameter). Passing a budget therefore also changes which basis
   some cold LPs start from. Visible in the control below as 104 → 105 nodes, with the
   bound unchanged to every printed digit.

## Measurement

QPLIB_1157, 20 s `time_limit`, in-repo repro script. This PR is one of **two** fixes;
the other is #1014 (the Rust kernel's node LPs ran with `SimplexOptions::deadline =
None`). Either alone still breaches:

```
DISCOPT_RLT_LINEQ=1
  baseline (neither fix)                    415.36 s   20.8x   VIOLATION
  + this PR only                            239.35 s   12.0x   VIOLATION
  + this PR and #1014                        20.88 s    1.04x  ok    bound −32.57250000001447

default path (control, RLT unset)
  baseline                                   20.17 s    1.01x  nodes=104  bound −12.422736363861812
  both fixes                                 20.20 s    1.01x  nodes=105  bound −12.422736363861812
```

Two unbudgeted LP paths in series. The Python side spent the whole budget before
`solve_spatial_tree` was ever reached, which is why #1014 looked like a no-op when it
merged — it was **masked**. Bounding the Python side hands control to the kernel,
where #1014 is what stops it. The control's bound is bit-identical to baseline and the
flagged arm's bound returns to its baseline value: the budget is honoured without
buying it with a weaker bound.

Class check (§2), 12 manifest-selected QPLIB instances at a 10 s budget, both fixes,
default flags: ratios 0.82–1.08x, `compared=12 over=0` (threshold 2x). A post-fix
conformance check, not an A/B — it shows nothing regressed into a breach, and I am not
claiming a broad speedup from it.

Load gate (§9): the "both fixes" runs were at load average 5.7–8.0, the cleanest of
the session; the 415 s baseline at 38–54 (`mediaanalysisd`, Dropbox — neither mine).
The intermediate 239 s figure is **not** a clean interleaved A/B and I am not
defending it as a precise number. What is load-robust is the 20.8x → 1.04x change and
the 1.01x control.

## Tests

Four new tests in `python/tests/test_incremental_mccormick_node.py`, all `smoke`:

- `test_incremental_fast_path_receives_the_callers_time_limit`
- `test_no_time_limit_leaves_the_fast_path_unbounded_as_before`
- `test_warm_deadline_opt_out_restores_the_unbounded_fast_path`
- `test_an_exhausted_budget_still_hands_the_lp_a_positive_floor`

All four **fail on the parent commit** — verified by stashing only the two source
files (leaving the tests in place) and re-running: 4 failed. With the fix: 19 passed.
Each asserts a nonzero observation count so a probe that never fires cannot read as a
pass (§6).

Closes #1009 (together with #1014, already merged).

Run locally on this branch: `pytest -m smoke` → 1012 passed, 1 skipped, 2 xpassed;
`pytest -m slow python/tests/test_adversarial_recent_fixes.py` → 10 passed. Rust
untouched.
