### PR TITLE
fix(lp): #1008 R1 the unstable-pivot recovery is not a deadline feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,35 @@ The release procedure that produces these entries is documented in
   test `cold_primal_does_not_claim_unbounded_on_a_bounded_lp` returns
   `Unbounded` (obj 351) without the certifier and `Numerical` with it, and
   asserts a rejection counter fired so the fixture is proven to reach the guard.
+
+- **A NaN variable bound reached the simplex and was read two contradictory
+  ways** (`fix(lp)`, #1008). The modeling layer spells "no bound" as **NaN**
+  (`Model.continuous(ub=None)` stores `array(nan)`); the LP layer spells it as
+  the sentinel `±1e20`. Nothing translated between them, and an untranslated NaN
+  does not fail loudly — every comparison against it is false, so each guard
+  reads it as whichever answer its comparison happens to be written for. The
+  ratio test asks `ub < INF` ("does this bound block?") and calls a NaN bound
+  **open**, stepping to `t = INF`; the ray certifier above asks `ub >= INF` ("is
+  this side open?") and calls the same bound **closed**. This is the
+  `INF`-is-`1e20` hazard already documented in `CLAUDE.md`, in its other guise:
+  there the sentinel silently survives a multiplication, here it is silently
+  absent.
+
+  Found by the certifier: a Benders recourse LP (`min -w` over `w ∈ [0, NaN]`,
+  `-w ≤ 0`) had been reported `unbounded` on the strength of a box no guard could
+  certify as recessive. That verdict was correct — the LP *is* unbounded below —
+  but it was correct by luck, resting on which of the two readings the ratio test
+  happened to use, over a box the engine could not derive it from.
+
+  Both halves are fixed: `lp_simplex._finite_box` translates the box (NaN and
+  `±inf`, and any magnitude past the sentinel, onto `±1e20`) so the simplex sees
+  one convention, and the PyO3 LP/MILP entry points refuse a NaN bound with a
+  `ValueError` naming the index, so a caller that skips the translation gets a
+  loud error instead of a verdict derived from two incompatible readings of the
+  same number. `±inf` is deliberately *not* refused: it satisfies `>= INF` and
+  fails `< INF`, so both readings already agree it is open. Regression tests in
+  `python/tests/test_1008_nan_lp_bound.py` fail without the translation
+  (`ValueError: ub[0] is NaN`) and pass with it.
   The pre-existing `unbounded_detected` / `unbounded_emits_a_valid_primal_ray`
   tests confirm a genuine unbounded ray still certifies untouched.
   `cargo test -p discopt-core` → 610 passed.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,51 @@ The release procedure that produces these entries is documented in
 
 ### Fixed
 
+- **The primal simplex could return a false `Unbounded` on a bounded LP**
+  (`fix(lp)`, #1008). The ratio test now certifies the primal ray before the
+  verdict is issued: `A d = 0`, `cᵀd < 0` under the cost the phase is actually
+  minimizing, and box recession on every coordinate `d` moves. A ray that fails
+  any of the three is a numerical breakdown, not an unbounded LP, so the status
+  becomes `Numerical` — an honest refusal, and the one that routes into
+  `dense_retry`'s dense-LU path, which a false `Unbounded` bypassed entirely.
+
+  `Infeasible` has never been taken on faith (`farkas_ray_certifies_cols`);
+  `Unbounded` was, and the asymmetry was not justified. "No basic variable
+  blocks" is a statement *about* `α = B⁻¹A_q`, so a silently broken ftran
+  produces it verbatim. On the captured QPLIB_2170 root relaxation it did: every
+  basic `α` came back zero for a column that is not zero, giving a ray with a
+  single nonzero, `|A d| = 1.0` and `cᵀd = 0`, against an LP HiGHS certifies
+  optimal at 0 in 81 pivots.
+
+  What that cost depends on the driver. `spatial_tree::verdict_for` already
+  lumps `Unbounded` with `Numerical` into `Undecided`, so there the damage was
+  the bypassed `dense_retry`, not a bad bound. `milp_driver` is the serious one:
+  a node LP returning `Unbounded` sets `out.unbounded`, which breaks the search
+  (`hit_unbounded`) and short-circuits `decide_status` ahead of every other
+  branch — so a single false node verdict returns `MilpStatus::Unbounded` for a
+  bounded MILP, discarding any incumbent. That is a false certificate, which is
+  the one output §1 gives no slack at all.
+
+  The stall-bail flip below does not subsume this. End to end on QPLIB_2170's
+  root relaxation with `DISCOPT_LP_DUAL_STALL_BAIL=0` — the shipped default —
+  and `time_limit=None`, `UnboundedRejectRowResidual` is 2: the false verdict was
+  reachable without the bail ever firing. The externally visible outcome on that
+  cell is unchanged (no solution either way); what changed is that the engine no
+  longer *claims* a certificate it cannot support. The remaining loss on that
+  cell is a separate defect (the unstable-pivot recovery is gated on
+  `bank_deadline_duals`, so a caller passing no `time_limit` loses it — the same
+  LP solves to `optimal 0` with `time_limit=40.0`); it is not addressed here.
+
+  The margins are built from accumulation magnitudes, not from the result
+  (#1017); the relative slack is `1e-7` rather than `gamma(nnz)` because the
+  residual carries the LU solve's error, not just summation rounding. Regression
+  test `cold_primal_does_not_claim_unbounded_on_a_bounded_lp` returns
+  `Unbounded` (obj 351) without the certifier and `Numerical` with it, and
+  asserts a rejection counter fired so the fixture is proven to reach the guard.
+  The pre-existing `unbounded_detected` / `unbounded_emits_a_valid_primal_ray`
+  tests confirm a genuine unbounded ray still certifies untouched.
+  `cargo test -p discopt-core` → 610 passed.
+
 - **The #1013 degeneracy-stall bail could turn a certified optimum into no bound,
   and shipped default-ON** (`fix(lp)`, #1008). `DISCOPT_LP_DUAL_STALL_BAIL` is now
   **default-OFF**; `=1`/`true`/`on` opts in, and the mechanism itself is unchanged.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,39 @@ The release procedure that produces these entries is documented in
   `Unbounded` (obj 351) without the certifier and `Numerical` with it, and
   asserts a rejection counter fired so the fixture is proven to reach the guard.
 
+- **The dual simplex's unstable-pivot recovery was gated on the caller passing a
+  `time_limit`** (`fix(lp)`, #1008). `SimplexOptions::bank_deadline_duals` is set
+  as `deadline.is_some()` and was doing double duty: besides banking the dual
+  loop's anytime floor (#928, its actual job), it also switched on the recovery
+  that re-tries a near-zero pivot instead of abandoning the re-solve. The two have
+  nothing to do with each other, so a caller who passed no `time_limit` silently
+  lost a numerical safeguard.
+
+  Measured on the captured QPLIB_2170 root relaxation, by counter rather than by
+  reading control flow:
+
+  | call | `DualUnstablePivotRecoveries` | `DualUnstablePivotBails` | result |
+  |---|---|---|---|
+  | `time_limit=None` | 0 | **1** | no solution |
+  | `time_limit=40.0` | **1** | 0 | **optimal 0** |
+
+  Exactly one unstable pivot separates a certified optimum from nothing, decided
+  solely by whether the caller bounded the LP in time. The recovery now has its
+  own gate, `SimplexOptions::recover_unstable_pivot`
+  (`DISCOPT_LP_UNSTABLE_PIVOT_RECOVERY`), and `bank_deadline_duals` is back to
+  banking duals only.
+
+  **Default-OFF for deadline-free callers, per §5**: the recovery changes which
+  pivot the dual loop takes, so it is bound-changing and stays behind the flag
+  until a corpus differential panel clears both the cert-clean and net-positive
+  bars. The deadline path keeps the recovery unconditionally
+  (`deadline.is_some() || …`), so it is bit-identical to what its own panel already
+  judged. Two counters (`DualUnstablePivotRecoveries` / `DualUnstablePivotBails`)
+  make the mechanism measurable instead of inferred, and
+  `unstable_pivot_recovery_is_not_gated_on_a_deadline` pins the split (bails 1 /
+  not optimal with the flag off, recoveries 1 / optimal 0 with it on, and asserts
+  no deadline is set in either arm).
+
 - **A NaN variable bound reached the simplex and was read two contradictory
   ways** (`fix(lp)`, #1008). The modeling layer spells "no bound" as **NaN**
   (`Model.continuous(ub=None)` stores `array(nan)`); the LP layer spells it as

--- a/crates/discopt-core/examples/feral_update_cost.rs
+++ b/crates/discopt-core/examples/feral_update_cost.rs
@@ -172,6 +172,7 @@ fn main() {
             warm_stall_cap_override: None,
             expel_zero_artificials: false,
             bank_deadline_duals: false,
+            recover_unstable_pivot: false,
             cold_dual_start: false,
             // Take the default for anything not named above, so adding a field
             // to `SimplexOptions` does not break the examples again (#1013).

--- a/crates/discopt-core/examples/milp_bench.rs
+++ b/crates/discopt-core/examples/milp_bench.rs
@@ -168,6 +168,7 @@ fn opts(n_struct: usize, integer_cols: Vec<usize>, tl: f64) -> MilpOptions {
             warm_stall_cap_override: None,
             expel_zero_artificials: false,
             bank_deadline_duals: false,
+            recover_unstable_pivot: false,
             cold_dual_start: false,
             // Take the default for anything not named above, so adding a field
             // to `SimplexOptions` does not break the examples again (#1013).

--- a/crates/discopt-core/examples/par_bench.rs
+++ b/crates/discopt-core/examples/par_bench.rs
@@ -132,6 +132,7 @@ fn opts(inst: &Instance) -> MilpOptions {
             warm_stall_cap_override: None,
             expel_zero_artificials: false,
             bank_deadline_duals: false,
+            recover_unstable_pivot: false,
             cold_dual_start: false,
             // Take the default for anything not named above, so adding a field
             // to `SimplexOptions` does not break the examples again (#1013).

--- a/crates/discopt-core/src/bin/e0_warm_bench.rs
+++ b/crates/discopt-core/src/bin/e0_warm_bench.rs
@@ -160,6 +160,7 @@ fn main() -> ExitCode {
         warm_stall_cap_override: None,
         expel_zero_artificials: true,
         bank_deadline_duals: false,
+        recover_unstable_pivot: false,
         dual_stall_patience: SimplexOptions::default().dual_stall_patience,
         cold_dual_start: false,
     };

--- a/crates/discopt-core/src/lp/simplex/dual.rs
+++ b/crates/discopt-core/src/lp/simplex/dual.rs
@@ -112,6 +112,34 @@ pub(super) fn stall_patience_default() -> usize {
     })
 }
 
+/// Whether the near-zero-pivot recovery is enabled for callers that did **not**
+/// supply a deadline, read once from `DISCOPT_LP_UNSTABLE_PIVOT_RECOVERY` (#1008
+/// R1). Default **off**: re-selecting after a refactorize can land on a different
+/// degenerate vertex, so graduating it needs the §5 corpus panel. The deadline
+/// path is not routed through here — it keeps the recovery it already had.
+pub fn unstable_pivot_recovery_default() -> bool {
+    static ON: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *ON.get_or_init(|| {
+        let raw = std::env::var("DISCOPT_LP_UNSTABLE_PIVOT_RECOVERY").unwrap_or_default();
+        parse_unstable_pivot_recovery(&raw).unwrap_or_else(|e| panic!("{e}"))
+    })
+}
+
+/// The parse table behind [`unstable_pivot_recovery_default`]. Unrecognized input
+/// is refused rather than defaulted, for the reason spelled out on
+/// [`parse_stall_patience`]: a typo in an A/B harness's arm that silently reads as
+/// a valid setting makes the harness measure one arm twice.
+fn parse_unstable_pivot_recovery(raw: &str) -> Result<bool, String> {
+    match raw.trim() {
+        "" | "0" | "false" | "False" | "off" | "OFF" => Ok(false),
+        "1" | "true" | "True" | "on" | "ON" => Ok(true),
+        other => Err(format!(
+            "DISCOPT_LP_UNSTABLE_PIVOT_RECOVERY={other:?} is not a recognized \
+             value. Use 1/true/on, or 0/false/off (the default)."
+        )),
+    }
+}
+
 /// The parse table behind [`stall_patience_default`], split out so the accepted
 /// and rejected spellings are testable without a process-global `OnceLock`.
 ///
@@ -946,10 +974,12 @@ impl<'a> PreparedDual<'a> {
             }
             let piv = alpha[r];
             if piv.abs() <= tol {
-                // Unstable (near-zero) pivot. On a solve with NO deadline this
-                // hands off to the robust cold fallback, exactly as before. On a
-                // deadline-carrying solve (#928) that hand-off forfeits the dual
-                // loop's anytime floor: the cold primal proves no usable bound
+                // Unstable (near-zero) pivot. Without the recovery this hands off
+                // to the robust cold fallback.
+                //
+                // #928 motivated the recovery from the deadline side: the
+                // hand-off forfeits the dual loop's anytime floor — the cold
+                // primal proves no usable bound
                 // mid-run, so if IT is then cut by the deadline the recovered
                 // floor collapses to the trivial `g(y=0)` box bound (measured on
                 // the hda node LP: floor -141697 vs optimum -64473 at every
@@ -957,12 +987,22 @@ impl<'a> PreparedDual<'a> {
                 // pivot is usually Forrest–Tomlin update drift, and the existing
                 // recovery for drift is refactorize + exact recompute — so do
                 // that in place and re-select, keeping the (monotone-bound) dual
-                // loop alive. Bounded: a few attempts per solve, then the old
+                // loop alive.
+                //
+                // But nothing in that reasoning is about deadlines, and #1008 R1
+                // is what a deadline-shaped gate costs: on QPLIB_2170's root
+                // relaxation the recovery fires once at `time_limit=40` and the
+                // LP solves to `optimal 0`; at `time_limit=None` the bail fires
+                // once instead and the caller gets nothing — same LP, same
+                // starting basis. The gate is now its own option, so a caller can
+                // ask for the recovery without inventing a deadline to get it.
+                //
+                // Bounded: a few attempts per solve, then the old
                 // cold bail; a genuinely singular selection re-trips immediately
                 // and exits through it. Sound: refactorize + exact recompute is
                 // the loop's soundness anchor already, and no pivot is taken on
                 // the near-zero element.
-                if opts.bank_deadline_duals && unstable_recoveries < UNSTABLE_RECOVERY_MAX {
+                if opts.recover_unstable_pivot && unstable_recoveries < UNSTABLE_RECOVERY_MAX {
                     unstable_recoveries += 1;
                     let cols: Vec<Vec<(usize, f64)>> = basis
                         .iter()
@@ -976,9 +1016,11 @@ impl<'a> PreparedDual<'a> {
                         dvec = refresh_rc!();
                         updates = 0;
                         since_refresh = 0;
+                        crate::profile::incr(crate::profile::Ctr::DualUnstablePivotRecoveries);
                         continue;
                     }
                 }
+                crate::profile::incr(crate::profile::Ctr::DualUnstablePivotBails);
                 return None; // unstable (near-zero) pivot → robust cold fallback
             }
             {
@@ -2193,6 +2235,77 @@ mod tests {
         );
     }
 
+    // #1008 R1: the near-zero-pivot recovery must not be reachable only by
+    // supplying a deadline.
+    //
+    // Same captured QPLIB_2170 relaxation and the same starting basis in both
+    // arms; the ONLY difference is `recover_unstable_pivot`. Off, the loop hits one
+    // unstable pivot and hands off to the cold primal, which fails — no bound. On,
+    // it refactorizes in place, re-selects, and reaches `optimal 0`, the value
+    // HiGHS certifies in 81 pivots.
+    //
+    // Before the split this option did not exist and the recovery rode on
+    // `bank_deadline_duals`, which `lp_bindings` sets to `deadline.is_some()`. So
+    // the two arms below were reachable from Python only by passing or omitting
+    // `time_limit` — a wall-clock argument silently deciding whether a bound comes
+    // back. `deadline` is `None` in both arms here, which is the point: the
+    // recovery has nothing to do with deadlines.
+    #[test]
+    fn unstable_pivot_recovery_is_not_gated_on_a_deadline() {
+        let _guard = crate::profile::test_guard();
+        crate::profile::reset();
+        crate::profile::set_enabled(true);
+
+        let json = include_str!("testdata/qplib2170_cold_fail_lp.json");
+        let (m, n, col_ptr, row_idx, vals, c, l, u, b, basic_vars, col_status) =
+            parse_stall_fixture(json);
+        let sp = SparseCols::from_csc(col_ptr, row_idx, vals);
+        let start = Basis {
+            col_status,
+            basic_vars,
+        };
+
+        let mut off = opts();
+        off.bank_deadline_duals = true;
+        off.recover_unstable_pivot = false;
+        assert!(off.deadline.is_none(), "no arm may carry a deadline");
+        let without = solve_lp_warm_csc(sp.clone(), m, n, &c, &l, &u, &b, Some(&start), &off);
+        let bails = crate::profile::counter(crate::profile::Ctr::DualUnstablePivotBails);
+
+        crate::profile::reset();
+        let mut on = off.clone();
+        on.recover_unstable_pivot = true;
+        let with = solve_lp_warm_csc(sp, m, n, &c, &l, &u, &b, Some(&start), &on);
+        let recoveries = crate::profile::counter(crate::profile::Ctr::DualUnstablePivotRecoveries);
+        crate::profile::set_enabled(false);
+
+        // The mechanism is what separates the arms, proven by counter rather than
+        // inferred from the outcome (§6): the same pivot goes one way or the other.
+        assert_eq!(
+            bails, 1,
+            "the OFF arm must bail on exactly one unstable pivot"
+        );
+        assert_eq!(
+            recoveries, 1,
+            "the ON arm must recover from exactly one unstable pivot"
+        );
+        assert_ne!(
+            without.status,
+            LpStatus::Optimal,
+            "the OFF arm is the defect: it must not already solve this LP"
+        );
+        assert_eq!(
+            with.status,
+            LpStatus::Optimal,
+            "the recovery must retain the bound with no deadline supplied"
+        );
+        assert!(
+            with.obj.abs() <= 1e-6,
+            "obj {} must match the HiGHS optimum 0",
+            with.obj
+        );
+    }
+
     // #1008: the cold primal must not CLAIM `Unbounded` on a bounded LP.
     //
     // Same captured QPLIB_2170 relaxation, entered through the cold path (no warm
@@ -2258,9 +2371,13 @@ mod tests {
     // converging all the same, which is precisely the case the 2048-pivot patience
     // cannot distinguish.
     //
-    // `bank_deadline_duals` is on in both arms to isolate the bail. That flag also
-    // gates the unstable-pivot recovery this LP needs (the #1008 R1 coupling); with
-    // it off, both arms fail and the bail's effect is invisible.
+    // Both arms set `bank_deadline_duals` and `recover_unstable_pivot` so the only
+    // variable is the bail. The second one is what this LP actually needs: it hits
+    // one near-zero pivot, and without the in-place refactorize+recompute recovery
+    // both arms fail and the bail's effect is invisible. Until #1008 R1 split them,
+    // setting `bank_deadline_duals` alone was enough — which is precisely the
+    // coupling R1 removes, and this test failing on that split is the coupling
+    // showing up in a unit test rather than only on a QPLIB relaxation.
     #[test]
     fn dual_stall_bail_can_cost_a_bound_when_the_cold_solve_fails() {
         let _guard = crate::profile::test_guard();
@@ -2282,6 +2399,7 @@ mod tests {
         // bail was default-ON.
         let mut shipped = opts();
         shipped.bank_deadline_duals = true;
+        shipped.recover_unstable_pivot = true;
         let ground = solve_lp_warm_csc(sp.clone(), m, n, &c, &l, &u, &b, Some(&start), &shipped);
         let bails_default = crate::profile::counter(crate::profile::Ctr::DualDegenerateStallBails);
         assert_eq!(
@@ -2308,6 +2426,7 @@ mod tests {
         let mut forced = opts();
         forced.dual_stall_patience = STALL_PATIENCE;
         forced.bank_deadline_duals = true;
+        forced.recover_unstable_pivot = true;
         let bailed = solve_lp_warm_csc(sp, m, n, &c, &l, &u, &b, Some(&start), &forced);
         let bails = crate::profile::counter(crate::profile::Ctr::DualDegenerateStallBails);
         crate::profile::set_enabled(false);

--- a/crates/discopt-core/src/lp/simplex/dual.rs
+++ b/crates/discopt-core/src/lp/simplex/dual.rs
@@ -2193,6 +2193,56 @@ mod tests {
         );
     }
 
+    // #1008: the cold primal must not CLAIM `Unbounded` on a bounded LP.
+    //
+    // Same captured QPLIB_2170 relaxation, entered through the cold path (no warm
+    // basis) — the route the stall bail hands off to. Before the ray certifier the
+    // cold solve returned `Unbounded` on an LP HiGHS certifies optimal at 0: every
+    // basic `α = B⁻¹A_q` came back zero for a column that is not zero, so the ratio
+    // test found no blocking row and the breakdown was read as a verdict. The
+    // captured ray had one nonzero, `|A d| = 1.0` and `cᵀd = 0` — it satisfies none
+    // of the three conditions an unbounded ray must satisfy.
+    //
+    // `Unbounded` on a minimization relaxation means a node bound of −∞, so a false
+    // one is a bound loss, not a slowdown. The certifier turns it into `Numerical`,
+    // an honest refusal that also routes into `dense_retry`'s dense-LU path.
+    #[test]
+    fn cold_primal_does_not_claim_unbounded_on_a_bounded_lp() {
+        let _guard = crate::profile::test_guard();
+        crate::profile::reset();
+        crate::profile::set_enabled(true);
+        let json = include_str!("testdata/qplib2170_cold_fail_lp.json");
+        let (m, n, col_ptr, row_idx, vals, c, l, u, b, _basic_vars, _col_status) =
+            parse_stall_fixture(json);
+        let sp = SparseCols::from_csc(col_ptr, row_idx, vals);
+        let mut o = opts();
+        o.bank_deadline_duals = true;
+
+        let cold = solve_csc_core(&sp, m, n, &c, &l, &u, &b, None, &o);
+        let rejects = crate::profile::counter(crate::profile::Ctr::UnboundedRejectRowResidual)
+            + crate::profile::counter(crate::profile::Ctr::UnboundedRejectObjective)
+            + crate::profile::counter(crate::profile::Ctr::UnboundedRejectBox);
+        crate::profile::set_enabled(false);
+
+        // The defect itself, asserted first so removing the guard reports the wrong
+        // *verdict* rather than a bookkeeping count.
+        assert_ne!(
+            cold.status,
+            LpStatus::Unbounded,
+            "cold solve claims Unbounded on an LP HiGHS certifies optimal at 0 \
+             (obj={})",
+            cold.obj
+        );
+        // And the probe fired: the certifier actually rejected a ray here, so the
+        // assertion above is exercising the guard and not an unrelated path where
+        // the fixture stopped reaching the ratio test's unbounded exit at all (§6).
+        assert!(
+            rejects > 0,
+            "the ray certifier never rejected anything on the LP that motivated it; \
+             this fixture no longer reaches the guard (rejects={rejects})"
+        );
+    }
+
     // #1008: the bound-neutrality the test above asserts is a property of THAT
     // fixture, not of the bail. It holds on `tspn12` because the cold solve the
     // bail hands off to happens to succeed. When the cold solve does *not* succeed,

--- a/crates/discopt-core/src/lp/simplex/mod.rs
+++ b/crates/discopt-core/src/lp/simplex/mod.rs
@@ -28,7 +28,8 @@ pub mod sparse;
 
 pub use batch::{solve_lp_batch, solve_lp_multi_rhs, LpInstance};
 pub use dual::{
-    solve_lp_warm, solve_lp_warm_csc, solve_lp_warm_scaled, solve_lp_warm_scaled_csc, PreparedDual,
+    solve_lp_warm, solve_lp_warm_csc, solve_lp_warm_scaled, solve_lp_warm_scaled_csc,
+    unstable_pivot_recovery_default, PreparedDual,
 };
 pub use presolve::{tighten_bounds, tighten_bounds_csc};
 pub use primal::{solve_lp, solve_lp_cols, solve_lp_cols_scaled, solve_lp_scaled};
@@ -122,18 +123,40 @@ pub struct SimplexOptions {
     /// basis's row-dual candidate `y = B⁻ᵀc_B` — whose Neumaier–Shcherbina
     /// evaluation is the monotone best-so-far dual objective — instead of falling
     /// back to a cold primal whose spent budget yields a near-useless initial
-    /// basis dual. It also enables two loop-preserving recoveries that exist only
-    /// to keep that anytime floor alive: an in-place refactorize+recompute retry
-    /// on a near-zero pivot, and handing the last exact-refresh duals to the cold
-    /// fallback when the loop breaks down and the fallback is then itself cut.
+    /// basis dual. It also enables handing the last exact-refresh duals to the
+    /// cold fallback when the loop breaks down and the fallback is then itself
+    /// cut — a recovery that exists only to keep that anytime floor alive.
     ///
     /// Default `false`: the MILP B&B driver also sets `deadline` on the default
-    /// route, and these recoveries change the pivot path (same audited optimum,
-    /// possibly a different degenerate vertex), which is *bound-changing* under
-    /// the §5 regime. Only the pure-LP warm binding (`solve_lp_warm_csc_py`)
-    /// sets it, and only when its caller passed a `time_limit` — i.e. exactly the
+    /// route, and this changes the pivot path (same audited optimum, possibly a
+    /// different degenerate vertex), which is *bound-changing* under the §5
+    /// regime. Only the pure-LP warm binding (`solve_lp_warm_csc_py`) sets it,
+    /// and only when its caller passed a `time_limit` — i.e. exactly the
     /// `DISCOPT_LP_WARM_DEADLINE` path whose graduation panel judges it.
     pub bank_deadline_duals: bool,
+    /// On a near-zero (unstable) dual pivot, refactorize + exact-recompute in
+    /// place and re-select instead of abandoning the warm loop for the cold
+    /// primal (#1008 R1).
+    ///
+    /// This used to be gated on [`bank_deadline_duals`](Self::bank_deadline_duals),
+    /// which `lp_bindings` sets to `deadline.is_some()`. Nothing about the
+    /// recovery is deadline-related: a tiny pivot is usually Forrest–Tomlin
+    /// update drift, and refactorize + exact recompute is the loop's soundness
+    /// anchor already. The coupling meant a caller who passed no `time_limit`
+    /// silently got the cold hand-off on the same LP and the same starting basis.
+    /// Measured on QPLIB_2170's root relaxation (`DISCOPT_PROFILE=1`, counters
+    /// `DualUnstablePivotRecoveries` / `DualUnstablePivotBails`): at
+    /// `time_limit=40` the recovery fires once and the LP solves to `optimal 0`
+    /// (HiGHS agrees, 81 pivots); at `time_limit=None` the bail fires once and
+    /// the caller gets nothing. One pivot, and the difference is whether a
+    /// deadline was supplied.
+    ///
+    /// Default `false` and opted into by `DISCOPT_LP_UNSTABLE_PIVOT_RECOVERY=1`:
+    /// re-selecting after a refactorize can land on a different degenerate
+    /// vertex, so this is bound-changing under §5 and needs a corpus panel that
+    /// is both cert-clean and net-positive before it graduates. The deadline
+    /// path's behavior is unchanged — it keeps the recovery it already had.
+    pub recover_unstable_pivot: bool,
     /// Consecutive degenerate dual pivots after which a **stalled** warm re-solve
     /// is abandoned for the cold solve; `0` disables the bail (#1013).
     ///
@@ -227,6 +250,7 @@ impl Default for SimplexOptions {
             warm_stall_cap_override: None,
             expel_zero_artificials: false,
             bank_deadline_duals: false,
+            recover_unstable_pivot: false,
             dual_stall_patience: dual::stall_patience_default(),
             cold_dual_start: false,
         }

--- a/crates/discopt-core/src/lp/simplex/primal.rs
+++ b/crates/discopt-core/src/lp/simplex/primal.rs
@@ -474,6 +474,18 @@ fn row_roundoff(terms: u32, term_scale: f64) -> f64 {
     8.0 * (terms as f64) * f64::EPSILON * term_scale
 }
 
+/// Relative slack allowed when certifying a primal unbounded ray (`ray_certifies_unbounded`).
+///
+/// Deliberately *not* `gamma(nnz)`: the residual `A d` carries the error of the LU
+/// solve that produced `α = B⁻¹A_q`, which is orders of magnitude above the
+/// summation rounding `γ` bounds. `1e-7` relative is loose enough that a ray from a
+/// healthy factorization certifies, and tight enough that the breakdown this guard
+/// exists for — `|A d| = 1.0` against an accumulation of `1.0`, a relative residual
+/// of 1 — is refused by a factor of 10⁷. A genuine unbounded ray rejected here means
+/// the factorization is that badly wrong, in which case `Numerical` is the right
+/// verdict on its own merits.
+const RAY_CERT_REL: f64 = 1e-7;
+
 /// The classic dot-product error factor `γ_k = k·u/(1 − k·u)` (Higham, *Accuracy and
 /// Stability of Numerical Algorithms*, §3.1): a sum of `k` floating-point terms
 /// evaluated in any order differs from the exact sum by at most `γ_k · Σ|terms|`.
@@ -1797,6 +1809,96 @@ impl<'a> Simplex<'a> {
         Ok(self.assemble(st, &art_sign))
     }
 
+    /// True when `d` is a certified primal unbounded ray for the LP as currently
+    /// loaded: `A d = 0`, `cᵀd < 0` under the cost actually in use, and the box
+    /// recedes on every coordinate `d` moves. Increments a rejection counter naming
+    /// the condition that failed.
+    ///
+    /// This is the primal mirror of `farkas_ray_certifies_cols`. The ratio test
+    /// concluding "no basic variable blocks" is a *statement about `α = B⁻¹A_q`*,
+    /// and an ftran that silently returns garbage produces exactly that statement,
+    /// so the conclusion has to be re-derived from `A` and `c` directly rather than
+    /// inherited from the object under suspicion.
+    ///
+    /// `cost` is the phase's own cost vector, not `self.c`: in phase 1 the loop is
+    /// minimizing infeasibility and `self.c` is not the objective being improved.
+    fn ray_certifies_unbounded(&self, d: &[f64], cost: &[f64], alpha: &[f64]) -> bool {
+        let (m, n) = (self.m, self.n);
+        if d.len() != n || !d.iter().all(|v| v.is_finite()) {
+            crate::profile::incr(crate::profile::Ctr::UnboundedRejectRowResidual);
+            return false;
+        }
+        // A basic *artificial* moving along the ray puts the direction in the
+        // extended space `[A | art]`; truncating it to the real columns silently
+        // drops those entries, so `A d = 0` would be checked against an incomplete
+        // vector. Phase 2 pins artificials to [0,0], so the ratio test blocks on
+        // them and this is unreachable; phase 1 minimizes a quantity bounded below
+        // by zero and therefore has no unbounded direction to find. Refuse either
+        // way rather than certify a truncation.
+        for i in 0..m {
+            if self.basis[i] >= n && alpha[i].abs() > self.tol {
+                crate::profile::incr(crate::profile::Ctr::UnboundedRejectRowResidual);
+                return false;
+            }
+        }
+        // `A d` alongside the magnitude bounding its rounding. Per #1017 the
+        // *result* of a cancelling sum says nothing about that sum's error, so the
+        // margin is built from the accumulation, not from `r[i]`.
+        let mut r = vec![0.0f64; m];
+        let mut r_abs = vec![0.0f64; m];
+        for j in 0..n {
+            let dj = d[j];
+            if dj == 0.0 {
+                continue;
+            }
+            let (rows, vals) = self.cols.col(j);
+            for (&i, &a) in rows.iter().zip(vals) {
+                let t = a * dj;
+                r[i] += t;
+                r_abs[i] += t.abs();
+            }
+        }
+        for i in 0..m {
+            if r[i].abs() > RAY_CERT_REL * (1.0 + r_abs[i]) {
+                crate::profile::incr(crate::profile::Ctr::UnboundedRejectRowResidual);
+                return false;
+            }
+        }
+        // In exact arithmetic `cᵀd = dir·d_q`, the entering reduced cost, which
+        // pricing already required to be `< −tol`. Recomputing it from `c` is
+        // therefore a cross-check of the btran that produced that reduced cost
+        // against the ftran that produced `α`. An all-zero `d` (no nonzero at all)
+        // lands here with `cd = 0` and is refused.
+        let mut cd = 0.0f64;
+        let mut cd_abs = 0.0f64;
+        for j in 0..n {
+            let t = cost[j] * d[j];
+            cd += t;
+            cd_abs += t.abs();
+        }
+        if !(cd < 0.0 && cd.abs() > RAY_CERT_REL * cd_abs) {
+            crate::profile::incr(crate::profile::Ctr::UnboundedRejectObjective);
+            return false;
+        }
+        // Recession: travelling along `d` forever must stay inside the box. `INF` is
+        // the sentinel `1e20`, so the comparison is against the *bound*, never a
+        // product involving it.
+        for j in 0..n {
+            let open = if d[j] > self.tol {
+                self.ub[j] >= INF
+            } else if d[j] < -self.tol {
+                self.lb[j] <= -INF
+            } else {
+                true
+            };
+            if !open {
+                crate::profile::incr(crate::profile::Ctr::UnboundedRejectBox);
+                return false;
+            }
+        }
+        true
+    }
+
     /// Primal simplex iterations for the given `cost`. Returns Ok(()) at
     /// optimality, Err(Unbounded/IterLimit/Numerical) otherwise.
     fn simplex_loop(
@@ -2032,6 +2134,27 @@ impl<'a> Simplex<'a> {
                         ray[bi] = -dir * alpha[i];
                     }
                 }
+                // #1008: certify the ray before CLAIMING unboundedness.
+                //
+                // The comment above says a caller verifies this. No caller did —
+                // the ray is exported to Python and read by nobody in Rust, while
+                // the *status* was returned on faith. `Infeasible` has never been
+                // taken on faith (`farkas_ray_certifies_cols`), and the asymmetry
+                // is not justified: "the ratio test found no blocking row" is also
+                // exactly what a silently broken ftran produces. On the captured
+                // QPLIB_2170 relaxation it did — every basic α came back zero for a
+                // column that is not zero, giving a ray with one nonzero, |A d| =
+                // 1.0 and cᵀd = 0, against an LP HiGHS certifies as optimal at 0.
+                //
+                // A ray that fails is a numerical breakdown, not an unbounded LP,
+                // so the verdict becomes `Numerical` — an honest refusal, and the
+                // status that routes into `dense_retry`'s robust LU path (§3:
+                // refuse loudly rather than claim). A genuine unbounded ray passes
+                // untouched, so no true `Unbounded` is downgraded.
+                if !self.ray_certifies_unbounded(&ray, cost, &alpha) {
+                    return Err(LpStatus::Numerical);
+                }
+                crate::profile::incr(crate::profile::Ctr::UnboundedRayCertified);
                 self.unbounded_ray = ray;
                 return Err(LpStatus::Unbounded);
             }

--- a/crates/discopt-core/src/profile.rs
+++ b/crates/discopt-core/src/profile.rs
@@ -241,6 +241,16 @@ counters!(
     UnboundedRejectRowResidual,
     UnboundedRejectObjective,
     UnboundedRejectBox,
+    // #1008 R1: the warm dual's unstable- (near-zero-) pivot exit, split by which
+    // way it went. `Recoveries` counts in-place refactorize+recompute+re-select,
+    // which keeps the monotone dual loop alive; `Bails` counts the hand-off to the
+    // cold primal. The recovery is gated on `bank_deadline_duals`, which
+    // `lp_bindings` sets to `deadline.is_some()` — so a caller passing no
+    // `time_limit` gets the bail on the same LP and the same starting basis. These
+    // two counters are what makes that a measurement rather than a reading of the
+    // control flow.
+    DualUnstablePivotRecoveries,
+    DualUnstablePivotBails,
     // The WARM path's own terminal histogram. `solve_lp_warm_csc` is the entry the
     // Python spatial engine's per-node LPs come through, and it can return without
     // ever reaching the cold primal's `assemble`, so the `LpVerdict*` counters above

--- a/crates/discopt-core/src/profile.rs
+++ b/crates/discopt-core/src/profile.rs
@@ -228,6 +228,19 @@ counters!(
     // one is a certificate #1017 removed — the whole cost side of that change, and the
     // only way to see it in a corpus run without an A/B rebuild.
     FarkasRejectCancellation,
+    // #1008: the same treatment for the PRIMAL unbounded ray, which had none. An
+    // `Infeasible` verdict must clear `farkas_ray_certifies_cols`; an `Unbounded`
+    // verdict was taken on faith from "the ratio test found no blocking row",
+    // which is also what a silently broken ftran looks like. `Certified` counts
+    // rays that pass; the three `Reject` counters say which condition failed —
+    // `A d = 0` (the ray is not a recession direction at all), `cᵀd < 0` (the
+    // objective does not improve along it), or box recession (it leaves the box).
+    // On the captured QPLIB_2170 relaxation the ray had ONE nonzero, |A d| = 1.0
+    // and cᵀd = 0: every basic α came back zero for a column that is not zero.
+    UnboundedRayCertified,
+    UnboundedRejectRowResidual,
+    UnboundedRejectObjective,
+    UnboundedRejectBox,
     // The WARM path's own terminal histogram. `solve_lp_warm_csc` is the entry the
     // Python spatial engine's per-node LPs come through, and it can return without
     // ever reaching the cold primal's `assemble`, so the `LpVerdict*` counters above

--- a/crates/discopt-python/src/lp_bindings.rs
+++ b/crates/discopt-python/src/lp_bindings.rs
@@ -21,8 +21,8 @@ use discopt_core::lp::crossover::{crossover_to_vertex, LpView};
 use discopt_core::lp::gomory::separate_gomory;
 use discopt_core::lp::mir::separate_mir;
 use discopt_core::lp::simplex::{
-    solve_lp as simplex_solve_lp, solve_lp_batch, solve_lp_warm, solve_lp_warm_csc, LpInstance,
-    LpStatus, SimplexOptions, SparseCols,
+    solve_lp as simplex_solve_lp, solve_lp_batch, solve_lp_warm, solve_lp_warm_csc,
+    unstable_pivot_recovery_default, LpInstance, LpStatus, SimplexOptions, SparseCols,
 };
 use numpy::{
     PyArray1, PyArray2, PyArrayMethods, PyReadonlyArray1, PyReadonlyArray2, PyUntypedArrayMethods,
@@ -406,6 +406,7 @@ pub fn solve_lp_py<'py>(
         warm_stall_cap_override: None,
         expel_zero_artificials: false,
         bank_deadline_duals: false,
+        recover_unstable_pivot: false,
         // #1013: hand a STALLED warm dual re-solve to the cold solve (default from
         // `DISCOPT_LP_DUAL_STALL_BAIL`). Inert on the cold-only entry points.
         dual_stall_patience: SimplexOptions::default().dual_stall_patience,
@@ -543,6 +544,7 @@ pub fn solve_lp_warm_py<'py>(
         warm_stall_cap_override: None,
         expel_zero_artificials: false,
         bank_deadline_duals: false,
+        recover_unstable_pivot: false,
         // #1013: hand a STALLED warm dual re-solve to the cold solve (default from
         // `DISCOPT_LP_DUAL_STALL_BAIL`). Inert on the cold-only entry points.
         dual_stall_patience: SimplexOptions::default().dual_stall_patience,
@@ -654,6 +656,14 @@ pub fn solve_lp_warm_csc_py<'py>(
         // driver's own deadline route keeps the default `false`, so the default
         // B&B pivot path is untouched.
         bank_deadline_duals: deadline.is_some(),
+        // #1008 R1: the near-zero-pivot recovery used to ride on the line above,
+        // so a caller who passed no `time_limit` lost it — measured on
+        // QPLIB_2170, that is the difference between `optimal 0` and no bound at
+        // all. It now has its own gate. `deadline.is_some()` keeps the deadline
+        // path bit-identical to what its own graduation panel judged; the env
+        // opt-in extends it to deadline-free callers and is default-OFF until the
+        // §5 panel graduates it.
+        recover_unstable_pivot: deadline.is_some() || unstable_pivot_recovery_default(),
         // #1013: hand a STALLED warm dual re-solve to the cold solve (default from
         // `DISCOPT_LP_DUAL_STALL_BAIL`). Inert on the cold-only entry points.
         dual_stall_patience: SimplexOptions::default().dual_stall_patience,
@@ -789,6 +799,7 @@ pub fn solve_lp_batch_py<'py>(
         warm_stall_cap_override: None,
         expel_zero_artificials: false,
         bank_deadline_duals: false,
+        recover_unstable_pivot: false,
         // #1013: hand a STALLED warm dual re-solve to the cold solve (default from
         // `DISCOPT_LP_DUAL_STALL_BAIL`). Inert on the cold-only entry points.
         dual_stall_patience: SimplexOptions::default().dual_stall_patience,
@@ -1167,6 +1178,7 @@ fn run_milp_hooked<'py>(
             warm_stall_cap_override: None,
             expel_zero_artificials: false,
             bank_deadline_duals: false,
+            recover_unstable_pivot: false,
             // #1013: hand a STALLED warm dual re-solve to the cold solve (default from
             // `DISCOPT_LP_DUAL_STALL_BAIL`). Inert on the cold-only entry points.
             dual_stall_patience: SimplexOptions::default().dual_stall_patience,

--- a/crates/discopt-python/src/lp_bindings.rs
+++ b/crates/discopt-python/src/lp_bindings.rs
@@ -89,6 +89,38 @@ fn parse_budget_secs(time_limit_s: Option<f64>) -> PyResult<Option<f64>> {
     }
 }
 
+/// Refuse a NaN entry in an LP's variable box.
+///
+/// A NaN bound has no meaning in an LP, and — worse — it reads *differently
+/// depending on which way the comparison is written*, because every comparison
+/// against NaN is false. The simplex asks "is this side open?" both ways:
+/// `ub < INF` (the ratio test's blocking check) calls a NaN upper bound **open**,
+/// while `ub >= INF` (the unbounded-ray box-recession check) calls the same bound
+/// **closed**. On issue #1008 that split produced an LP the ratio test walked to
+/// `t = INF` on and reported `unbounded`, over a box it could not certify as
+/// recessive. This is the `INF`-is-`1e20` hazard from CLAUDE.md in its other
+/// guise: there the sentinel silently survived a multiplication, here it is
+/// silently absent.
+///
+/// The modeling layer spells "no bound" as NaN (`Model.continuous(ub=None)` →
+/// `array(nan)`); the LP layer spells it as the sentinel `±1e20`. Translating
+/// between the two is the caller's job — `lp_simplex._finite_box` does it — and
+/// this refuses loudly rather than let an untranslated box reach the simplex and
+/// be read two ways. `±inf` is *not* rejected: it satisfies `>= INF` and fails
+/// `< INF`, so both readings agree it is open.
+fn check_box_not_nan(lb: &[f64], ub: &[f64]) -> PyResult<()> {
+    for (name, v) in [("lb", lb), ("ub", ub)] {
+        if let Some(j) = v.iter().position(|x| x.is_nan()) {
+            return Err(PyValueError::new_err(format!(
+                "{name}[{j}] is NaN; an LP bound must be finite or the ±1e20 \
+                 unbounded sentinel (NaN is read as both open and closed by \
+                 different guards — see issue #1008)"
+            )));
+        }
+    }
+    Ok(())
+}
+
 /// Push an interior LP optimum `x` to a vertex of the optimal face.
 ///
 /// `a` is the C-contiguous `m × n` equality-constraint matrix; `c`, `lb`, `ub`
@@ -351,6 +383,7 @@ pub fn solve_lp_py<'py>(
     max_iter: usize,
 ) -> PyResult<(String, Bound<'py, PyArray1<f64>>, f64, usize)> {
     let dims = a.shape();
+    check_box_not_nan(lb.as_slice()?, ub.as_slice()?)?;
     let (m, n) = (dims[0], dims[1]);
     let a_flat = a
         .as_slice()
@@ -487,6 +520,7 @@ pub fn solve_lp_warm_py<'py>(
     Bound<'py, PyArray1<f64>>,
 )> {
     let dims = a.shape();
+    check_box_not_nan(lb.as_slice()?, ub.as_slice()?)?;
     let (m, n) = (dims[0], dims[1]);
     let a_flat = a
         .as_slice()
@@ -599,6 +633,7 @@ pub fn solve_lp_warm_csc_py<'py>(
     // otherwise leave profiling uninitialized and dump() a no-op. Cheap; first call
     // per process fixes the flag.
     discopt_core::profile::init_from_env();
+    check_box_not_nan(lb.as_slice()?, ub.as_slice()?)?;
     let col_ptr: Vec<usize> = col_ptr.as_slice()?.iter().map(|&x| x as usize).collect();
     let row_idx: Vec<usize> = row_idx.as_slice()?.iter().map(|&x| x as usize).collect();
     let vals_v: Vec<f64> = vals.as_slice()?.to_vec();
@@ -714,6 +749,7 @@ pub fn solve_lp_batch_py<'py>(
     Bound<'py, PyArray1<f64>>,
 )> {
     let dims = a.shape();
+    check_box_not_nan(lb.as_slice()?, ub.as_slice()?)?;
     let (m, n) = (dims[0], dims[1]);
     let k = b.shape()[0];
     if b.shape()[1] != m {
@@ -907,6 +943,7 @@ pub fn solve_milp_py<'py>(
     debug_hook: Option<Py<PyAny>>,
 ) -> PyResult<(String, Bound<'py, PyArray1<f64>>, f64, f64, usize, usize)> {
     let dims = a.shape();
+    check_box_not_nan(lb.as_slice()?, ub.as_slice()?)?;
     let (m, n) = (dims[0], dims[1]);
     // Materialize owned copies of the borrowed numpy inputs. `PyReadonlyArray`
     // borrows are only valid while the GIL is held, so we copy before releasing
@@ -1013,6 +1050,7 @@ pub fn solve_milp_csc_py<'py>(
     debug_hook: Option<Py<PyAny>>,
 ) -> PyResult<(String, Bound<'py, PyArray1<f64>>, f64, f64, usize, usize)> {
     let col_ptr_v: Vec<usize> = col_ptr.as_slice()?.iter().map(|&x| x as usize).collect();
+    check_box_not_nan(lb.as_slice()?, ub.as_slice()?)?;
     let row_idx_v: Vec<usize> = row_idx.as_slice()?.iter().map(|&x| x as usize).collect();
     let vals_v: Vec<f64> = vals.as_slice()?.to_vec();
     let c_owned: Vec<f64> = c.as_slice()?.to_vec();

--- a/docs/dev/performance-plan.md
+++ b/docs/dev/performance-plan.md
@@ -2692,3 +2692,55 @@ rather than by name, §2). It returns `Unbounded` on the old default and
 `bank_deadline_duals` coupling that makes QPLIB_2170 solvable only when the caller
 passes a `time_limit` (#1008 R1) — both tracked in #1008.
 
+### 18c. The false `Unbounded` is a broken ftran read as a verdict (#1008, 2026-08-13)
+
+§18b left this open. It is not a property of the stall bail: with
+`DISCOPT_LP_DUAL_STALL_BAIL=0` (the default since #1021) and `time_limit=None`,
+QPLIB_2170's root relaxation still reaches the ratio test's unbounded exit —
+`UnboundedRejectRowResidual = 2` end to end.
+
+**What the engine was doing.** `Infeasible` is issued only after
+`farkas_ray_certifies_cols` accepts a dual ray. `Unbounded` was issued on the
+strength of "the ratio test found no blocking row" alone. But that sentence is a
+statement *about* `α = B⁻¹A_q`, so an ftran that silently returns zeros produces
+it verbatim — which is exactly what happens here. The captured ray:
+
+| quantity | required | measured |
+|---|---|---|
+| nonzeros in `d` | ≥ 1 basic + entering | **1** (the entering column only) |
+| `max_i |A d|_i` | 0 | **1.0** |
+| `cᵀd` | < 0 | **0.0** |
+| box-recession violations | 0 | 0 |
+
+Three of the four conditions fail. The LP is `optimal 0` (HiGHS, 81 pivots).
+
+**Blast radius, by driver.** `spatial_tree::verdict_for` already maps
+`Unbounded`, `IterLimit` and `Numerical` alike to `NodeVerdict::Undecided`, so
+there the cost was only the bypassed `dense_retry` — which is gated on
+`Numerical | IterLimit` and so never ran. `milp_driver` is the serious one:
+`out.unbounded` at any node sets `hit_unbounded`, breaks the search loop, and
+short-circuits `decide_status` ahead of every other branch, returning
+`MilpStatus::Unbounded` for a bounded MILP and discarding any incumbent. One
+false node verdict is enough.
+
+**The fix** is the primal mirror of the Farkas path: `ray_certifies_unbounded`
+checks `A d = 0`, `cᵀd < 0` under the cost the *phase* is minimizing (not
+`self.c` — phase 1 is minimizing infeasibility), and box recession, refusing with
+`Numerical` when any fails. Margins are built from accumulation magnitudes rather
+than results (#1017). The relative slack is `1e-7`, deliberately not
+`gamma(nnz)`: the residual carries the LU solve's error, not just summation
+rounding. It rejects the observed breakdown by a factor of 10⁷.
+
+`Numerical` is also the status that routes into `dense_retry`, so the honest
+refusal is strictly more useful than the false claim.
+
+**Not a bound recovery.** On QPLIB_2170 at `time_limit=None` the outcome stays
+"no solution" — the engine simply stops claiming a certificate it cannot support.
+The remaining loss on that cell is the `bank_deadline_duals` coupling (#1008 R1,
+still open): the same LP solves to `optimal 0` at `time_limit=40.0`. The four-cell
+BAIL × time_limit A/B is otherwise unchanged from §18b, so nothing regressed.
+
+Pinned by `cold_primal_does_not_claim_unbounded_on_a_bounded_lp` (returns
+`Unbounded` obj 351 without the certifier, `Numerical` with it) and by the
+pre-existing `unbounded_detected` / `unbounded_emits_a_valid_primal_ray`, which
+confirm a genuine unbounded ray still certifies untouched.

--- a/docs/dev/performance-plan.md
+++ b/docs/dev/performance-plan.md
@@ -2792,3 +2792,46 @@ before being trusted as a baseline, and it reproduced the pass.
 
 Pinned by `python/tests/test_1008_nan_lp_bound.py` (3 tests; 2 fail with
 `ValueError: ub[0] is NaN` when `_finite_box` is neutered).
+
+### 18e. The unstable-pivot recovery was gated on the caller's `time_limit` (#1008 R1, 2026-08-13)
+
+§18c closed the false certificate on QPLIB_2170 but left the bound loss standing,
+and named the suspect: `SimplexOptions::bank_deadline_duals`, set as
+`deadline.is_some()`, was doing double duty. Besides banking the dual loop's
+anytime floor (#928 — its actual job) it also switched on the recovery that
+re-tries a near-zero pivot instead of abandoning the warm re-solve.
+
+**Entry experiment** (CLAUDE.md §4), run before the implementation and read from
+counters rather than from control flow — two new counters exist precisely so this
+is a measurement:
+
+| call | `DualUnstablePivotRecoveries` | `DualUnstablePivotBails` | ray rejects | result |
+|---|---|---|---|---|
+| `time_limit=None` | 0 | **1** | 2 | no solution |
+| `time_limit=40.0` | **1** | 0 | 0 | **optimal 0** |
+
+One unstable pivot separates a certified optimum from nothing, and which side you
+land on is decided solely by whether the caller bounded the LP in time. QPLIB_2738
+fires neither counter — its loss was the #1013 stall bail, already fixed — so this
+is a distinct mechanism, not a second reading of the same cell.
+
+**The fix** is an unbundling, not a new mechanism: `recover_unstable_pivot` gets
+its own field and its own env gate (`DISCOPT_LP_UNSTABLE_PIVOT_RECOVERY`), and
+`bank_deadline_duals` goes back to banking duals. The deadline path keeps the
+recovery unconditionally (`deadline.is_some() || unstable_pivot_recovery_default()`)
+so it stays bit-identical to what its own panel judged.
+
+**Status: default-OFF for deadline-free callers.** Taking a different pivot is
+bound-changing, so §5 applies and the flag stays off until a corpus differential
+panel clears *both* bars. The graduation panel (88 captured relaxation LPs,
+`scratchpad/i1008/r1_panel.py`, one process per arm because the flag is read once
+via `OnceLock`, HiGHS as oracle, every LP at `time_limit=None` — the exact call
+shape that lost the recovery) was **started and stopped at 18/88 on arm 0 with arm
+1 not begun**; no claim is made from that partial data and none of it is reported
+here. Running it to completion on both arms is what remains before the default can
+flip. Until then this ships as the `DISCOPT_CUT_INHERIT` precedent has it: the
+mechanism lands, the measurement is recorded, the default does not move.
+
+Pinned by `unstable_pivot_recovery_is_not_gated_on_a_deadline` (flag off → bails 1,
+not optimal; flag on → recoveries 1, optimal 0; both arms assert
+`deadline.is_none()`, which is the coupling under test).

--- a/docs/dev/performance-plan.md
+++ b/docs/dev/performance-plan.md
@@ -2744,3 +2744,51 @@ Pinned by `cold_primal_does_not_claim_unbounded_on_a_bounded_lp` (returns
 `Unbounded` obj 351 without the certifier, `Numerical` with it) and by the
 pre-existing `unbounded_detected` / `unbounded_emits_a_valid_primal_ray`, which
 confirm a genuine unbounded ray still certifies untouched.
+
+### 18d. A NaN bound is read as both open and closed (#1008, 2026-08-13)
+
+The certifier in §18c turned a CI job red on `test_c3_unbounded_recourse_reported`
+(`unbounded` → `iteration_limit`). The measurement — profile counters on the
+Benders solve, `DISCOPT_PROFILE=1` — put the rejection at
+`UnboundedRejectBox = 2`, not at the residual or objective margins. The LP behind
+it, captured by wrapping the recourse oracle:
+
+```
+min -w   s.t.  -w <= 0,   w in [0, nan]
+```
+
+The **upper bound is NaN**. `Model.continuous(ub=None)` stores `array(nan)`; the
+Rust simplex reads the sentinel `±1e20`. Nothing translated between the two, and
+NaN does not announce itself, because every comparison against it is false — so
+each guard reads the same bound as whichever answer its comparison is written for:
+
+| guard | question asked | NaN answer | reading |
+|---|---|---|---|
+| ratio test | `ub < INF` — does this bound block? | false | **open** → `t = INF` → `unbounded` |
+| §18c ray certifier | `ub >= INF` — is this side open? | false | **closed** → refuse |
+
+So the pre-#1022 `unbounded` on that LP was *correct but underived*: right answer,
+resting on which of the two readings the ratio test happened to use, over a box
+the engine could not certify as recessive. The certifier did not break it — it
+made a latent ambiguity observable. This is the `INF`-is-`1e20` hazard already in
+`CLAUDE.md`, in its other guise: there the sentinel silently survives a
+multiplication; here it is silently absent.
+
+**The fix has two halves**, and needs both. `lp_simplex._finite_box` translates
+the box (NaN, `±inf`, and any magnitude past the sentinel → `±1e20`) so the
+simplex sees one convention; the PyO3 LP/MILP entry points refuse a NaN bound
+with a `ValueError` naming the index, so a caller that skips the translation gets
+a loud error rather than a verdict derived from two incompatible readings. `±inf`
+is deliberately *not* refused — it satisfies `>= INF` and fails `< INF`, so both
+readings already agree it is open.
+
+**Method note.** The regression was found by CI and diagnosed by counter, not by
+reading control flow: the first probe (`c3_probe.py`) printed every
+`Unbounded*`/`Farkas*` counter and the *box* counter was the one that moved. A
+control-flow reading would have blamed the residual margin, which is where the
+§18c work had been concentrated. Baseline separation followed CLAUDE.md §8 — the
+pre-#1022 `.so` was asserted to *lack* the `UnboundedRejectRowResidual` marker
+before being trusted as a baseline, and it reproduced the pass.
+
+Pinned by `python/tests/test_1008_nan_lp_bound.py` (3 tests; 2 fail with
+`ValueError: ub[0] is NaN` when `_finite_box` is neutered).

--- a/python/discopt/solvers/lp_simplex.py
+++ b/python/discopt/solvers/lp_simplex.py
@@ -76,6 +76,33 @@ def _reject_unknown_kwargs(kwargs: dict[str, Any]) -> None:
         )
 
 
+#: The LP layer's "no bound" sentinel. The Rust simplex tests openness as
+#: ``ub >= INF`` / ``lb <= -INF`` with ``INF = 1e20``; anything at or beyond it is
+#: unbounded on that side.
+_LP_INF = 1e20
+
+
+def _finite_box(lb: np.ndarray, ub: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
+    """Translate a modeling-layer box into the LP layer's sentinel convention.
+
+    The two layers spell "no bound" differently: ``Model.continuous(ub=None)``
+    stores **NaN**, while the simplex reads the sentinel ``±1e20``. A NaN that
+    crosses untranslated is not merely unhelpful — it is read *both ways*, since
+    every comparison against NaN is false. The ratio test's ``ub < INF`` calls a
+    NaN upper bound open and steps to ``t = INF``; the unbounded-ray box-recession
+    check's ``ub >= INF`` calls the same bound closed. Issue #1008: a Benders
+    recourse LP over ``w ∈ [0, NaN]`` was walked to an unbounded ray the box could
+    not certify, so the verdict depended on which guard you asked.
+
+    NaN means unbounded on that side, and ``±inf`` (and any magnitude past the
+    sentinel, which the simplex already treats as unbounded) is clamped onto it so
+    the two readings agree. Finite bounds pass through untouched.
+    """
+    lo = np.where(np.isnan(lb), -_LP_INF, np.maximum(lb, -_LP_INF))
+    hi = np.where(np.isnan(ub), _LP_INF, np.minimum(ub, _LP_INF))
+    return lo, hi
+
+
 def _dense_rows(A: Optional[Union[np.ndarray, sp.spmatrix]], n: int) -> np.ndarray:
     """Dense ``(m, n)`` view of a constraint block, or an empty ``(0, n)``."""
     if A is None:
@@ -181,13 +208,17 @@ def solve_lp(
         a_std = sp.csc_matrix((0, n), dtype=np.float64)
     c_std = np.concatenate([c_arr, np.zeros(m)])
     if bounds is not None:
-        lb = np.array([lo for lo, _ in bounds], dtype=np.float64)
-        ub = np.array([hi for _, hi in bounds], dtype=np.float64)
+        # `None`/NaN on either side means "no bound" here (scipy's spelling and
+        # the modeling layer's); `_finite_box` maps both onto the LP sentinel.
+        lb, ub = _finite_box(
+            np.array([lo for lo, _ in bounds], dtype=np.float64),
+            np.array([hi for _, hi in bounds], dtype=np.float64),
+        )
     else:
         lb = np.zeros(n, dtype=np.float64)
-        ub = np.full(n, 1e20, dtype=np.float64)
+        ub = np.full(n, _LP_INF, dtype=np.float64)
     lb_std = np.concatenate([lb, np.zeros(m)])
-    ub_std = np.concatenate([ub, np.full(m_ub, 1e20), np.zeros(m_eq)])
+    ub_std = np.concatenate([ub, np.full(m_ub, _LP_INF), np.zeros(m_eq)])
 
     _warm_kw: dict[str, Any] = {}
     if max_iter is not None:
@@ -318,11 +349,13 @@ def solve_lp_batch(
     for t, (b_ub, bounds) in enumerate(instances):
         b_stack[t, :] = np.asarray(b_ub, dtype=np.float64).ravel()
         if bounds is not None:
-            lb_stack[t, :n] = [lo for lo, _ in bounds]
-            ub_stack[t, :n] = [hi for _, hi in bounds]
+            lb_stack[t, :n], ub_stack[t, :n] = _finite_box(
+                np.array([lo for lo, _ in bounds], dtype=np.float64),
+                np.array([hi for _, hi in bounds], dtype=np.float64),
+            )
         else:
-            ub_stack[t, :n] = 1e20
-        ub_stack[t, n:] = 1e20  # slacks in [0, inf)
+            ub_stack[t, :n] = _LP_INF
+        ub_stack[t, n:] = _LP_INF  # slacks in [0, inf)
 
     statuses, xs, objs = solve_lp_batch_py(
         np.ascontiguousarray(c_std),

--- a/python/tests/test_1008_nan_lp_bound.py
+++ b/python/tests/test_1008_nan_lp_bound.py
@@ -1,0 +1,96 @@
+"""A NaN variable bound must never reach the simplex (#1008 follow-up).
+
+The modeling layer and the LP layer spell "no bound" differently:
+``Model.continuous(ub=None)`` stores **NaN**, while the Rust simplex reads the
+sentinel ``±1e20`` (``INF``). An untranslated NaN is not merely unhelpful — it is
+read *two contradictory ways*, because every comparison against NaN is false:
+
+* the ratio test asks ``ub < INF`` ("is this bound blocking?") → **false** for NaN,
+  so the bound is skipped and the step runs to ``t = INF`` → ``unbounded``;
+* the unbounded-ray box-recession check asks ``ub >= INF`` ("is this side open?")
+  → also **false** for NaN, so the very same bound reads as closed.
+
+Found while the #1008 ray certifier was landing: a Benders recourse LP
+(``min -w`` over ``w ∈ [0, NaN]``, ``-w ≤ 0``) reached the simplex with a NaN
+upper bound and had been reported ``unbounded`` on the strength of a box no guard
+could certify as recessive. The verdict was right by luck, not by derivation —
+the ratio test's reading happened to be the one that mattered. This is the same
+class as the ``INF``-is-``1e20`` hazard in CLAUDE.md, with the sentinel silently
+*absent* rather than silently surviving a multiplication.
+
+Two halves, both pinned here:
+
+1. ``lp_simplex`` translates the box (NaN and ``±inf`` → the sentinel), so the
+   simplex sees one unambiguous convention;
+2. the PyO3 LP entry points refuse a NaN bound outright, so a caller that skips
+   the translation gets a loud ``ValueError`` instead of a verdict derived from
+   two incompatible readings of the same number.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from discopt.solvers import SolveStatus
+from discopt.solvers.lp_simplex import _LP_INF, _finite_box, solve_lp
+
+
+def test_finite_box_maps_no_bound_onto_the_lp_sentinel():
+    lo, hi = _finite_box(
+        np.array([np.nan, -np.inf, -2.5, -1e30]),
+        np.array([np.nan, np.inf, 4.0, 1e30]),
+    )
+    # NaN and -inf are the same statement ("no lower bound") once translated, and a
+    # magnitude past the sentinel is already unbounded to the simplex.
+    assert lo.tolist() == [-_LP_INF, -_LP_INF, -2.5, -_LP_INF]
+    assert hi.tolist() == [_LP_INF, _LP_INF, 4.0, _LP_INF]
+    assert not np.isnan(lo).any() and not np.isnan(hi).any()
+
+
+def test_nan_upper_bound_still_solves_as_unbounded():
+    """The Benders recourse LP that exposed this: ``min -w``, ``-w ≤ 0``, ``w ≥ 0``.
+
+    Genuinely unbounded below. Before the translation the NaN reached the simplex
+    and the answer depended on which guard was asked; after it the box is the
+    sentinel and the ray certifies on its own merits.
+    """
+    r = solve_lp(
+        np.array([-1.0]),
+        A_ub=np.array([[-1.0]]),
+        b_ub=np.array([0.0]),
+        bounds=[(0.0, float("nan"))],
+    )
+    assert r.status == SolveStatus.UNBOUNDED
+
+    # `None` is the caller-facing spelling of the same thing and must agree.
+    r_none = solve_lp(
+        np.array([-1.0]),
+        A_ub=np.array([[-1.0]]),
+        b_ub=np.array([0.0]),
+        bounds=[(0.0, None)],
+    )
+    assert r_none.status == SolveStatus.UNBOUNDED
+
+
+def test_binding_refuses_a_nan_bound_loudly():
+    """A caller that skips the translation gets an error, not a lucky verdict."""
+    from discopt._rust import solve_lp_warm_csc_py
+
+    a = np.array([[-1.0, 1.0]])  # one row: structural `w`, plus its slack
+    with pytest.raises(ValueError, match="is NaN"):
+        solve_lp_warm_csc_py(
+            np.ascontiguousarray([-1.0, 0.0]),
+            1,
+            2,
+            np.ascontiguousarray([0, 1, 2], dtype=np.int64),
+            np.ascontiguousarray([0, 0], dtype=np.int64),
+            np.ascontiguousarray(a.ravel()[a.ravel() != 0.0]),
+            np.ascontiguousarray([0.0]),
+            np.ascontiguousarray([0.0, 0.0]),
+            np.ascontiguousarray([np.nan, _LP_INF]),  # the NaN upper bound
+            None,
+            None,
+            1e-9,
+            1000,
+            None,
+        )


### PR DESCRIPTION
## The defect

`SimplexOptions::bank_deadline_duals` is set as `deadline.is_some()` and was doing
double duty. Besides banking the dual loop's anytime floor (#928 — its actual job) it
also switched on the recovery that re-tries a **near-zero pivot** instead of abandoning
the warm re-solve. The two have nothing to do with each other, so **a caller who passed
no `time_limit` silently lost a numerical safeguard**.

Found while landing #1022: that PR stopped the engine from *claiming* a certificate it
could not support on QPLIB_2170, but the bound loss on that cell stayed, and named this
as the suspect.

## Entry experiment (§4), before any implementation

Read from **counters**, not from control flow — the two counters
(`DualUnstablePivotRecoveries` / `DualUnstablePivotBails`) exist precisely so this is a
measurement. Captured QPLIB_2170 root relaxation:

| call | recoveries | bails | ray rejects | result |
|---|---|---|---|---|
| `time_limit=None` | 0 | **1** | 2 | no solution |
| `time_limit=40.0` | **1** | 0 | 0 | **optimal 0** |

Exactly one unstable pivot separates a certified optimum from nothing, and which side
you land on is decided solely by whether the caller bounded the LP in time. QPLIB_2738
fires *neither* counter — its loss was the #1013 stall bail, already fixed — so this is
a distinct mechanism, not a second reading of the same cell.

## The change

An unbundling, not a new mechanism. `recover_unstable_pivot` gets its own
`SimplexOptions` field and its own env gate (`DISCOPT_LP_UNSTABLE_PIVOT_RECOVERY`);
`bank_deadline_duals` goes back to banking duals only. The deadline path keeps the
recovery unconditionally (`deadline.is_some() || unstable_pivot_recovery_default()`), so
it is **bit-identical** to what its own graduation panel judged.

## Default-OFF, and what remains

Taking a different pivot is bound-changing, so CLAUDE.md §5 applies: the flag stays off
for deadline-free callers until a corpus differential panel clears **both** bars.

The panel exists (`scratchpad/i1008/r1_panel.py` + `r1_report.py`: 88 captured
relaxation LPs, one process per arm because the flag is read once via `OnceLock`, HiGHS
as oracle, every LP at `time_limit=None` — the exact call shape that lost the recovery).
It was **started and stopped at 18/88 on arm 0, with arm 1 not begun.** No claim is made
from that partial data and none of it is reported here. Running it to completion on both
arms is what remains before the default can flip. Until then this follows the
`DISCOPT_CUT_INHERIT` precedent: the mechanism lands, the measurement is recorded, the
default does not move.

## Verification

- `cargo test -p discopt-core` — **611 passed** (610 + the new
  `unstable_pivot_recovery_is_not_gated_on_a_deadline`).
- `pytest -m smoke` — 1028 passed, 1 skipped, 2 xpassed.
- `pytest -m slow python/tests/test_adversarial_recent_fixes.py` — 10 passed.
- The `.so` under test was asserted to carry the `DISCOPT_LP_UNSTABLE_PIVOT_RECOVERY`
  marker (§8) before any measurement was trusted.

`dual_stall_bail_can_cost_a_bound_when_the_cold_solve_fails` needed
`recover_unstable_pivot = true` in both arms: that fixture only solved *because* the
recovery rode on `bank_deadline_duals` — the coupling showing up in a unit test.

## Stacking

Branches off `fix/1008-certify-unbounded-ray` (#1022) and includes its commits; merge
#1022 first and this diff reduces to the R1 change alone.

Contributes to #1008

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017PQaiDVuY5Rs3tga98tnNo
