### PR TITLE
fix(lp): #1008 certify the primal ray before claiming Unbounded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,35 @@ The release procedure that produces these entries is documented in
   test `cold_primal_does_not_claim_unbounded_on_a_bounded_lp` returns
   `Unbounded` (obj 351) without the certifier and `Numerical` with it, and
   asserts a rejection counter fired so the fixture is proven to reach the guard.
+
+- **A NaN variable bound reached the simplex and was read two contradictory
+  ways** (`fix(lp)`, #1008). The modeling layer spells "no bound" as **NaN**
+  (`Model.continuous(ub=None)` stores `array(nan)`); the LP layer spells it as
+  the sentinel `±1e20`. Nothing translated between them, and an untranslated NaN
+  does not fail loudly — every comparison against it is false, so each guard
+  reads it as whichever answer its comparison happens to be written for. The
+  ratio test asks `ub < INF` ("does this bound block?") and calls a NaN bound
+  **open**, stepping to `t = INF`; the ray certifier above asks `ub >= INF` ("is
+  this side open?") and calls the same bound **closed**. This is the
+  `INF`-is-`1e20` hazard already documented in `CLAUDE.md`, in its other guise:
+  there the sentinel silently survives a multiplication, here it is silently
+  absent.
+
+  Found by the certifier: a Benders recourse LP (`min -w` over `w ∈ [0, NaN]`,
+  `-w ≤ 0`) had been reported `unbounded` on the strength of a box no guard could
+  certify as recessive. That verdict was correct — the LP *is* unbounded below —
+  but it was correct by luck, resting on which of the two readings the ratio test
+  happened to use, over a box the engine could not derive it from.
+
+  Both halves are fixed: `lp_simplex._finite_box` translates the box (NaN and
+  `±inf`, and any magnitude past the sentinel, onto `±1e20`) so the simplex sees
+  one convention, and the PyO3 LP/MILP entry points refuse a NaN bound with a
+  `ValueError` naming the index, so a caller that skips the translation gets a
+  loud error instead of a verdict derived from two incompatible readings of the
+  same number. `±inf` is deliberately *not* refused: it satisfies `>= INF` and
+  fails `< INF`, so both readings already agree it is open. Regression tests in
+  `python/tests/test_1008_nan_lp_bound.py` fail without the translation
+  (`ValueError: ub[0] is NaN`) and pass with it.
   The pre-existing `unbounded_detected` / `unbounded_emits_a_valid_primal_ray`
   tests confirm a genuine unbounded ray still certifies untouched.
   `cargo test -p discopt-core` → 610 passed.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,51 @@ The release procedure that produces these entries is documented in
 
 ### Fixed
 
+- **The primal simplex could return a false `Unbounded` on a bounded LP**
+  (`fix(lp)`, #1008). The ratio test now certifies the primal ray before the
+  verdict is issued: `A d = 0`, `cᵀd < 0` under the cost the phase is actually
+  minimizing, and box recession on every coordinate `d` moves. A ray that fails
+  any of the three is a numerical breakdown, not an unbounded LP, so the status
+  becomes `Numerical` — an honest refusal, and the one that routes into
+  `dense_retry`'s dense-LU path, which a false `Unbounded` bypassed entirely.
+
+  `Infeasible` has never been taken on faith (`farkas_ray_certifies_cols`);
+  `Unbounded` was, and the asymmetry was not justified. "No basic variable
+  blocks" is a statement *about* `α = B⁻¹A_q`, so a silently broken ftran
+  produces it verbatim. On the captured QPLIB_2170 root relaxation it did: every
+  basic `α` came back zero for a column that is not zero, giving a ray with a
+  single nonzero, `|A d| = 1.0` and `cᵀd = 0`, against an LP HiGHS certifies
+  optimal at 0 in 81 pivots.
+
+  What that cost depends on the driver. `spatial_tree::verdict_for` already
+  lumps `Unbounded` with `Numerical` into `Undecided`, so there the damage was
+  the bypassed `dense_retry`, not a bad bound. `milp_driver` is the serious one:
+  a node LP returning `Unbounded` sets `out.unbounded`, which breaks the search
+  (`hit_unbounded`) and short-circuits `decide_status` ahead of every other
+  branch — so a single false node verdict returns `MilpStatus::Unbounded` for a
+  bounded MILP, discarding any incumbent. That is a false certificate, which is
+  the one output §1 gives no slack at all.
+
+  The stall-bail flip below does not subsume this. End to end on QPLIB_2170's
+  root relaxation with `DISCOPT_LP_DUAL_STALL_BAIL=0` — the shipped default —
+  and `time_limit=None`, `UnboundedRejectRowResidual` is 2: the false verdict was
+  reachable without the bail ever firing. The externally visible outcome on that
+  cell is unchanged (no solution either way); what changed is that the engine no
+  longer *claims* a certificate it cannot support. The remaining loss on that
+  cell is a separate defect (the unstable-pivot recovery is gated on
+  `bank_deadline_duals`, so a caller passing no `time_limit` loses it — the same
+  LP solves to `optimal 0` with `time_limit=40.0`); it is not addressed here.
+
+  The margins are built from accumulation magnitudes, not from the result
+  (#1017); the relative slack is `1e-7` rather than `gamma(nnz)` because the
+  residual carries the LU solve's error, not just summation rounding. Regression
+  test `cold_primal_does_not_claim_unbounded_on_a_bounded_lp` returns
+  `Unbounded` (obj 351) without the certifier and `Numerical` with it, and
+  asserts a rejection counter fired so the fixture is proven to reach the guard.
+  The pre-existing `unbounded_detected` / `unbounded_emits_a_valid_primal_ray`
+  tests confirm a genuine unbounded ray still certifies untouched.
+  `cargo test -p discopt-core` → 610 passed.
+
 - **The #1013 degeneracy-stall bail could turn a certified optimum into no bound,
   and shipped default-ON** (`fix(lp)`, #1008). `DISCOPT_LP_DUAL_STALL_BAIL` is now
   **default-OFF**; `=1`/`true`/`on` opts in, and the mechanism itself is unchanged.

--- a/crates/discopt-core/src/lp/simplex/dual.rs
+++ b/crates/discopt-core/src/lp/simplex/dual.rs
@@ -2193,6 +2193,56 @@ mod tests {
         );
     }
 
+    // #1008: the cold primal must not CLAIM `Unbounded` on a bounded LP.
+    //
+    // Same captured QPLIB_2170 relaxation, entered through the cold path (no warm
+    // basis) — the route the stall bail hands off to. Before the ray certifier the
+    // cold solve returned `Unbounded` on an LP HiGHS certifies optimal at 0: every
+    // basic `α = B⁻¹A_q` came back zero for a column that is not zero, so the ratio
+    // test found no blocking row and the breakdown was read as a verdict. The
+    // captured ray had one nonzero, `|A d| = 1.0` and `cᵀd = 0` — it satisfies none
+    // of the three conditions an unbounded ray must satisfy.
+    //
+    // `Unbounded` on a minimization relaxation means a node bound of −∞, so a false
+    // one is a bound loss, not a slowdown. The certifier turns it into `Numerical`,
+    // an honest refusal that also routes into `dense_retry`'s dense-LU path.
+    #[test]
+    fn cold_primal_does_not_claim_unbounded_on_a_bounded_lp() {
+        let _guard = crate::profile::test_guard();
+        crate::profile::reset();
+        crate::profile::set_enabled(true);
+        let json = include_str!("testdata/qplib2170_cold_fail_lp.json");
+        let (m, n, col_ptr, row_idx, vals, c, l, u, b, _basic_vars, _col_status) =
+            parse_stall_fixture(json);
+        let sp = SparseCols::from_csc(col_ptr, row_idx, vals);
+        let mut o = opts();
+        o.bank_deadline_duals = true;
+
+        let cold = solve_csc_core(&sp, m, n, &c, &l, &u, &b, None, &o);
+        let rejects = crate::profile::counter(crate::profile::Ctr::UnboundedRejectRowResidual)
+            + crate::profile::counter(crate::profile::Ctr::UnboundedRejectObjective)
+            + crate::profile::counter(crate::profile::Ctr::UnboundedRejectBox);
+        crate::profile::set_enabled(false);
+
+        // The defect itself, asserted first so removing the guard reports the wrong
+        // *verdict* rather than a bookkeeping count.
+        assert_ne!(
+            cold.status,
+            LpStatus::Unbounded,
+            "cold solve claims Unbounded on an LP HiGHS certifies optimal at 0 \
+             (obj={})",
+            cold.obj
+        );
+        // And the probe fired: the certifier actually rejected a ray here, so the
+        // assertion above is exercising the guard and not an unrelated path where
+        // the fixture stopped reaching the ratio test's unbounded exit at all (§6).
+        assert!(
+            rejects > 0,
+            "the ray certifier never rejected anything on the LP that motivated it; \
+             this fixture no longer reaches the guard (rejects={rejects})"
+        );
+    }
+
     // #1008: the bound-neutrality the test above asserts is a property of THAT
     // fixture, not of the bail. It holds on `tspn12` because the cold solve the
     // bail hands off to happens to succeed. When the cold solve does *not* succeed,

--- a/crates/discopt-core/src/lp/simplex/primal.rs
+++ b/crates/discopt-core/src/lp/simplex/primal.rs
@@ -474,6 +474,18 @@ fn row_roundoff(terms: u32, term_scale: f64) -> f64 {
     8.0 * (terms as f64) * f64::EPSILON * term_scale
 }
 
+/// Relative slack allowed when certifying a primal unbounded ray (`ray_certifies_unbounded`).
+///
+/// Deliberately *not* `gamma(nnz)`: the residual `A d` carries the error of the LU
+/// solve that produced `α = B⁻¹A_q`, which is orders of magnitude above the
+/// summation rounding `γ` bounds. `1e-7` relative is loose enough that a ray from a
+/// healthy factorization certifies, and tight enough that the breakdown this guard
+/// exists for — `|A d| = 1.0` against an accumulation of `1.0`, a relative residual
+/// of 1 — is refused by a factor of 10⁷. A genuine unbounded ray rejected here means
+/// the factorization is that badly wrong, in which case `Numerical` is the right
+/// verdict on its own merits.
+const RAY_CERT_REL: f64 = 1e-7;
+
 /// The classic dot-product error factor `γ_k = k·u/(1 − k·u)` (Higham, *Accuracy and
 /// Stability of Numerical Algorithms*, §3.1): a sum of `k` floating-point terms
 /// evaluated in any order differs from the exact sum by at most `γ_k · Σ|terms|`.
@@ -1797,6 +1809,96 @@ impl<'a> Simplex<'a> {
         Ok(self.assemble(st, &art_sign))
     }
 
+    /// True when `d` is a certified primal unbounded ray for the LP as currently
+    /// loaded: `A d = 0`, `cᵀd < 0` under the cost actually in use, and the box
+    /// recedes on every coordinate `d` moves. Increments a rejection counter naming
+    /// the condition that failed.
+    ///
+    /// This is the primal mirror of `farkas_ray_certifies_cols`. The ratio test
+    /// concluding "no basic variable blocks" is a *statement about `α = B⁻¹A_q`*,
+    /// and an ftran that silently returns garbage produces exactly that statement,
+    /// so the conclusion has to be re-derived from `A` and `c` directly rather than
+    /// inherited from the object under suspicion.
+    ///
+    /// `cost` is the phase's own cost vector, not `self.c`: in phase 1 the loop is
+    /// minimizing infeasibility and `self.c` is not the objective being improved.
+    fn ray_certifies_unbounded(&self, d: &[f64], cost: &[f64], alpha: &[f64]) -> bool {
+        let (m, n) = (self.m, self.n);
+        if d.len() != n || !d.iter().all(|v| v.is_finite()) {
+            crate::profile::incr(crate::profile::Ctr::UnboundedRejectRowResidual);
+            return false;
+        }
+        // A basic *artificial* moving along the ray puts the direction in the
+        // extended space `[A | art]`; truncating it to the real columns silently
+        // drops those entries, so `A d = 0` would be checked against an incomplete
+        // vector. Phase 2 pins artificials to [0,0], so the ratio test blocks on
+        // them and this is unreachable; phase 1 minimizes a quantity bounded below
+        // by zero and therefore has no unbounded direction to find. Refuse either
+        // way rather than certify a truncation.
+        for i in 0..m {
+            if self.basis[i] >= n && alpha[i].abs() > self.tol {
+                crate::profile::incr(crate::profile::Ctr::UnboundedRejectRowResidual);
+                return false;
+            }
+        }
+        // `A d` alongside the magnitude bounding its rounding. Per #1017 the
+        // *result* of a cancelling sum says nothing about that sum's error, so the
+        // margin is built from the accumulation, not from `r[i]`.
+        let mut r = vec![0.0f64; m];
+        let mut r_abs = vec![0.0f64; m];
+        for j in 0..n {
+            let dj = d[j];
+            if dj == 0.0 {
+                continue;
+            }
+            let (rows, vals) = self.cols.col(j);
+            for (&i, &a) in rows.iter().zip(vals) {
+                let t = a * dj;
+                r[i] += t;
+                r_abs[i] += t.abs();
+            }
+        }
+        for i in 0..m {
+            if r[i].abs() > RAY_CERT_REL * (1.0 + r_abs[i]) {
+                crate::profile::incr(crate::profile::Ctr::UnboundedRejectRowResidual);
+                return false;
+            }
+        }
+        // In exact arithmetic `cᵀd = dir·d_q`, the entering reduced cost, which
+        // pricing already required to be `< −tol`. Recomputing it from `c` is
+        // therefore a cross-check of the btran that produced that reduced cost
+        // against the ftran that produced `α`. An all-zero `d` (no nonzero at all)
+        // lands here with `cd = 0` and is refused.
+        let mut cd = 0.0f64;
+        let mut cd_abs = 0.0f64;
+        for j in 0..n {
+            let t = cost[j] * d[j];
+            cd += t;
+            cd_abs += t.abs();
+        }
+        if !(cd < 0.0 && cd.abs() > RAY_CERT_REL * cd_abs) {
+            crate::profile::incr(crate::profile::Ctr::UnboundedRejectObjective);
+            return false;
+        }
+        // Recession: travelling along `d` forever must stay inside the box. `INF` is
+        // the sentinel `1e20`, so the comparison is against the *bound*, never a
+        // product involving it.
+        for j in 0..n {
+            let open = if d[j] > self.tol {
+                self.ub[j] >= INF
+            } else if d[j] < -self.tol {
+                self.lb[j] <= -INF
+            } else {
+                true
+            };
+            if !open {
+                crate::profile::incr(crate::profile::Ctr::UnboundedRejectBox);
+                return false;
+            }
+        }
+        true
+    }
+
     /// Primal simplex iterations for the given `cost`. Returns Ok(()) at
     /// optimality, Err(Unbounded/IterLimit/Numerical) otherwise.
     fn simplex_loop(
@@ -2032,6 +2134,27 @@ impl<'a> Simplex<'a> {
                         ray[bi] = -dir * alpha[i];
                     }
                 }
+                // #1008: certify the ray before CLAIMING unboundedness.
+                //
+                // The comment above says a caller verifies this. No caller did —
+                // the ray is exported to Python and read by nobody in Rust, while
+                // the *status* was returned on faith. `Infeasible` has never been
+                // taken on faith (`farkas_ray_certifies_cols`), and the asymmetry
+                // is not justified: "the ratio test found no blocking row" is also
+                // exactly what a silently broken ftran produces. On the captured
+                // QPLIB_2170 relaxation it did — every basic α came back zero for a
+                // column that is not zero, giving a ray with one nonzero, |A d| =
+                // 1.0 and cᵀd = 0, against an LP HiGHS certifies as optimal at 0.
+                //
+                // A ray that fails is a numerical breakdown, not an unbounded LP,
+                // so the verdict becomes `Numerical` — an honest refusal, and the
+                // status that routes into `dense_retry`'s robust LU path (§3:
+                // refuse loudly rather than claim). A genuine unbounded ray passes
+                // untouched, so no true `Unbounded` is downgraded.
+                if !self.ray_certifies_unbounded(&ray, cost, &alpha) {
+                    return Err(LpStatus::Numerical);
+                }
+                crate::profile::incr(crate::profile::Ctr::UnboundedRayCertified);
                 self.unbounded_ray = ray;
                 return Err(LpStatus::Unbounded);
             }

--- a/crates/discopt-core/src/profile.rs
+++ b/crates/discopt-core/src/profile.rs
@@ -228,6 +228,19 @@ counters!(
     // one is a certificate #1017 removed — the whole cost side of that change, and the
     // only way to see it in a corpus run without an A/B rebuild.
     FarkasRejectCancellation,
+    // #1008: the same treatment for the PRIMAL unbounded ray, which had none. An
+    // `Infeasible` verdict must clear `farkas_ray_certifies_cols`; an `Unbounded`
+    // verdict was taken on faith from "the ratio test found no blocking row",
+    // which is also what a silently broken ftran looks like. `Certified` counts
+    // rays that pass; the three `Reject` counters say which condition failed —
+    // `A d = 0` (the ray is not a recession direction at all), `cᵀd < 0` (the
+    // objective does not improve along it), or box recession (it leaves the box).
+    // On the captured QPLIB_2170 relaxation the ray had ONE nonzero, |A d| = 1.0
+    // and cᵀd = 0: every basic α came back zero for a column that is not zero.
+    UnboundedRayCertified,
+    UnboundedRejectRowResidual,
+    UnboundedRejectObjective,
+    UnboundedRejectBox,
     // The WARM path's own terminal histogram. `solve_lp_warm_csc` is the entry the
     // Python spatial engine's per-node LPs come through, and it can return without
     // ever reaching the cold primal's `assemble`, so the `LpVerdict*` counters above

--- a/crates/discopt-python/src/lp_bindings.rs
+++ b/crates/discopt-python/src/lp_bindings.rs
@@ -89,6 +89,38 @@ fn parse_budget_secs(time_limit_s: Option<f64>) -> PyResult<Option<f64>> {
     }
 }
 
+/// Refuse a NaN entry in an LP's variable box.
+///
+/// A NaN bound has no meaning in an LP, and — worse — it reads *differently
+/// depending on which way the comparison is written*, because every comparison
+/// against NaN is false. The simplex asks "is this side open?" both ways:
+/// `ub < INF` (the ratio test's blocking check) calls a NaN upper bound **open**,
+/// while `ub >= INF` (the unbounded-ray box-recession check) calls the same bound
+/// **closed**. On issue #1008 that split produced an LP the ratio test walked to
+/// `t = INF` on and reported `unbounded`, over a box it could not certify as
+/// recessive. This is the `INF`-is-`1e20` hazard from CLAUDE.md in its other
+/// guise: there the sentinel silently survived a multiplication, here it is
+/// silently absent.
+///
+/// The modeling layer spells "no bound" as NaN (`Model.continuous(ub=None)` →
+/// `array(nan)`); the LP layer spells it as the sentinel `±1e20`. Translating
+/// between the two is the caller's job — `lp_simplex._finite_box` does it — and
+/// this refuses loudly rather than let an untranslated box reach the simplex and
+/// be read two ways. `±inf` is *not* rejected: it satisfies `>= INF` and fails
+/// `< INF`, so both readings agree it is open.
+fn check_box_not_nan(lb: &[f64], ub: &[f64]) -> PyResult<()> {
+    for (name, v) in [("lb", lb), ("ub", ub)] {
+        if let Some(j) = v.iter().position(|x| x.is_nan()) {
+            return Err(PyValueError::new_err(format!(
+                "{name}[{j}] is NaN; an LP bound must be finite or the ±1e20 \
+                 unbounded sentinel (NaN is read as both open and closed by \
+                 different guards — see issue #1008)"
+            )));
+        }
+    }
+    Ok(())
+}
+
 /// Push an interior LP optimum `x` to a vertex of the optimal face.
 ///
 /// `a` is the C-contiguous `m × n` equality-constraint matrix; `c`, `lb`, `ub`
@@ -351,6 +383,7 @@ pub fn solve_lp_py<'py>(
     max_iter: usize,
 ) -> PyResult<(String, Bound<'py, PyArray1<f64>>, f64, usize)> {
     let dims = a.shape();
+    check_box_not_nan(lb.as_slice()?, ub.as_slice()?)?;
     let (m, n) = (dims[0], dims[1]);
     let a_flat = a
         .as_slice()
@@ -487,6 +520,7 @@ pub fn solve_lp_warm_py<'py>(
     Bound<'py, PyArray1<f64>>,
 )> {
     let dims = a.shape();
+    check_box_not_nan(lb.as_slice()?, ub.as_slice()?)?;
     let (m, n) = (dims[0], dims[1]);
     let a_flat = a
         .as_slice()
@@ -599,6 +633,7 @@ pub fn solve_lp_warm_csc_py<'py>(
     // otherwise leave profiling uninitialized and dump() a no-op. Cheap; first call
     // per process fixes the flag.
     discopt_core::profile::init_from_env();
+    check_box_not_nan(lb.as_slice()?, ub.as_slice()?)?;
     let col_ptr: Vec<usize> = col_ptr.as_slice()?.iter().map(|&x| x as usize).collect();
     let row_idx: Vec<usize> = row_idx.as_slice()?.iter().map(|&x| x as usize).collect();
     let vals_v: Vec<f64> = vals.as_slice()?.to_vec();
@@ -714,6 +749,7 @@ pub fn solve_lp_batch_py<'py>(
     Bound<'py, PyArray1<f64>>,
 )> {
     let dims = a.shape();
+    check_box_not_nan(lb.as_slice()?, ub.as_slice()?)?;
     let (m, n) = (dims[0], dims[1]);
     let k = b.shape()[0];
     if b.shape()[1] != m {
@@ -907,6 +943,7 @@ pub fn solve_milp_py<'py>(
     debug_hook: Option<Py<PyAny>>,
 ) -> PyResult<(String, Bound<'py, PyArray1<f64>>, f64, f64, usize, usize)> {
     let dims = a.shape();
+    check_box_not_nan(lb.as_slice()?, ub.as_slice()?)?;
     let (m, n) = (dims[0], dims[1]);
     // Materialize owned copies of the borrowed numpy inputs. `PyReadonlyArray`
     // borrows are only valid while the GIL is held, so we copy before releasing
@@ -1013,6 +1050,7 @@ pub fn solve_milp_csc_py<'py>(
     debug_hook: Option<Py<PyAny>>,
 ) -> PyResult<(String, Bound<'py, PyArray1<f64>>, f64, f64, usize, usize)> {
     let col_ptr_v: Vec<usize> = col_ptr.as_slice()?.iter().map(|&x| x as usize).collect();
+    check_box_not_nan(lb.as_slice()?, ub.as_slice()?)?;
     let row_idx_v: Vec<usize> = row_idx.as_slice()?.iter().map(|&x| x as usize).collect();
     let vals_v: Vec<f64> = vals.as_slice()?.to_vec();
     let c_owned: Vec<f64> = c.as_slice()?.to_vec();

--- a/docs/dev/performance-plan.md
+++ b/docs/dev/performance-plan.md
@@ -2692,3 +2692,55 @@ rather than by name, §2). It returns `Unbounded` on the old default and
 `bank_deadline_duals` coupling that makes QPLIB_2170 solvable only when the caller
 passes a `time_limit` (#1008 R1) — both tracked in #1008.
 
+### 18c. The false `Unbounded` is a broken ftran read as a verdict (#1008, 2026-08-13)
+
+§18b left this open. It is not a property of the stall bail: with
+`DISCOPT_LP_DUAL_STALL_BAIL=0` (the default since #1021) and `time_limit=None`,
+QPLIB_2170's root relaxation still reaches the ratio test's unbounded exit —
+`UnboundedRejectRowResidual = 2` end to end.
+
+**What the engine was doing.** `Infeasible` is issued only after
+`farkas_ray_certifies_cols` accepts a dual ray. `Unbounded` was issued on the
+strength of "the ratio test found no blocking row" alone. But that sentence is a
+statement *about* `α = B⁻¹A_q`, so an ftran that silently returns zeros produces
+it verbatim — which is exactly what happens here. The captured ray:
+
+| quantity | required | measured |
+|---|---|---|
+| nonzeros in `d` | ≥ 1 basic + entering | **1** (the entering column only) |
+| `max_i |A d|_i` | 0 | **1.0** |
+| `cᵀd` | < 0 | **0.0** |
+| box-recession violations | 0 | 0 |
+
+Three of the four conditions fail. The LP is `optimal 0` (HiGHS, 81 pivots).
+
+**Blast radius, by driver.** `spatial_tree::verdict_for` already maps
+`Unbounded`, `IterLimit` and `Numerical` alike to `NodeVerdict::Undecided`, so
+there the cost was only the bypassed `dense_retry` — which is gated on
+`Numerical | IterLimit` and so never ran. `milp_driver` is the serious one:
+`out.unbounded` at any node sets `hit_unbounded`, breaks the search loop, and
+short-circuits `decide_status` ahead of every other branch, returning
+`MilpStatus::Unbounded` for a bounded MILP and discarding any incumbent. One
+false node verdict is enough.
+
+**The fix** is the primal mirror of the Farkas path: `ray_certifies_unbounded`
+checks `A d = 0`, `cᵀd < 0` under the cost the *phase* is minimizing (not
+`self.c` — phase 1 is minimizing infeasibility), and box recession, refusing with
+`Numerical` when any fails. Margins are built from accumulation magnitudes rather
+than results (#1017). The relative slack is `1e-7`, deliberately not
+`gamma(nnz)`: the residual carries the LU solve's error, not just summation
+rounding. It rejects the observed breakdown by a factor of 10⁷.
+
+`Numerical` is also the status that routes into `dense_retry`, so the honest
+refusal is strictly more useful than the false claim.
+
+**Not a bound recovery.** On QPLIB_2170 at `time_limit=None` the outcome stays
+"no solution" — the engine simply stops claiming a certificate it cannot support.
+The remaining loss on that cell is the `bank_deadline_duals` coupling (#1008 R1,
+still open): the same LP solves to `optimal 0` at `time_limit=40.0`. The four-cell
+BAIL × time_limit A/B is otherwise unchanged from §18b, so nothing regressed.
+
+Pinned by `cold_primal_does_not_claim_unbounded_on_a_bounded_lp` (returns
+`Unbounded` obj 351 without the certifier, `Numerical` with it) and by the
+pre-existing `unbounded_detected` / `unbounded_emits_a_valid_primal_ray`, which
+confirm a genuine unbounded ray still certifies untouched.

--- a/docs/dev/performance-plan.md
+++ b/docs/dev/performance-plan.md
@@ -2744,3 +2744,51 @@ Pinned by `cold_primal_does_not_claim_unbounded_on_a_bounded_lp` (returns
 `Unbounded` obj 351 without the certifier, `Numerical` with it) and by the
 pre-existing `unbounded_detected` / `unbounded_emits_a_valid_primal_ray`, which
 confirm a genuine unbounded ray still certifies untouched.
+
+### 18d. A NaN bound is read as both open and closed (#1008, 2026-08-13)
+
+The certifier in §18c turned a CI job red on `test_c3_unbounded_recourse_reported`
+(`unbounded` → `iteration_limit`). The measurement — profile counters on the
+Benders solve, `DISCOPT_PROFILE=1` — put the rejection at
+`UnboundedRejectBox = 2`, not at the residual or objective margins. The LP behind
+it, captured by wrapping the recourse oracle:
+
+```
+min -w   s.t.  -w <= 0,   w in [0, nan]
+```
+
+The **upper bound is NaN**. `Model.continuous(ub=None)` stores `array(nan)`; the
+Rust simplex reads the sentinel `±1e20`. Nothing translated between the two, and
+NaN does not announce itself, because every comparison against it is false — so
+each guard reads the same bound as whichever answer its comparison is written for:
+
+| guard | question asked | NaN answer | reading |
+|---|---|---|---|
+| ratio test | `ub < INF` — does this bound block? | false | **open** → `t = INF` → `unbounded` |
+| §18c ray certifier | `ub >= INF` — is this side open? | false | **closed** → refuse |
+
+So the pre-#1022 `unbounded` on that LP was *correct but underived*: right answer,
+resting on which of the two readings the ratio test happened to use, over a box
+the engine could not certify as recessive. The certifier did not break it — it
+made a latent ambiguity observable. This is the `INF`-is-`1e20` hazard already in
+`CLAUDE.md`, in its other guise: there the sentinel silently survives a
+multiplication; here it is silently absent.
+
+**The fix has two halves**, and needs both. `lp_simplex._finite_box` translates
+the box (NaN, `±inf`, and any magnitude past the sentinel → `±1e20`) so the
+simplex sees one convention; the PyO3 LP/MILP entry points refuse a NaN bound
+with a `ValueError` naming the index, so a caller that skips the translation gets
+a loud error rather than a verdict derived from two incompatible readings. `±inf`
+is deliberately *not* refused — it satisfies `>= INF` and fails `< INF`, so both
+readings already agree it is open.
+
+**Method note.** The regression was found by CI and diagnosed by counter, not by
+reading control flow: the first probe (`c3_probe.py`) printed every
+`Unbounded*`/`Farkas*` counter and the *box* counter was the one that moved. A
+control-flow reading would have blamed the residual margin, which is where the
+§18c work had been concentrated. Baseline separation followed CLAUDE.md §8 — the
+pre-#1022 `.so` was asserted to *lack* the `UnboundedRejectRowResidual` marker
+before being trusted as a baseline, and it reproduced the pass.
+
+Pinned by `python/tests/test_1008_nan_lp_bound.py` (3 tests; 2 fail with
+`ValueError: ub[0] is NaN` when `_finite_box` is neutered).

--- a/python/discopt/solvers/lp_simplex.py
+++ b/python/discopt/solvers/lp_simplex.py
@@ -76,6 +76,33 @@ def _reject_unknown_kwargs(kwargs: dict[str, Any]) -> None:
         )
 
 
+#: The LP layer's "no bound" sentinel. The Rust simplex tests openness as
+#: ``ub >= INF`` / ``lb <= -INF`` with ``INF = 1e20``; anything at or beyond it is
+#: unbounded on that side.
+_LP_INF = 1e20
+
+
+def _finite_box(lb: np.ndarray, ub: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
+    """Translate a modeling-layer box into the LP layer's sentinel convention.
+
+    The two layers spell "no bound" differently: ``Model.continuous(ub=None)``
+    stores **NaN**, while the simplex reads the sentinel ``±1e20``. A NaN that
+    crosses untranslated is not merely unhelpful — it is read *both ways*, since
+    every comparison against NaN is false. The ratio test's ``ub < INF`` calls a
+    NaN upper bound open and steps to ``t = INF``; the unbounded-ray box-recession
+    check's ``ub >= INF`` calls the same bound closed. Issue #1008: a Benders
+    recourse LP over ``w ∈ [0, NaN]`` was walked to an unbounded ray the box could
+    not certify, so the verdict depended on which guard you asked.
+
+    NaN means unbounded on that side, and ``±inf`` (and any magnitude past the
+    sentinel, which the simplex already treats as unbounded) is clamped onto it so
+    the two readings agree. Finite bounds pass through untouched.
+    """
+    lo = np.where(np.isnan(lb), -_LP_INF, np.maximum(lb, -_LP_INF))
+    hi = np.where(np.isnan(ub), _LP_INF, np.minimum(ub, _LP_INF))
+    return lo, hi
+
+
 def _dense_rows(A: Optional[Union[np.ndarray, sp.spmatrix]], n: int) -> np.ndarray:
     """Dense ``(m, n)`` view of a constraint block, or an empty ``(0, n)``."""
     if A is None:
@@ -181,13 +208,17 @@ def solve_lp(
         a_std = sp.csc_matrix((0, n), dtype=np.float64)
     c_std = np.concatenate([c_arr, np.zeros(m)])
     if bounds is not None:
-        lb = np.array([lo for lo, _ in bounds], dtype=np.float64)
-        ub = np.array([hi for _, hi in bounds], dtype=np.float64)
+        # `None`/NaN on either side means "no bound" here (scipy's spelling and
+        # the modeling layer's); `_finite_box` maps both onto the LP sentinel.
+        lb, ub = _finite_box(
+            np.array([lo for lo, _ in bounds], dtype=np.float64),
+            np.array([hi for _, hi in bounds], dtype=np.float64),
+        )
     else:
         lb = np.zeros(n, dtype=np.float64)
-        ub = np.full(n, 1e20, dtype=np.float64)
+        ub = np.full(n, _LP_INF, dtype=np.float64)
     lb_std = np.concatenate([lb, np.zeros(m)])
-    ub_std = np.concatenate([ub, np.full(m_ub, 1e20), np.zeros(m_eq)])
+    ub_std = np.concatenate([ub, np.full(m_ub, _LP_INF), np.zeros(m_eq)])
 
     _warm_kw: dict[str, Any] = {}
     if max_iter is not None:
@@ -318,11 +349,13 @@ def solve_lp_batch(
     for t, (b_ub, bounds) in enumerate(instances):
         b_stack[t, :] = np.asarray(b_ub, dtype=np.float64).ravel()
         if bounds is not None:
-            lb_stack[t, :n] = [lo for lo, _ in bounds]
-            ub_stack[t, :n] = [hi for _, hi in bounds]
+            lb_stack[t, :n], ub_stack[t, :n] = _finite_box(
+                np.array([lo for lo, _ in bounds], dtype=np.float64),
+                np.array([hi for _, hi in bounds], dtype=np.float64),
+            )
         else:
-            ub_stack[t, :n] = 1e20
-        ub_stack[t, n:] = 1e20  # slacks in [0, inf)
+            ub_stack[t, :n] = _LP_INF
+        ub_stack[t, n:] = _LP_INF  # slacks in [0, inf)
 
     statuses, xs, objs = solve_lp_batch_py(
         np.ascontiguousarray(c_std),

--- a/python/tests/test_1008_nan_lp_bound.py
+++ b/python/tests/test_1008_nan_lp_bound.py
@@ -1,0 +1,96 @@
+"""A NaN variable bound must never reach the simplex (#1008 follow-up).
+
+The modeling layer and the LP layer spell "no bound" differently:
+``Model.continuous(ub=None)`` stores **NaN**, while the Rust simplex reads the
+sentinel ``±1e20`` (``INF``). An untranslated NaN is not merely unhelpful — it is
+read *two contradictory ways*, because every comparison against NaN is false:
+
+* the ratio test asks ``ub < INF`` ("is this bound blocking?") → **false** for NaN,
+  so the bound is skipped and the step runs to ``t = INF`` → ``unbounded``;
+* the unbounded-ray box-recession check asks ``ub >= INF`` ("is this side open?")
+  → also **false** for NaN, so the very same bound reads as closed.
+
+Found while the #1008 ray certifier was landing: a Benders recourse LP
+(``min -w`` over ``w ∈ [0, NaN]``, ``-w ≤ 0``) reached the simplex with a NaN
+upper bound and had been reported ``unbounded`` on the strength of a box no guard
+could certify as recessive. The verdict was right by luck, not by derivation —
+the ratio test's reading happened to be the one that mattered. This is the same
+class as the ``INF``-is-``1e20`` hazard in CLAUDE.md, with the sentinel silently
+*absent* rather than silently surviving a multiplication.
+
+Two halves, both pinned here:
+
+1. ``lp_simplex`` translates the box (NaN and ``±inf`` → the sentinel), so the
+   simplex sees one unambiguous convention;
+2. the PyO3 LP entry points refuse a NaN bound outright, so a caller that skips
+   the translation gets a loud ``ValueError`` instead of a verdict derived from
+   two incompatible readings of the same number.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from discopt.solvers import SolveStatus
+from discopt.solvers.lp_simplex import _LP_INF, _finite_box, solve_lp
+
+
+def test_finite_box_maps_no_bound_onto_the_lp_sentinel():
+    lo, hi = _finite_box(
+        np.array([np.nan, -np.inf, -2.5, -1e30]),
+        np.array([np.nan, np.inf, 4.0, 1e30]),
+    )
+    # NaN and -inf are the same statement ("no lower bound") once translated, and a
+    # magnitude past the sentinel is already unbounded to the simplex.
+    assert lo.tolist() == [-_LP_INF, -_LP_INF, -2.5, -_LP_INF]
+    assert hi.tolist() == [_LP_INF, _LP_INF, 4.0, _LP_INF]
+    assert not np.isnan(lo).any() and not np.isnan(hi).any()
+
+
+def test_nan_upper_bound_still_solves_as_unbounded():
+    """The Benders recourse LP that exposed this: ``min -w``, ``-w ≤ 0``, ``w ≥ 0``.
+
+    Genuinely unbounded below. Before the translation the NaN reached the simplex
+    and the answer depended on which guard was asked; after it the box is the
+    sentinel and the ray certifies on its own merits.
+    """
+    r = solve_lp(
+        np.array([-1.0]),
+        A_ub=np.array([[-1.0]]),
+        b_ub=np.array([0.0]),
+        bounds=[(0.0, float("nan"))],
+    )
+    assert r.status == SolveStatus.UNBOUNDED
+
+    # `None` is the caller-facing spelling of the same thing and must agree.
+    r_none = solve_lp(
+        np.array([-1.0]),
+        A_ub=np.array([[-1.0]]),
+        b_ub=np.array([0.0]),
+        bounds=[(0.0, None)],
+    )
+    assert r_none.status == SolveStatus.UNBOUNDED
+
+
+def test_binding_refuses_a_nan_bound_loudly():
+    """A caller that skips the translation gets an error, not a lucky verdict."""
+    from discopt._rust import solve_lp_warm_csc_py
+
+    a = np.array([[-1.0, 1.0]])  # one row: structural `w`, plus its slack
+    with pytest.raises(ValueError, match="is NaN"):
+        solve_lp_warm_csc_py(
+            np.ascontiguousarray([-1.0, 0.0]),
+            1,
+            2,
+            np.ascontiguousarray([0, 1, 2], dtype=np.int64),
+            np.ascontiguousarray([0, 0], dtype=np.int64),
+            np.ascontiguousarray(a.ravel()[a.ravel() != 0.0]),
+            np.ascontiguousarray([0.0]),
+            np.ascontiguousarray([0.0, 0.0]),
+            np.ascontiguousarray([np.nan, _LP_INF]),  # the NaN upper bound
+            None,
+            None,
+            1e-9,
+            1000,
+            None,
+        )


### PR DESCRIPTION
## The defect

`Infeasible` is issued only after `farkas_ray_certifies_cols` accepts a dual ray.
`Unbounded` was issued on the strength of "the ratio test found no blocking row"
alone — and that sentence is a statement *about* `alpha = B^-1 A_q`, so an ftran
that silently returns zeros produces it verbatim. The asymmetry between the two
verdicts was never justified.

On the captured QPLIB_2170 root relaxation (vendored by #1021 as
`qplib2170_cold_fail_lp.json`, 1755x3193) it happens for real: every basic
`alpha` comes back zero for a column that is not zero.

| quantity | required | measured |
|---|---|---|
| nonzeros in `d` | >= 1 basic + entering | **1** (the entering column only) |
| `max_i abs(A d)_i` | 0 | **1.0** |
| `c . d` | < 0 | **0.0** |
| box-recession violations | 0 | 0 |

Three of the four conditions fail. HiGHS certifies the same LP `optimal 0` in 81
pivots.

## Why it matters, by driver

`spatial_tree::verdict_for` already maps `Unbounded`, `IterLimit` and `Numerical`
alike to `NodeVerdict::Undecided`, so there the cost was only the bypassed
`dense_retry` — which is gated on `Numerical | IterLimit` and so never ran on a
false `Unbounded`.

`milp_driver` is the serious one. A node LP returning `Unbounded` sets
`out.unbounded`, which sets `hit_unbounded`, breaks the search loop, and
short-circuits `decide_status` ahead of every other branch — returning
`MilpStatus::Unbounded` for a bounded MILP and discarding any incumbent. One
false node verdict is enough to produce a false global certificate, which is the
output CLAUDE.md section 1 gives no slack at all.

## The fix

`ray_certifies_unbounded` is the primal mirror of the Farkas path. It checks
`A d = 0`, `c . d < 0`, and box recession, and refuses with `Numerical` — an
honest refusal, and the status that routes into `dense_retry`'s dense-LU path —
when any condition fails.

Three details that are easy to get wrong:

- **The cost vector is the phase's, not `self.c`.** The loop is shared with
  phase 1, which is minimizing infeasibility; certifying against `self.c` there
  would be checking the wrong objective.
- **A basic artificial moving along the ray is refused.** It puts the direction
  in the extended space `[A | art]`, so truncating to the real columns would
  check `A d = 0` against an incomplete vector. (Phase 2 pins artificials to
  [0,0] so the ratio test blocks on them; phase 1 minimizes a quantity bounded
  below by zero. Unreachable both ways — refused rather than assumed.)
- **Margins are built from accumulation magnitudes, not results** (#1017). The
  relative slack is `1e-7` and deliberately not `gamma(nnz)`: the residual
  carries the LU solve's error, not just summation rounding. It rejects the
  observed breakdown by a factor of 1e7.

## This is not subsumed by #1021

With `DISCOPT_LP_DUAL_STALL_BAIL=0` — the default since #1021 — and
`time_limit=None`, the reject still fires end to end on QPLIB_2170:
`UnboundedRejectRowResidual = 2`. The false verdict was reachable without the
stall bail ever firing.

The externally visible outcome on that cell is unchanged (no solution either
way); what changed is that the engine no longer claims a certificate it cannot
support. The remaining loss there is a separate, still-open defect — the
unstable-pivot recovery is gated on `bank_deadline_duals`, so a caller passing no
`time_limit` loses it; the same LP solves to `optimal 0` at `time_limit=40.0`
(#1008 R1). The full BAIL x time_limit A/B is otherwise unchanged from the
numbers in `docs/dev/performance-plan.md` section 18b, so nothing regressed.

## Verification

- `cargo test -p discopt-core` -> **610 passed**, 0 failed (plus 4 + 1 doc).
- `pytest -m smoke` -> **1028 passed**, 1 skipped, 2 xpassed.
- `pytest -m slow python/tests/test_adversarial_recent_fixes.py` -> **10 passed**.
- New test `cold_primal_does_not_claim_unbounded_on_a_bounded_lp`: returns
  `Unbounded` (obj 351) with the certifier bypassed, `Numerical` with it. It also
  asserts a rejection counter fired, so the fixture is proven to reach the guard
  rather than silently drifting off it (CLAUDE.md section 6).
- **No genuine `Unbounded` is downgraded**: the pre-existing `unbounded_detected`
  and `unbounded_emits_a_valid_primal_ray` both still pass, i.e. a real unbounded
  ray certifies untouched.

Rationale recorded in `docs/dev/performance-plan.md` section 18c.

Contributes to #1008

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017PQaiDVuY5Rs3tga98tnNo


---

## Follow-up commit: a NaN bound was reaching the simplex (`ef90a93`)

The first CI run caught a real regression from the certifier —
`test_c3_unbounded_recourse_reported` went `unbounded` → `iteration_limit` — and the
cause was not the certifier's margins. It was a **NaN upper bound** reaching the LP.

The modeling layer spells "no bound" as NaN (`Model.continuous(ub=None)` stores
`array(nan)`); the LP layer spells it as the sentinel `±1e20`. Nothing translated
between them, and an untranslated NaN does not fail loudly — every comparison against
NaN is false, so each guard reads the same bound as whichever answer its comparison is
written for:

| guard | question | NaN answer | reading |
|---|---|---|---|
| ratio test | `ub < INF` — does this bound block? | false | **open** → step to `t = INF` → `unbounded` |
| ray certifier (this PR) | `ub >= INF` — is this side open? | false | **closed** → refuse |

So the Benders recourse LP (`min -w` over `w ∈ [0, NaN]`, `-w ≤ 0`) had been reported
`unbounded` over a box no guard could certify as recessive. That verdict is *correct* —
the LP is unbounded below — but it was correct by luck, resting on which of the two
readings the ratio test happened to use. The certifier did not break it; it surfaced it.

This is the `INF`-is-`1e20` hazard already in `CLAUDE.md`, in its other guise: there the
sentinel silently survives a multiplication, here it is silently absent.

**Fix, both halves:**
1. `lp_simplex._finite_box` translates the box (NaN, `±inf`, and any magnitude past the
   sentinel → `±1e20`) so the simplex sees one convention.
2. The PyO3 LP/MILP entry points refuse a NaN bound with a `ValueError` naming the index
   — a caller that skips the translation gets a loud error, not a verdict derived from
   two incompatible readings of the same number. `±inf` is deliberately not refused: it
   satisfies `>= INF` and fails `< INF`, so both readings already agree it is open.

**Verification** (R1 work-in-progress stashed out, so this is the branch as CI sees it;
`_rust.so` asserted to carry the NaN-guard marker and *not* the R1 marker):
- `python/tests/test_1008_nan_lp_bound.py` — 3 tests, fail-before / pass-after: with
  `_finite_box` neutered, 2 of the 3 fail with `ValueError: ub[0] is NaN`.
- `cargo test -p discopt-core` — 610 passed.
- `pytest -m smoke` — 1028 passed, 1 skipped, 2 xpassed.
- Adversarial suite — 10 passed.
- **The lane that failed** (`correctness and not slow and not integration and not
  amp_benchmark and not requires_cyipopt and not memory_heavy`, serial, `--ignore=test_amp.py`)
  — **337 passed**, 3 skipped, 4 xfailed. CI's failing run was 336 passed + 1 failed.
