### PR TITLE
refactor(dfo): #1010 extract the shared DFO oracle and GLce merit into `_dfo_common`

### DIFF
--- a/python/discopt/solvers/_dfo_common.py
+++ b/python/discopt/solvers/_dfo_common.py
@@ -1,0 +1,173 @@
+"""Machinery shared by the derivative-free backends (``direct``, ``surrogate``).
+
+Both backends are black-box searches over a finite box: they see the model only
+through "evaluate at a point, get an objective and a total constraint violation",
+and they rank the points they have seen with the DIRECT-GLce auxiliary function
+(Stripinis, Paulavičius & Žilinskas 2018). Those two pieces are the whole of
+their shared surface, and they are the two pieces that *must* agree exactly:
+
+* The oracle decides what a point is *worth*. If the two backends disagree there,
+  a comparison between them measures the plumbing rather than the algorithms.
+* The merit rule decides which point is *better*. A drift between two copies
+  would have them rank the same pair of points differently while both cite the
+  same source.
+
+They lived as two copies until #1010, and the duplication had already cost
+something: the guard rejecting a ``cl``/``cu`` length mismatch landed in
+``direct`` first and had to be applied to ``surrogate`` separately. That guard
+protects a *feasibility verdict*, so the copy without it was silently wrong
+rather than loudly broken — which is the failure mode this module exists to
+remove.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Callable, Optional
+
+import numpy as np
+
+from discopt.modeling.core import Model
+
+logger = logging.getLogger(__name__)
+
+Oracle = Callable[[np.ndarray], tuple[float, float]]
+
+
+def build_oracle(model: Model, *, log_prefix: str) -> tuple[Oracle, int, np.ndarray]:
+    """``(evaluate, n_vars, integer_mask)`` for ``model``.
+
+    ``evaluate`` maps a model point to ``(objective, total_violation)``. Both come
+    from the one evaluator funnel the rest of the solver uses, so an opaque
+    ``dm.custom`` body is evaluated exactly as the local NLP path would.
+
+    ``log_prefix`` names the calling backend in the "evaluator backend is X" line
+    and changes nothing else — the values a backend sees must not depend on which
+    backend asked for them.
+    """
+    from discopt.solver import _extract_variable_info, _infer_constraint_bounds, _make_evaluator
+
+    evaluator = _make_evaluator(model)
+    logger.info("%s: evaluator backend is %s", log_prefix, type(evaluator).__name__)
+
+    n_vars, _lb, _ub, int_offsets, int_sizes = _extract_variable_info(model)
+    integer_mask = np.zeros(n_vars, dtype=bool)
+    for off, size in zip(int_offsets, int_sizes):
+        integer_mask[off : off + size] = True
+
+    n_cons = int(getattr(evaluator, "n_constraints", 0) or 0)
+    cl: Optional[np.ndarray]
+    cu: Optional[np.ndarray]
+    if n_cons:
+        cl_raw, cu_raw = _infer_constraint_bounds(model, evaluator)
+        cl = np.asarray(cl_raw, dtype=np.float64)
+        cu = np.asarray(cu_raw, dtype=np.float64)
+        # The violation sum below indexes cl and cu against the same g vector, so
+        # a length mismatch would broadcast-or-truncate into a silently wrong
+        # violation — i.e. a wrong feasibility verdict, not a crash. Refuse loudly.
+        if cl.shape != (n_cons,) or cu.shape != (n_cons,):
+            raise ValueError(
+                f"constraint bounds do not match the evaluator: n_constraints={n_cons} "
+                f"but cl has shape {cl.shape} and cu has shape {cu.shape}"
+            )
+    else:
+        cl = cu = None
+
+    def evaluate(x: np.ndarray) -> tuple[float, float]:
+        fval = float(evaluator.evaluate_objective(x))
+        if not np.isfinite(fval):
+            # A black box may be undefined here. Treat it as an unusable point
+            # rather than letting a NaN poison the ordering: +inf loses every
+            # comparison, which is the honest ranking for "no value". A backend
+            # that has to *fit* the merit rather than only compare it asks
+            # ``glce_merit`` for a finite stand-in (see ``finite_fill``).
+            fval = np.inf
+        viol = 0.0
+        if cl is not None:
+            g = np.asarray(evaluator.evaluate_constraints(x), dtype=np.float64)
+            g = np.where(np.isfinite(g), g, np.inf)
+            viol = float(np.sum(np.maximum(0.0, g - cu)) + np.sum(np.maximum(0.0, cl - g)))
+        return fval, viol
+
+    return evaluate, n_vars, integer_mask
+
+
+def glce_merit(
+    f: np.ndarray,
+    v: np.ndarray,
+    best_feasible_value: Optional[float],
+    eps_cons: float,
+    *,
+    finite_fill: bool,
+) -> np.ndarray:
+    """The DIRECT-GLce auxiliary value, one per evaluated point. Lower is better.
+
+    * **Phase A** (``best_feasible_value is None``, nothing feasible seen yet):
+      rank by total violation, so the search first hunts for feasibility.
+    * **Phase B** (a feasible point exists): a feasible point ranks by its
+      objective; an infeasible one is penalized by its violation *plus*
+      ``|f - f_min|``. That last term is what stops an infeasible point from
+      earning credit for an objective below the incumbent, and it needs no
+      penalty weight to be tuned.
+    * The ``ce`` refinement: a violation within ``eps_cons`` counts as feasible,
+      so the ranking is not discontinuous exactly at the boundary where optima
+      usually sit (DIRECT has no convergence guarantee across a discontinuity).
+
+    ``finite_fill`` decides what happens to a non-finite merit — which arises
+    when the black box was undefined at a point and the oracle returned ``+inf``.
+    It is an explicit argument because the two backends genuinely want different
+    answers, not because they drifted:
+
+    * ``False`` (DIRECT): the merit is only ever *compared*, and ``+inf`` is the
+      honest ranking for "no value" — it loses every comparison and the point is
+      never selected.
+    * ``True`` (surrogate): the merit is *fitted*, and an infinite right-hand
+      side makes the interpolation system meaningless. The non-finite entries are
+      mapped to the worst finite merit plus the observed spread, which keeps the
+      one thing the point does tell us — that the region is bad — without
+      discarding it or poisoning the fit. With no finite merit at all there is no
+      spread to speak of, so every point is given the same value: an
+      uninformative but well-posed system.
+    """
+    f = np.asarray(f, dtype=np.float64)
+    v = np.asarray(v, dtype=np.float64)
+    if best_feasible_value is None:
+        merit = v.copy()
+    else:
+        near_feasible = v <= eps_cons
+        merit = np.where(near_feasible, f, f + v + np.abs(f - best_feasible_value))
+    if not finite_fill:
+        return merit
+    bad = ~np.isfinite(merit)
+    if bad.any():
+        finite = merit[~bad]
+        if finite.size == 0:
+            merit = np.zeros_like(merit)
+        else:
+            spread = float(finite.max() - finite.min())
+            merit = np.where(bad, finite.max() + spread + 1.0, merit)
+    out: np.ndarray = merit
+    return out
+
+
+def glce_merit_scalar(
+    fval: float,
+    viol: float,
+    best_feasible_value: Optional[float],
+    eps_cons: float,
+) -> float:
+    """:func:`glce_merit` for a single point, for callers that rank one at a time.
+
+    Delegates rather than restating the formula: a second scalar implementation
+    of the rule is exactly the drift this module exists to prevent. ``finite_fill``
+    is not offered because a single point has no other point to take a finite
+    stand-in from.
+    """
+    merit = glce_merit(
+        np.array([fval], dtype=np.float64),
+        np.array([viol], dtype=np.float64),
+        best_feasible_value,
+        eps_cons,
+        finite_fill=False,
+    )
+    return float(merit[0])

--- a/python/discopt/solvers/_dfo_common.py
+++ b/python/discopt/solvers/_dfo_common.py
@@ -56,8 +56,12 @@ def build_oracle(model: Model, *, log_prefix: str) -> tuple[Oracle, int, np.ndar
         integer_mask[off : off + size] = True
 
     n_cons = int(getattr(evaluator, "n_constraints", 0) or 0)
-    cl: Optional[np.ndarray]
-    cu: Optional[np.ndarray]
+    # One binding rather than two: cl and cu are set together and cleared
+    # together, so a single Optional makes that inseparable. Two independent
+    # Optionals are exactly the shape of the bug fixed in 067abc6, where a
+    # ``cl``-keyed guard left ``cu`` at a different length and the violation sum
+    # broadcast to zero.
+    bounds: Optional[tuple[np.ndarray, np.ndarray]] = None
     if n_cons:
         cl_raw, cu_raw = _infer_constraint_bounds(model, evaluator)
         cl = np.asarray(cl_raw, dtype=np.float64)
@@ -70,8 +74,7 @@ def build_oracle(model: Model, *, log_prefix: str) -> tuple[Oracle, int, np.ndar
                 f"constraint bounds do not match the evaluator: n_constraints={n_cons} "
                 f"but cl has shape {cl.shape} and cu has shape {cu.shape}"
             )
-    else:
-        cl = cu = None
+        bounds = (cl, cu)
 
     def evaluate(x: np.ndarray) -> tuple[float, float]:
         fval = float(evaluator.evaluate_objective(x))
@@ -83,10 +86,11 @@ def build_oracle(model: Model, *, log_prefix: str) -> tuple[Oracle, int, np.ndar
             # ``glce_merit`` for a finite stand-in (see ``finite_fill``).
             fval = np.inf
         viol = 0.0
-        if cl is not None:
+        if bounds is not None:
+            lo, hi = bounds
             g = np.asarray(evaluator.evaluate_constraints(x), dtype=np.float64)
             g = np.where(np.isfinite(g), g, np.inf)
-            viol = float(np.sum(np.maximum(0.0, g - cu)) + np.sum(np.maximum(0.0, cl - g)))
+            viol = float(np.sum(np.maximum(0.0, g - hi)) + np.sum(np.maximum(0.0, lo - g)))
         return fval, viol
 
     return evaluate, n_vars, integer_mask
@@ -137,7 +141,8 @@ def glce_merit(
         near_feasible = v <= eps_cons
         merit = np.where(near_feasible, f, f + v + np.abs(f - best_feasible_value))
     if not finite_fill:
-        return merit
+        compared: np.ndarray = merit
+        return compared
     bad = ~np.isfinite(merit)
     if bad.any():
         finite = merit[~bad]

--- a/python/discopt/solvers/direct.py
+++ b/python/discopt/solvers/direct.py
@@ -114,6 +114,7 @@ from typing import Callable, Optional
 import numpy as np
 
 from discopt.modeling.core import Model, SolveResult
+from discopt.solvers._dfo_common import build_oracle, glce_merit, glce_merit_scalar
 
 logger = logging.getLogger(__name__)
 
@@ -402,24 +403,22 @@ class _DirectSearch:
     def rank_values(self) -> np.ndarray:
         """Per-rectangle ranking value, following DIRECT-GLce.
 
-        * **Phase A** (no feasible point yet): rank by total constraint violation,
-          so the search first hunts for feasibility.
-        * **Phase B** (a feasible point exists): a feasible centre ranks by its
-          objective; an infeasible one is penalized by its violation *plus*
-          ``|f - f_min|``. That last term is what stops an infeasible point from
-          earning credit for an objective below the incumbent, and it needs no
-          penalty weight to be tuned.
-        * The ``ce`` refinement: a violation within ``eps_cons`` is treated as
-          feasible, so the ranking is not discontinuous exactly at the boundary
-          where optima usually sit (DIRECT has no convergence guarantee across a
-          discontinuity).
+        The rule itself lives in :func:`_dfo_common.glce_merit`, shared with the
+        surrogate backend: the two must rank the same point identically or a
+        comparison between them measures the plumbing instead of the algorithms.
+
+        ``finite_fill=False`` because this value is only ever *compared*. A point
+        where the black box was undefined carries ``+inf``, which loses every
+        comparison — the honest ranking for "no value". The surrogate backend,
+        which has to *fit* the merit, needs a finite stand-in instead.
         """
-        f = np.asarray(self.part.fvals, dtype=np.float64)
-        v = np.asarray(self.part.viols, dtype=np.float64)
-        if self.best_feasible_value is None:
-            return v
-        near_feasible = v <= self.eps_cons
-        return np.where(near_feasible, f, f + v + np.abs(f - self.best_feasible_value))
+        return glce_merit(
+            np.asarray(self.part.fvals, dtype=np.float64),
+            np.asarray(self.part.viols, dtype=np.float64),
+            self.best_feasible_value,
+            self.eps_cons,
+            finite_fill=False,
+        )
 
     # -- evaluation --------------------------------------------------------
     def evaluate(
@@ -663,11 +662,8 @@ class _DirectSearch:
             self.stats.evals += 1
 
     def _scalar_rank(self, fval: float, viol: float) -> float:
-        if self.best_feasible_value is None:
-            return viol
-        if viol <= self.eps_cons:
-            return fval
-        return fval + viol + abs(fval - self.best_feasible_value)
+        """:meth:`rank_values` for one point, for callers that rank one at a time."""
+        return glce_merit_scalar(fval, viol, self.best_feasible_value, self.eps_cons)
 
     # -- driver ------------------------------------------------------------
     def run(
@@ -759,57 +755,6 @@ class _DirectSearch:
 # ══════════════════════════════════════════════════════════════════════════════
 # Model-facing entry point
 # ══════════════════════════════════════════════════════════════════════════════
-
-
-def _build_oracle(model: Model, feas_tol: float):
-    """``(evaluate, n_vars, integer_mask)`` for ``model``.
-
-    ``evaluate`` maps a model point to ``(objective, total_violation)``. Both come
-    from the one evaluator funnel the rest of the solver uses, so an opaque
-    ``dm.custom`` body is evaluated exactly as the local NLP path would.
-    """
-    from discopt.solver import _extract_variable_info, _infer_constraint_bounds, _make_evaluator
-
-    evaluator = _make_evaluator(model)
-    logger.info("DIRECT: evaluator backend is %s", type(evaluator).__name__)
-
-    n_vars, _lb, _ub, int_offsets, int_sizes = _extract_variable_info(model)
-    integer_mask = np.zeros(n_vars, dtype=bool)
-    for off, size in zip(int_offsets, int_sizes):
-        integer_mask[off : off + size] = True
-
-    n_cons = int(getattr(evaluator, "n_constraints", 0) or 0)
-    if n_cons:
-        cl, cu = _infer_constraint_bounds(model, evaluator)
-        cl = np.asarray(cl, dtype=np.float64)
-        cu = np.asarray(cu, dtype=np.float64)
-        # The violation sum below indexes cl and cu against the same g vector, so
-        # a length mismatch would broadcast-or-truncate into a silently wrong
-        # violation — i.e. a wrong feasibility verdict, not a crash. Refuse loudly.
-        if cl.shape != (n_cons,) or cu.shape != (n_cons,):
-            raise ValueError(
-                f"constraint bounds do not match the evaluator: n_constraints={n_cons} "
-                f"but cl has shape {cl.shape} and cu has shape {cu.shape}"
-            )
-    else:
-        cl = cu = None
-
-    def evaluate(x: np.ndarray) -> tuple[float, float]:
-        fval = float(evaluator.evaluate_objective(x))
-        if not np.isfinite(fval):
-            # A black box may be undefined here. Treat it as an unusable point
-            # rather than letting a NaN poison the ordering: +inf loses every
-            # comparison, which is the honest ranking for "no value".
-            fval = np.inf
-        viol = 0.0
-        if cl is not None:
-            g = np.asarray(evaluator.evaluate_constraints(x), dtype=np.float64)
-            g = np.where(np.isfinite(g), g, np.inf)
-            viol = float(np.sum(np.maximum(0.0, g - cu)) + np.sum(np.maximum(0.0, cl - g)))
-        return fval, viol
-
-    del feas_tol  # the caller owns the tolerance; kept for signature stability
-    return evaluate, n_vars, integer_mask
 
 
 def _refine_derivative_free(
@@ -1060,7 +1005,7 @@ def solve_direct(
             n_vars,
         )
 
-    oracle, n_from_model, integer_mask = _build_oracle(model, feasibility_tolerance)
+    oracle, n_from_model, integer_mask = build_oracle(model, log_prefix="DIRECT")
     if n_from_model != n_vars:
         raise ValueError(f"variable-count mismatch: box has {n_vars}, evaluator has {n_from_model}")
 

--- a/python/discopt/solvers/surrogate.py
+++ b/python/discopt/solvers/surrogate.py
@@ -298,6 +298,7 @@ from typing import Any, Callable, Optional, Sequence
 import numpy as np
 
 from discopt.modeling.core import Constant, Model, SolveResult
+from discopt.solvers._dfo_common import build_oracle, glce_merit
 
 logger = logging.getLogger(__name__)
 
@@ -1220,36 +1221,23 @@ class _SurrogateSearch:
     def merits(self) -> np.ndarray:
         """The scalar the surrogate is fitted to, one per evaluated point.
 
-        Identical in form to ``_DirectSearch.rank_values`` (DIRECT-GLce): total
-        violation while nothing feasible is known, then the objective for
-        near-feasible points and ``f + viol + |f - f_min|`` for the rest. The
-        ``|f - f_min|`` term denies an infeasible point credit for a low
-        objective and needs no penalty weight to be tuned. For an unconstrained
-        model this is just the objective.
+        The rule itself lives in :func:`_dfo_common.glce_merit`, shared with
+        ``_DirectSearch.rank_values``: the two backends must optimize the same
+        thing to be comparable. For an unconstrained model it is just the
+        objective.
 
-        A non-finite objective (a black box undefined at that point) is mapped to
-        the worst finite merit plus the observed spread, rather than to ``+inf``:
-        an infinite value would make the interpolation system meaningless, while
-        dropping the point would throw away the one thing it does tell us, that
-        the region is bad.
+        ``finite_fill=True`` because this value is *fitted*, not only compared: a
+        non-finite objective (a black box undefined at that point) would make the
+        interpolation system meaningless as ``+inf``, while dropping the point
+        would throw away the one thing it does tell us, that the region is bad.
         """
-        f = np.asarray(self.f, dtype=np.float64)
-        v = np.asarray(self.viol, dtype=np.float64)
-        if self.best_feasible_value is None:
-            merit = v.copy()
-        else:
-            near = v <= self.eps_cons
-            merit = np.where(near, f, f + v + np.abs(f - self.best_feasible_value))
-        bad = ~np.isfinite(merit)
-        if bad.any():
-            finite = merit[~bad]
-            if finite.size == 0:
-                merit = np.zeros_like(merit)
-            else:
-                spread = float(finite.max() - finite.min())
-                merit = np.where(bad, finite.max() + spread + 1.0, merit)
-        out: np.ndarray = merit
-        return out
+        return glce_merit(
+            np.asarray(self.f, dtype=np.float64),
+            np.asarray(self.viol, dtype=np.float64),
+            self.best_feasible_value,
+            self.eps_cons,
+            finite_fill=True,
+        )
 
     # -- proposal ----------------------------------------------------------
     def propose(
@@ -1434,60 +1422,6 @@ class _SurrogateSearch:
 # ══════════════════════════════════════════════════════════════════════════════
 # Model-facing entry point
 # ══════════════════════════════════════════════════════════════════════════════
-
-
-def _build_oracle(model: Model, feas_tol: float):
-    """``(evaluate, n_vars, integer_mask)`` for ``model``.
-
-    ``evaluate`` maps a model point to ``(objective, total_violation)``. Both come
-    from the one evaluator funnel the rest of the solver uses, so an opaque
-    ``dm.custom`` body is evaluated exactly as the local NLP path would. This
-    mirrors ``direct._build_oracle`` deliberately: the two backends must see
-    identical values for a given point, or a comparison between them measures the
-    plumbing instead of the algorithms.
-    """
-    from discopt.solver import _extract_variable_info, _infer_constraint_bounds, _make_evaluator
-
-    evaluator = _make_evaluator(model)
-    logger.info("surrogate: evaluator backend is %s", type(evaluator).__name__)
-
-    n_vars, _lb, _ub, int_offsets, int_sizes = _extract_variable_info(model)
-    integer_mask = np.zeros(n_vars, dtype=bool)
-    for off, size in zip(int_offsets, int_sizes):
-        integer_mask[off : off + size] = True
-
-    n_cons = int(getattr(evaluator, "n_constraints", 0) or 0)
-    if n_cons:
-        cl, cu = _infer_constraint_bounds(model, evaluator)
-        cl = np.asarray(cl, dtype=np.float64)
-        cu = np.asarray(cu, dtype=np.float64)
-        # Same guard as ``direct._build_oracle``: the violation sum indexes cl and
-        # cu against the same g, so a length mismatch broadcasts or truncates into
-        # a silently wrong violation -- a wrong feasibility verdict, not a crash.
-        if cl.shape != (n_cons,) or cu.shape != (n_cons,):
-            raise ValueError(
-                f"constraint bounds do not match the evaluator: n_constraints={n_cons} "
-                f"but cl has shape {cl.shape} and cu has shape {cu.shape}"
-            )
-    else:
-        cl = cu = None
-
-    def evaluate(x: np.ndarray) -> tuple[float, float]:
-        fval = float(evaluator.evaluate_objective(x))
-        if not np.isfinite(fval):
-            # A black box may be undefined here. +inf loses every comparison,
-            # which is the honest ranking for "no value"; ``merits`` then maps it
-            # to a finite worst-case so the fit stays well posed.
-            fval = np.inf
-        viol = 0.0
-        if cl is not None:
-            g = np.asarray(evaluator.evaluate_constraints(x), dtype=np.float64)
-            g = np.where(np.isfinite(g), g, np.inf)
-            viol = float(np.sum(np.maximum(0.0, g - cu)) + np.sum(np.maximum(0.0, cl - g)))
-        return fval, viol
-
-    del feas_tol  # the caller owns the tolerance; kept for signature stability
-    return evaluate, n_vars, integer_mask
 
 
 def _refine_locally(
@@ -1767,7 +1701,7 @@ def solve_surrogate(
             n_vars,
         )
 
-    oracle, n_from_model, integer_mask = _build_oracle(model, feasibility_tolerance)
+    oracle, n_from_model, integer_mask = build_oracle(model, log_prefix="surrogate")
     if n_from_model != n_vars:
         raise ValueError(f"variable-count mismatch: box has {n_vars}, evaluator has {n_from_model}")
 

--- a/python/tests/test_dfo_common.py
+++ b/python/tests/test_dfo_common.py
@@ -1,0 +1,285 @@
+"""Tests for :mod:`discopt.solvers._dfo_common`, shared by ``direct`` and ``surrogate``.
+
+Two properties are checked here, and neither had a test before #1010 extracted
+the module:
+
+* **The two backends see identical values.** Both docstrings asserted it, nothing
+  measured it. The extraction makes it true by construction, so this test is the
+  guard against a future caller re-forking the oracle — it drives the *backends'*
+  search objects, not ``build_oracle`` twice, so it fails if either backend stops
+  routing through the shared implementation.
+* **The merit rule, directly.** ``test_direct_units`` covered phases A/B and the
+  ``ε_cons`` band; ``test_surrogate_units`` covered phases A/B and the non-finite
+  fill. Each was a partial covering of one copy. The rule now has one home and
+  one set of tests, with ``finite_fill`` exercised in both settings.
+"""
+
+from __future__ import annotations
+
+import os
+
+os.environ.setdefault("JAX_PLATFORMS", "cpu")
+os.environ.setdefault("JAX_ENABLE_X64", "1")
+
+import numpy as np
+import pytest
+from discopt import modeling as dm
+from discopt.solvers._dfo_common import glce_merit, glce_merit_scalar
+
+pytestmark = pytest.mark.unit
+
+
+# ── the merit rule (DIRECT-GLce) ─────────────────────────────────────────────
+
+
+def _merit(f, v, best, eps=1e-6, *, finite_fill=False):
+    return glce_merit(
+        np.asarray(f, float), np.asarray(v, float), best, eps, finite_fill=finite_fill
+    )
+
+
+def test_phase_a_ranks_by_violation_before_any_feasible_point():
+    """With nothing feasible yet, the search minimizes total violation.
+
+    The objective must not enter at all: the second point has a far better ``f``
+    and must still lose on violation alone.
+    """
+    merit = _merit(f=[100.0, -100.0], v=[5.0, 9.0], best=None)
+    assert merit[0] < merit[1], merit
+    np.testing.assert_allclose(merit, [5.0, 9.0])
+
+
+def test_phase_b_denies_credit_to_an_infeasible_low_objective():
+    """An infeasible point cannot outrank the incumbent by having a lower objective.
+
+    The ``|f - f_min|`` term is what removes that credit, and it needs no penalty
+    weight to be tuned.
+    """
+    merit = _merit(f=[10.0, -1e6], v=[0.0, 3.0], best=10.0)
+    assert merit[0] < merit[1], merit
+    # Feasible point ranks by its objective; the infeasible one by the full rule.
+    assert merit[0] == pytest.approx(10.0)
+    assert merit[1] == pytest.approx(-1e6 + 3.0 + abs(-1e6 - 10.0))
+
+
+def test_the_eps_cons_band_is_treated_as_feasible():
+    """The 'ce' refinement: no penalty discontinuity right at the feasible boundary.
+
+    Inside the band the merit is exactly ``f``; a hair outside it the penalty
+    switches on. Both arms are asserted so the test fails if the band widens to
+    everything or collapses to nothing.
+    """
+    inside = _merit(f=[4.0], v=[1e-6], best=5.0, eps=1e-3)
+    assert inside[0] == pytest.approx(4.0)
+
+    outside = _merit(f=[4.0], v=[1e-2], best=5.0, eps=1e-3)
+    assert outside[0] == pytest.approx(4.0 + 1e-2 + 1.0)
+
+
+def test_the_band_boundary_is_inclusive():
+    """``v == eps_cons`` counts as feasible, matching ``_offer`` in both backends.
+
+    The incumbent bookkeeping accepts ``viol <= eps_cons``; if the merit used a
+    strict ``<`` the point that became the incumbent would still be ranked as
+    infeasible.
+    """
+    assert _merit(f=[4.0], v=[1e-3], best=5.0, eps=1e-3)[0] == pytest.approx(4.0)
+
+
+def test_an_unconstrained_model_ranks_by_the_objective_alone():
+    """Zero violation everywhere reduces the rule to ``f``."""
+    merit = _merit(f=[3.0, 1.0, 2.0], v=[0.0, 0.0, 0.0], best=1.0)
+    np.testing.assert_allclose(merit, [3.0, 1.0, 2.0])
+
+
+# -- the finite_fill choice ---------------------------------------------------
+
+
+def test_finite_fill_false_leaves_an_undefined_objective_at_infinity():
+    """DIRECT's setting: the merit is only compared, so ``+inf`` loses everything.
+
+    This is the honest ranking for "the black box had no value here", and it
+    costs nothing because the value is never fitted.
+    """
+    merit = _merit(f=[1.0, 3.0, np.inf], v=[0.0, 0.0, 0.0], best=1.0, finite_fill=False)
+    assert np.isinf(merit[2])
+    assert np.isfinite(merit[:2]).all()
+
+
+def test_finite_fill_true_maps_an_undefined_objective_to_a_finite_worst_case():
+    """The surrogate's setting: an infinite right-hand side has no fit.
+
+    ``+inf`` makes every interpolation coefficient ``nan``; dropping the point
+    throws away the one thing it does tell us, which is that the region is bad.
+    Mapping it to the worst finite merit plus the observed spread keeps both.
+    """
+    merit = _merit(f=[1.0, 3.0, np.inf], v=[0.0, 0.0, 0.0], best=1.0, finite_fill=True)
+    assert np.all(np.isfinite(merit))
+    assert merit[2] > merit[1]
+    assert merit[2] == pytest.approx(3.0 + (3.0 - 1.0) + 1.0)
+
+
+def test_finite_fill_true_with_no_finite_merit_at_all_is_well_posed():
+    """Every point undefined leaves no spread to borrow; the fit must still exist.
+
+    Zeros are uninformative but finite, which is the only property the
+    interpolation system needs. ``nan`` or ``inf`` here would propagate into every
+    coefficient.
+    """
+    merit = _merit(f=[np.inf, np.inf], v=[0.0, 0.0], best=1.0, finite_fill=True)
+    np.testing.assert_allclose(merit, [0.0, 0.0])
+
+
+def test_finite_fill_does_not_disturb_an_all_finite_merit():
+    """The fill is a repair, not a transform: with nothing to repair it is identity."""
+    args = dict(f=[3.0, 1.0, 7.0], v=[0.0, 2.0, 0.0], best=1.0)
+    np.testing.assert_allclose(_merit(**args, finite_fill=True), _merit(**args, finite_fill=False))
+
+
+def test_an_empty_point_set_returns_an_empty_merit():
+    """Called before the first evaluation lands; must not raise on either fill."""
+    for fill in (True, False):
+        assert _merit(f=[], v=[], best=None, finite_fill=fill).shape == (0,)
+        assert _merit(f=[], v=[], best=1.0, finite_fill=fill).shape == (0,)
+
+
+# -- the scalar wrapper -------------------------------------------------------
+
+
+@pytest.mark.parametrize("best", [None, 10.0])
+@pytest.mark.parametrize("fval,viol", [(4.0, 0.0), (4.0, 1e-8), (4.0, 3.0), (np.inf, 0.0)])
+def test_the_scalar_wrapper_agrees_with_the_array_form(fval, viol, best):
+    """``glce_merit_scalar`` must be the array rule at ``n=1``, not a second rule.
+
+    That is the drift the shared module exists to prevent, so it is asserted
+    rather than assumed — including on the ``+inf`` arm, where a hand-written
+    scalar copy would be easy to get subtly different.
+    """
+    expected = _merit(f=[fval], v=[viol], best=best, finite_fill=False)[0]
+    got = glce_merit_scalar(fval, viol, best, 1e-6)
+    if np.isinf(expected):
+        assert np.isinf(got) and np.sign(got) == np.sign(expected)
+    else:
+        assert got == pytest.approx(expected)
+
+
+# ── the two backends see identical values ────────────────────────────────────
+
+
+def _opaque_constrained_model() -> dm.Model:
+    """A model whose objective and constraint bodies are both opaque ``dm.custom``.
+
+    Opaque on purpose: this is the regime both backends exist for, and it is the
+    case where a divergence in the oracle would be least visible — there is no
+    algebraic form to check the evaluated value against.
+    """
+    m = dm.Model("dfo_oracle_parity")
+    x = m.continuous("x", shape=2, lb=-2.0, ub=3.0)
+    k = m.integer("k", lb=0, ub=4)
+    m.minimize(dm.custom(lambda v: v[0] ** 2 + 3.0 * v[1], name="obj")(x))
+    # Two constraints with different bound shapes so cl and cu are both exercised.
+    m.subject_to(dm.custom(lambda v: v[0] * v[1], name="c_bilinear")(x) <= 1.0)
+    m.subject_to(dm.custom(lambda a, b: a + b, name="c_couple")(x[0], k) >= -1.0)
+    return m
+
+
+def _sample_points(rng: np.random.Generator, n_vars: int, n_points: int) -> list[np.ndarray]:
+    """Points spanning feasible, infeasible and boundary regions of the box."""
+    return [rng.uniform(-2.0, 3.0, size=n_vars) for _ in range(n_points)]
+
+
+def test_the_two_backends_evaluate_a_point_identically():
+    """The property the duplication was trusted to preserve and nothing checked.
+
+    Routed through each backend's *own* entry point (``direct.build_oracle`` and
+    ``surrogate.build_oracle`` as each module imports it), so it fails if either
+    backend stops using the shared implementation — not just if the shared one
+    changes. Values must match exactly, not approximately: they come from the same
+    evaluator, so any difference at all is plumbing.
+    """
+    from discopt.solvers import direct as direct_mod
+    from discopt.solvers import surrogate as surrogate_mod
+
+    model = _opaque_constrained_model()
+    d_oracle, d_n, d_mask = direct_mod.build_oracle(model, log_prefix="DIRECT")
+    s_oracle, s_n, s_mask = surrogate_mod.build_oracle(model, log_prefix="surrogate")
+
+    assert d_n == s_n
+    np.testing.assert_array_equal(d_mask, s_mask)
+    assert d_mask.any(), "the parity model must exercise the integer-mask path"
+
+    rng = np.random.default_rng(20260813)
+    compared = 0
+    saw_feasible = False
+    saw_infeasible = False
+    for x in _sample_points(rng, d_n, 40):
+        f_d, v_d = d_oracle(x)
+        f_s, v_s = s_oracle(x)
+        assert f_d == f_s, (x, f_d, f_s)
+        assert v_d == v_s, (x, v_d, v_s)
+        compared += 1
+        saw_feasible |= v_d == 0.0
+        saw_infeasible |= v_d > 0.0
+
+    # CLAUDE.md §6: prove the probe fired, and that it covered both verdicts --
+    # a run that only ever saw feasible points would not test the violation sum.
+    assert compared == 40, compared
+    assert saw_feasible and saw_infeasible, (saw_feasible, saw_infeasible)
+
+
+def test_the_two_backends_agree_on_an_unconstrained_model():
+    """The ``cl is None`` branch, which the constrained parity test never reaches."""
+    from discopt.solvers import direct as direct_mod
+    from discopt.solvers import surrogate as surrogate_mod
+
+    m = dm.Model("dfo_oracle_parity_unconstrained")
+    x = m.continuous("x", shape=2, lb=-1.0, ub=1.0)
+    m.minimize(dm.custom(lambda v: v[0] ** 2 + v[1] ** 2, name="obj")(x))
+
+    d_oracle, d_n, _ = direct_mod.build_oracle(m, log_prefix="DIRECT")
+    s_oracle, _, _ = surrogate_mod.build_oracle(m, log_prefix="surrogate")
+
+    rng = np.random.default_rng(7)
+    compared = 0
+    for x_pt in _sample_points(rng, d_n, 10):
+        assert d_oracle(np.clip(x_pt, -1.0, 1.0)) == s_oracle(np.clip(x_pt, -1.0, 1.0))
+        compared += 1
+    assert compared == 10, compared
+
+
+@pytest.mark.parametrize(
+    "cl,cu",
+    [
+        ([-1.0], [1.0, 1.0]),  # cu too long
+        ([-1.0, -1.0, -1.0], [1.0, 1.0]),  # cl too long
+    ],
+)
+def test_a_constraint_bound_length_mismatch_is_refused(monkeypatch, cl, cu):
+    """The guard that had to be applied twice — now once, so it cannot diverge again.
+
+    A length mismatch against ``g`` is a *legal* numpy broadcast, so it produces a
+    silently wrong violation — a wrong feasibility verdict, not a crash. Both
+    directions are covered because a one-sided check would pass one of them.
+
+    ``_infer_constraint_bounds`` is patched at its definition site rather than on
+    ``_dfo_common``, since ``build_oracle`` imports it inside the function body.
+    """
+    import discopt.solver as solver_mod
+    from discopt.solvers._dfo_common import build_oracle as shared_build_oracle
+
+    monkeypatch.setattr(
+        solver_mod,
+        "_infer_constraint_bounds",
+        lambda model, evaluator: (np.array(cl), np.array(cu)),
+    )
+    with pytest.raises(ValueError, match="constraint bounds do not match the evaluator"):
+        shared_build_oracle(_opaque_constrained_model(), log_prefix="DIRECT")
+
+
+def test_matched_constraint_bounds_are_not_refused():
+    """No-false-refusal control for the guard above."""
+    from discopt.solvers._dfo_common import build_oracle as shared_build_oracle
+
+    oracle, n_vars, _ = shared_build_oracle(_opaque_constrained_model(), log_prefix="DIRECT")
+    fval, viol = oracle(np.zeros(n_vars))
+    assert np.isfinite(fval) and np.isfinite(viol)

--- a/python/tests/test_direct_units.py
+++ b/python/tests/test_direct_units.py
@@ -26,6 +26,7 @@ os.environ.setdefault("JAX_ENABLE_X64", "1")
 
 import numpy as np
 import pytest
+from discopt.solvers._dfo_common import glce_merit
 from discopt.solvers.direct import (
     _DirectSearch,
     _lower_right_hull,
@@ -237,37 +238,55 @@ def test_evaluation_cache_serves_repeated_points():
 # ── constraint handling (DIRECT-GLce) ────────────────────────────────────────
 
 
-def test_glce_phase_a_ranks_by_violation_before_any_feasible_point():
-    """With nothing feasible yet, the search minimizes total violation."""
-    s = _DirectSearch(np.zeros(1), np.ones(1))
-    s.part.add(np.array([0.5]), np.zeros(1, dtype=np.int64), 100.0, 5.0)
-    s.part.add(np.array([0.5]), np.zeros(1, dtype=np.int64), -100.0, 9.0)
-    assert s.best_feasible_value is None
-    ranks = s.rank_values()
-    assert ranks[0] < ranks[1], "phase A must prefer the less-violating point"
+def test_rank_values_reads_the_partition_through_the_shared_merit_rule():
+    """``rank_values`` is wiring, not a formula: the rule lives in ``_dfo_common``.
 
-
-def test_glce_phase_b_denies_credit_to_infeasible_low_objective():
-    """An infeasible point cannot outrank the incumbent by having a lower objective.
-
-    The ``|f - f_min|`` term is what removes that credit, and it needs no penalty
-    weight to be tuned.
+    The rule's own behaviour (both phases, the ``ε_cons`` band, ``finite_fill``)
+    is covered in ``test_dfo_common``. What is checked *here* is what only this
+    class can get wrong — that it feeds the partition's own ``fvals``/``viols``
+    and its own incumbent and tolerance, in that order.
     """
-    s = _DirectSearch(np.zeros(1), np.ones(1))
-    s.best_feasible_value = 10.0
-    s.part.add(np.array([0.5]), np.zeros(1, dtype=np.int64), 10.0, 0.0)  # feasible incumbent
-    s.part.add(np.array([0.5]), np.zeros(1, dtype=np.int64), -1e6, 3.0)  # infeasible, great f
-    ranks = s.rank_values()
-    assert ranks[0] < ranks[1], "an infeasible point must not win on objective alone"
-
-
-def test_glce_treats_violation_within_eps_cons_as_feasible():
-    """The 'ce' refinement: no penalty discontinuity right at the feasible boundary."""
     s = _DirectSearch(np.zeros(1), np.ones(1))
     s.best_feasible_value = 5.0
     s.eps_cons = 1e-3
-    s.part.add(np.array([0.5]), np.zeros(1, dtype=np.int64), 4.0, 1e-6)
-    assert s.rank_values()[0] == pytest.approx(4.0)
+    s.part.add(np.array([0.5]), np.zeros(1, dtype=np.int64), 4.0, 1e-6)  # inside the band
+    s.part.add(np.array([0.5]), np.zeros(1, dtype=np.int64), -1e6, 3.0)  # infeasible, great f
+
+    expected = glce_merit(
+        np.array(s.part.fvals, dtype=np.float64),
+        np.array(s.part.viols, dtype=np.float64),
+        s.best_feasible_value,
+        s.eps_cons,
+        finite_fill=False,
+    )
+    np.testing.assert_array_equal(s.rank_values(), expected)
+    assert s.rank_values()[0] < s.rank_values()[1], "an infeasible point must not win on f alone"
+
+
+def test_rank_values_leaves_an_undefined_objective_at_infinity():
+    """DIRECT ranks by comparison, so ``finite_fill=False`` is the right choice here.
+
+    A point where the black box was undefined carries ``+inf``, which loses every
+    comparison and is never selected. This pins the flag: the surrogate backend
+    passes ``True`` because it *fits* the merit, and picking that up here would
+    make an undefined point selectable.
+    """
+    s = _DirectSearch(np.zeros(1), np.ones(1))
+    s.best_feasible_value = 1.0
+    s.part.add(np.array([0.5]), np.zeros(1, dtype=np.int64), 1.0, 0.0)
+    s.part.add(np.array([0.5]), np.zeros(1, dtype=np.int64), np.inf, 0.0)
+    assert np.isinf(s.rank_values()[1])
+
+
+def test_scalar_rank_matches_rank_values_on_the_same_point():
+    """The one-at-a-time ranker used by the polish must not drift from the batch one."""
+    s = _DirectSearch(np.zeros(1), np.ones(1))
+    s.best_feasible_value = 10.0
+    s.eps_cons = 1e-3
+    for fval, viol in [(10.0, 0.0), (4.0, 1e-6), (-1e6, 3.0)]:
+        s.part = type(s.part)()
+        s.part.add(np.array([0.5]), np.zeros(1, dtype=np.int64), fval, viol)
+        assert s._scalar_rank(fval, viol) == pytest.approx(s.rank_values()[0])
 
 
 # ── engine-level behaviour ───────────────────────────────────────────────────

--- a/python/tests/test_surrogate_units.py
+++ b/python/tests/test_surrogate_units.py
@@ -28,6 +28,7 @@ import math
 
 import numpy as np
 import pytest
+from discopt.solvers._dfo_common import glce_merit
 from discopt.solvers.surrogate import (
     AcquisitionNotExpressible,
     KrigingSurrogate,
@@ -444,34 +445,40 @@ def test_a_repeated_point_is_refused_rather_than_duplicated_in_the_design():
     assert s.stats.evals == 1
 
 
-def test_merit_ranks_violation_first_then_objective():
-    """The GLce merit the surrogate is fitted to, in both phases.
+def test_merits_reads_the_evaluated_points_through_the_shared_merit_rule():
+    """``merits`` is wiring, not a formula: the rule lives in ``_dfo_common``.
 
-    Phase A (nothing feasible known) ranks by total violation so the search first
-    hunts for feasibility; phase B denies an infeasible point credit for a low
-    objective via the ``|f - f_min|`` term, which needs no penalty weight tuned.
-    Same construction as ``_DirectSearch.rank_values`` on purpose — the two
-    backends must optimize the same thing to be comparable.
+    The rule's own behaviour (both phases, the ``ε_cons`` band, ``finite_fill``)
+    is covered in ``test_dfo_common``, shared with ``_DirectSearch.rank_values``
+    so the two backends cannot rank the same point differently. What is checked
+    *here* is what only this class can get wrong — that it feeds its own ``f``,
+    ``viol``, incumbent and tolerance, in that order.
     """
     s = _SurrogateSearch(np.zeros(1), np.ones(1))
     s.X = [np.array([0.1]), np.array([0.2])]
-    s.f = [100.0, -100.0]
-    s.viol = [5.0, 9.0]
-    assert s.best_feasible_value is None
-    assert s.merits()[0] < s.merits()[1], "phase A must prefer the less-violating point"
-
-    s.best_feasible_value = 10.0
     s.f = [10.0, -1e6]
     s.viol = [0.0, 3.0]
+    s.best_feasible_value = 10.0
+
+    expected = glce_merit(
+        np.asarray(s.f, dtype=np.float64),
+        np.asarray(s.viol, dtype=np.float64),
+        s.best_feasible_value,
+        s.eps_cons,
+        finite_fill=True,
+    )
+    np.testing.assert_array_equal(s.merits(), expected)
     assert s.merits()[0] < s.merits()[1], "an infeasible point must not win on objective alone"
 
 
-def test_merit_maps_an_undefined_objective_to_a_finite_worst_case():
-    """A black box that returns nothing must not poison the interpolation system.
+def test_merits_maps_an_undefined_objective_to_a_finite_worst_case():
+    """This backend *fits* the merit, so it must pass ``finite_fill=True``.
 
-    ``+inf`` in the right-hand side makes every coefficient ``nan``; dropping the
-    point throws away the one thing it does tell us, which is that the region is
-    bad. Mapping it to the worst finite merit plus the observed spread keeps both.
+    ``+inf`` in the right-hand side makes every interpolation coefficient ``nan``;
+    dropping the point throws away the one thing it does tell us, which is that
+    the region is bad. This pins the flag rather than the fill arithmetic (which
+    ``test_dfo_common`` covers): picking up DIRECT's ``False`` here would silently
+    break every fit that touches an undefined point.
     """
     s = _SurrogateSearch(np.zeros(1), np.ones(1))
     s.X = [np.array([0.1]), np.array([0.2]), np.array([0.3])]

--- a/scripts/dfo_extraction_neutrality_panel.py
+++ b/scripts/dfo_extraction_neutrality_panel.py
@@ -1,0 +1,330 @@
+"""Bound-neutrality panel for the ``_dfo_common`` extraction (issue #1010).
+
+Issue #1010 is a **pure refactor**: the oracle and the DIRECT-GLce merit rule move
+out of ``solvers/direct.py`` and ``solvers/surrogate.py`` into
+``solvers/_dfo_common.py``, and neither backend keeps a copy. CLAUDE.md §5's
+bound-neutral regime therefore applies with no slack: ``solve_direct`` and
+``solve_surrogate`` must return *exactly* unchanged objective, point, and
+evaluation count. Any drift — even an apparent improvement — means the extraction
+changed behaviour.
+
+Usage::
+
+    python -u scripts/dfo_extraction_neutrality_panel.py record out.json
+    python -u scripts/dfo_extraction_neutrality_panel.py compare before.json after.json
+
+``record`` is run once on the baseline tree and once on the branch; ``compare``
+does the exact comparison. Splitting it that way is what lets the baseline run
+happen in a worktree checked out at the merge base, which is the only way to
+measure "unchanged" for a refactor that deletes the old code.
+
+Determinism, deliberately:
+
+* every arm has an ``max_evals`` budget and a *generous* ``time_limit``. An arm
+  whose status is ``time_limit`` is recorded as such and makes the comparison
+  fail loudly rather than silently comparing two different amounts of work —
+  a wall-clock budget produces a different answer on a busier machine with no
+  code change involved (CLAUDE.md §9).
+* the surrogate backend is seeded; DIRECT has no RNG.
+* ``local_refine`` arms use ``derivative-free``, whose Powell budget is an
+  evaluation count. The ``nlp`` refiner takes ``deadline - now`` as its own time
+  limit, so it is wall-clock dependent by construction and cannot be part of a
+  byte-exact panel.
+* the surrogate arms use ``acquisition_optimizer="multistart"`` for the same
+  reason. The default ``"auto"`` path runs discopt's spatial B&B on the
+  acquisition under ``acquisition_time_limit`` (20s) and falls back to its
+  incumbent when that binds, so which point it proposes depends on how much B&B
+  fits in 20s — a busier machine proposes a different point with no code change
+  involved. Multistart is seeded and has no clock in it.
+
+Two limits this panel states rather than hides:
+
+* it does **not** cover the certified/B&B acquisition path, for the reason above.
+  That path consumes the extracted code only through ``merits()`` (via
+  ``_acquisition_f_min``), which every multistart arm exercises identically, and
+  ``python/tests/test_surrogate.py`` covers it end to end.
+* ``direct/phase_a_only`` reports no objective and no point by design (nothing in
+  its box is feasible). Its comparison is the evaluation count, the status and
+  the full counter dict — which is exactly the phase-A merit path.
+
+The panel covers, for each backend, the paths the extracted code actually has:
+the unconstrained oracle (``cl is None``), the constrained oracle (the violation
+sum), an integer model (the integer mask), phase A (nothing feasible in the box)
+and phase B, and — for DIRECT — the scalar merit via the derivative-free polish.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import sys
+
+os.environ.setdefault("JAX_PLATFORMS", "cpu")
+os.environ.setdefault("JAX_ENABLE_X64", "1")
+
+from pathlib import Path  # noqa: E402
+
+import discopt  # noqa: E402
+import discopt.modeling as dm  # noqa: E402
+import numpy as np  # noqa: E402
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "python" / "tests"))
+from support import direct_testfuncs as tfs  # noqa: E402
+
+TIME_LIMIT = 600.0
+
+# See the module docstring: the default "auto" acquisition is wall-clock bounded,
+# so it cannot be part of a byte-exact panel. Multistart is seeded and clock-free.
+_ACQ = {"acquisition_optimizer": "multistart"}
+
+
+# ── the panel ────────────────────────────────────────────────────────────────
+
+
+def _testfunc_model(name: str):
+    model, _ = tfs.build_model(tfs.get(name))
+    return model
+
+
+def _constrained_model():
+    """Feasible region reachable from the box: phase A then phase B."""
+    m = dm.Model("dfo_panel_constrained")
+    x = m.continuous("x", shape=2, lb=-2.0, ub=2.0)
+    m.minimize(dm.custom(lambda v: v[0] ** 2 + v[1] ** 2 + 3.0 * v[0], name="obj")(x))
+    m.subject_to(dm.custom(lambda v: v[0] * v[1], name="bilin")(x) <= 0.5)
+    m.subject_to(dm.custom(lambda v: v[0] + v[1], name="lin")(x) >= -1.0)
+    return m
+
+
+def _infeasible_model():
+    """No point in the box is feasible: the run stays in phase A throughout.
+
+    Phase A is the arm where the merit rule is *only* the violation, so a drift
+    that cancelled inside the phase-B formula would still show here.
+    """
+    m = dm.Model("dfo_panel_phase_a")
+    x = m.continuous("x", shape=2, lb=0.0, ub=1.0)
+    m.minimize(dm.custom(lambda v: v[0] + v[1], name="lin")(x))
+    m.subject_to(x[0] + x[1] >= 10.0)
+    return m
+
+
+def _integer_model():
+    """Exercises the integer mask ``build_oracle`` returns."""
+    m = dm.Model("dfo_panel_integer")
+    a = m.continuous("a", lb=-3.0, ub=3.0)
+    k = m.integer("k", lb=-4, ub=4)
+    m.minimize(dm.custom(lambda p, q: (p - 1.3) ** 2 + (q - 2.0) ** 2, name="obj")(a, k))
+    m.subject_to(dm.custom(lambda p, q: p + q, name="sum")(a, k) <= 4.0)
+    return m
+
+
+def cases() -> list[tuple[str, object, dict]]:
+    """``(case_id, model_factory, solve kwargs)``, in a fixed order."""
+    out: list[tuple[str, object, dict]] = []
+
+    # -- DIRECT ---------------------------------------------------------------
+    for name in ("branin", "six_hump_camel", "rastrigin_2", "sphere_2", "hartman_3"):
+        out.append(
+            (
+                f"direct/{name}",
+                lambda name=name: _testfunc_model(name),
+                dict(solver="direct", max_evals=400, local_refine=False),
+            )
+        )
+    out.append(
+        (
+            "direct/branin+dfo_refine",  # the scalar merit path (_scalar_rank)
+            lambda: _testfunc_model("branin"),
+            dict(
+                solver="direct",
+                max_evals=400,
+                local_refine=True,
+                local_refine_method="derivative-free",
+            ),
+        )
+    )
+    out.append(
+        (
+            "direct/constrained",
+            _constrained_model,
+            dict(solver="direct", max_evals=400, local_refine=False),
+        )
+    )
+    out.append(
+        (
+            "direct/phase_a_only",
+            _infeasible_model,
+            dict(solver="direct", max_evals=200, local_refine=False),
+        )
+    )
+    out.append(
+        (
+            "direct/integer",
+            _integer_model,
+            dict(solver="direct", max_evals=300, local_refine=False),
+        )
+    )
+
+    # -- surrogate ------------------------------------------------------------
+    for name in ("branin", "six_hump_camel", "sphere_2"):
+        out.append(
+            (
+                f"surrogate/{name}",
+                lambda name=name: _testfunc_model(name),
+                dict(solver="surrogate", max_evals=60, seed=11, **_ACQ),
+            )
+        )
+    out.append(
+        (
+            "surrogate/branin+kriging",
+            lambda: _testfunc_model("branin"),
+            dict(solver="surrogate", max_evals=50, seed=11, surrogate="kriging", **_ACQ),
+        )
+    )
+    out.append(
+        (
+            "surrogate/constrained",
+            _constrained_model,
+            dict(solver="surrogate", max_evals=60, seed=11, **_ACQ),
+        )
+    )
+    out.append(
+        (
+            "surrogate/phase_a_only",
+            _infeasible_model,
+            dict(solver="surrogate", max_evals=40, seed=11, **_ACQ),
+        )
+    )
+    out.append(
+        (
+            "surrogate/integer",
+            _integer_model,
+            dict(solver="surrogate", max_evals=60, seed=11, **_ACQ),
+        )
+    )
+    return out
+
+
+# ── record ───────────────────────────────────────────────────────────────────
+
+
+def _point(result) -> object:
+    if result.x is None:
+        return None
+    # repr of the exact float bits: this panel compares byte-exactly, so a
+    # rounded decimal here would hide precisely the drift it is looking for.
+    return {
+        k: [v.hex() for v in np.asarray(val, dtype=np.float64).reshape(-1)]
+        for k, val in sorted(result.x.items())
+    }
+
+
+def record(path: str) -> int:
+    # CLAUDE.md §8: prove which code is loaded before measuring anything.
+    print(f"discopt from {discopt.__file__}", flush=True)
+    marker = "present" if importlib.util.find_spec("discopt.solvers._dfo_common") else "absent"
+    print(f"marker discopt.solvers._dfo_common: {marker}", flush=True)
+
+    rows: dict[str, dict] = {}
+    timed_out: list[str] = []
+    for case_id, factory, kwargs in cases():
+        model = factory()
+        result = model.solve(time_limit=TIME_LIMIT, **kwargs)
+        backend = case_id.split("/", 1)[0]
+        # Every counter in DirectStats/SurrogateStats, not just ``evals``: they
+        # are all integers with no wall-clock term, so the whole dict is a legal
+        # byte-exact comparison and a wider one than the issue asks for.
+        stats = {
+            k: v for k, v in (result.solver_stats or {}).items() if k.startswith(backend + "/")
+        }
+        row = {
+            "status": result.status,
+            "objective": None if result.objective is None else float(result.objective).hex(),
+            "x": _point(result),
+            "evals": stats.get(f"{backend}/evals"),
+            "stats": stats,
+            "node_count": result.node_count,
+        }
+        rows[case_id] = row
+        if result.status == "time_limit":
+            timed_out.append(case_id)
+        print(
+            f"  {case_id:34s} status={row['status']:15s} evals={row['evals']!r:6} "
+            f"obj={result.objective!r}",
+            flush=True,
+        )
+
+    payload = {"marker": marker, "discopt_file": discopt.__file__, "rows": rows}
+    Path(path).write_text(json.dumps(payload, indent=1, sort_keys=True))
+    print(f"\nrecorded {len(rows)} cases -> {path}", flush=True)
+    if timed_out:
+        # Not a failure of the refactor, but the panel cannot claim neutrality on
+        # an arm whose work was cut by a clock (CLAUDE.md §9).
+        print(f"WARNING: {len(timed_out)} arm(s) hit the time backstop: {timed_out}", flush=True)
+    if not rows:
+        print("PANEL RECORDED NOTHING")
+        return 2
+    return 0
+
+
+# ── compare ──────────────────────────────────────────────────────────────────
+
+
+def compare(before_path: str, after_path: str) -> int:
+    before = json.loads(Path(before_path).read_text())
+    after = json.loads(Path(after_path).read_text())
+    print(f"before: marker={before['marker']}  {before['discopt_file']}")
+    print(f"after:  marker={after['marker']}   {after['discopt_file']}")
+    if before["marker"] != "absent" or after["marker"] != "present":
+        # The whole point of the baseline is that it predates the extraction. If
+        # both trees have the shared module, the "baseline" is the branch and the
+        # comparison measures nothing (CLAUDE.md §8).
+        print(
+            "BASELINE/BRANCH MARKERS ARE WRONG: baseline must lack the module, branch must have it"
+        )
+        return 2
+
+    b_rows, a_rows = before["rows"], after["rows"]
+    missing = sorted(set(b_rows) ^ set(a_rows))
+    if missing:
+        print(f"CASE SETS DIFFER: {missing}")
+        return 2
+
+    compared = 0
+    drift: list[str] = []
+    for case_id in sorted(b_rows):
+        b, a = b_rows[case_id], a_rows[case_id]
+        if b["status"] == "time_limit" or a["status"] == "time_limit":
+            print(f"  {case_id:34s} INCONCLUSIVE (time backstop bound an arm), not counted")
+            continue
+        compared += 1
+        for field in ("status", "objective", "x", "evals", "stats", "node_count"):
+            if b[field] != a[field]:
+                drift.append(f"{case_id}: {field} {b[field]!r} -> {a[field]!r}")
+        print(f"  {case_id:34s} {'identical' if b == a else 'DRIFT'}")
+
+    # CLAUDE.md §6: an executed-comparison count, and a non-zero exit when it is
+    # zero. A panel that skipped everything must not read as a pass.
+    print(f"\ncompared={compared} cases across {len(b_rows)} arms")
+    for d in drift:
+        print(f"DRIFT {d}")
+    if compared == 0:
+        print("PANEL COMPARED NOTHING")
+        return 2
+    if drift:
+        print(f"{len(drift)} drift findings — the extraction is NOT bound-neutral")
+        return 1
+    print("no drift: objective, point and evaluation count are exactly unchanged")
+    return 0
+
+
+if __name__ == "__main__":
+    if len(sys.argv) >= 3 and sys.argv[1] == "record":
+        sys.exit(record(sys.argv[2]))
+    if len(sys.argv) >= 4 and sys.argv[1] == "compare":
+        sys.exit(compare(sys.argv[2], sys.argv[3]))
+    print(__doc__)
+    print("usage: record <out.json> | compare <before.json> <after.json>")
+    sys.exit(2)


### PR DESCRIPTION
## Summary

Closes #1010.

`solvers/direct.py` and `solvers/surrogate.py` each carried a copy of the two things that must agree exactly: `_build_oracle` (what a point is *worth*) and the DIRECT-GLce merit rule (which point is *better*). The duplication had already cost something — the `cl`/`cu` shape guard landed in `direct` first and had to be applied to `surrogate` separately in 602b92f, and that guard protects a *feasibility verdict*, so the copy without it was silently wrong rather than loudly broken.

New `python/discopt/solvers/_dfo_common.py`:

- **`build_oracle(model, *, log_prefix)`** — one implementation; `log_prefix` only changes which backend name appears in the "evaluator backend is X" line.
- **`glce_merit(f, v, best_feasible_value, eps_cons, *, finite_fill)`** — the merit rule, with the non-finite fill as an explicit **required** argument. That was the one real difference between the two copies, and the shared module forces it to be a stated choice rather than an accident of which file was written second: DIRECT passes `False` because it only ever *compares* the merit (`+inf` loses every comparison — the honest ranking for "no value"); the surrogate passes `True` because it *fits* it (an infinite right-hand side makes the interpolation system meaningless). The issue raised this as an open question; the answer is recorded in the docstring.
- **`glce_merit_scalar(...)`** for `_DirectSearch._scalar_rank`, delegating to the array form rather than restating the formula.

Neither backend keeps a copy: no `_build_oracle` body and no merit formula remains in either file.

`scripts/dfo_extraction_neutrality_panel.py` is the bound-neutrality panel (below), kept as a rerunnable script rather than a number in a comment.

## Correctness

Pure refactor of a backend that issues **no certificate at all** — `solve_direct` and `solve_surrogate` return `bound=None`, `gap=None`, `gap_certified=False`, and never `status="optimal"`/`"infeasible"`. So there is no certificate this change could falsify, and the panel below shows the returned incumbents are bit-identical anyway.

The one guard involved is strengthened rather than weakened: the `cl`/`cu` length check now exists in exactly one place instead of two that must be kept in sync by hand. A length mismatch is a *legal* numpy broadcast, so it produces a silently wrong violation — a wrong feasibility verdict, not a crash — which is why it refuses loudly.

- [x] Cannot produce a false certificate (this backend issues none; incumbents bit-identical per the panel)
- [x] No validation, fallback, or safety guard was weakened to make a check pass

## Tests run (state the result — numbers, not adjectives)

- [x] `pytest -m smoke` → **1004 passed, 15 skipped, 8675 deselected, 2 xpassed** (322.98s)
- [x] `pytest -m slow python/tests/test_adversarial_recent_fixes.py` → **10 passed** (149.55s)
- [x] `cargo test -p discopt-core` → **N/A** — no Rust touched
- [x] `ruff check` / `ruff format --check` clean, and `mypy` clean on the three changed modules

Also run: the backends' own suites — `test_dfo_common`, `test_direct`, `test_direct_units`, `test_direct_heuristic`, `test_surrogate`, `test_surrogate_units`, `test_surrogate_protocol` → **179 passed**, plus the deselected slow arms of `test_direct`/`test_surrogate` → **33 passed**.

<sub>Note, unrelated to this branch: `ruff format --check` fails on `test_log_square_relaxation.py` and `test_mo_augmecon2.py` with the ruff that happens to be first on `PATH` in this environment (0.15.8). With the pinned 0.14.6 everything is clean. Both files are untouched here and fail identically on `main`.</sub>

## Regression test

New `python/tests/test_dfo_common.py` (23 tests):

- **The merit rule, directly** — both phases, the `ε_cons` band and its inclusive boundary, both `finite_fill` settings including the no-finite-merit and empty-input edges, and the scalar wrapper checked against the array form. This replaces the two partial coverings the issue names (`test_direct_units` covered phases + band; `test_surrogate_units` covered phases + fill — each of one copy).
- **The cross-backend identity** — the property the duplication was trusted to preserve and *nothing* checked: the two backends return identical `(f, v)` on 40 sampled points of a constrained model with opaque `dm.custom` bodies, routed through each backend's own entry point so it fails if either re-forks. It counts its comparisons and asserts it saw both a feasible and an infeasible verdict, so it cannot pass by measuring nothing (CLAUDE.md §6).

The two backend unit files keep *wiring* tests instead: each feeds its own arrays, incumbent and tolerance, and passes its own `finite_fill`.

**Mutation-tested, 4 arms, each reverted after:**

| Mutation | Result |
| --- | --- |
| Drop the `cl`/`cu` shape guard | both mismatch arms fail |
| `surrogate.merits` with `finite_fill=False` | its undefined-objective test fails |
| `direct.rank_values` with `finite_fill=True` | its `+inf` test fails |
| Surrogate re-forks the oracle without the violation sum | the parity test fails |

- [x] Added a regression test that fails before / passes after

## Bound-neutral verification (CLAUDE.md §5)

Not bound-*changing* — this is the bound-**neutral** regime, so the bar is *exactly* unchanged results and any drift, even an apparent improvement, means the extraction changed behaviour.

`scripts/dfo_extraction_neutrality_panel.py` records a 16-arm panel and compares byte-exactly. Run once on a merge-base worktree with the new module asserted **absent**, once on this branch with it asserted **present** (CLAUDE.md §8):

```
before: marker=absent   .../base/python/discopt/__init__.py
after:  marker=present  /home/user/discopt/python/discopt/__init__.py
  direct/branin … direct/branin+dfo_refine … direct/constrained …
  direct/phase_a_only … direct/integer … surrogate/branin+kriging … (16 arms)   identical

compared=16 cases across 16 arms
no drift: objective, point and evaluation count are exactly unchanged
```

- **Suite**: 16 arms — both backends × {unconstrained, constrained, integer, phase-A-only}, plus DIRECT's derivative-free polish (the `_scalar_rank` path) and a kriging arm. Together these cover every path the extracted code has: the `cl is None` branch, the violation sum, the integer mask, phase A, phase B and the scalar merit.
- **Baseline**: merge base `8930b49`, in a separate worktree.
- **Compared**: status, objective and every solution coordinate at `float.hex()` precision, plus the entire `DirectStats`/`SurrogateStats` counter dict — stricter than the `evals` the issue asks for.

Two limits the panel states rather than hides. The surrogate arms use `acquisition_optimizer="multistart"`: the default `auto` acquisition is bounded by a 20s wall clock and falls back to its B&B incumbent, so it proposes a different point on a busier machine with no code change involved (CLAUDE.md §9) — that path reaches the extracted code only through `merits()`, which every multistart arm exercises identically, and `test_surrogate.py` covers it end to end. Likewise `local_refine` arms use `derivative-free` (an evaluation budget) rather than `nlp` (which takes `deadline - now` as its own limit). The panel exits non-zero if it compared nothing.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nh2nLeAQnk5Dmk3vTVBAuz)_