### PR TITLE
docs: bring the README and docs site up to date with the current tree

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,32 +10,44 @@
 
 
 
-A hybrid Mixed-Integer Nonlinear Programming (MINLP) solver combining a Rust backend, JAX automatic differentiation, and Python orchestration. Solves MINLP problems via NLP-based spatial Branch and Bound with JIT-compiled objective/gradient/Hessian evaluation.
+A Mixed-Integer Nonlinear Programming (MINLP) solver built on a Rust core with
+Python orchestration. Solves MINLPs by spatial Branch and Bound over rigorous
+convex relaxations, with an in-house primal/dual simplex for the per-node LPs and
+a Rust automatic-differentiation tape (via POUNCE) for objective, gradient,
+Jacobian, and Hessian evaluation.
 
 ## Features
 
 - **Algebraic modeling API** -- continuous, binary, and integer variables with operator overloading
-- **Spatial Branch and Bound** -- Rust-powered node pool, branching, and pruning
-- **JIT-compiled NLP evaluation** -- objective, gradient, Hessian, and constraint Jacobian via JAX
-- **Three NLP backends** -- POUNCE (pure-Rust Ipopt port; default for single solves), pure-JAX interior-point method (vmap-batched B&B node engine), cyipopt (Ipopt)
-- **Convex relaxations** -- McCormick envelopes (28 functions including sigmoid/softplus/tanh and the trig/inverse-trig/`erf` families), piecewise McCormick, alphaBB underestimators
-- **Neural network embedding** -- embed trained feedforward networks (ReLU, sigmoid, tanh, softplus) as MINLP constraints via big-M, full-space, and reduced-space strategies; interval arithmetic bound propagation; ONNX import (`pip install discopt[nn]`)
-- **Generalized disjunctive programming** -- `BooleanVar`, propositional logic operators (`land`, `lor`, `lnot`, `atleast`, `atmost`, `exactly`), `either_or()`, `if_then()`; reformulated via big-M, multiple big-M (LP-tightened), hull, or Logic-based Outer Approximation (`gdp_method="loa"`)
-- **Complementarity / MPEC** -- `Model.complementarity(x, y)` reformulated via GDP disjunction (default), Scholtes regularization, or SOS1
-- **Specialized problem classes** -- pooling problem (pq-formulation), geometric programming (posynomial detection + log-space convex reformulation), AC optimal power flow (rectangular QCQP)
+- **Spatial Branch and Bound** -- Rust-powered node pool, branching, and pruning; the native Rust spatial B&B kernel is the default engine (`DISCOPT_NATIVE_SPATIAL_KERNEL=0` opts back to the Python tree)
+- **Rust AD tape for NLP evaluation** -- objective, gradient, constraint Jacobian, and Lagrangian Hessian (dense and sparse) come from a POUNCE-backed tape with no JAX on the path; `DISCOPT_NLP_EVAL=jax` restores the legacy JAX evaluator
+- **In-house LP/MILP engine** -- pure-Rust primal/dual simplex with warm starts and a sparse LU basis (`feral`); HiGHS is no longer on the LP/MILP path
+- **NLP backends** -- POUNCE (pure-Rust Ipopt port, the universal default) and cyipopt (Ipopt); `nlp_solver="simplex"` selects the pure-Rust warm-started-simplex MILP B&B. The pure-JAX IPM has been retired -- `"ipm"`/`"sparse_ipm"` remain as back-compat aliases
+- **Convex relaxations** -- McCormick envelopes over 28 primitive operations (bilinear, powers, `exp`/`log` family, trig and inverse-trig, hyperbolics, `sigmoid`/`softplus`/`tanh`, `abs`/`min`/`max`/`sign`/`entropy`) plus a 19-intrinsic univariate envelope table in the uniform factorable engine (adding `erf`, `log1p`, and the inverse hyperbolics); piecewise McCormick, alphaBB underestimators, and G-convexity / convex-transformable relaxations
+- **Certified global MINLP** -- Adaptive Multivariate Partitioning (`solver="amp"`) for nonconvex bilinear/trilinear/signomial/trig models, and a signomial global optimizer (`DISCOPT_SGO`) for mixed-sign signomial and integer-signomial problems
+- **Decomposition solvers** -- MIP-NLP family (`solver="mip-nlp"`: OA, ECP, FP, GOA, LP/NLP-BB), Benders and Generalized Benders (GBD), Lagrangian decomposition, and an automatic structure/decomposition advisor
+- **Derivative-free optimization** -- `solver="direct"` (sampling search over black-box `dm.custom` bodies) and `solver="surrogate"` (surrogate-model search); both are explicitly non-certifying, and a governed variant runs as a root heuristic
+- **Neural network & tree embedding** -- embed trained feedforward networks (ReLU, sigmoid, tanh, softplus) as MINLP constraints via big-M, full-space, and reduced-space formulations; decision trees and gradient-boosted ensembles via per-leaf MILP encoding; interval-arithmetic bound propagation; ONNX / scikit-learn / PyTorch readers. Trainable surrogates (`nn.trainable`, `nn.surrogate`) emit symbolic weights so a surrogate can be fit *simultaneously* with a physics model
+- **Generalized disjunctive programming** -- `BooleanVar`, propositional logic operators (`land`, `lor`, `lnot`, `atleast`, `atmost`, `exactly`), `either_or()`, `if_then()`; reformulated via big-M, multiple big-M (LP-tightened), hull, or Logic-based Outer Approximation (`gdp_method="loa"`), with a disjunct-selection primal constructor on by default
+- **Complementarity / MPEC** -- `Model.complementarity(x, y)` (elementwise over vectors/arrays) reformulated via GDP disjunction (default), Scholtes regularization, or SOS1
+- **Bilevel programming** -- KKT and strong-duality reformulations of the follower problem, including certified/convex-NLP followers
+- **Stochastic programming** -- extensive form, L-shaped, progressive hedging, multistage, SAA, risk measures, and distributionally-robust variants
+- **Geometric programming** -- posynomial detection with an exact log-space convex reformulation (auto-routed), plus GP-structured MINLPs solved by integer B&B over exact convex log-space node relaxations (`solver="gp-minlp"`)
 - **Robust & multi-objective optimization** -- uncertainty sets with affine decision rules; scalarization (weighted-sum, ε-constraint, Tchebycheff, NBI, NNC) with Pareto-front analysis
-- **Parameter estimation** -- weighted-least-squares estimation with exact JAX Fisher-information Jacobians; model-based design of experiments (D/A/E-optimality, identifiability, model discrimination) is available via the [discopt-doe](https://github.com/jkitchin/discopt-doe) plugin
-- **Presolve** -- FBBT (interval arithmetic, probing, Big-M simplification, integrality-aware snapping, periodic-variable reduction), OBBT with LP warm-start
-- **Cutting planes** -- reformulation-linearization (RLT, a first-class `rlt_cuts=True` option), PSD/SOC cuts for QCQP, and outer approximation (OA); `cuts='auto'` by default
-- **Primal heuristics** -- multi-start NLP, feasibility pump, diving, RINS, local branching
+- **Parameter estimation** -- weighted-least-squares estimation with exact Fisher-information Jacobians; model-based design of experiments (D/A/E-optimality, identifiability, model discrimination) is available via the [discopt-doe](https://github.com/jkitchin/discopt-doe) plugin
+- **Presolve** -- FBBT (interval arithmetic, probing, Big-M simplification, integrality-aware snapping, periodic-variable reduction), reverse-FBBT auxiliary cascade, substitution-graph aggregation with postsolve, OBBT with LP warm-start
+- **Cutting planes** -- reformulation-linearization (RLT, a first-class `rlt=True` option), PSD/SOC cuts for QCQP, GMI cuts, and outer approximation (OA); the structure-gated `rlt="auto"` policy is the default
+- **Primal heuristics** -- multi-start NLP, feasibility pump, diving, RINS, local branching, QUBO/Ising local search, one-hot swap local search for graph-partition MIQPs
 - **Infeasibility diagnosis** -- irreducible infeasible subsystem (`compute_iis`) and conflict analysis / no-good cuts
 - **Differentiable optimization** -- parameter sensitivity via envelope theorem and KKT implicit differentiation, including differentiable MILP/MIQP (fix-and-differentiate)
-- **.nl file import** -- read AMPL-format models via Rust parser
+- **Model import & export** -- read AMPL `.nl` (Rust parser), GAMS `.gms`, and QPLIB native format; write `.nl`, `.lp`, `.mps`, and GAMS
 - **Pyomo solver plugin** -- use discopt from existing Pyomo models via `SolverFactory("discopt")` (`pip install discopt[pyomo]`); see [docs/pyomo_solver.md](docs/pyomo_solver.md)
-- **Dynamic optimization** -- DAE collocation (Radau/Legendre) and finite differences for optimal control, parameter estimation, and PDE-constrained optimization
-- **CUTEst interface** -- NLP benchmarking against the CUTEst test set
+- **GAMS solver link** -- run discopt *as* a GAMS solver through the GMO/GEV API (`discopt gams-register`, `discopt gams-daemon`); see [docs/gams_solver_link.md](docs/gams_solver_link.md)
+- **Warm solve daemon** -- `discopt solve model.nl` routes through a persistent daemon that keeps the process warm across solves
+- **Dynamic optimization** -- DAE collocation (Radau/Legendre), finite differences, and method-of-lines for optimal control, parameter estimation, and PDE-constrained optimization, with multi-experiment trajectory fitting
+- **Benchmark interfaces** -- CUTEst (NLP test set), MINLPLib `.nl`, and QPLIB (453 quadratic instances, 390 nonconvex, with reference solution vectors)
 - **LLM integration** (optional) -- conversational model building, diagnostics, and reformulation suggestions
-- **Extensive test suite** -- 339 Rust + 3,700+ Python test functions
+- **Extensive test suite** -- 619 Rust + 7,100+ Python test functions
 
 ## Quick Start
 
@@ -60,76 +72,109 @@ print(result.x)          # {"x": 0.5, "y": 0.5, "z": 0.0}
 ## Architecture
 
 ```
-Model.solve()  -->  Python orchestrator  -->  Rust TreeManager (B&B engine)
+Model.solve()  -->  Python orchestrator  -->  Rust B&B kernel / TreeManager
                         |                          |
-                  JAX NLPEvaluator           Node pool / branching / pruning
-                  NLP backends:              Zero-copy numpy arrays (PyO3)
-                    pounce  (pure-Rust Ipopt port)  [default single solve]
-                    ipm     (pure-JAX, vmap batch)  [B&B node relaxations]
-                    cyipopt (Ipopt)
+                  NLP evaluation:            Node pool / branching / pruning
+                    POUNCE AD tape           In-house primal/dual simplex (node LPs)
+                    (default, JAX-free)      Zero-copy numpy arrays (PyO3)
+                  NLP backends:
+                    pounce  (pure-Rust Ipopt port)  [default]
+                    cyipopt (Ipopt)                 [fallback]
 ```
 
-**Rust backend** (`crates/discopt-core`): Expression IR, Branch and Bound tree (node pool, branching, pruning), .nl file parser, FBBT/presolve (interval arithmetic, probing, Big-M simplification).
+**Rust backend** (`crates/discopt-core`): Expression IR, Branch and Bound tree (node
+pool, branching, pruning), the native spatial B&B kernel, in-house primal/dual
+simplex with a sparse LU basis (`feral`), .nl file parser, FBBT/presolve (interval
+arithmetic, probing, Big-M simplification).
 
-**Rust-Python bindings** (`crates/discopt-python`): PyO3 bindings with zero-copy numpy array transfer for the B&B tree manager, expression IR, batch dispatch, and .nl parser.
+**Rust-Python bindings** (`crates/discopt-python`): PyO3 bindings with zero-copy numpy
+array transfer for the B&B tree manager, expression IR, batch dispatch, and .nl parser.
 
-**JAX layer** (`python/discopt/_relax`): DAG compiler mapping modeling expressions to JAX primitives, JIT-compiled NLP evaluator (objective, gradient, Hessian, constraint Jacobian), McCormick convex/concave relaxations (28 functions), and a relaxation compiler with vmap support.
+**NLP evaluation** (`python/discopt/_tape_nlp_evaluator.py`, `_nl_expr_compiler.py`):
+objective, gradient, constraints, Jacobian, and Lagrangian Hessian (dense and sparse)
+from a POUNCE Rust AD tape. This is the default; expressions with no tape opcode (an
+opaque `dm.custom` body, a matrix norm) fall back to the JAX evaluator, and
+`DISCOPT_NLP_EVAL=jax` selects it wholesale. Pure LP, QP, MIQP, and simplex-MILP
+solves never import JAX at all.
 
-**Solver wrappers** (`python/discopt/solvers`): POUNCE (pure-Rust Ipopt port), cyipopt NLP wrapper for Ipopt, HiGHS LP and MILP wrappers with warm-start support.
+**Relaxation layer** (`python/discopt/_relax`): DAG compiler, the uniform factorable
+relaxation engine, McCormick convex/concave envelopes, alphaBB, piecewise McCormick,
+cutting planes, convexity detection, and the relaxation compiler with vmap support.
+This layer still uses JAX for envelope evaluation and cut separation.
 
-**CUTEst interface** (`python/discopt/interfaces/cutest.py`): PyCUTEst-based evaluator for NLP benchmarking against the CUTEst test set.
+**Solver wrappers** (`python/discopt/solvers`): POUNCE (pure-Rust Ipopt port) for
+LP/QP/NLP, the in-house simplex LP/MILP backends, cyipopt for Ipopt, AMP, the MIP-NLP
+decomposition family, GDPopt-LOA, the DFO backends (`direct`, `surrogate`), and an
+optional Gurobi backend. highspy is used only on the OA/GDP paths.
 
-**Orchestrator** (`python/discopt/solver.py`): End-to-end `Model.solve()` connecting all components. At each B&B node: solve continuous NLP relaxation with tightened bounds, prune infeasible nodes, fathom integer-feasible solutions, branch on most fractional variable.
+**Interfaces** (`python/discopt/interfaces`): PyCUTEst-based evaluator for NLP
+benchmarking against the CUTEst test set, and a native QPLIB reader.
+
+**Orchestrator** (`python/discopt/solver.py`): End-to-end `Model.solve()` connecting all
+components. At each B&B node: solve the relaxation with tightened bounds, prune
+infeasible nodes, fathom integer-feasible solutions, branch on the selected variable.
 
 ## NLP Backends
 
-| Backend              | Implementation       | Use Case                                   |
-|----------------------|----------------------|--------------------------------------------|
-| `pounce` (default)   | Pure-Rust Ipopt port | Single-problem NLP; fastest wall-clock     |
-| `ipm`                | Pure-JAX IPM         | B&B inner loop; GPU-batched via `jax.vmap`  |
-| `cyipopt`            | Ipopt via cyipopt    | Single-problem NLP; most robust            |
+| Backend                        | Implementation                        | Use Case                                    |
+|--------------------------------|---------------------------------------|---------------------------------------------|
+| `pounce` (default)             | Pure-Rust Ipopt port                  | Universal default: LP/QP/MILP/MIQP/NLP/MINLP |
+| `ipopt` / `cyipopt`            | Ipopt via cyipopt                     | NLP node and continuous solves; most robust |
+| `simplex`                      | Pure-Rust warm-started simplex B&B    | MILP; the fully JAX-free MILP path          |
+| `ipm` / `sparse_ipm`           | Back-compat aliases                   | Simplex-first LP/MILP routing; resolve to POUNCE for NLP/MINLP |
 
-For single continuous solves the default NLP backend resolves to a KKT-valid
-solver -- POUNCE when installed, falling back to cyipopt, then to the pure-JAX
-IPM. The pure-JAX `ipm` remains the vmap-batched engine for B&B node relaxations.
+The pure-JAX interior-point method has been retired. `nlp_solver="ipm"` is kept as an
+alias so existing scripts keep working: it selects the simplex-first matrix routing for
+LP/MILP and resolves to POUNCE for NLP/MINLP.
 
 ```python
-result = model.solve()                       # default: POUNCE when installed
+result = model.solve()                       # default: POUNCE
 result = model.solve(nlp_solver="pounce")    # POUNCE (pure-Rust Ipopt port)
-result = model.solve(nlp_solver="ipm")       # Pure-JAX IPM
-result = model.solve(nlp_solver="cyipopt")   # Ipopt
+result = model.solve(nlp_solver="ipopt")     # Ipopt via cyipopt
+result = model.solve(nlp_solver="simplex")   # pure-Rust simplex MILP B&B
 ```
 
 ## Benchmarks
 
-Performance measured on Apple M4 Pro (CPU, JAX 0.8.2). "Warm" times exclude JIT compilation. All solvers produce matching objective values.
+The numbers below are the committed outputs of
+[`docs/notebooks/benchmarks_by_class.ipynb`](docs/notebooks/benchmarks_by_class.ipynb),
+re-executed on the current Rust AD tape backend (Python 3.12, CPU, median of 3 runs
+including setup). Absolute times are machine-dependent -- the notebook is the
+reproducible source. All solvers agree on the objective value.
 
 | Problem Class | discopt | Comparison | Notes |
 |---------------|---------|------------|-------|
-| **LP** (n=100) | 0.015s warm | HiGHS 0.002s, scipy 0.002s | Algebraic extraction, no autodiff |
-| **QP** (n=100) | 0.04s warm | scipy SLSQP 0.02s | Was 66s before algebraic extraction |
-| **MILP** (n=25) | 0.002s | HiGHS MIP 0.002s | B&B + LP relaxation, correct objectives |
-| **MIQP** (n=10) | 0.004s | NLP path 4.9s | QP-specialized path: 1000x+ speedup |
-| **NLP** (n=20, Rosenbrock) | IPM 1.1s warm, POUNCE 0.42s, Ipopt 0.43s | -- | POUNCE fastest single-solve; IPM best for batched B&B |
-| **MINLP** (n=10) | 0.9s (batch=1) | 0.9s (batch=16) | vmap batching helps with deeper B&B trees |
+| **LP** (n=100) | 0.234s | HiGHS 0.0015s, scipy 0.0019s | Algebraic extraction, no autodiff |
+| **QP** (n=100) | 0.417s | scipy SLSQP 0.023s | -- |
+| **MILP** (n=25, 8 int) | 0.019s | HiGHS MIP 0.0017s | B&B + LP relaxation, correct objectives |
+| **MIQP** (n=10) | 0.018s | forced NLP path 0.707s | QP-specialized path: ~40x speedup |
+| **NLP** (n=20, Rosenbrock) | POUNCE 0.120s | cyipopt 0.126s | Two implementations of the same IPM |
+| **MINLP** (n=10) | 0.026s (batch=1) | 0.026s (batch=16) | These trees close in 1-5 nodes, so batching has nothing to fill |
+
+HiGHS (C++ simplex) and scipy remain faster on the LP/MILP classes, as expected for
+mature production codes; discopt's value on these classes is that they are reachable
+from the same model object as the MINLP path.
 
 See the benchmark notebooks for full scaling plots and details:
-- [Benchmarks by Problem Class](docs/notebooks/benchmarks_by_class.ipynb) -- LP, QP, MILP, MIQP, NLP (3 backends), MINLP
-- [IPM vs POUNCE vs Ipopt](docs/notebooks/ipm_vs_ipopt.ipynb) -- detailed NLP backend comparison (incl. vmap-batched IPM for B&B inner loops)
+- [Benchmarks by Problem Class](docs/notebooks/benchmarks_by_class.ipynb) -- LP, QP, MILP, MIQP, NLP, MINLP
+- [NLP Backend Comparison](docs/notebooks/ipm_vs_ipopt.ipynb) -- POUNCE vs Ipopt
 
 ## Installation
 
-Requires Rust 1.84+ and Python 3.10+. POUNCE (the default single-solve NLP
-backend) is a pure-Rust Ipopt port with no system dependencies; cyipopt is an
-optional fallback that needs the Ipopt C library.
+Requires Rust 1.84+ and Python 3.10+. POUNCE -- the default numerical engine -- is a
+pure-Rust Ipopt port installed as a core dependency, with no system libraries needed.
+cyipopt is an optional fallback that needs the Ipopt C library.
 
 ```bash
-# Install the POUNCE NLP backend (pure-Rust Ipopt port)
-pip install pounce-solver
+pip install discopt
 
 # Optional cyipopt fallback (needs the Ipopt C library; macOS: brew install ipopt)
 pip install "discopt[ipopt]"
+```
 
+From a source checkout:
+
+```bash
 # Build Rust-Python bindings
 cd crates/discopt-python && maturin develop && cd ../..
 
@@ -141,6 +186,9 @@ JAX_PLATFORMS=cpu JAX_ENABLE_X64=1 make test
 `make test` matches the PR CI gate: ordinary non-slow tests plus the
 `pr_correctness` subset. Full correctness, integration, and benchmark markers
 remain available through the explicit Make targets.
+
+Optional extras: `ipopt`, `cutest`, `gams`, `llm`, `sdp`, `nn` (ONNX), `pyomo`,
+`ml` (scikit-learn), `xgboost`, `lightgbm`, `gnn`, `learned`, `sympy`, `dev`, `all`.
 
 ### Solving nonconvex MINLPs with AMP
 
@@ -164,7 +212,7 @@ print(result.status, result.objective, result.gap)
 ```
 
 AMP iterates a piecewise-McCormick / convex-hull MILP relaxation against an
-NLP subproblem (Ipopt) and refines the partition where the relaxation gap is
+NLP subproblem and refines the partition where the relaxation gap is
 largest. At every iteration `LB_k <= global_opt <= UB_k`, so termination at
 `gap <= rel_gap` yields a certified global optimum.
 
@@ -179,7 +227,7 @@ Common tuning knobs (all keyword-only on `Model.solve(solver="amp", ...)`):
 | `convhull_ebd` | `False` | Logarithmic Gray-code embedded SOS2 binaries |
 | `presolve_bt` | `True` | OBBT/FBBT bound tightening before the first MILP |
 | `obbt_at_root` | `True` | Strengthen variable bounds at the root |
-| `milp_solver` | `"auto"` | MILP master backend: `"auto"`, `"highs"`, `"pounce"`, `"simplex"`, or `"gurobi"` |
+| `milp_solver` | `"auto"` | MILP master backend: `"auto"`, `"pounce"`, `"simplex"`, or `"gurobi"` |
 | `partition_method` | `"adaptive"` | How to pick which variable/interval to refine |
 
 Gurobi can be used as AMP's MILP-master subsolver without changing the global
@@ -198,13 +246,14 @@ tuning knobs above is in `docs/notebooks/amp_global_minlp.ipynb`.
 ### AMP Test Suites
 
 Routine AMP development uses a fast default regression battery. The fast
-environment uses solver-independent checks plus HiGHS-backed MILP relaxations,
-and excludes optional cyipopt, longer Alpine, MINLPTests, and incidence-style
-AMP benchmark coverage. AMP and PR-fast Make targets run pytest through
-`scripts/run_memory_capped_pytest.sh`, which applies a 32 GB address-space cap
-with `prlimit` when available. Override with `PYTEST_MEMORY_LIMIT_MB=...`, or
-set `PYTEST_MEMORY_LIMIT_MB=0` to disable the cap. The broad `make test-quick`
-dev-loop target remains uncapped and excludes `memory_heavy` tests.
+environment uses solver-independent checks plus MILP relaxations on the in-house
+backends, and excludes optional cyipopt, longer Alpine, MINLPTests, and
+incidence-style AMP benchmark coverage. AMP and PR-fast Make targets run pytest
+through `scripts/run_memory_capped_pytest.sh`, which applies a 32 GB
+address-space cap with `prlimit` when available. Override with
+`PYTEST_MEMORY_LIMIT_MB=...`, or set `PYTEST_MEMORY_LIMIT_MB=0` to disable the
+cap. The broad `make test-quick` dev-loop target remains uncapped and excludes
+`memory_heavy` tests.
 
 ```bash
 make test-amp-fast
@@ -218,8 +267,8 @@ opt-in because they can require optional solvers and longer solve budgets:
 pixi exec -s python=3.12 -s ipopt -s pkg-config -s c-compiler -s cxx-compiler -s gfortran -- \
   uv venv --allow-existing .venv
 source .venv/bin/activate
-uv pip install maturin pytest pytest-timeout numpy scipy jax jaxlib highspy cyipopt
-uv pip install -e ".[dev,ipopt,highs]"
+uv pip install maturin pytest pytest-timeout numpy scipy jax jaxlib cyipopt
+uv pip install -e ".[dev,ipopt]"
 maturin develop
 make test-amp-integration
 ```
@@ -236,9 +285,10 @@ PYTEST_MEMORY_LIMIT_MB=0 make test-amp-integration
 
 WSL users should also set explicit memory and swap limits in `.wslconfig` so a
 single uncapped compile-heavy test cannot restart the host session. A stricter
-12 GB cap is useful for reproducing memory pressure, but the current JAX/XLA
-CPU stack can reserve more than 12 GB of virtual address space during AMP runs;
-use the `memory_heavy` marker selection when running with tighter caps.
+12 GB cap is useful for reproducing memory pressure, but the JAX/XLA CPU stack
+used by the relaxation layer can reserve more than 12 GB of virtual address
+space during AMP runs; use the `memory_heavy` marker selection when running with
+tighter caps.
 
 The full Python test suite remains available with `make test-all`.
 
@@ -255,7 +305,7 @@ directly from the repository.
 |---|---|---|
 | **[discopt-doe](https://github.com/jkitchin/discopt-doe)** | `pip install discopt-doe` | Model-based **design of experiments** — D/A/E-optimality, identifiability, model discrimination — as a `discopt doe ...` CLI loop (templates/new/status/fit/extend/gui) around an `.xlsx` workbook, with an optional Streamlit GUI. |
 | **[discopt-aggregation](https://github.com/jkitchin/discopt-aggregation)** | `pip install discopt-aggregation` | **Variable aggregation** (reduced-space presolve): substitutes variables defined by equality constraints to yield a smaller reduced-space formulation, then recovers them from the solution ([Naik et al., arXiv:2502.13869](https://arxiv.org/abs/2502.13869)). Exposes `aggregate`/`solve` under `discopt.aggregation`. |
-| **[discopt-apps](https://github.com/jkitchin/discopt-apps)** | `pip install "git+https://github.com/jkitchin/discopt-apps.git"` | **Application builders** for the modeling language: AC optimal power flow (`discopt.opf`) and pooling (`discopt.pooling`). |
+| **[discopt-apps](https://github.com/jkitchin/discopt-apps)** | `pip install "git+https://github.com/jkitchin/discopt-apps.git"` | **Application builders** for the modeling language: AC optimal power flow (`discopt.opf`) and the pooling problem in pq-formulation (`discopt.pooling`). Both moved out of the core package. |
 | **[discopt-course](https://github.com/jkitchin/discopt-course)** | `pip install "git+https://github.com/jkitchin/discopt-course.git"` | An **optimization course** plus an interactive `discopt tutor ...` CLI (`discopt.course`) that walks through modeling and solving exercises. |
 
 ```bash
@@ -285,9 +335,18 @@ After installation, the `discopt` command is available on your PATH:
 ```bash
 discopt about            # Version and installation info
 discopt test             # Smoke-test the install
+discopt solve model.nl   # Solve a .nl model (warm-routed through the solve daemon)
 discopt convert in.gms out.nl
+discopt daemon status    # Control the warm solve daemon (serve/stop/kill/status)
+discopt gams-register    # Register discopt as a GAMS solver
+discopt gams-daemon      # Control the warm GAMS solver daemon
+discopt gams-verify      # Run the packaged .gms corpus through GAMS with solver=discopt
 discopt install-skills   # Install Claude Code slash commands and agents
 ```
+
+`discopt solve` accepts the usual solve controls as flags (`--profile`,
+`--time-limit`, `--gap`, `--solver`, `--rlt`, `--partitions`, `--tuning`,
+`--json`, `--sol`).
 
 External packages can add subcommands through the `"discopt.cli"` entry-point
 group (see the protocol notes in `python/discopt/cli.py`). For example, the
@@ -320,30 +379,28 @@ relevant new papers from arXiv and OpenAlex.
 
 Tutorial notebooks are available in `docs/notebooks/`:
 
-- **Quickstart** -- basic modeling and solving
-- **MINLP Examples** -- mixed-integer nonlinear programs
-- **Advanced Features** -- relaxations, presolve, cutting planes, branching policies
+- **Quickstart**, **Modeling Guide**, **Sets and Indexing** -- basic modeling and solving
+- **Problem-class tutorials** -- LP, QP, MILP, MIQP, MINLP, GDP, DAE, robust, multi-objective, complementarity/MPEC, bilevel, stochastic, pooling, geometric programming
+- **Solver backends** -- OA, MIP-NLP, Benders, GBD, Lagrangian, the decomposition advisor, AMP global MINLP, DIRECT and surrogate DFO, POUNCE, cyipopt, and solver selection
+- **Advanced Features** -- relaxations, presolve, bound tightening, cutting planes, convexity detection, symbolic envelopes, primal heuristics, IIS/conflict analysis, callbacks, warm starts, export formats
 - **Global Optimization** -- which problems discopt can and can't certify as global
-- **IPM vs Ipopt** -- backend comparison (incl. vmap-batched IPM)
-- **Dynamic Optimization** -- DAE collocation for optimal control, parameter estimation, and PDEs
-- **Neural Network Embedding** -- optimize over trained ML surrogates as MINLP constraints
-- **Decision-Focused Learning** -- differentiable optimization in ML pipelines
-- **GDP Tutorial** -- disjunctive programming, logical constraints, big-M/hull/LOA reformulations
+- **Applications** -- neural network embedding, neural DAEs, AC OPF, decision-focused learning, parameter estimation
+- **Appendix** -- solver comparison, the GAMS solver link, references
 
 Full documentation is built with Jupyter Book: `jupyter-book build docs/`
 
 ## Project Statistics
 
-*Last updated: 2026-06-18*
+*Last updated: 2026-08-14*
 
 | Category | Count |
 |----------|-------|
-| **Python source** (`python/discopt/`) | 226 files, ~103,700 lines |
-| **Rust source** (`crates/`) | 55 files, ~29,000 lines |
-| **Test code** (`python/tests/`) | 222 files, ~72,100 lines |
-| **Total source + tests** | ~500 files, ~205,000 lines |
-| **Python tests** | 3,700+ |
-| **Rust tests** | 339 |
+| **Python source** (`python/discopt/`) | 333 files, ~170,200 lines |
+| **Rust source** (`crates/`) | 77 files, ~58,800 lines |
+| **Test code** (`python/tests/`) | 566 files, ~161,000 lines |
+| **Total source + tests** | ~976 files, ~390,000 lines |
+| **Python tests** | 7,100+ |
+| **Rust tests** | 619 |
 | **Tutorial notebooks** (`docs/notebooks/`) | 63 |
 
 ## Development History

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -118,10 +118,11 @@ This is the fundamental difference. discopt is a **solver** with an integrated m
 ```
 Python modeling API
     │
-    ├──→ JAX DAG compiler → autodiff (grad, Hessian, Jacobian)
+    ├──→ Rust AD tape (POUNCE) → grad, Jacobian, Lagrangian Hessian
+    │
+    ├──→ JAX relaxation layer
     │        │
     │        ├──→ McCormick / alphaBB / ICNN relaxations
-    │        ├──→ Pure-JAX IPM (Mehrotra predictor-corrector)
     │        ├──→ Convexity detection → bypass / per-constraint OA
     │        └──→ vmap batching → parallel node evaluation
     │

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -6,25 +6,28 @@
 :align: center
 ```
 
-A hybrid Mixed-Integer Nonlinear Programming (MINLP) solver combining a Rust backend, JAX automatic differentiation, and Python orchestration. Solves MINLP problems via NLP-based spatial Branch & Bound {cite:p}`Land1960,Belotti2013` with JIT-compiled objective/gradient/Hessian evaluation.
+A Mixed-Integer Nonlinear Programming (MINLP) solver built on a Rust core with Python orchestration. Solves MINLPs by spatial Branch & Bound {cite:p}`Land1960,Belotti2013` over rigorous convex relaxations, with an in-house primal/dual simplex for the per-node LPs and a Rust automatic-differentiation tape for objective/gradient/Jacobian/Hessian evaluation.
 
 ## Architecture
 
 ```
-Model.solve()  -->  Python orchestrator  -->  Rust TreeManager (B&B engine)
+Model.solve()  -->  Python orchestrator  -->  Rust B&B kernel / TreeManager
                         |                          |
-                  JAX NLPEvaluator           Node pool / branching / pruning
-                  NLP backends:              Zero-copy numpy arrays (PyO3)
-                    pounce  (pure-Rust Ipopt port)  [default single solve]
-                    ipm     (pure-JAX, vmap batch)  [B&B node relaxations]
-                    cyipopt (Ipopt)
+                  NLP evaluation:            Node pool / branching / pruning
+                    POUNCE AD tape           In-house primal/dual simplex (node LPs)
+                    (default, JAX-free)      Zero-copy numpy arrays (PyO3)
+                  NLP backends:
+                    pounce  (pure-Rust Ipopt port)  [default]
+                    cyipopt (Ipopt)                 [fallback]
 ```
 
-**Rust backend** (`crates/discopt-core`): Expression IR, Branch & Bound tree (node pool, branching, pruning), .nl file parser, FBBT/presolve (interval arithmetic, probing, Big-M simplification).
+**Rust backend** (`crates/discopt-core`): Expression IR, Branch & Bound tree (node pool, branching, pruning), the native spatial B&B kernel, in-house primal/dual simplex with a sparse LU basis (`feral`), .nl file parser, FBBT/presolve (interval arithmetic, probing, Big-M simplification).
 
-**JAX layer** (`python/discopt/_relax`): DAG compiler mapping modeling expressions to JAX primitives, JIT-compiled NLP evaluator (objective, gradient, Hessian, constraint Jacobian), McCormick convex/concave relaxations {cite:p}`McCormick1976` (28 functions including sigmoid, softplus, tanh), and a relaxation compiler with vmap support.
+**NLP evaluation** (`python/discopt/_tape_nlp_evaluator.py`, `_nl_expr_compiler.py`): objective, gradient, constraints, Jacobian, and Lagrangian Hessian (dense and sparse) from a POUNCE Rust AD tape, with no JAX on the path. Expressions with no tape opcode fall back to the JAX evaluator, and `DISCOPT_NLP_EVAL=jax` selects it wholesale. Pure LP, QP, MIQP, and simplex-MILP solves never import JAX at all.
 
-**Solver wrappers** (`python/discopt/solvers`): POUNCE (pure-Rust Ipopt port), cyipopt NLP wrapper for Ipopt {cite:p}`Wachter2006`, HiGHS LP and MILP wrappers with warm-start support (MILP used by the LOA decomposition solver).
+**Relaxation layer** (`python/discopt/_relax`): DAG compiler, the uniform factorable relaxation engine, McCormick convex/concave relaxations {cite:p}`McCormick1976` (28 primitive operations including sigmoid, softplus, tanh), alphaBB, piecewise McCormick, cutting planes, and a relaxation compiler with vmap support. This layer still uses JAX for envelope evaluation and cut separation.
+
+**Solver wrappers** (`python/discopt/solvers`): POUNCE (pure-Rust Ipopt port) for LP/QP/NLP, the in-house simplex LP/MILP backends, cyipopt for Ipopt {cite:p}`Wachter2006`, AMP, the MIP-NLP decomposition family, GDPopt-LOA, the derivative-free backends, and an optional Gurobi backend. highspy is used only on the OA/GDP paths.
 
 **Neural network embedding** (`python/discopt/nn`): embeds trained feedforward networks as algebraic MINLP constraints {cite:p}`Ceccon2022` via full-space (smooth activations), ReLU big-M MILP {cite:p}`Anderson2020`, and reduced-space strategies; interval arithmetic bound propagation; ONNX model import.
 
@@ -93,23 +96,25 @@ print(result.confidence_intervals)
 
 ## NLP Backend Comparison
 
-discopt supports three NLP solver backends, each with different strengths:
+`Model.solve()` accepts these `nlp_solver` selectors:
 
-| Backend              | Implementation       | Use Case                                   |
-|----------------------|----------------------|--------------------------------------------|
-| `pounce` (default)   | Pure-Rust Ipopt port | Single-problem NLP; fastest wall-clock     |
-| `ipm`                | Pure-JAX IPM         | B&B inner loop; GPU-batched via `jax.vmap`  |
-| `cyipopt`            | Ipopt via cyipopt    | Single-problem NLP; most robust            |
+| Backend                  | Implementation                     | Use Case                                    |
+|--------------------------|------------------------------------|---------------------------------------------|
+| `pounce` (default)       | Pure-Rust Ipopt port               | Universal default: LP/QP/MILP/MIQP/NLP/MINLP |
+| `ipopt` / `cyipopt`      | Ipopt via cyipopt                  | NLP node and continuous solves; most robust |
+| `simplex`                | Pure-Rust warm-started simplex B&B | MILP; the fully JAX-free MILP path          |
+| `ipm` / `sparse_ipm`     | Back-compat aliases                | Simplex-first LP/MILP routing; resolve to POUNCE for NLP/MINLP |
 
-For single continuous solves the default NLP backend resolves to a KKT-valid
-solver — POUNCE when installed, falling back to cyipopt, then to the pure-JAX
-IPM. The pure-JAX `ipm` remains the vmap-batched engine for B&B node relaxations.
+The pure-JAX interior-point method has been retired. `nlp_solver="ipm"` is kept as
+an alias so existing scripts keep working: it selects the simplex-first matrix
+routing for LP/MILP and resolves to POUNCE for NLP/MINLP. See
+{doc}`notebooks/ipm_vs_ipopt` for a measured comparison.
 
 ```python
-result = model.solve()                       # default: POUNCE when installed
+result = model.solve()                       # default: POUNCE
 result = model.solve(nlp_solver="pounce")    # POUNCE (pure-Rust Ipopt port)
-result = model.solve(nlp_solver="ipm")       # Pure-JAX IPM
-result = model.solve(nlp_solver="cyipopt")   # Ipopt
+result = model.solve(nlp_solver="ipopt")     # Ipopt via cyipopt
+result = model.solve(nlp_solver="simplex")   # pure-Rust simplex MILP B&B
 ```
 
 ## Contents

--- a/docs/mip_nlp.md
+++ b/docs/mip_nlp.md
@@ -425,11 +425,14 @@ master.
 ## Backend limitations
 
 - `nlp_solver` controls fixed-integer NLP subproblems. POUNCE is the default
-  single-solve backend when installed, with cyipopt and the pure-JAX IPM used
-  where configured.
+  backend, with cyipopt used where configured. The `"ipm"` selector is a
+  back-compat alias that resolves to POUNCE on this path; the pure-JAX IPM it
+  used to name has been retired.
 - `milp_solver` controls MILP masters where a method exposes that option.
-  `highs`, `pounce`, `simplex`, `gurobi`, or `auto` may be accepted depending on
-  the method and installed extras.
+  The accepted values are `auto` (simplex-first, then POUNCE), `pounce`,
+  `simplex`, and `gurobi`; anything else raises `ValueError`. HiGHS was removed
+  from the MILP path in issue #356. Some methods narrow this further —
+  `lp_nlp_bb` and `solution_pool` require `gurobi`.
 - `solution_pool=True` currently requires `milp_solver="gurobi"`.
 - `lp_nlp_bb` requires `milp_solver="gurobi"` for lazy callbacks.
 - MIP-NLP methods ignore branch-and-bound-only options such as spatial branching

--- a/docs/notebooks/ipm_vs_ipopt.ipynb
+++ b/docs/notebooks/ipm_vs_ipopt.ipynb
@@ -5,20 +5,26 @@
    "id": "cell-0",
    "metadata": {},
    "source": [
-    "# NLP Backend Comparison: POUNCE vs IPM vs Ipopt\n",
+    "# NLP Backend Comparison: POUNCE vs Ipopt\n",
     "\n",
-    "discopt supports three NLP backends for solving continuous relaxations:\n",
+    "discopt solves continuous relaxations through two distinct NLP engines:\n",
     "\n",
     "| Backend | Flag | Description |\n",
     "|---------|------|-------------|\n",
-    "| **POUNCE** | `nlp_solver=\"pounce\"` | Rust interior-point method via PyO3 bindings |\n",
-    "| **discopt IPM** | `nlp_solver=\"ipm\"` | Pure-JAX primal-dual interior point method {cite:p}`Nocedal2006` (the vmap-batched B&B node engine) |\n",
+    "| **POUNCE** | `nlp_solver=\"pounce\"` | Pure-Rust primal-dual interior-point method {cite:p}`Nocedal2006` via PyO3 bindings; the universal default |\n",
     "| **Ipopt** | `nlp_solver=\"ipopt\"` | Industry-standard NLP solver {cite:p}`Wachter2006` via cyipopt |\n",
     "\n",
-    "This notebook compares them on a representative set of problems, measuring:\n",
+    "The comparison below runs a *third* selector, `nlp_solver=\"ipm\"`. This is a\n",
+    "**back-compat alias, not a third engine**: the pure-JAX interior-point method it\n",
+    "used to name has been retired, and on the NLP/MINLP path `\"ipm\"` now resolves to\n",
+    "POUNCE. It is kept in the sweep deliberately — the `pounce` and `IPM` columns\n",
+    "below agree to every printed digit, and to the node on the MINLPs, which is what\n",
+    "that alias resolving to the same engine looks like from the outside.\n",
+    "\n",
+    "This notebook measures:\n",
     "- **Accuracy**: objective value agreement with known optima\n",
     "- **Speed**: wall-clock solve time\n",
-    "- **Robustness**: convergence status"
+    "- **Robustness**: convergence status\n"
    ]
   },
   {
@@ -63,9 +69,12 @@
    "source": [
     "## Test Problems\n",
     "\n",
-    "We define a mix of problem types built with `dm.Model()` and solve with all three backends.\n",
+    "We define a mix of problem types built with `dm.Model()` and solve with each backend selector.\n",
     "\n",
-    "All three backends support both `dm.Model()`-built models and `.nl` file models. The `.nl` evaluator uses the Rust expression evaluator with finite differences, which is compatible with all backends."
+    "Both backends support `dm.Model()`-built models and `.nl` file models alike. Derivatives\n",
+    "come from the same source in either case: a Rust automatic-differentiation tape built by\n",
+    "`discopt._nl_expr_compiler` and consumed through `TapeNLPEvaluator`, so the objective,\n",
+    "gradient, Jacobian, and Lagrangian Hessian are exact rather than finite-differenced.\n"
    ]
   },
   {
@@ -604,12 +613,25 @@
     "\n",
     "Key takeaways:\n",
     "\n",
-    "- **POUNCE** (`nlp_solver=\"pounce\"`) is the project's own Rust interior-point solver, integrated via PyO3 bindings. It provides the Hessian of the full Lagrangian for better convergence with constraints.\n",
-    "- **discopt IPM** (`nlp_solver=\"ipm\"`) is a pure-JAX implementation that supports `jax.vmap` for batch solving at B&B nodes and can run on GPU.\n",
-    "- **Ipopt** (`nlp_solver=\"ipopt\"`) is the industry-standard NLP solver, more mature and robust. Required for differentiable solving.\n",
-    "- All three backends should produce the same optimal objective values (to solver tolerance).\n",
-    "- The IPM backend's advantage is batch solving on GPU — this notebook uses CPU only.\n",
-    "- POUNCE avoids the cyipopt/Ipopt dependency and provides a fully self-contained solver stack."
+    "- **POUNCE** (`nlp_solver=\"pounce\"`) is the project's own Rust interior-point solver,\n",
+    "  integrated via PyO3 bindings. It provides the Hessian of the full Lagrangian for\n",
+    "  better convergence with constraints, and it is the default for every problem class.\n",
+    "- **Ipopt** (`nlp_solver=\"ipopt\"`) is the industry-standard NLP solver, and the more\n",
+    "  mature and battle-tested of the two. POUNCE is a Rust port of the same primal-dual\n",
+    "  interior-point algorithm, so the two agree closely on well-conditioned problems —\n",
+    "  as they do on every row above.\n",
+    "- **`nlp_solver=\"ipm\"` is an alias, not a backend.** The pure-JAX IPM it named has been\n",
+    "  retired; the selector now resolves to POUNCE on the NLP/MINLP path (and to\n",
+    "  simplex-first matrix routing for LP/MILP). The identical `pounce` and `IPM` columns\n",
+    "  above are the evidence, not a coincidence. Existing scripts passing `\"ipm\"` keep\n",
+    "  working; new code should say `\"pounce\"`.\n",
+    "- Read the timing table with care. Each problem is a **single** untimed-warmup run, and\n",
+    "  the `pounce` column is measured first, so it absorbs one-off setup cost — that is the\n",
+    "  whole of the 0.1402s vs 0.0023s gap on the unconstrained quadratic, and of POUNCE's\n",
+    "  larger total. It is not a POUNCE-vs-Ipopt result. For scaling measurements with\n",
+    "  median-of-3 timing, see `benchmarks_by_class.ipynb`.\n",
+    "- POUNCE avoids the cyipopt/Ipopt system dependency and provides a fully self-contained\n",
+    "  solver stack; it ships as a core dependency of discopt.\n"
    ]
   }
  ],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,12 +5,20 @@ build-backend = "maturin"
 [project]
 name = "discopt"
 version = "0.7.1.dev0"
-description = "Hybrid MINLP solver combining Rust and JAX"
+description = "MINLP solver with a Rust core: spatial branch and bound over convex relaxations"
 requires-python = ">=3.10"
 authors = [{name = "John Kitchin"}]
 license = {text = "EPL-2.0"}
 readme = "README.md"
-keywords = ["optimization", "MINLP", "branch-and-bound", "nonlinear", "solver", "JAX"]
+keywords = [
+    "optimization",
+    "MINLP",
+    "branch-and-bound",
+    "global-optimization",
+    "nonlinear",
+    "solver",
+    "rust",
+]
 classifiers = [
     "Development Status :: 3 - Alpha",
     "Intended Audience :: Science/Research",

--- a/python/discopt/__init__.py
+++ b/python/discopt/__init__.py
@@ -22,7 +22,7 @@ modeling
 solver
     Solve orchestrator: Branch & Bound with NLP relaxations.
 solvers
-    NLP solver backends: POUNCE (pure-Rust Ipopt port), pure-JAX IPM (vmap batch), cyipopt (Ipopt).
+    NLP solver backends: POUNCE (pure-Rust Ipopt port, the default) and cyipopt (Ipopt).
 """
 
 __version__ = "0.7.1.dev0"

--- a/python/discopt/cli.py
+++ b/python/discopt/cli.py
@@ -51,7 +51,10 @@ def _cmd_about(_args):
         license_text = meta["License"] or ""
     except importlib.metadata.PackageNotFoundError:
         pkg_version = version
-        summary = "Hybrid MINLP solver combining Rust and JAX"
+        # Fallback only when the distribution metadata is unreadable (e.g. a
+        # source tree with no installed dist). Keep in sync with the `description`
+        # field in pyproject.toml, which is the real source.
+        summary = "MINLP solver with a Rust core: spatial branch and bound over convex relaxations"
         license_text = "EPL-2.0"
 
     try:


### PR DESCRIPTION
## Summary

The README's Project Statistics were a 2026-06-18 snapshot, and its architecture description predated the JAX removal. Audited every claim in it against the tree and the PRs merged since, then followed the same defect into the docs site, a tutorial notebook, and the distribution metadata.

Docs and metadata only — no solver math, no behavior change.

### The headline: the README described a JAX solver that no longer exists

#922 moved NLP evaluation to a POUNCE Rust AD tape (`_tape_nlp_evaluator.py`, default ON, `DISCOPT_NLP_EVAL=jax` opts out), and `test_lazy_jax_linear_path.py` pins LP/QP/MIQP and the simplex MILP path as importing no JAX at all. The tagline, the "JIT-compiled NLP evaluation … via JAX" bullet, and the "JAX layer" architecture block all said the opposite. JAX is still real in the relaxation layer (envelope evaluation, cut separation) — that is now the only place the docs claim it.

Relatedly, **the pure-JAX IPM has been retired**. `nlp_solver="ipm"` is a back-compat alias, but the docs sold it as the vmap-batched B&B node engine, and listed "three NLP backends" against `_valid_nlp_solvers`' actual six.

### Claims that were wrong, not merely dated

| Claim | Reality |
|---|---|
| `pip install -e ".[dev,ipopt,highs]"` | There is no `highs` extra in `pyproject.toml` — that line could never have worked |
| "HiGHS LP and MILP wrappers with warm-start support" | HiGHS is off the LP/MILP path (#356); highspy survives only on OA/GDP |
| `milp_solver="highs"` accepted (`docs/mip_nlp.md`) | Raises `ValueError` — `get_milp_solver` accepts only `auto`/`pounce`/`simplex`/`gurobi` |
| Pooling and AC OPF listed as core features | Both moved to `discopt-apps` |
| `rlt_cuts=True`, `cuts='auto'` | Not public options; the public control is `rlt` (default `"auto"`) |
| `pip install pounce-solver` as a separate step | POUNCE is a core dependency |
| `.nl` evaluator "uses finite differences" (notebook) | No finite-difference path exists; `.nl` uses the same exact AD tape |

### Benchmarks

The table predated the tape backend. Replaced with the committed outputs of the re-executed `benchmarks_by_class.ipynb`: MIQP speedup is **~40x, not "1000x+"**; NLP n=20 is 0.120s vs a claimed 0.42s; MINLP n=10 is 0.026s vs 0.9s. LP/QP moved the other way (0.234s vs a claimed 0.015s "warm") — the old figures excluded JIT while the notebook is median-of-3 including setup, so the two were never measuring the same thing.

Dropped the "Apple M4 Pro / JAX 0.8.2" attribution: I cannot verify the hardware of the re-executed run, so the notebook is now cited as the reproducible source instead.

### Statistics were roughly half the real size

Re-counted: 333 Python / 77 Rust / 566 test files (was 226/55/222), ~390k total lines (was ~205k), **7,173** `def test_` functions (claimed 3,700+), **619** Rust `#[test]`s (claimed 339).

### Shipped but undocumented

DFO (`solver="direct"` / `"surrogate"`, #1006), the QPLIB reader and corpus (#1005), the decomposition family (MIP-NLP OA/ECP/FP/GOA/LP-NLP-BB, Benders, GBD, Lagrangian, advisor), bilevel, stochastic programming, the GAMS solver link and `.lp`/`.mps`/GAMS export, the warm solve daemon, GP-structured MINLP and the signomial global optimizer, tree-ensemble embedding + sklearn/torch readers + trainable surrogates in `nn`, the native Rust spatial kernel and in-house simplex as defaults, and five CLI verbs (`solve`, `daemon`, `gams-register`, `gams-daemon`, `gams-verify`) that had accumulated past `about`/`test`/`convert`.

### `ipm_vs_ipopt.ipynb`

Its intro contradicted `benchmarks_by_class.ipynb`, which already says the JAX IPM was retired. The notebook's own committed outputs settle it: the `pounce` and `IPM` columns agree to every printed digit (3.55e-15, 6.38e-11, 2.51e-09) and to the node on all four MINLPs. Rewrote the intro and summary to say so and to use those outputs as the evidence, and flagged that the timing table is a single un-warmed run with `pounce` measured first — that ordering is the whole of the 0.1402s vs 0.0023s gap, not a POUNCE-vs-Ipopt result.

**Only markdown cells changed; every code cell and output is byte-identical, so no re-execution was needed and none was done.** `nbformat.validate` passes.

### Metadata

`pyproject.toml`'s `description` and `JAX` keyword are the PyPI-facing text and carried the same framing. `cli.py` had the old description hardcoded as the `discopt about` fallback. Both updated; `docs/intro.md`, `docs/comparison.md`, `docs/mip_nlp.md`, and the `discopt/__init__.py` docstring got the same one-line corrections.

`docs/intro.md`'s JAX-autodiff claims for parameter estimation are left alone — `estimate.py` does still use JAX for the Fisher information Jacobians.

## Correctness

- [x] Cannot produce a false certificate — N/A, no solver-math change. The diff is markdown plus two Python string literals (a module docstring line and the `discopt about` metadata fallback).
- [x] No validation, fallback, or safety guard was weakened

## Tests run (state the result — numbers, not adjectives)

- [ ] `pytest -m smoke` → **not run** — the compiled extension is not built in this container (no `maturin`), so `import discopt` fails. See the note below.
- [ ] `pytest -m slow python/tests/test_adversarial_recent_fixes.py` → **not run**, same reason
- [x] `cargo test -p discopt-core` → N/A, no Rust touched
- [x] `ruff check python/` → `All checks passed!`; `ruff format --check` → `2 files already formatted`

On the un-run suites: `python -m py_compile` passes on both touched Python files, and `grep` finds no test asserting on the changed strings (the only in-repo occurrence of the old description was the `cli.py` fallback itself, now updated). I'd still like CI to confirm rather than take that on my word.

## Regression test

- [x] N/A — docs and metadata only.

## Bound-changing / performance change?

N/A.

### Known remaining staleness, not fixed here

`docs/notebooks/tutorial_solver_pounce.ipynb` is built around benchmarking POUNCE against the retired pure-JAX IPM — four separate places in its prose, and its *code* runs that comparison. Unlike `ipm_vs_ipopt.ipynb`, correcting it means re-executing the notebook, which I can't do without a built extension. Worth a follow-up issue. `solvers/gdpopt_loa.py`'s "no MILP backend" error message also still suggests `pip install highspy`, which no longer helps.


---
_Generated by [Claude Code](https://claude.ai/code/session_01FnirbmKvXZGfcKF3Ka42xB)_