### PR TITLE
test(ci): fix the two near-threshold timeouts that have been masking main's signal

### DIFF
--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -52,6 +52,71 @@ def heterogeneous_array_bounds():
     return make
 
 
+# The convex kernel's per-instance solve budget in the correctness lane. It was
+# 300 s, chosen when clay0303hfsg measured 194 s there. The feral 0.16.0 bump
+# (#1025, threshold-Markowitz pivoting) moved that instance's rounding trajectory
+# -- measured locally as 141 -> 207 nodes (+47%) and 7.00 s -> 9.03 s (+29%),
+# sound in both (bound 26669.109557 / 26669.109563, optimum 26669.10955143) --
+# and 194 s became >=300 s, i.e. the budget itself started deciding the result.
+# CI is ~30-40x this machine on this instance (9.4 s local vs 194 s pre-bump; the
+# docstring in test_convex_kernel_perspective_865 records a 40x spread), so 600 s
+# restores roughly 2x margin over the ~250-350 s the bumped solve should now take.
+# This is a wall budget, not a correctness threshold: every caller still asserts
+# `optimal`/`exhausted` and full bound soundness, and none of those assertions
+# changes with a larger budget.
+CONVEX_KERNEL_BUDGET_S = 600.0
+
+
+@pytest.fixture(scope="session")
+def convex_kernel_solve():
+    """One convex-kernel solve per instance, shared across the correctness lane.
+
+    Three tests in two files each ran ``build_convex_spec`` + ``solve_convex_tree``
+    on clay0303hfsg with identical arguments, so the correctness lane paid for the
+    same tree three times -- 900 s of a 1353 s lane once the solves started hitting
+    their budget. ``test_convex_kernel_perspective_865`` already learned this lesson
+    within one file ("an earlier split into two tests re-solved the same instance and
+    added 251 s for nothing"); this extends it across files.
+
+    Sharing is information-neutral only because the solve is deterministic, which is
+    measured rather than assumed: three repeats returned byte-identical
+    ``status='optimal'``, bound 26669.109563083734, incumbent 26669.109572474063 and
+    207 nodes (8 executed comparisons; wall 9.37 s +/- 0.33 s). The env var
+    ``DISCOPT_CONVEX_KERNEL`` does not enter into it -- it gates ``try_convex_solve``
+    on the ``Model.solve()`` path, not these direct calls, which is why the 865 test
+    reaches the same tree without the ``kernel_on`` fixture.
+
+    Returns
+    -------
+    callable
+        ``solve(name) -> {"model", "spec", "result"}`` for ``<name>.nl`` in the
+        vendored MINLPLib corpus, memoized for the session. ``spec`` may be ``None``
+        (callers assert kernel-eligibility themselves). The returned objects are
+        shared: read them, do not mutate them.
+    """
+    import discopt.modeling as dm
+    from discopt.solvers._convex_kernel import build_convex_spec, solve_convex_tree
+
+    data_dir = os.path.join(os.path.dirname(__file__), "data", "minlplib_nl")
+    cache: dict[str, dict] = {}
+
+    def solve(name: str) -> dict:
+        if name not in cache:
+            model = dm.from_nl(os.path.join(data_dir, f"{name}.nl"))
+            spec = build_convex_spec(model)
+            result = (
+                None
+                if spec is None
+                else solve_convex_tree(
+                    spec, initial_incumbent=None, time_limit_s=CONVEX_KERNEL_BUDGET_S
+                )
+            )
+            cache[name] = {"model": model, "spec": spec, "result": result}
+        return cache[name]
+
+    return solve
+
+
 def pytest_configure(config):
     """Register custom markers."""
     config.addinivalue_line("markers", "correctness: Known-optimum correctness validation")

--- a/python/tests/test_871_cut_free_retry.py
+++ b/python/tests/test_871_cut_free_retry.py
@@ -41,7 +41,6 @@ import pytest
 os.environ.setdefault("JAX_PLATFORMS", "cpu")
 os.environ.setdefault("JAX_ENABLE_X64", "1")
 
-import discopt.modeling as dm  # noqa: E402
 from discopt.modeling.core import ObjectiveSense  # noqa: E402
 
 _DATA = os.path.join(os.path.dirname(__file__), "data", "minlplib_nl")
@@ -60,25 +59,29 @@ def kernel_on(monkeypatch):
 
 
 @pytest.mark.correctness
-@pytest.mark.timeout(600)
-def test_clay0303hfsg_certifies_after_the_cut_free_retry(kernel_on):
+@pytest.mark.timeout(900)
+def test_clay0303hfsg_certifies_after_the_cut_free_retry(kernel_on, convex_kernel_solve):
     """The instance #871 blocks now certifies, and the certified value is correct.
 
     Fail-before / pass-after: with the retry removed this returns ``exhausted`` with
     bound 26668.921579 (measured), so the ``optimal`` assertion is what the change
     buys. Not marked ``slow`` — every CI lane excludes ``slow`` (``ci.yml`` 178 / 262 /
     388), and a guard that cannot run is documentation. It carries an explicit
-    ``timeout(600)`` because the solve is ~7 s locally but far slower on CI runners.
-    """
-    from discopt.solvers._convex_kernel import build_convex_spec, solve_convex_tree
+    ``timeout(900)`` because the solve is ~9 s locally but far slower on CI runners;
+    it must stay above ``CONVEX_KERNEL_BUDGET_S`` so the solver's own budget, not
+    pytest, is what bounds the run.
 
+    The solve comes from the session-scoped ``convex_kernel_solve`` fixture: three
+    tests across two files were re-running this identical deterministic tree, which
+    is what pushed the correctness lane to 1353 s. See the fixture's docstring in
+    ``conftest.py`` for the determinism measurement.
+    """
     opt = _known_optimum("clay0303hfsg")
-    m = dm.from_nl(os.path.join(_DATA, "clay0303hfsg.nl"))
+    solved = convex_kernel_solve("clay0303hfsg")
+    m, spec, r = solved["model"], solved["spec"], solved["result"]
     assert m._objective.sense == ObjectiveSense.MINIMIZE, "sense assumed below"
-    spec = build_convex_spec(m)
     assert spec is not None, "clay0303hfsg must be kernel-eligible"
 
-    r = solve_convex_tree(spec, initial_incumbent=None, time_limit_s=300.0)
     inc, bound, status = r["incumbent"], r["bound"], r["status"]
     tol = 1e-4 * max(1.0, abs(opt))
 
@@ -98,12 +101,12 @@ def test_clay0303hfsg_certifies_after_the_cut_free_retry(kernel_on):
 
 
 @pytest.mark.correctness
-@pytest.mark.timeout(600)
+@pytest.mark.timeout(900)
 @pytest.mark.parametrize(
     "name",
     ["syn05m", "syn05hfsg", "clay0303hfsg"],
 )
-def test_kernel_certificates_stay_correct(kernel_on, name):
+def test_kernel_certificates_stay_correct(kernel_on, name, convex_kernel_solve):
     """No instance that already certified may regress, and none may certify wrongly.
 
     Reads the objective SENSE from the model rather than assuming MINIMIZE: `syn*` are
@@ -117,8 +120,6 @@ def test_kernel_certificates_stay_correct(kernel_on, name):
     non-regression is covered by the measurement in this module's docstring and by
     ``test_convex_kernel_perspective_865``.
     """
-    from discopt.solvers._convex_kernel import build_convex_spec, solve_convex_tree
-
     path = os.path.join(_DATA, f"{name}.nl")
     if not os.path.exists(path):
         pytest.skip(f"{name}.nl not vendored")
@@ -129,12 +130,11 @@ def test_kernel_certificates_stay_correct(kernel_on, name):
         # vendored). Skipping is honest; asserting against a transcribed literal is how
         # a wrong oracle gets published, which happened once already on this issue.
         pytest.skip(f"no recorded optimum for {name} in known_optima.toml")
-    m = dm.from_nl(path)
+    solved = convex_kernel_solve(name)
+    m, spec, r = solved["model"], solved["spec"], solved["result"]
     maximize = m._objective.sense == ObjectiveSense.MAXIMIZE
-    spec = build_convex_spec(m)
     assert spec is not None, f"{name} must be kernel-eligible"
 
-    r = solve_convex_tree(spec, initial_incumbent=None, time_limit_s=300.0)
     inc, bound, status = r["incumbent"], r["bound"], r["status"]
     tol = 1e-4 * (1.0 + abs(opt))
 

--- a/python/tests/test_convex_kernel_perspective_865.py
+++ b/python/tests/test_convex_kernel_perspective_865.py
@@ -231,8 +231,8 @@ def test_only_exponent_two_is_admitted():
 
 
 @pytest.mark.correctness
-@pytest.mark.timeout(600)
-def test_clay0303hfsg_is_sound_and_any_certificate_is_correct():
+@pytest.mark.timeout(900)
+def test_clay0303hfsg_is_sound_and_any_certificate_is_correct(convex_kernel_solve):
     """THE check whose absence let the #879 false certificate ship.
 
     Exactness and convexity of the marshaled rows both PASSED while the kernel
@@ -246,13 +246,19 @@ def test_clay0303hfsg_is_sound_and_any_certificate_is_correct():
     ``slow`` (``ci.yml`` 178 / 262 / 388), so as a slow test this guard would never
     execute on a PR — reproducing the exact #879 gap it exists to close.
 
-    It does need an explicit ``timeout(600)``: the solve is ~7 s on an M-series laptop
+    It does need an explicit ``timeout(900)``: the solve is ~9 s on an M-series laptop
     but **263 s** on the CI runner, which blew the lane's 120 s default. That 40x
-    spread is why "it only takes 7 s" is not a safe basis for a marker decision.
+    spread is why "it only takes 9 s" is not a safe basis for a marker decision. The
+    marker must also stay above ``CONVEX_KERNEL_BUDGET_S`` so the solver's budget, not
+    pytest, is what bounds the run.
 
     ONE solve, both facts. Asserting soundness and conditionally checking the
     certificate costs a single tree; an earlier split into two tests re-solved the same
-    instance and added 251 s for nothing.
+    instance and added 251 s for nothing. That was a within-file lesson; the same
+    duplication existed *across* files (two more tests in ``test_871_cut_free_retry``
+    re-solved this instance), so the tree now comes from the session-scoped
+    ``convex_kernel_solve`` fixture in ``conftest.py``, which records the determinism
+    measurement that makes sharing information-neutral.
 
     Measured today: ``status='exhausted'``, incumbent 26669.109572 (the known optimum
     to 7 figures), bound 26668.921579, relative gap 7.0e-06 — inside the usual 1e-4,
@@ -264,10 +270,9 @@ def test_clay0303hfsg_is_sound_and_any_certificate_is_correct():
     below tightens automatically to the full #879 check.
     """
     opt = known_optimum("clay0303hfsg")
-    m = dm.from_nl(os.path.join(_DATA, "clay0303hfsg.nl"))
-    spec = build_convex_spec(m)
+    solved = convex_kernel_solve("clay0303hfsg")
+    spec, r = solved["spec"], solved["result"]
     assert spec is not None
-    r = solve_convex_tree(spec, initial_incumbent=None, time_limit_s=300.0)
     inc, bound, status = r["incumbent"], r["bound"], r["status"]
     tol = 1e-4 * max(1.0, abs(opt))
 

--- a/python/tests/test_direct_units.py
+++ b/python/tests/test_direct_units.py
@@ -329,6 +329,10 @@ def test_search_respects_the_evaluation_budget():
         assert s.stats.evals <= budget, (budget, s.stats.evals)
 
 
+class _Answered(Exception):
+    """Stops a DIRECT run from the iteration hook once its crossing is recorded."""
+
+
 def test_reproduces_the_surveys_published_evaluation_counts():
     """Guards the whole engine against the class of bug the entry experiment hit.
 
@@ -342,15 +346,33 @@ def test_reproduces_the_surveys_published_evaluation_counts():
     def linear(x):
         return 1.0 + float(np.sum(x)), 0.0
 
+    def crossed(value):
+        return value is not None and abs(value - 1.0) <= 1e-2
+
     def evals_to_one_percent(divide, break_ties):
+        # Every arm asks one question -- at which evaluation does the incumbent
+        # first come within 1% -- so the budget past that point buys no assertion
+        # and is pure cost. The budget stays at the survey's 40,000 (the original
+        # rules need ~14.5k of it, and a regression that pushed a crossing past
+        # the budget must still show up as `None`); the hook stops the search the
+        # moment the answer is recorded. `history` is append-only and the value is
+        # the FIRST crossing, so stopping after it is observed cannot change what
+        # this returns -- verified equal to the run-to-budget values (16555/503/203).
+        # Without this the three arms burn 120k evaluations of hull maintenance
+        # nothing asserts, which under `--cov` on a CI runner overran the timeout.
         s = _DirectSearch(np.zeros(5), np.ones(5), divide=divide, break_ties=break_ties)
         history: list[tuple[int, float]] = []
-        s.run(
-            linear,
-            max_evals=40000,
-            on_iteration=lambda se: history.append((se.stats.evals, se.best_feasible_value)),
-        )
-        return next((e for e, v in history if v is not None and abs(v - 1.0) <= 1e-2), None)
+
+        def observe(se):
+            history.append((se.stats.evals, se.best_feasible_value))
+            if crossed(se.best_feasible_value):
+                raise _Answered
+
+        try:
+            s.run(linear, max_evals=40000, on_iteration=observe)
+        except _Answered:
+            pass  # our own sentinel only; any real failure still propagates
+        return next((e for e, v in history if crossed(v)), None)
 
     original = evals_to_one_percent("all", False)
     no_ties = evals_to_one_percent("all", True)

--- a/python/tests/test_sparse_hessian.py
+++ b/python/tests/test_sparse_hessian.py
@@ -161,14 +161,33 @@ class TestRouting:
 class TestEndToEndSolve:
     """A discretized collocation NLP solves (does not hang) via the sparse path."""
 
+    # This is a real NLP solve, not a unit test, and it runs inside the
+    # xdist-parallel PR-fast lane and the coverage lane, both of which pass
+    # `--timeout=120`. 120 s is a unit-test bound; it was deciding this test's
+    # result on a loaded runner rather than backstopping a hang. 300 s matches
+    # what the other end-to-end solves in this suite already declare
+    # (test_examples_gallery.py, test_c40_util_false_optimal.py) and still
+    # catches what this test exists to catch: if the compressed-HVP path
+    # regressed to dense `jax.hessian` assembly, the cost is O(n^2) in ~500
+    # variables, not a 3x slip.
+    @pytest.mark.timeout(300)
     def test_dae_collocation_solve_does_not_hang(self):
         sys.setrecursionlimit(100000)
-        # nfe=25 keeps this a fast plumbing smoke test: it still routes through
-        # the compressed-HVP Hessian path (asserted below), but solves in a few
+        # nfe keeps this a fast plumbing smoke test: it still routes through the
+        # compressed-HVP Hessian path (asserted below), but solves in a few
         # seconds even on the ipm fallback used in CI (where pounce is absent).
         # The O(n²)→O(seeds) scaling that actually defeats the dense-assembly
         # hang is proven separately, without a solve, by TestSeedCount.
-        m, _k = _dae_estimation_model(nfe=25, n_states=1)
+        #
+        # It was 25, which had stopped being "a few seconds": measured solve wall
+        # is 15.56 s at nfe=25 against 4.41 s at 15, and coverage instrumentation
+        # plus a slow runner took that past the 120 s timeout. 15 keeps every
+        # assertion here — the routing switch flips to sparse by nfe=10, so 15
+        # clears it with margin, and the objective still lands at 5.98e-08 against
+        # the 1e-4 bar. Do not lower it further: below the routing boundary this
+        # test would exercise the dense path, which is what the `_use_sparse_hessian`
+        # assertion above exists to catch.
+        m, _k = _dae_estimation_model(nfe=15, n_states=1)
         assert NLPEvaluator(m)._use_sparse_hessian()
         try:
             import pounce  # noqa: F401


### PR DESCRIPTION
`main`'s CI has had no trustworthy signal since 2026-08-13. Three tests have been timing out near-threshold — not deterministically, which is the part that matters: a rerun of `bd9c4c5c` passed all ten jobs, so for two days a real regression would have been indistinguishable from the noise.

Three independent causes, three commits.

---

## 1. `test_direct_units.py::test_reproduces_the_surveys_published_evaluation_counts`

The standing red on **Python coverage** since `bce881ff` (~10 consecutive `main` runs), always `pytest-timeout` at 120s.

### Measured cause

Each arm asks exactly one question — at which evaluation does the incumbent first come within 1% — and then keeps running to the 40,000-evaluation budget. Three arms, ~120,000 evaluations, of which everything past the crossing is hull maintenance that no assertion reads.

The evaluations are not the cost; the partition work is. Run-to-budget, per arm:

| arm | crossing | evals burned | wall |
|---|---:|---:|---:|
| original (`all`, no tie-break) | 16,555 | 39,999 | 1.01s |
| no_ties (`all`, tie-break) | 503 | 39,999 | 6.26s |
| one_side (`one`, tie-break) | 203 | 39,999 | 14.75s |

The two arms that answer at evaluation 503 and 203 are the two that dominate the wall. Coverage instrumentation costs 2.3x locally (bare **17.5s → 40.0s** under `--cov`), and a runner 2–3x slower puts that on the 120s limit.

### Fix

The iteration hook raises a sentinel once the crossing is recorded. `history` is append-only and the value read out is the **first** crossing, so stopping after it is observed cannot change what the arm returns. That is asserted rather than assumed — a differential probe ran both variants:

```
original  crossing=16555 (identical)  evals 39999->16555  wall 1.01s->0.31s
no_ties   crossing=503   (identical)  evals 39999->503    wall 6.26s->0.01s
one_side  crossing=203   (identical)  evals 39999->203    wall 14.75s->0.00s
executed equivalence comparisons: 3
```

Only the sentinel type is caught; a real failure still propagates (CLAUDE.md §7).

### No assertion is weakened

The published-count bounds (192 ± 60, 470 ± 120, `original > 5000`), the ordering check, and the not-`None` checks are untouched, and the budget **stays at 40,000** so a regression that pushed a crossing past it still surfaces as `None`. The obvious cheaper fix — shrinking the budget — was rejected for exactly that reason: it would have made "did it ever converge?" unanswerable.

What is dropped is assertion-free churn past the crossing. If long-run hull stability is worth guarding, it wants its own test with its own assertions, not a silent tail on this one. Flagging it rather than assuming it away.

| | before | after |
|---|---:|---:|
| three arms, wall | 22.02s | **0.32s** |
| the test under `--cov` | 40.01s | **1.15s** |
| headroom vs the 120s limit | ~3x | **~100x** |

---

## 2. `test_sparse_hessian.py::TestEndToEndSolve::test_dae_collocation_solve_does_not_hang`

The second near-threshold test — it timed out at 120s in **Python coverage** and **Python fast** on this PR's first run. Same failure mode, different cause.

### Measured cause

A phase split says the solve dominates: build 0.00s, evaluator 0.03–0.11s, the rest is the NLP. Solve wall against `nfe`, on the `ipm` backend CI uses (pounce absent):

| nfe | solve wall | `_use_sparse_hessian()` |
|---:|---:|---|
| 5 | 0.83s | **False** — below the routing switch |
| 10 | 1.68s | sparse |
| 12 | 3.37s | sparse |
| 15 | 4.41s | sparse |
| 18 | 8.02s | sparse |
| 25 | 15.56s | sparse ← what was committed |

In the exact CI configuration (pounce blocked + `--cov`) the whole test was **18.76s before, 8.18s after**. The PR-fast lane additionally runs it under xdist, so the runner's effective factor over this machine is ≥6.4x — which is how 18.76s locally becomes a 120s timeout there.

### Fix

**`nfe` 25 → 15.** Nothing here asserts anything about `nfe`. The O(n²)→O(seeds) scaling that actually defeats the dense-assembly hang is proven *without a solve* by `TestSeedCount`, at nfe=25 and 75; this test is the plumbing check that a discretized collocation NLP routes through the compressed-HVP path and solves. 15 keeps every assertion — the routing switch flips to sparse by nfe=10 so 15 clears it with margin (and `_use_sparse_hessian()` is still asserted), and the objective still lands at 5.98e-08 against the 1e-4 bar. A comment marks the floor: below the routing boundary this test would silently exercise the *dense* path, which is precisely what it exists to rule out.

**`@pytest.mark.timeout(300)`.** This is an end-to-end NLP solve running under lanes that pass `--timeout=120` — a unit-test bound that was deciding the test's result on a loaded runner rather than backstopping a hang. 300 is what the other end-to-end solves in this suite already declare (`test_examples_gallery.py`, `test_c40_util_false_optimal.py`). It does not weaken the guard: a regression from compressed HVPs back to dense `jax.hessian` assembly is O(n²) in ~500 variables, not a 3x slip.

---

## 3. `clay0303hfsg` in the correctness lane

Three tests across two files, all `status=time_limit` against the **solver's own 300s budget** (not `pytest-timeout`), on a PR that touches neither file. This one has a real cause behind it.

### What happened

| | pre-bump `main` (`6a78c837`, feral 0.15.1) | this PR (feral 0.16.0) — failing run | this PR — **passing** run |
|---|---:|---:|---:|
| `test_clay0303hfsg_certifies_after_the_cut_free_retry` | 198.69s | 303.91s | **295.92s** |
| `test_kernel_certificates_stay_correct[clay0303hfsg]` | 194.00s | 301.35s | 289.80s |
| `test_clay0303hfsg_is_sound_and_any_certificate_is_correct` | 193.75s | 301.30s | 289.41s |
| lane total | 962.57s | 1353.44s (2 failed) | 1315.39s |

The distribution now straddles the 300s budget. **The green run passed at 295.92 / 300 — 1.4% margin.** That is a coin landing heads, not a signal, which is why a green run is not a reason to leave this alone.

The cause is the feral 0.16.0 bump from #1025 (threshold-Markowitz pivoting, bound-changing by construction; clay0303hfsg is one of the 18 instances that panel recorded as *worse*). Interleaved local A/B with per-arm `feral-<version>` marker assertions on the loaded extension: **141 → 207 nodes (+47%), 7.00s → 9.03s (+29%)**. Both arms are **sound** — bound 26669.109557429114 (0.15.1) and 26669.109563083734 (0.16.0) against the oracle optimum 26669.10955143, both `optimal`, both ≤ opt+tol. Nothing is wrong with the certificate; the instance stopped fitting a budget that used to have ~35% headroom.

### Fix

**Solve it once.** All three tests called `build_convex_spec` + `solve_convex_tree` on clay0303hfsg with *identical* arguments — 900s of a 1353s lane spent on the same tree three times. (`DISCOPT_CONVEX_KERNEL` does not enter into it: that env var gates `try_convex_solve` on the `Model.solve()` path, not these direct calls, which is why the 865 test reaches the same tree without the `kernel_on` fixture.) The solve now comes from a session-scoped `convex_kernel_solve` fixture in `conftest.py`. `test_871`'s own docstring already recorded this lesson *within* one file — "an earlier split into two tests re-solved the same instance and added 251 s for nothing" — the same duplication existed *across* files.

Sharing is information-neutral only if the solve is deterministic, so that was the entry experiment (§4) rather than an assumption:

```
solve 0: wall=  9.83s {'status': 'optimal', 'bound': 26669.109563083734, 'incumbent': 26669.109572474063, 'nodes': 207}
solve 1: wall=  9.10s {'status': 'optimal', 'bound': 26669.109563083734, 'incumbent': 26669.109572474063, 'nodes': 207}
solve 2: wall=  9.18s {'status': 'optimal', 'bound': 26669.109563083734, 'incumbent': 26669.109572474063, 'nodes': 207}
wall mean=9.37s sd=0.33s
executed determinism comparisons: 8
```

**Budget 300s → 600s** (`CONVEX_KERNEL_BUDGET_S`), markers 600 → 900 so the solver's budget rather than pytest is what bounds the run. Measured CI wall for the bumped solve is 289–304s across two runs, so 600s restores ~2x margin.

### No assertion is weakened

Every caller still asserts `optimal` (or `optimal`/`exhausted` in the 865 test), `bound ≤ opt + tol`, `incumbent ≥ opt − tol`, and the `bound ≤ incumbent` certificate invariant — each with its own executed-assertion counter. None of those change with a larger wall budget. **Net lane time goes down, not up.**

### Confirmed on CI

| | before (green run, old code) | after |
|---|---:|---:|
| clay0303hfsg solves in the lane | 3 (295.92 / 289.80 / 289.41s) | **1** (327.55s) |
| margin against the budget | 295.92 / 300 = **1.01x** | 327.55 / 600 = **1.83x** |
| correctness lane total | 1315.39s | **769.86s** (−41.5%) |
| tests passed | 337 | 337 |

Note the 327.55s: **this run would have failed under the old 300s budget.** Two of the three previous runs of this lane straddled it, and the numbers say the straddling continues — the change is what stops it being a coin flip, not a cosmetic tidy-up.

---

## Verification

- `test_direct_units.py` under `--cov` — **59 passed in 8.68s** (this test 0.66s, no longer in the top two)
- `test_sparse_hessian.py` in the CI configuration (pounce blocked, `--cov`, `--timeout=120`) — **7 passed in 10.69s**, this test 6.22s
- `test_871_cut_free_retry.py` + `test_convex_kernel_perspective_865.py` — **17 passed, 2 skipped in 12.93s**; the clay solve now appears once at 9.55s, against 28.11s of solve time before
- differential equivalence probe (DIRECT) — 3/3 crossings identical, executed-count printed (§6)
- determinism probe (kernel solve) — 8/8 comparisons identical, executed-count printed (§6), `feral-0.16.0` marker asserted present and `feral-0.15.1` asserted absent on the loaded extension (§8)
- CI at `49ce168f` (fixes 1 and 2 only) — **all 10 jobs green**, which is what established that fix 3's lane was passing at 295.92s/300s rather than failing
- CI at `76866968` (all three fixes) — **all 10 jobs green**, correctness lane 1315.39s → 769.86s with the same 337 passed
- `pytest -m smoke` — **1028 passed**, 1 skipped, 2 xpassed (identical to the pre-change run)
- `pytest -m slow python/tests/test_adversarial_recent_fixes.py` — **10 passed**
- `ruff check` + `ruff format --check` clean
- No Rust touched, so `cargo test` was not required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017PQaiDVuY5Rs3tga98tnNo
