### PR TITLE
perf(lp): #1008 attribute LP wall to the LU, and kill the refactorize-less fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,31 @@ The release procedure that produces these entries is documented in
 
 ## [Unreleased]
 
+### Added
+
+- **LP refactorization attribution, and the measurement it settled** (`perf(lp)`,
+  #1008). Three counters — `DualRefactorizations`, `DualRefacCap`,
+  `DualRefacFtFail` — plus `DISCOPT_LP_REFAC_INTERVAL`, which exposes the update
+  cap both simplex loops previously hardcoded as a literal `48`. Unset is **48**,
+  so every solve is byte-identical to the previous engine; an unparseable value is
+  refused loudly rather than read as the default (an A/B arm that silently reads
+  as the baseline makes a harness measure it twice).
+
+  The dual loop's refactorizations were previously invisible: the existing
+  `Refactorizations`/`Refac*` counters are incremented only by the primal, so an
+  LP the dual solved outright reported 100+ `LuSparseFactorizations` against zero
+  refactorization events.
+
+  What they measured, over captured relaxation LPs: **`LuNumeric` is 72.6% of LP
+  wall and pricing is 1.5%** (`PriceSweep` alone 0.1%), so #1008's cost is the LU
+  and not the PRICE loop. And raising the interval — the fix that attribution most
+  obviously suggests — is a **regression**: 48 → 100+ gives +19% factorizations
+  and **+312% factor nonzeros** (fill 5.32x → 13.7x), because above ~100 the cap
+  stops firing and the product-form update runs to its own stability limit
+  instead, landing the search on denser bases. The 48-update cap is load-bearing.
+  No default moved. Details and the falsification record in
+  `docs/dev/performance-plan.md` §18f.
+
 ### Fixed
 
 - **The primal simplex could return a false `Unbounded` on a bounded LP**

--- a/crates/discopt-core/src/lp/simplex/dual.rs
+++ b/crates/discopt-core/src/lp/simplex/dual.rs
@@ -112,6 +112,55 @@ pub(super) fn stall_patience_default() -> usize {
     })
 }
 
+/// How many product-form updates may accumulate before the basis is refactorized
+/// from scratch, read once from `DISCOPT_LP_REFAC_INTERVAL` (#1008 D3).
+///
+/// Default **48**, the constant both simplex loops hardcoded before this gate
+/// existed — unset, every solve is byte-identical to the previous engine.
+///
+/// The constant is under measurement because it is the *only* thing that sets how
+/// often the dominant cost is paid. Attribution over 19 captured relaxation LPs:
+/// `LuNumeric` is **72.6%** of LP wall while `FtUpdate` is **1.9%**, i.e. in
+/// aggregate the updates this cap truncates are ~38x cheaper than the
+/// factorizations it forces. On `QPLIB_1451_rlt0` every one of the 265 primal
+/// refactorizations was cap-triggered (`RefacCap`; 12764 pivots / 48 = 266) — the
+/// adaptive `refac_work_budget` gate beside it never fired, because the fixed cap
+/// always trips first. A cap tuned for cheap factors is exactly backwards when a
+/// factor costs ~0.6s at a 19x fill ratio.
+///
+/// Read once per process: the interval changes the pivot *path* (a refactorization
+/// reseeds `x_B` exactly), so flipping it mid-solve would make a measurement
+/// incomparable with itself.
+pub(super) fn refac_interval_default() -> usize {
+    static INTERVAL: std::sync::OnceLock<usize> = std::sync::OnceLock::new();
+    *INTERVAL.get_or_init(|| {
+        let raw = std::env::var("DISCOPT_LP_REFAC_INTERVAL").unwrap_or_default();
+        parse_refac_interval(&raw).unwrap_or_else(|e| panic!("{e}"))
+    })
+}
+
+/// The parse table behind [`refac_interval_default`]. Unrecognized input is
+/// refused rather than defaulted, for the reason on [`parse_stall_patience`]: an
+/// A/B arm whose value silently reads as the default makes the harness measure one
+/// arm twice. Zero is refused too — it would refactorize on every pivot, which is
+/// not a cap anyone means to ask for.
+fn parse_refac_interval(raw: &str) -> Result<usize, String> {
+    let t = raw.trim();
+    if t.is_empty() {
+        return Ok(48);
+    }
+    match t.parse::<usize>() {
+        Ok(0) => Err("DISCOPT_LP_REFAC_INTERVAL=0 would refactorize on every \
+                      pivot; use a positive interval (the default is 48)."
+            .to_string()),
+        Ok(n) => Ok(n),
+        Err(_) => Err(format!(
+            "DISCOPT_LP_REFAC_INTERVAL={t:?} is not a positive integer. \
+             Use a positive update count, or leave it unset for the default 48."
+        )),
+    }
+}
+
 /// Whether the near-zero-pivot recovery is enabled for callers that did **not**
 /// supply a deadline, read once from `DISCOPT_LP_UNSTABLE_PIVOT_RECOVERY` (#1008
 /// R1). Default **off**: re-selecting after a refactorize can land on a different
@@ -665,6 +714,7 @@ impl<'a> PreparedDual<'a> {
         let mut since_refresh = 0usize;
 
         let mut updates = 0usize;
+        let refac_interval = refac_interval_default();
         // Dual Devex reference weights γ_i ≥ 1, one per basic slot. The leaving
         // variable maximizes (bound violation)²/γ_i — a cheap steepest-edge
         // approximation that cuts dual iterations versus plain largest-violation
@@ -1101,7 +1151,15 @@ impl<'a> PreparedDual<'a> {
             stat[q] = BASIC;
             let need_refac = lu.update(r, &raw_q).is_err();
             updates += 1;
-            if need_refac || updates >= 48 {
+            if need_refac || updates >= refac_interval {
+                // #1008 D3: attribute the trigger. Priority FT-fail > cap, matching
+                // the primal loop's convention so the two are comparable.
+                crate::profile::incr(if need_refac {
+                    crate::profile::Ctr::DualRefacFtFail
+                } else {
+                    crate::profile::Ctr::DualRefacCap
+                });
+                crate::profile::incr(crate::profile::Ctr::DualRefactorizations);
                 let cols: Vec<Vec<(usize, f64)>> = basis
                     .iter()
                     .map(|&j| {
@@ -1546,6 +1604,32 @@ mod tests {
         }
 
         assert_eq!(checked, 21, "probe did not run every case it claims to");
+    }
+
+    /// `DISCOPT_LP_REFAC_INTERVAL` (#1008 D3). Unset must be exactly the constant
+    /// both loops hardcoded before the gate existed, so an unset environment is
+    /// byte-identical to the previous engine; anything unparseable must be refused
+    /// rather than silently read as that default, which would make an A/B harness
+    /// measure the baseline twice and report "no difference".
+    #[test]
+    fn refac_interval_parses_or_refuses() {
+        let mut checked = 0;
+        assert_eq!(parse_refac_interval(""), Ok(48), "unset must be the old 48");
+        assert_eq!(parse_refac_interval("  "), Ok(48));
+        checked += 2;
+        for (raw, want) in [("48", 48usize), ("100", 100), (" 500 ", 500), ("1", 1)] {
+            assert_eq!(parse_refac_interval(raw), Ok(want));
+            checked += 1;
+        }
+        // 0 would refactorize on every pivot — not a cap anyone means to ask for.
+        for bad in ["0", "-1", "1.5", "on", "true", "48x", "None"] {
+            assert!(
+                parse_refac_interval(bad).is_err(),
+                "{bad:?} must be refused loudly, not silently defaulted"
+            );
+            checked += 1;
+        }
+        assert_eq!(checked, 13, "probe did not run every case it claims to");
     }
 
     #[test]

--- a/crates/discopt-core/src/lp/simplex/primal.rs
+++ b/crates/discopt-core/src/lp/simplex/primal.rs
@@ -1410,6 +1410,7 @@ impl<'a> Simplex<'a> {
         const PIVOT_MIN: f64 = 1e-7;
         const ART_TOL: f64 = 1e-9;
         let mut updates_since_refac = 0usize;
+        let refac_interval = super::dual::refac_interval_default();
         // Rows whose basic artificial cannot be reduced (no reducing pivot, or only
         // degenerate zero-step pivots that never lower its value): a genuine
         // redundant-row infeasibility. Skipped so the pass always makes progress.
@@ -1603,7 +1604,7 @@ impl<'a> Simplex<'a> {
                     let col = self.column(q, art_sign);
                     let need_refac = self.lu.update(li, &col).is_err();
                     updates_since_refac += 1;
-                    if need_refac || updates_since_refac >= 48 {
+                    if need_refac || updates_since_refac >= refac_interval {
                         self.refactorize(art_sign)?;
                         updates_since_refac = 0;
                         xb = self.basic_values(art_sign)?;
@@ -1637,6 +1638,7 @@ impl<'a> Simplex<'a> {
         }
         let mut xb = self.basic_values(art_sign)?;
         let mut updates_since_refac = 0usize;
+        let refac_interval = super::dual::refac_interval_default();
         // NEUTRALITY: the legacy emission substitutes, for a basic artificial in
         // constraint row `r`, that row's own zero-valued structural SINGLETON
         // (its slack in the `[A_ub|I]` standard form every production node LP
@@ -1702,7 +1704,7 @@ impl<'a> Simplex<'a> {
             let col = self.column(q, art_sign);
             let need_refac = self.lu.update(slot, &col).is_err();
             updates_since_refac += 1;
-            if need_refac || updates_since_refac >= 48 {
+            if need_refac || updates_since_refac >= refac_interval {
                 self.refactorize(art_sign)?;
                 updates_since_refac = 0;
                 xb = self.basic_values(art_sign)?;
@@ -1909,6 +1911,7 @@ impl<'a> Simplex<'a> {
     ) -> Result<(), LpStatus> {
         let m = self.m;
         let mut updates = 0usize;
+        let refac_interval = super::dual::refac_interval_default();
         let mut stall = 0usize;
         // Adaptive refactorization budget (discopt#268 / feral#87): the FT basis
         // update is O(bump²) on non-localized spikes — on a wide lifted-McCormick
@@ -2241,12 +2244,12 @@ impl<'a> Simplex<'a> {
                         self.lu.update(slot, &col).is_err()
                     };
                     updates += 1;
-                    // Refactorize on: a failed FT update, the hard 48-update cap, or
+                    // Refactorize on: a failed FT update, the fixed refactorization interval, or
                     // the adaptive work gate (accumulated bump-update work exceeded
                     // the factor's nnz — the wide-McCormick-bump regime).
                     let work_gate =
                         refac_work_budget > 0 && self.lu.ft_update_work() > refac_work_budget;
-                    if need_refac || updates >= 48 || work_gate {
+                    if need_refac || updates >= refac_interval || work_gate {
                         // THRU-5: attribute the trigger (priority: FT-fail > cap > gate).
                         crate::profile::incr(if need_refac {
                             // ENGINE-1 (#557): split the FT-fail by feral's own
@@ -2265,7 +2268,7 @@ impl<'a> Simplex<'a> {
                                     Some(Singular) => {
                                         crate::profile::incr(crate::profile::Ctr::RefacFtSingular)
                                     }
-                                    // UpdateBudget can't reach here (discopt's 48-cap
+                                    // UpdateBudget can't reach here (discopt's fixed-interval cap
                                     // trips first) and None means the dense path;
                                     // leave the sub-split silent, the aggregate still
                                     // counts it.
@@ -2273,7 +2276,7 @@ impl<'a> Simplex<'a> {
                                 }
                             }
                             crate::profile::Ctr::RefacFtFail
-                        } else if updates >= 48 {
+                        } else if updates >= refac_interval {
                             crate::profile::Ctr::RefacCap
                         } else {
                             crate::profile::Ctr::RefacWorkGate

--- a/crates/discopt-core/src/profile.rs
+++ b/crates/discopt-core/src/profile.rs
@@ -166,7 +166,7 @@ counters!(
     // THRU-5: split the primal refactorization trigger into its three causes so the
     // wide-McCormick refactor thrash can be attributed. RefacFtFail = the FT
     // (product-form) update returned Err (numerical bump breakdown → forced
-    // refactor); RefacCap = the hard 48-update cap; RefacWorkGate = the adaptive
+    // refactor); RefacCap = the fixed refactorization interval (DISCOPT_LP_REFAC_INTERVAL); RefacWorkGate = the adaptive
     // work gate (accumulated update work exceeded factor nnz × mult).
     RefacFtFail,
     RefacCap,
@@ -336,6 +336,15 @@ counters!(
     LuSparseFactorizations,
     LuBasisNnz,
     LuFactorNnz,
+    // #1008 D3: the DUAL loop's refactorizations. Previously invisible — the
+    // `Refactorizations`/`Refac*` counters above are incremented only by the
+    // primal loop, so on an LP the dual solved outright the profile showed 100+
+    // `LuSparseFactorizations` against zero refactorization events and the cost
+    // could not be attributed to a trigger. `DualRefacCap` is the fixed-interval
+    // cap (`DISCOPT_LP_REFAC_INTERVAL`), `DualRefacFtFail` a failed FT update.
+    DualRefactorizations,
+    DualRefacCap,
+    DualRefacFtFail,
 );
 
 /// Add `n` to a counter (for accumulated quantities such as nonzero counts,

--- a/docs/dev/performance-plan.md
+++ b/docs/dev/performance-plan.md
@@ -2826,11 +2826,29 @@ bound-changing, so §5 applies and the flag stays off until a corpus differentia
 panel clears *both* bars. The graduation panel (88 captured relaxation LPs,
 `scratchpad/i1008/r1_panel.py`, one process per arm because the flag is read once
 via `OnceLock`, HiGHS as oracle, every LP at `time_limit=None` — the exact call
-shape that lost the recovery) was **started and stopped at 18/88 on arm 0 with arm
-1 not begun**; no claim is made from that partial data and none of it is reported
-here. Running it to completion on both arms is what remains before the default can
-flip. Until then this ships as the `DISCOPT_CUT_INHERIT` precedent has it: the
-mechanism lands, the measurement is recorded, the default does not move.
+shape that lost the recovery) has since **run to completion on both arms**. Result:
+
+| bar | verdict | evidence |
+|---|---|---|
+| **cert-clean** | **PASS** | 82 LPs compared; 0 bounds below the HiGHS optimum, 0 certification regressions, 0 objective drift, 0 LPs at the iteration cap |
+| **net-positive** | **FAIL** | 0 bounds recovered; retention identical at 72/82 in both arms |
+
+**GRADUATE: NO — the flag stays default-OFF.** The mechanism is *sound*, not
+*helpful*: precisely the `DISCOPT_CUT_INHERIT` outcome, and per §5 a cert-clean
+but neutral flag stays off with the measurement recorded.
+
+The probe was **not empty**, which is what makes the FAIL meaningful (§6): the
+recovery fired on 5 ON-arm LPs (`QPLIB_2590_rlt0/rlt1`, `QPLIB_2819_rlt0`,
+`QPLIB_2823_rlt1`, `QPLIB_3089_rlt1`, 12 recoveries total) against 7 OFF-arm bails.
+So the ON arm really did take different pivots on those LPs and still recovered no
+bound the OFF arm lacked — a measured neutral, not an arm compared against itself.
+6 of the 88 LPs were skipped (`_dual_start_slack_basis` rejected the start, so they
+never enter the warm path) and are named in the log rather than silently dropped.
+
+Wall was 2829.81s OFF vs 2835.45s ON — a single unreplicated run, on a machine
+that was also running the §18f interval experiment (load I created myself), so it
+is directional only and supports no timing claim in either direction. It is
+recorded because a 0.2% spread is worth knowing is *not* a signal.
 
 Pinned by `unstable_pivot_recovery_is_not_gated_on_a_deadline` (flag off → bails 1,
 not optimal; flag on → recoveries 1, optimal 0; both arms assert

--- a/docs/dev/performance-plan.md
+++ b/docs/dev/performance-plan.md
@@ -2835,3 +2835,98 @@ mechanism lands, the measurement is recorded, the default does not move.
 Pinned by `unstable_pivot_recovery_is_not_gated_on_a_deadline` (flag off → bails 1,
 not optimal; flag on → recoveries 1, optimal 0; both arms assert
 `deadline.is_none()`, which is the coupling under test).
+
+### 18f. LP wall is LU factorization, and the 48-update cap is load-bearing (#1008 D3, 2026-08-13)
+
+Two results: an attribution that redirects #1008's planned work, and a
+falsification that kills the fix that attribution most obviously suggests.
+
+**The attribution.** Phase profile over the 19 captured relaxation LPs the R1
+panel had finished (`scratchpad/i1008/attrib.py`, share-of-wall over 600.5s):
+
+| phase | share of LP wall |
+|---|---|
+| **LuNumeric** (`SparseLu::factor`) | **72.6%** |
+| Refactorize (primal, outer timer) | 7.7% |
+| LuSymbolic (`SparseLuSymbolic::analyze`) | 5.0% |
+| FtUpdate | 1.9% |
+| PriceBtran + AlphaFtran + PriceSweep | **1.5%** |
+
+`PriceSweep` alone is **0.1%**. The planned D2 work — column-wise PRICE at
+O(nnz(A)) per pivot — therefore targets a phase that is 1.5% of wall on this
+corpus and cannot pay for the 8.7x–29x gap in the issue title. **D2 is
+deprioritized**; the cost is the LU.
+
+Shares, not speeds: the two panel arms ran concurrently, so absolute ms are
+contention-inflated (§9). Contention inflates all phases alike, so the shares hold
+and no speed claim is made from them. Per-LP, the `LuNumeric` share tracks the
+fill ratio directly — fill 1.0 → ~5%, fill ~6–7 → ~50%, `QPLIB_1451_rlt0` at fill
+**19.1x** → **74.8%**.
+
+**The hypothesis this suggested, and its falsification.** Both simplex loops
+refactorized on a hardcoded `updates >= 48`. On `QPLIB_1451_rlt0` all 265 primal
+refactorizations were cap-triggered (`RefacCap`; 12764 pivots / 48 = 266) and the
+adaptive `refac_work_budget` gate beside it never fired, because the fixed cap
+always trips first. With `FtUpdate` at 1.9% against `LuNumeric` at 72.6%, the
+updates the cap truncates looked ~38x cheaper than the factorizations it forces,
+so raising the interval should have cut the dominant cost.
+
+It does the opposite. Entry experiment over 16 captured LPs
+(`scratchpad/i1008/refac_entry.py` + `refac_report.py`, one process per interval —
+the gate is a `OnceLock`), counters exact and load-independent:
+
+| interval | factorizations | factor nnz | basis nnz | fill | cap-trig | FT-fail |
+|---|---|---|---|---|---|---|
+| **48** (default) | **667** | **75.1M** | 14.1M | **5.32x** | 651 | 0 |
+| 100 / 200 / 500 | 792 | 309.4M | 22.5M | **13.7x** | 0 | 776 |
+
+**+19% factorizations and +312% factor nonzeros.** Above ~100 the arms are
+*identical*: the cap stops firing entirely and feral's product-form update reaches
+its own stability limit instead (`DualRefacCap` 651 → 0, `DualRefacFtFail` 0 →
+776). Letting updates accumulate to that limit lands the search on denser bases
+(`basis_nnz` 14.1M → 22.5M — a different pivot path, not merely different factors)
+and then produces far denser factors from them. Directional wall agreed: 30.5s →
+195s.
+
+**Kill criterion met; the direction is dead.** The 48-update cap is not mistuned,
+it is load-bearing — it refactorizes *before* the update degrades, and the cheap
+fresh factor it produces is the point. "Refactorize less often" is not available
+as a #1008 fix. Correctness was unaffected throughout (64 arm×LP comparisons
+against HiGHS, **0 deviations**), so this is a performance verdict only.
+
+**The single-instance trap, for the record (§2).** On `QPLIB_1423_rlt1` alone,
+raising the interval *helped* — 66 → 55 factorizations, 11.37M → 9.55M factor nnz.
+That one LP was read first and looked like confirmation. The corpus aggregate
+reverses it 4x. Nothing here was claimed until the 16-LP aggregate ran.
+
+**What shipped.** Instrumentation and a measurement knob, no default change:
+`DISCOPT_LP_REFAC_INTERVAL` (default **48** — unset is byte-identical to the
+previous engine, unparseable input refused loudly rather than read as the default,
+which would make an A/B harness measure the baseline twice), and three counters
+that made the falsification visible at all — `DualRefactorizations`,
+`DualRefacCap`, `DualRefacFtFail`. The dual loop's refactorizations were
+previously **unattributed**: the `Refactorizations`/`Refac*` counters are
+incremented only by the primal, so an LP the dual solved outright showed 100+
+`LuSparseFactorizations` against zero refactorization events, and the aggregate
+above could not have been computed.
+
+**Corrections to statements made earlier in this issue's work (§11).**
+
+1. `QPLIB_1451_rlt0` was described mid-investigation as "545 seconds at zero
+   pivots". It is not: `Phase1Pivots 9` + `Phase2Pivots 12755` = **12,764 pivots**.
+   The panel's `iters=0` is the *cold-fallback* signature (`DualColdFallbacks 1`;
+   dual.rs documents `iters == 0` as exactly that) — the dual was abandoned and the
+   cold primal did the work without reporting its iteration count. The reported
+   `iters` on a cold-fallback solve is an observability gap, not a pivot count.
+2. The `piv` column of `attrib.py` is a **primal-only** count
+   (`Phase1Pivots + Phase2Pivots`). It reads 0 for the 18 LPs the dual solved
+   because dual pivots are not in those counters — not because those LPs pivoted
+   zero times.
+
+**What the attribution leaves open.** The cost is `LuNumeric` and the lever is
+fill, not frequency. feral's `analyze` already triangularizes and runs AMD on the
+residual bump, so the 19.1x fill on `QPLIB_1451_rlt0` is *after* a fill-reducing
+ordering — the next question for #1008 is whether that fill is intrinsic to these
+bases or an artifact of static ordering under partial pivoting (the usual remedy
+being threshold-Markowitz pivoting, which chooses pivots dynamically against both
+sparsity and stability). That is a feral-side question and is **not** opened here.

--- a/scratchpad/i1008/attrib.py
+++ b/scratchpad/i1008/attrib.py
@@ -1,0 +1,62 @@
+"""Attribute LP wall to phases across every LP the R1 panel has finished.
+
+Shares, not absolute times: the two panel arms ran concurrently, so absolute ms
+are contention-inflated (CLAUDE.md §9). Contention inflates all phases roughly
+alike, so share-of-wall is the defensible quantity here; no absolute-speed claim
+is made. Prints an executed-parse count and exits non-zero if it is zero (§6).
+"""
+import re, sys, json
+
+LOG = "scratchpad/i1008/r1_arm0.log"
+PHASES = ["LuNumeric", "LuSymbolic", "Refactorize", "FtUpdate", "PriceBtran",
+          "PriceSweep", "AlphaFtran", "DualPivotLoop"]
+
+lines = open(LOG).read().splitlines()
+ph = re.compile(r"^\s{2}(\w+)\s+(\d+) calls\s+([\d.]+) ms")
+ctr = re.compile(r"^\s{2}(\w+)\s+(\d+)\s*$")
+res = re.compile(r"^(\S+)\s+(optimal|infeasible|unbounded|iteration_limit|error)\s.*\(([\d.]+)s\)")
+
+cur_ph, cur_ct, rows = {}, {}, []
+for ln in lines:
+    m = ph.match(ln)
+    if m:
+        cur_ph[m.group(1)] = (int(m.group(2)), float(m.group(3)))
+        continue
+    m = ctr.match(ln)
+    if m:
+        cur_ct[m.group(1)] = int(m.group(2))
+        continue
+    m = res.match(ln)
+    if m:
+        rows.append((m.group(1), m.group(2), float(m.group(3)), cur_ph, cur_ct))
+        cur_ph, cur_ct = {}, {}
+
+assert rows, "parsed no LP result lines"
+print(f"{'tag':<22}{'wall_s':>9}{'piv':>7}{'facs':>6}{'fill':>7}  " +
+      "".join(f"{p[:9]:>10}" for p in ("LuNumeric", "LuSymbol", "FtUpdate", "Price*")))
+tot_wall = 0.0
+agg = {p: 0.0 for p in PHASES}
+n = 0
+for tag, st, wall, p, c in rows:
+    if not p:
+        continue
+    n += 1
+    piv = c.get("Phase1Pivots", 0) + c.get("Phase2Pivots", 0)
+    facs = c.get("LuSparseFactorizations", 0)
+    bn, fn = c.get("LuBasisNnz", 0), c.get("LuFactorNnz", 0)
+    fill = fn / bn if bn else float("nan")
+    price = sum(p.get(k, (0, 0.0))[1] for k in ("PriceBtran", "PriceSweep", "AlphaFtran"))
+    g = lambda k: p.get(k, (0, 0.0))[1] / 1000.0 / wall * 100
+    print(f"{tag:<22}{wall:>9.1f}{piv:>7}{facs:>6}{fill:>7.1f}  "
+          f"{g('LuNumeric'):>9.1f}%{g('LuSymbolic'):>9.1f}%{g('FtUpdate'):>9.1f}%"
+          f"{price/1000/wall*100:>9.1f}%")
+    tot_wall += wall
+    for k in PHASES:
+        agg[k] += p.get(k, (0, 0.0))[1] / 1000.0
+
+print(f"\nLPs with a phase profile: {n} (of {len(rows)} results parsed)")
+print(f"total wall {tot_wall:.1f}s")
+for k in PHASES:
+    print(f"  {k:<16}{agg[k]:>9.1f}s  {agg[k]/tot_wall*100:>6.1f}% of wall")
+print(f"\nexecuted: results_parsed={len(rows)} profiles_attributed={n}")
+sys.exit(0 if n else 1)

--- a/scratchpad/i1008/r1_panel.py
+++ b/scratchpad/i1008/r1_panel.py
@@ -1,0 +1,142 @@
+"""#1008 R1 graduation panel: `DISCOPT_LP_UNSTABLE_PIVOT_RECOVERY` ON vs OFF.
+
+One process per arm — the flag is read once per process via `OnceLock`, so a
+single process cannot measure both. Emits one JSON line per LP; `r1_report.py`
+joins the two arms.
+
+Every LP is solved with `time_limit=None`, which is the whole point: that is the
+call shape where `lp_bindings` used to withhold the recovery because it rode on
+`bank_deadline_duals = deadline.is_some()`.
+
+HiGHS is the oracle. A discopt objective BELOW the HiGHS optimum by more than the
+tolerance is a false (too-good) bound on a minimization LP and fails the panel
+outright (CLAUDE.md §1/§5 cert-clean); a bound that is merely absent is a
+retention loss, counted separately.
+
+Prints a per-LP line as it goes (§10) and an executed count, exiting non-zero if
+zero LPs were compared (§6). Nothing is caught (§7).
+"""
+
+import glob
+import json
+import os
+import subprocess
+import sys
+import time
+
+import numpy as np
+import scipy.sparse as sp
+from scipy.optimize import linprog
+
+import discopt
+
+WT = "/private/tmp/wtR1"
+assert discopt.__file__.startswith(WT), discopt.__file__
+import discopt._rust as _rust  # noqa: E402
+
+assert _rust.__file__.startswith(WT), _rust.__file__
+
+# §8: the option under test exists ONLY in the build under test. Assert the marker
+# is present rather than trusting the path — an editable install can point
+# elsewhere than it appears to.
+MARKER = "DISCOPT_LP_UNSTABLE_PIVOT_RECOVERY"
+blob = open(_rust.__file__, "rb").read()
+assert MARKER.encode() in blob, f"loaded a build without {MARKER}: {_rust.__file__}"
+print(f"# marker {MARKER} present in {_rust.__file__}", flush=True)
+
+ARM = os.environ["DISCOPT_LP_UNSTABLE_PIVOT_RECOVERY"]
+OUT = os.environ["R1_OUT"]
+print(f"# arm DISCOPT_LP_UNSTABLE_PIVOT_RECOVERY={ARM!r}", flush=True)
+
+from discopt.solvers.milp_simplex import _dual_start_slack_basis  # noqa: E402
+
+# Iteration cap, applied IDENTICALLY to both arms and reported per LP. It is not
+# a deadline: `time_limit=None` — the call shape that used to lose the recovery —
+# is preserved exactly. Without a cap the large LPs (QPLIB_1451_rlt0 is
+# 7392 x 1890) run for hours at the 100k default and the panel never completes.
+# An LP that hits the cap returns `iteration_limit` in BOTH arms, i.e. it
+# contributes a neutral row rather than a silently dropped one; `r1_report.py`
+# counts them so the coverage this costs is visible (CLAUDE.md: no silent caps).
+MAX_ITER = int(os.environ.get("R1_MAX_ITER", "20000"))
+print(f"# max_iter cap = {MAX_ITER} (both arms; time_limit stays None)", flush=True)
+
+paths = sorted(glob.glob(os.path.join(WT, "scratchpad/i1008/lps/*.npz")))
+assert paths, "no captured LPs"
+
+fh = open(OUT, "w")
+n_done = 0
+n_skipped = 0
+skipped = []
+for p in paths:
+    tag = os.path.basename(p)[:-4]
+    z = np.load(p)
+    nrow, ncol = int(z["shape"][0]), int(z["shape"][1])
+    A = sp.csc_matrix((z["data"], z["indices"], z["indptr"]), shape=(nrow, ncol))
+    c, b, lo, hi = z["c"], z["b"], z["lo"], z["hi"]
+
+    r = linprog(c, A_ub=A, b_ub=b, bounds=list(zip(lo, hi)), method="highs")
+    ref = float(r.fun) if r.status == 0 else None
+
+    st = _dual_start_slack_basis(c, lo, hi, nrow)
+    if st is None:
+        # No dual-feasible slack start => this LP never enters the warm path, so it
+        # cannot exercise the option under test. Skipped, but COUNTED and named: a
+        # panel that silently drops rows reads as broader coverage than it has.
+        n_skipped += 1
+        skipped.append(tag)
+        print(f"{tag:<24} SKIP (dual start rejected)", flush=True)
+        continue
+    c_std = np.ascontiguousarray(np.concatenate([c, np.zeros(nrow)]))
+    lb_std = np.ascontiguousarray(np.concatenate([lo, np.zeros(nrow)]))
+    ub_std = np.ascontiguousarray(np.concatenate([hi, np.full(nrow, np.inf)]))
+    af = sp.hstack([A, sp.identity(nrow, format="csc")], format="csc")
+
+    _rust.profile_reset_py()
+    t0 = time.perf_counter()
+    out = _rust.solve_lp_warm_csc_py(
+        c_std,
+        nrow,
+        ncol + nrow,
+        np.ascontiguousarray(af.indptr, dtype=np.int64),
+        np.ascontiguousarray(af.indices, dtype=np.int64),
+        np.ascontiguousarray(af.data, dtype=np.float64),
+        np.ascontiguousarray(b),
+        lb_std,
+        ub_std,
+        np.ascontiguousarray(st[0], dtype=np.int8),
+        np.ascontiguousarray(st[1], dtype=np.int64),
+        1e-9,
+        MAX_ITER,
+        None,  # time_limit: the call shape that used to lose the recovery
+    )
+    wall = time.perf_counter() - t0
+    ctr = _rust.profile_counters_py()
+
+    rec = {
+        "tag": tag,
+        "arm": ARM,
+        "rows": nrow,
+        "cols": ncol,
+        "nnz": int(A.nnz),
+        "status": out[0],
+        "obj": float(out[2]),
+        "iters": int(out[3]),
+        "wall": wall,
+        "ref": ref,
+        "iter_capped": int(out[3]) >= MAX_ITER,
+        "recoveries": int(ctr.get("DualUnstablePivotRecoveries", 0)),
+        "bails": int(ctr.get("DualUnstablePivotBails", 0)),
+    }
+    fh.write(json.dumps(rec) + "\n")
+    fh.flush()
+    n_done += 1
+    print(
+        f"{tag:<24} {rec['status']:<10} obj={rec['obj']:.9g} ref={ref} "
+        f"iters={rec['iters']}{'(CAP)' if rec['iter_capped'] else ''} "
+        f"rec={rec['recoveries']} bail={rec['bails']} ({wall:.2f}s)",
+        flush=True,
+    )
+
+fh.close()
+print(f"\nexecuted: lps={n_done}  skipped={n_skipped} {skipped}")
+assert n_done, "panel compared nothing"

--- a/scratchpad/i1008/r1_report.py
+++ b/scratchpad/i1008/r1_report.py
@@ -1,0 +1,117 @@
+"""Join the two #1008 R1 panel arms and apply the CLAUDE.md §5 graduation bars.
+
+Bar 1 — **cert-clean** (hard, zero slack): no arm may report an objective BELOW
+its HiGHS reference by more than the tolerance (a false, too-good bound on a
+minimization LP), and no LP that the OFF arm bounds may lose its bound in the ON
+arm (a certification regression).
+
+Bar 2 — **net-positive**: the ON arm must be measurably helpful broadly, not
+merely sound. For this flag the currency is *bound retention* — how many LPs come
+back with a usable bound — with wall clock as a secondary watch.
+
+Prints an executed-comparison count and exits non-zero if it is zero (§6).
+"""
+
+import json
+import os
+import sys
+
+WT = "/private/tmp/wtR1"
+TOL_ABS, TOL_REL = 1e-6, 1e-4
+
+
+def load(path):
+    return {json.loads(line)["tag"]: json.loads(line) for line in open(path)}
+
+
+off = load(os.path.join(WT, "scratchpad/i1008/r1_arm0.jsonl"))
+on = load(os.path.join(WT, "scratchpad/i1008/r1_arm1.jsonl"))
+tags = sorted(set(off) & set(on))
+assert tags, "the two arms share no LP"
+
+
+def bounded(r):
+    """Did this arm come back with a usable bound?"""
+    return r["status"] == "optimal"
+
+
+def tol(ref):
+    return max(TOL_ABS, TOL_REL * abs(ref))
+
+
+n_cmp = 0
+false_bounds, regressions, gains, drift = [], [], [], []
+fired_on, fired_off = [], []
+
+for t in tags:
+    a, b = off[t], on[t]
+    ref = a["ref"]
+    n_cmp += 1
+
+    if b["recoveries"]:
+        fired_on.append((t, b["recoveries"]))
+    if a["bails"]:
+        fired_off.append((t, a["bails"]))
+
+    # Bar 1a: a bound below the true optimum is a false bound, in EITHER arm.
+    if ref is not None:
+        for name, r in (("off", a), ("on", b)):
+            if bounded(r) and r["obj"] < ref - tol(ref):
+                false_bounds.append((t, name, r["obj"], ref))
+        # Objective drift on LPs both arms bound.
+        if bounded(a) and bounded(b) and abs(a["obj"] - b["obj"]) > tol(ref):
+            drift.append((t, a["obj"], b["obj"], ref))
+
+    # Bar 1b / Bar 2: bound retention, both directions.
+    if bounded(a) and not bounded(b):
+        regressions.append((t, a["obj"], b["status"]))
+    if bounded(b) and not bounded(a):
+        gains.append((t, a["status"], b["obj"], ref))
+
+n_capped = sum(1 for t in tags if off[t].get("iter_capped") or on[t].get("iter_capped"))
+n_off = sum(bounded(off[t]) for t in tags)
+n_on = sum(bounded(on[t]) for t in tags)
+w_off = sum(off[t]["wall"] for t in tags)
+w_on = sum(on[t]["wall"] for t in tags)
+
+print(f"LPs compared: {n_cmp}")
+print(f"\nmechanism fired:")
+print(f"  ON  arm recoveries : {len(fired_on)} LPs {fired_on}")
+print(f"  OFF arm bails      : {len(fired_off)} LPs {fired_off}")
+print(f"  LPs that hit the iteration cap in either arm: {n_capped}")
+print(f"\nbound retention:")
+print(f"  OFF bounded: {n_off}/{n_cmp}")
+print(f"  ON  bounded: {n_on}/{n_cmp}")
+print(f"  gains (OFF lost -> ON bounds): {len(gains)}")
+for g in gains:
+    print(f"    {g[0]}: off={g[1]} -> on obj={g[2]:.9g} (HiGHS {g[3]:.9g})")
+print(f"  regressions (OFF bounded -> ON lost): {len(regressions)}")
+for r in regressions:
+    print(f"    {r[0]}: off obj={r[1]:.9g} -> on status={r[2]}")
+print(f"\nfalse bounds (below the HiGHS optimum): {len(false_bounds)}")
+for f in false_bounds:
+    print(f"    {f[0]} [{f[1]}]: obj={f[2]:.9g} < ref={f[3]:.9g}")
+print(f"objective drift on commonly-bounded LPs: {len(drift)}")
+for d in drift:
+    print(f"    {d[0]}: off={d[1]:.9g} on={d[2]:.9g} ref={d[3]:.9g}")
+print(f"\nwall (sum, single unreplicated run - directional only):")
+print(f"  OFF {w_off:.2f}s   ON {w_on:.2f}s")
+
+cert_clean = not false_bounds and not regressions and not drift
+# A mechanism that never fires is an EMPTY probe, not a passing one (CLAUDE.md
+# §6). With zero recoveries the ON arm is bit-identical to the OFF arm, so
+# "no regressions" is arithmetic, not evidence; net-positive cannot be earned.
+fired = len(fired_on) > 0
+net_positive = fired and len(gains) > 0
+print(f"\ncert-clean : {'PASS' if cert_clean else 'FAIL'}")
+if not fired:
+    print("\nNOTE: the recovery fired on 0 panel LPs. The ON arm is therefore")
+    print("      bit-identical to the OFF arm and this panel can establish")
+    print("      cert-cleanliness only — net-positive is UNMEASURED, not passed.")
+print(f"net-positive: {'PASS' if net_positive else 'FAIL'}  "
+      f"({len(gains)} bounds recovered, mechanism fired on {len(fired_on)} LPs)")
+print(f"GRADUATE    : {'YES' if (cert_clean and net_positive) else 'NO'}")
+
+print(f"\nexecuted: comparisons={n_cmp} mechanism_firings={len(fired_on) + len(fired_off)}")
+if not n_cmp:
+    sys.exit(1)

--- a/scratchpad/i1008/refac_entry.py
+++ b/scratchpad/i1008/refac_entry.py
@@ -1,0 +1,145 @@
+"""#1008 D3 entry experiment: does the fixed refactorization interval set the cost?
+
+Hypothesis (from the attribution over 19 captured relaxation LPs): `LuNumeric` is
+72.6% of LP wall and `FtUpdate` is 1.9%, so the hardcoded `updates >= 48` cap
+forces the dominant cost far more often than the updates it truncates are worth.
+Raising the interval should cut `LuSparseFactorizations` and the total factor
+nonzeros roughly in proportion, without changing the LP's answer.
+
+Kill criterion: if raising the interval does NOT reduce total factor work, the
+interval is not what sets the cost and this direction dies here. If it reduces
+factor work but any LP's objective moves off the HiGHS optimum, it dies for
+correctness (CLAUDE.md §1, zero slack).
+
+**Counter-based on purpose.** The R1 graduation panel is running on this machine,
+so wall-clock is contended and a timing claim would violate §9 (no load gate, no
+interleave, no spread). `LuSparseFactorizations` and `LuFactorNnz` are exact
+integer counts, independent of load — they measure the factor work performed, and
+`LuNumeric` time is proportional to it at fixed fill. Wall is recorded but is
+reported as directional only and no speed claim is made from it.
+
+One process per interval: the gate is a `OnceLock`, read once per process.
+
+Prints an executed-comparison count and exits non-zero if it is zero (§6).
+Nothing is caught (§7).
+"""
+
+import glob
+import json
+import os
+import sys
+import time
+
+import numpy as np
+import scipy.sparse as sp
+from scipy.optimize import linprog
+
+import discopt
+
+WT = "/private/tmp/wt1008d"
+assert discopt.__file__.startswith(WT), discopt.__file__
+import discopt._rust as _rust  # noqa: E402
+
+assert _rust.__file__.startswith(WT), _rust.__file__
+
+# §8: assert the marker unique to the build under test. The 48-cap was a literal
+# before this change, so the env-var name appears ONLY in a build that has the
+# gate — a stale .so from another worktree fails here instead of silently
+# reporting the baseline twice.
+MARKER = "DISCOPT_LP_REFAC_INTERVAL"
+blob = open(_rust.__file__, "rb").read()
+assert MARKER.encode() in blob, f"loaded a build without {MARKER}: {_rust.__file__}"
+print(f"# marker {MARKER} present in {_rust.__file__}", flush=True)
+
+INTERVAL = os.environ[MARKER]
+OUT = os.environ["REFAC_OUT"]
+MAX_ITER = int(os.environ.get("REFAC_MAX_ITER", "20000"))
+print(f"# arm {MARKER}={INTERVAL!r}  max_iter={MAX_ITER}", flush=True)
+
+from discopt.solvers.milp_simplex import _dual_start_slack_basis  # noqa: E402
+
+paths = sorted(glob.glob(os.path.join(WT, "scratchpad/i1008/lps/*.npz")))
+assert paths, "no captured LPs"
+LIMIT = int(os.environ.get("REFAC_LIMIT", "0"))
+if LIMIT:
+    paths = paths[:LIMIT]
+
+fh = open(OUT, "w")
+n_done = 0
+n_skipped = 0
+for p in paths:
+    tag = os.path.basename(p)[:-4]
+    z = np.load(p)
+    nrow, ncol = int(z["shape"][0]), int(z["shape"][1])
+    A = sp.csc_matrix((z["data"], z["indices"], z["indptr"]), shape=(nrow, ncol))
+    c, b, lo, hi = z["c"], z["b"], z["lo"], z["hi"]
+
+    r = linprog(c, A_ub=A, b_ub=b, bounds=list(zip(lo, hi)), method="highs")
+    ref = float(r.fun) if r.status == 0 else None
+
+    st = _dual_start_slack_basis(c, lo, hi, nrow)
+    if st is None:
+        n_skipped += 1
+        print(f"{tag:<24} SKIP (dual start rejected)", flush=True)
+        continue
+
+    c_std = np.ascontiguousarray(np.concatenate([c, np.zeros(nrow)]))
+    lb_std = np.ascontiguousarray(np.concatenate([lo, np.zeros(nrow)]))
+    ub_std = np.ascontiguousarray(np.concatenate([hi, np.full(nrow, np.inf)]))
+    af = sp.hstack([A, sp.identity(nrow, format="csc")], format="csc")
+
+    _rust.profile_reset_py()
+    t0 = time.perf_counter()
+    out = _rust.solve_lp_warm_csc_py(
+        c_std,
+        nrow,
+        ncol + nrow,
+        np.ascontiguousarray(af.indptr, dtype=np.int64),
+        np.ascontiguousarray(af.indices, dtype=np.int64),
+        np.ascontiguousarray(af.data, dtype=np.float64),
+        np.ascontiguousarray(b),
+        lb_std,
+        ub_std,
+        np.ascontiguousarray(st[0], dtype=np.int8),
+        np.ascontiguousarray(st[1], dtype=np.int64),
+        1e-9,
+        MAX_ITER,
+        None,
+    )
+    wall = time.perf_counter() - t0
+    ctr = _rust.profile_counters_py()
+
+    rec = {
+        "tag": tag,
+        "interval": INTERVAL,
+        "rows": nrow,
+        "cols": ncol,
+        "status": out[0],
+        "obj": float(out[2]),
+        "wall": wall,
+        "ref": ref,
+        "facs": int(ctr.get("LuSparseFactorizations", 0)),
+        "basis_nnz": int(ctr.get("LuBasisNnz", 0)),
+        "factor_nnz": int(ctr.get("LuFactorNnz", 0)),
+        "dual_refac": int(ctr.get("DualRefactorizations", 0)),
+        "dual_refac_cap": int(ctr.get("DualRefacCap", 0)),
+        "dual_refac_ft": int(ctr.get("DualRefacFtFail", 0)),
+        "primal_refac": int(ctr.get("Refactorizations", 0)),
+        "dual_pivots": int(ctr.get("DualDegeneratePivots", 0)),
+        "p1": int(ctr.get("Phase1Pivots", 0)),
+        "p2": int(ctr.get("Phase2Pivots", 0)),
+        "cold_fallback": int(ctr.get("DualColdFallbacks", 0)),
+    }
+    fh.write(json.dumps(rec) + "\n")
+    fh.flush()
+    n_done += 1
+    print(
+        f"{tag:<24} {rec['status']:<10} obj={rec['obj']:.9g} "
+        f"facs={rec['facs']} (dual_cap={rec['dual_refac_cap']} "
+        f"dual_ft={rec['dual_refac_ft']} primal={rec['primal_refac']}) "
+        f"fnnz={rec['factor_nnz']} ({wall:.2f}s)",
+        flush=True,
+    )
+
+print(f"\nexecuted: solved={n_done} skipped={n_skipped}", flush=True)
+sys.exit(0 if n_done else 1)

--- a/scratchpad/i1008/refac_report.py
+++ b/scratchpad/i1008/refac_report.py
@@ -1,0 +1,52 @@
+"""Compare refactorization-interval arms. Counters are exact; wall is directional
+only (the R1 panel was running concurrently — CLAUDE.md §9)."""
+import json, sys, os
+
+TOL_ABS, TOL_REL = 1e-6, 1e-4
+arms = {}
+for iv in ("48", "100", "200", "500"):
+    p = f"scratchpad/i1008/refac_{iv}.jsonl"
+    if os.path.exists(p):
+        arms[iv] = {json.loads(l)["tag"]: json.loads(l) for l in open(p)}
+base = arms["48"]
+tags = sorted(set.intersection(*[set(a) for a in arms.values()]))
+assert tags, "arms share no LP"
+
+n_cmp = 0
+bad = []
+print(f"{'interval':>9}{'facs':>8}{'factor_nnz':>14}{'basis_nnz':>12}{'cap':>7}{'ftfail':>8}{'wall_s':>9}")
+for iv, a in arms.items():
+    facs = sum(a[t]["facs"] for t in tags)
+    fnnz = sum(a[t]["factor_nnz"] for t in tags)
+    bnnz = sum(a[t]["basis_nnz"] for t in tags)
+    cap = sum(a[t]["dual_refac_cap"] for t in tags)
+    ft = sum(a[t]["dual_refac_ft"] for t in tags)
+    wall = sum(a[t]["wall"] for t in tags)
+    print(f"{iv:>9}{facs:>8}{fnnz:>14}{bnnz:>12}{cap:>7}{ft:>8}{wall:>9.2f}")
+
+# Correctness, zero slack: every arm must agree with HiGHS on every LP.
+for iv, a in arms.items():
+    for t in tags:
+        r = a[t]
+        n_cmp += 1
+        if r["ref"] is None:
+            continue
+        tol = max(TOL_ABS, TOL_REL * abs(r["ref"]))
+        if r["status"] != "optimal":
+            bad.append((iv, t, f"status={r['status']}"))
+        elif abs(r["obj"] - r["ref"]) > tol:
+            bad.append((iv, t, f"obj={r['obj']:.9g} vs HiGHS {r['ref']:.9g}"))
+
+b48, f48 = sum(base[t]["facs"] for t in tags), sum(base[t]["factor_nnz"] for t in tags)
+if "500" in arms:
+    b5 = sum(arms["500"][t]["facs"] for t in tags)
+    f5 = sum(arms["500"][t]["factor_nnz"] for t in tags)
+    print(f"\n48 -> 500: factorizations {b48} -> {b5} ({(1-b5/b48)*100:.1f}% fewer), "
+          f"factor nnz {f48/1e6:.2f}M -> {f5/1e6:.2f}M ({(1-f5/f48)*100:.1f}% less)")
+print(f"fill ratio at 48: {f48/sum(base[t]['basis_nnz'] for t in tags):.2f}x")
+print(f"\nLPs: {len(tags)}   arms: {sorted(arms)}")
+print(f"correctness deviations: {len(bad)}")
+for x in bad:
+    print("   ", x)
+print(f"\nexecuted: comparisons={n_cmp}")
+sys.exit(1 if not n_cmp else 0)


### PR DESCRIPTION
## What this is

Two measurements on #1008 and **no default change**: an attribution that
redirects the issue's planned work, and a falsification that kills the fix that
attribution most obviously suggests.

`Contributes to #1008` — the perf gap itself is not closed here.

## The attribution: it's the LU, not the PRICE loop

Phase profile over the 19 captured relaxation LPs the R1 graduation panel had
finished (`scratchpad/i1008/attrib.py`, share-of-wall over 600.5s):

| phase | share of LP wall |
|---|---|
| **LuNumeric** (`SparseLu::factor`) | **72.6%** |
| Refactorize (primal, outer timer) | 7.7% |
| LuSymbolic (`SparseLuSymbolic::analyze`) | 5.0% |
| FtUpdate | 1.9% |
| PriceBtran + AlphaFtran + PriceSweep | **1.5%** |

`PriceSweep` alone is **0.1%**. The planned D2 work — column-wise PRICE at
O(nnz(A)) per pivot — targets 1.5% of wall on this corpus and cannot pay for the
8.7x–29x gap in the issue title. Per-LP the `LuNumeric` share tracks the fill
ratio directly: fill 1.0 → ~5%, fill ~6–7 → ~50%, `QPLIB_1451_rlt0` at fill
19.1x → 74.8%.

Shares, not speeds. The two panel arms ran concurrently, so absolute ms are
contention-inflated (CLAUDE.md §9); contention inflates all phases alike, so the
shares hold and no speed claim is made from them.

## The falsification: the 48-update cap is load-bearing

Both simplex loops refactorized on a hardcoded `updates >= 48`. On
`QPLIB_1451_rlt0` all 265 primal refactorizations were cap-triggered (`RefacCap`;
12764 pivots / 48 = 266) and the adaptive `refac_work_budget` gate beside it never
fired, because the fixed cap always trips first. With `FtUpdate` at 1.9% against
`LuNumeric` at 72.6%, raising the interval should have cut the dominant cost.

It does the opposite. 16 captured LPs, one process per interval (the gate is a
`OnceLock`), counters exact and load-independent:

| interval | factorizations | factor nnz | basis nnz | fill | cap-trig | FT-fail |
|---|---|---|---|---|---|---|
| **48** (default) | **667** | **75.1M** | 14.1M | **5.32x** | 651 | 0 |
| 100 / 200 / 500 | 792 | 309.4M | 22.5M | **13.7x** | 0 | 776 |

**+19% factorizations, +312% factor nonzeros.** Above ~100 the arms are
*identical*: the cap stops firing entirely and feral's product-form update reaches
its own stability limit instead. Letting updates accumulate to that limit lands
the search on denser bases (`basis_nnz` 14.1M → 22.5M — a different pivot path,
not merely different factors) and then produces far denser factors from them.
Directional wall agreed: 30.5s → 195s.

The cap refactorizes *before* the update degrades, and the cheap fresh factor it
produces is the point. **"Refactorize less often" is not available as a #1008
fix.** Correctness was unaffected throughout: 64 arm×LP comparisons against
HiGHS, **0 deviations** — a performance verdict only.

**The single-instance trap, for the record (§2).** On `QPLIB_1423_rlt1` alone
raising the interval *helped* (66 → 55 factorizations, 11.37M → 9.55M factor nnz).
That LP was read first and looked like confirmation; the corpus aggregate reverses
it 4x. Nothing was claimed until the 16-LP aggregate ran.

## What actually ships

Instrumentation and a measurement knob. No default moves.

- **`DISCOPT_LP_REFAC_INTERVAL`** — exposes the cap both loops hardcoded as a
  literal `48`, at all five sites. Unset is **48**, so every solve is
  byte-identical to the previous engine. Unparseable input (including `0`, which
  would refactorize on every pivot) is refused loudly rather than read as the
  default — an A/B arm that silently reads as the baseline makes a harness measure
  it twice, the `parse_stall_patience` lesson.
- **`DualRefactorizations` / `DualRefacCap` / `DualRefacFtFail`** — the dual
  loop's refactorizations were **unattributed**. The existing
  `Refactorizations`/`Refac*` counters are incremented only by the primal, so an
  LP the dual solved outright showed 100+ `LuSparseFactorizations` against zero
  refactorization events. The table above could not have been computed without
  these.

## Corrections to earlier statements in this issue's work (§11)

1. `QPLIB_1451_rlt0` was described mid-investigation as "545 seconds at zero
   pivots". It is not: `Phase1Pivots 9` + `Phase2Pivots 12755` = **12,764
   pivots**. The panel's `iters=0` is the *cold-fallback* signature
   (`DualColdFallbacks 1`; `dual.rs` documents `iters == 0` as exactly that) — the
   dual was abandoned and the cold primal did the work without reporting its
   iteration count.
2. `attrib.py`'s `piv` column is a **primal-only** count. It reads 0 for the 18
   LPs the dual solved because dual pivots are not in those counters, not because
   those LPs pivoted zero times.

## What this leaves open

The cost is `LuNumeric` and the lever is **fill, not frequency**. feral's
`analyze` already triangularizes and runs AMD on the residual bump, so 19.1x fill
is *after* a fill-reducing ordering. Whether that fill is intrinsic to these bases
or an artifact of static ordering under partial pivoting is the next #1008
question — a feral-side one, **not opened here**.

## Verification

- `cargo test -p discopt-core` — **612 passed** (611 + `refac_interval_parses_or_refuses`)
- `pytest -m smoke` — **1028 passed, 1 skipped, 2 xpassed**
- `pytest -m slow python/tests/test_adversarial_recent_fixes.py` — **10 passed**
- Build under test asserted by marker, not by path (§8): `DISCOPT_LP_REFAC_INTERVAL`
  present in the loaded `.so` — the string exists only in a build that has the gate,
  so a stale `.so` fails instead of silently reporting the baseline twice.

Recorded in `docs/dev/performance-plan.md` §18f.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017PQaiDVuY5Rs3tga98tnNo

---

## Also in this PR: the R1 graduation panel completed

§18e said the R1 panel had been started and stopped at 18/88 and that completing
it was what remained before `DISCOPT_LP_UNSTABLE_PIVOT_RECOVERY` could flip
default-ON. It has since finished both arms, so that stale claim is replaced with
the result:

| bar | verdict | evidence |
|---|---|---|
| **cert-clean** | **PASS** | 82 LPs; 0 bounds below the HiGHS optimum, 0 certification regressions, 0 objective drift, 0 at the iteration cap |
| **net-positive** | **FAIL** | 0 bounds recovered; retention identical at 72/82 in both arms |

**GRADUATE: NO** — the flag stays default-OFF, which *confirms* the default
already shipped in #1023 rather than overturning it. Sound but not helpful: the
`DISCOPT_CUT_INHERIT` outcome.

The FAIL is meaningful because the probe was **not empty** (§6): the recovery
fired on 5 ON-arm LPs (12 recoveries) against 7 OFF-arm bails, so the ON arm
genuinely took different pivots and still recovered nothing the OFF arm lacked.
6 of 88 LPs were skipped (dual start rejected) and are named, not dropped. Wall
(2829.81s OFF vs 2835.45s ON) is directional only — one unreplicated run on a
machine also running the interval experiment above, i.e. load I created myself.

Doc-only change; no code moves with it.
