### PR TITLE
docs(1029): re-execute the POUNCE tutorial against engines that exist

### DIFF
--- a/docs/notebooks/estimation.md
+++ b/docs/notebooks/estimation.md
@@ -46,7 +46,7 @@ class MyExperiment(Experiment):
 
 $$\min_\theta \sum_i \left(\frac{y_i^{\text{obs}} - y_i^{\text{model}}(\theta)}{\sigma_i}\right)^2$$
 
-and solves it with discopt's NLP solvers (Ipopt or pure-JAX IPM). The result
+and solves it with discopt's NLP solvers (POUNCE by default, or Ipopt). The result
 includes estimated parameter values, the Fisher Information Matrix, parameter
 covariance ($\text{Cov}(\theta) \approx \text{FIM}^{-1}$), and 95% confidence
 intervals.

--- a/docs/notebooks/tutorial_solver_pounce.ipynb
+++ b/docs/notebooks/tutorial_solver_pounce.ipynb
@@ -8,23 +8,25 @@
     "# POUNCE: Pure-Rust Ipopt Port\n",
     "\n",
     "This tutorial introduces **POUNCE**, a pure-Rust port of the Ipopt\n",
-    "interior-point NLP solver. POUNCE is compiled\n",
-    "to a shared library via [maturin](https://www.maturin.rs/) and exposed to\n",
-    "Python through [PyO3](https://pyo3.rs/) bindings.\n",
+    "interior-point NLP solver. POUNCE ships as its own compiled Python\n",
+    "package, built with [maturin](https://www.maturin.rs/) and exposed to\n",
+    "Python through [PyO3](https://pyo3.rs/) bindings; `discopt` drives it\n",
+    "through a cyipopt-compatible interface.\n",
     "\n",
     "By the end of this notebook you will be able to:\n",
     "\n",
     "1. Solve NLPs using the `nlp_solver=\"pounce\"` backend.\n",
     "2. Understand the architecture: Rust solver with Python evaluation callbacks.\n",
     "3. Configure POUNCE solver options.\n",
-    "4. Compare POUNCE performance against the pure-JAX IPM and Ipopt backends.\n",
+    "4. Compare POUNCE performance against the Ipopt backend, and see why\n",
+    "   `nlp_solver=\"ipm\"` is a compatibility alias rather than a third engine.\n",
     "5. Use POUNCE as the NLP subsolver inside Branch-and-Bound for MINLPs.\n",
     "\n",
     "**When to choose POUNCE:**\n",
     "\n",
     "- **Deployment without C dependencies.** Unlike Ipopt (which requires\n",
-    "  BLAS, LAPACK, and optionally HSL), POUNCE is a single compiled `.so`\n",
-    "  with no external C/Fortran dependencies.\n",
+    "  BLAS, LAPACK, and optionally HSL), POUNCE is a single compiled\n",
+    "  extension with no external C/Fortran dependencies.\n",
     "- **Single-threaded performance.** Rust's zero-cost abstractions and\n",
     "  lack of garbage collection yield competitive single-threaded speed.\n",
     "- **No Python GIL concerns.** The Rust solver releases the GIL during\n",
@@ -40,19 +42,14 @@
    "id": "setup",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-11T02:54:09.683569Z",
-     "iopub.status.busy": "2026-08-11T02:54:09.683345Z",
-     "iopub.status.idle": "2026-08-11T02:54:09.796738Z",
-     "shell.execute_reply": "2026-08-11T02:54:09.796390Z"
+     "iopub.execute_input": "2026-08-15T17:24:58.919812Z",
+     "iopub.status.busy": "2026-08-15T17:24:58.919719Z",
+     "iopub.status.idle": "2026-08-15T17:24:58.921279Z",
+     "shell.execute_reply": "2026-08-15T17:24:58.921000Z"
     }
    },
    "outputs": [],
    "source": [
-    "import os\n",
-    "\n",
-    "os.environ[\"JAX_PLATFORMS\"] = \"cpu\"\n",
-    "os.environ[\"JAX_ENABLE_X64\"] = \"1\"\n",
-    "\n",
     "import time\n",
     "\n",
     "import discopt.modeling as dm\n",
@@ -74,13 +71,16 @@
     "  |  formulates Model, builds NLPEvaluator\n",
     "  v\n",
     "Python (discopt.solvers.nlp_pounce)\n",
-    "  |  maps evaluator callbacks to POUNCE API\n",
+    "  |  maps evaluator callbacks onto pounce.Problem\n",
+    "  |  (shape-compatible with cyipopt.Problem, so the cyipopt\n",
+    "  |   callback adapter is reused unchanged)\n",
     "  v\n",
-    "PyO3 bindings (discopt._rust.solve_POUNCE)\n",
-    "  |  wraps Python evaluator as POUNCE::NlpProblem\n",
+    "PyO3 bindings (the `pounce` package's compiled extension)\n",
+    "  |  wraps the Python evaluator as a POUNCE NLP problem\n",
     "  v\n",
-    "Rust solver (POUNCE crate)\n",
+    "Rust solver (POUNCE)\n",
     "  |  primal-dual IPM with line search\n",
+    "  |  sparse symmetric LDL^T factorization (the pure-Rust FERAL backend)\n",
     "  |  calls back into Python for f(x), grad(x), Hessian(x)\n",
     "```\n",
     "\n",
@@ -93,7 +93,10 @@
     "- No external C libraries (BLAS, LAPACK, HSL) are required --- all\n",
     "  linear algebra is implemented in Rust.\n",
     "- Variable and constraint bounds are passed once at initialization;\n",
-    "  the Rust solver caches them as owned `Vec<f64>` data."
+    "  the Rust solver caches them as owned `Vec<f64>` data.\n",
+    "- Nothing on this path touches JAX. The evaluator is numpy, and the\n",
+    "  factorization is Rust, so there is no tracing or compilation step\n",
+    "  between calling `solve()` and the first IPM iteration."
    ]
   },
   {
@@ -113,10 +116,10 @@
    "id": "unconstrained-quadratic",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-11T02:54:09.798184Z",
-     "iopub.status.busy": "2026-08-11T02:54:09.798093Z",
-     "iopub.status.idle": "2026-08-11T02:54:09.937712Z",
-     "shell.execute_reply": "2026-08-11T02:54:09.937298Z"
+     "iopub.execute_input": "2026-08-15T17:24:58.922317Z",
+     "iopub.status.busy": "2026-08-15T17:24:58.922256Z",
+     "iopub.status.idle": "2026-08-15T17:24:59.058714Z",
+     "shell.execute_reply": "2026-08-15T17:24:59.058415Z"
     }
    },
    "outputs": [
@@ -128,7 +131,7 @@
       "Objective: 0.000000\n",
       "x = 3.000000  (expected 3.0)\n",
       "y = -1.000000  (expected -1.0)\n",
-      "Time:      0.1261s\n"
+      "Time:      0.1232s\n"
      ]
     }
    ],
@@ -157,10 +160,10 @@
    "id": "constrained-simple",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-11T02:54:09.938727Z",
-     "iopub.status.busy": "2026-08-11T02:54:09.938663Z",
-     "iopub.status.idle": "2026-08-11T02:54:09.944093Z",
-     "shell.execute_reply": "2026-08-11T02:54:09.943730Z"
+     "iopub.execute_input": "2026-08-15T17:24:59.059896Z",
+     "iopub.status.busy": "2026-08-15T17:24:59.059835Z",
+     "iopub.status.idle": "2026-08-15T17:24:59.065003Z",
+     "shell.execute_reply": "2026-08-15T17:24:59.064648Z"
     }
    },
    "outputs": [
@@ -222,10 +225,10 @@
    "id": "rosenbrock-solve",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-11T02:54:09.945108Z",
-     "iopub.status.busy": "2026-08-11T02:54:09.945040Z",
-     "iopub.status.idle": "2026-08-11T02:54:10.086477Z",
-     "shell.execute_reply": "2026-08-11T02:54:10.086163Z"
+     "iopub.execute_input": "2026-08-15T17:24:59.066103Z",
+     "iopub.status.busy": "2026-08-15T17:24:59.066027Z",
+     "iopub.status.idle": "2026-08-15T17:24:59.233319Z",
+     "shell.execute_reply": "2026-08-15T17:24:59.232989Z"
     }
    },
    "outputs": [
@@ -284,10 +287,10 @@
    "id": "config-demo",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-11T02:54:10.087630Z",
-     "iopub.status.busy": "2026-08-11T02:54:10.087569Z",
-     "iopub.status.idle": "2026-08-11T02:54:10.092184Z",
-     "shell.execute_reply": "2026-08-11T02:54:10.091854Z"
+     "iopub.execute_input": "2026-08-15T17:24:59.234601Z",
+     "iopub.status.busy": "2026-08-15T17:24:59.234524Z",
+     "iopub.status.idle": "2026-08-15T17:24:59.239026Z",
+     "shell.execute_reply": "2026-08-15T17:24:59.238732Z"
     }
    },
    "outputs": [
@@ -297,7 +300,7 @@
      "text": [
       "Status: optimal, Objective: 0.000000\n",
       "x = 2.0000, y = 3.0000\n",
-      "Wall time: 0.0024s (limit was 10s)\n"
+      "Wall time: 0.0022s (limit was 10s)\n"
      ]
     }
    ],
@@ -321,15 +324,24 @@
    "source": [
     "## Performance Comparison\n",
     "\n",
-    "We compare three NLP solver backends on five small problems:\n",
+    "`discopt` exposes **two** NLP engines for continuous solves:\n",
     "\n",
-    "- **`\"ipm\"`** --- pure-JAX interior-point method (Mehrotra predictor-corrector)\n",
-    "- **`\"pounce\"`** --- Rust IPM via PyO3\n",
-    "- **`\"ipopt\"`** --- Ipopt via cyipopt (requires BLAS/LAPACK)\n",
+    "- **`\"pounce\"`** --- the pure-Rust IPM described above; the default.\n",
+    "- **`\"ipopt\"`** --- Ipopt via cyipopt (requires BLAS/LAPACK, optionally HSL).\n",
     "\n",
-    "Each problem is solved once per backend. Note that the first JAX IPM\n",
-    "call includes JIT compilation overhead; subsequent calls of the same\n",
-    "size reuse the compiled kernel.\n",
+    "`nlp_solver=\"ipm\"` and `nlp_solver=\"sparse_ipm\"` are still accepted, but they\n",
+    "are **compatibility aliases, not engines**. Each named the pure-JAX\n",
+    "interior-point method that used to sit behind them; that solver has been\n",
+    "retired, and both selectors now resolve to POUNCE. The cell after the\n",
+    "comparison demonstrates this directly rather than asking you to take it on\n",
+    "faith.\n",
+    "\n",
+    "The sweep below therefore compares POUNCE against Ipopt, and only those two.\n",
+    "Each problem is solved once per backend with no warm-up run, so read the\n",
+    "absolute numbers as an order of magnitude rather than a benchmark --- the\n",
+    "first solve in the sweep absorbs one-off setup cost. For scaling measurements\n",
+    "with repeated timing, see\n",
+    "[`benchmarks_by_class.ipynb`](benchmarks_by_class.ipynb).\n",
     "\n",
     "The interior-point framework is described in {cite:p}`Wright1997`."
    ]
@@ -340,10 +352,10 @@
    "id": "perf-problems",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-11T02:54:10.093192Z",
-     "iopub.status.busy": "2026-08-11T02:54:10.093129Z",
-     "iopub.status.idle": "2026-08-11T02:54:10.097516Z",
-     "shell.execute_reply": "2026-08-11T02:54:10.097117Z"
+     "iopub.execute_input": "2026-08-15T17:24:59.240168Z",
+     "iopub.status.busy": "2026-08-15T17:24:59.240095Z",
+     "iopub.status.idle": "2026-08-15T17:24:59.244954Z",
+     "shell.execute_reply": "2026-08-15T17:24:59.244608Z"
     }
    },
    "outputs": [
@@ -431,10 +443,10 @@
    "id": "perf-benchmark",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-11T02:54:10.098444Z",
-     "iopub.status.busy": "2026-08-11T02:54:10.098388Z",
-     "iopub.status.idle": "2026-08-11T02:54:10.508481Z",
-     "shell.execute_reply": "2026-08-11T02:54:10.508091Z"
+     "iopub.execute_input": "2026-08-15T17:24:59.246263Z",
+     "iopub.status.busy": "2026-08-15T17:24:59.246185Z",
+     "iopub.status.idle": "2026-08-15T17:24:59.538471Z",
+     "shell.execute_reply": "2026-08-15T17:24:59.538121Z"
     }
    },
    "outputs": [
@@ -442,18 +454,18 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Problem                   |        ipm |     pounce |      ipopt\n",
-      "----------------------------------------------------------------\n",
-      "Quadratic (n=2)           |    0.0021s |    0.0018s |    0.0017s\n",
-      "Constrained (n=5)         |    0.0021s |    0.0020s |    0.0021s\n",
-      "Rosenbrock (n=2)          |    0.1156s |    0.1177s |    0.1160s\n",
-      "Sum-of-squares (n=10)     |    0.0032s |    0.0028s |    0.0031s\n",
-      "Portfolio (n=8)           |    0.0126s |    0.0124s |    0.0120s\n"
+      "Problem                   |       pounce |        ipopt\n",
+      "-------------------------------------------------------\n",
+      "Quadratic (n=2)           |      0.0023s |      0.0019s\n",
+      "Constrained (n=5)         |      0.0023s |      0.0021s\n",
+      "Rosenbrock (n=2)          |      0.1312s |      0.1205s\n",
+      "Sum-of-squares (n=10)     |      0.0030s |      0.0028s\n",
+      "Portfolio (n=8)           |      0.0118s |      0.0117s\n"
      ]
     }
    ],
    "source": [
-    "backends = [\"ipm\", \"pounce\", \"ipopt\"]\n",
+    "backends = [\"pounce\", \"ipopt\"]\n",
     "results_table = []\n",
     "\n",
     "for name, model in problems:\n",
@@ -467,22 +479,19 @@
     "            row[f\"{backend}_obj\"] = f\"{r.objective:.6f}\"\n",
     "            row[f\"{backend}_status\"] = r.status\n",
     "        except Exception as e:\n",
-    "            row[f\"{backend}_time\"] = \"error\"\n",
+    "            # Ipopt is an optional dependency; if cyipopt is missing the table\n",
+    "            # says so instead of pretending the backend ran.\n",
+    "            row[f\"{backend}_time\"] = \"unavailable\"\n",
     "            row[f\"{backend}_obj\"] = str(e)[:30]\n",
-    "            row[f\"{backend}_status\"] = \"error\"\n",
+    "            row[f\"{backend}_status\"] = \"unavailable\"\n",
     "    results_table.append(row)\n",
     "\n",
     "# Display results\n",
-    "header = f\"{'Problem':<25s} | {'ipm':>10s} | {'pounce':>10s} | {'ipopt':>10s}\"\n",
+    "header = f\"{'Problem':<25s} | {'pounce':>12s} | {'ipopt':>12s}\"\n",
     "print(header)\n",
     "print(\"-\" * len(header))\n",
     "for row in results_table:\n",
-    "    print(\n",
-    "        f\"{row['Problem']:<25s} | \"\n",
-    "        f\"{row['ipm_time']:>10s} | \"\n",
-    "        f\"{row['pounce_time']:>10s} | \"\n",
-    "        f\"{row['ipopt_time']:>10s}\"\n",
-    "    )"
+    "    print(f\"{row['Problem']:<25s} | {row['pounce_time']:>12s} | {row['ipopt_time']:>12s}\")"
    ]
   },
   {
@@ -491,10 +500,10 @@
    "id": "perf-objectives",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-11T02:54:10.509682Z",
-     "iopub.status.busy": "2026-08-11T02:54:10.509609Z",
-     "iopub.status.idle": "2026-08-11T02:54:10.511661Z",
-     "shell.execute_reply": "2026-08-11T02:54:10.511328Z"
+     "iopub.execute_input": "2026-08-15T17:24:59.539642Z",
+     "iopub.status.busy": "2026-08-15T17:24:59.539569Z",
+     "iopub.status.idle": "2026-08-15T17:24:59.541217Z",
+     "shell.execute_reply": "2026-08-15T17:24:59.540928Z"
     }
    },
    "outputs": [
@@ -502,27 +511,67 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Problem                   |      ipm obj |   pounce obj |    ipopt obj\n",
-      "----------------------------------------------------------------------\n",
-      "Quadratic (n=2)           |     0.000000 |     0.000000 |     0.000000\n",
-      "Constrained (n=5)         |     1.250000 |     1.250000 |     1.250000\n",
-      "Rosenbrock (n=2)          |    -0.000000 |    -0.000000 |    -0.000000\n",
-      "Sum-of-squares (n=10)     |     0.000000 |     0.000000 |     0.000000\n",
-      "Portfolio (n=8)           |     0.002064 |     0.002064 |     0.002064\n"
+      "Problem                   |     pounce obj |      ipopt obj\n",
+      "------------------------------------------------------------\n",
+      "Quadratic (n=2)           |       0.000000 |       0.000000\n",
+      "Constrained (n=5)         |       1.250000 |       1.250000\n",
+      "Rosenbrock (n=2)          |      -0.000000 |      -0.000000\n",
+      "Sum-of-squares (n=10)     |       0.000000 |       0.000000\n",
+      "Portfolio (n=8)           |       0.002064 |       0.002064\n"
      ]
     }
    ],
    "source": [
-    "# Verify all backends agree on objective values\n",
-    "print(f\"{'Problem':<25s} | {'ipm obj':>12s} | {'pounce obj':>12s} | {'ipopt obj':>12s}\")\n",
-    "print(\"-\" * 70)\n",
+    "# Verify both backends agree on objective values\n",
+    "print(f\"{'Problem':<25s} | {'pounce obj':>14s} | {'ipopt obj':>14s}\")\n",
+    "print(\"-\" * 60)\n",
     "for row in results_table:\n",
-    "    print(\n",
-    "        f\"{row['Problem']:<25s} | \"\n",
-    "        f\"{row['ipm_obj']:>12s} | \"\n",
-    "        f\"{row['pounce_obj']:>12s} | \"\n",
-    "        f\"{row['ipopt_obj']:>12s}\"\n",
-    "    )"
+    "    print(f\"{row['Problem']:<25s} | {row['pounce_obj']:>14s} | {row['ipopt_obj']:>14s}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "4dba67f3",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-15T17:24:59.542119Z",
+     "iopub.status.busy": "2026-08-15T17:24:59.542062Z",
+     "iopub.status.idle": "2026-08-15T17:24:59.580769Z",
+     "shell.execute_reply": "2026-08-15T17:24:59.580465Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "selector     | status     | objective (repr, full precision)\n",
+      "--------------------------------------------------------------\n",
+      "pounce       | optimal    | 0.002063987656113868\n",
+      "ipm          | optimal    | 0.002063987656113868\n",
+      "sparse_ipm   | optimal    | 0.002063987656113868\n",
+      "\n",
+      "ipm == pounce         (exact): True\n",
+      "sparse_ipm == pounce  (exact): True\n"
+     ]
+    }
+   ],
+   "source": [
+    "# `nlp_solver=\"ipm\"` and `nlp_solver=\"sparse_ipm\"` are not engines. Both named the\n",
+    "# retired pure-JAX IPM; both now resolve to POUNCE. Exact float equality below is\n",
+    "# what that looks like from the outside -- not \"close\", identical.\n",
+    "objectives = {}\n",
+    "print(f\"{'selector':<12s} | {'status':<10s} | objective (repr, full precision)\")\n",
+    "print(\"-\" * 62)\n",
+    "for selector in (\"pounce\", \"ipm\", \"sparse_ipm\"):\n",
+    "    r = make_portfolio(8).solve(nlp_solver=selector)\n",
+    "    objectives[selector] = r.objective\n",
+    "    print(f\"{selector:<12s} | {r.status:<10s} | {r.objective!r}\")\n",
+    "\n",
+    "print()\n",
+    "print(\"ipm == pounce         (exact):\", objectives[\"ipm\"] == objectives[\"pounce\"])\n",
+    "print(\"sparse_ipm == pounce  (exact):\", objectives[\"sparse_ipm\"] == objectives[\"pounce\"])"
    ]
   },
   {
@@ -532,12 +581,20 @@
    "source": [
     "**Notes on timing:**\n",
     "\n",
-    "- The pure-JAX IPM (`\"ipm\"`) includes JIT compilation time on the first\n",
-    "  call. Subsequent solves of the same problem size are significantly faster.\n",
+    "- There is no compilation step to amortize. The NLP path is numpy plus a\n",
+    "  compiled Rust solver, so nothing is traced or JIT-compiled between the\n",
+    "  `solve()` call and the first IPM iteration; a repeated solve of the same\n",
+    "  problem is not systematically cheaper than the first.\n",
     "- POUNCE times include the overhead of PyO3 callback crossings (Python\n",
-    "  to Rust and back for each evaluation).\n",
-    "- Ipopt typically has the most mature linear algebra (via HSL or MUMPS),\n",
-    "  which gives it an advantage on larger problems."
+    "  to Rust and back for each evaluation). On problems this small that\n",
+    "  overhead, not the linear algebra, is most of the wall time.\n",
+    "- Both solvers factor a sparse KKT system --- Ipopt through MA57/MUMPS,\n",
+    "  POUNCE through its pure-Rust FERAL LDL^T backend. Ipopt's linear algebra\n",
+    "  is the more mature of the two, and on large problems that maturity is\n",
+    "  where the difference shows up. Five problems of eight variables or fewer\n",
+    "  cannot tell you anything about that; see\n",
+    "  [`benchmarks_by_class.ipynb`](benchmarks_by_class.ipynb) for problems at a\n",
+    "  size where the comparison means something."
    ]
   },
   {
@@ -555,14 +612,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 10,
    "id": "bnb-minlp",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-11T02:54:10.512647Z",
-     "iopub.status.busy": "2026-08-11T02:54:10.512593Z",
-     "iopub.status.idle": "2026-08-11T02:54:10.519229Z",
-     "shell.execute_reply": "2026-08-11T02:54:10.518889Z"
+     "iopub.execute_input": "2026-08-15T17:24:59.582001Z",
+     "iopub.status.busy": "2026-08-15T17:24:59.581932Z",
+     "iopub.status.idle": "2026-08-15T17:24:59.589058Z",
+     "shell.execute_reply": "2026-08-15T17:24:59.588722Z"
     }
    },
    "outputs": [
@@ -576,7 +633,7 @@
       "y = 1\n",
       "Node count: 1\n",
       "Gap:        0.00e+00\n",
-      "Wall time:  0.0028s\n"
+      "Wall time:  0.0037s\n"
      ]
     }
    ],
@@ -602,14 +659,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 11,
    "id": "bnb-larger",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-11T02:54:10.520150Z",
-     "iopub.status.busy": "2026-08-11T02:54:10.520083Z",
-     "iopub.status.idle": "2026-08-11T02:54:10.531454Z",
-     "shell.execute_reply": "2026-08-11T02:54:10.531096Z"
+     "iopub.execute_input": "2026-08-15T17:24:59.590067Z",
+     "iopub.status.busy": "2026-08-15T17:24:59.590012Z",
+     "iopub.status.idle": "2026-08-15T17:24:59.601109Z",
+     "shell.execute_reply": "2026-08-15T17:24:59.600702Z"
     }
    },
    "outputs": [
@@ -622,7 +679,7 @@
       "x = [0. 2. 3.]\n",
       "z = [0. 1. 1.]\n",
       "Node count: 7\n",
-      "Wall time:  0.0059s\n"
+      "Wall time:  0.0056s\n"
      ]
     }
    ],
@@ -662,20 +719,23 @@
     "| Scenario | Recommended backend |\n",
     "|----------|--------------------|\n",
     "| Deployment in containers / minimal dependencies | **POUNCE** --- no C toolchain needed |\n",
-    "| Batch solving many small NLPs | **ipm** --- JIT-compiled, amortized overhead |\n",
-    "| Large-scale NLPs (n > 1000) | **ipopt** --- sparse linear algebra (HSL/MUMPS) |\n",
-    "| Differentiable optimization / sensitivity | **ipm** --- native JAX autodiff |\n",
+    "| Batch solving many small NLPs | **POUNCE** --- no compilation step to amortize |\n",
+    "| Large-scale NLPs (n > 1000) | **ipopt** --- decades of tuning in HSL/MUMPS |\n",
+    "| Differentiable optimization / sensitivity | **POUNCE** --- the default in `discopt._relax.differentiable`, which differentiates through the solve via the envelope theorem |\n",
     "| Single-threaded, no-GIL performance | **POUNCE** --- Rust execution |\n",
     "| General-purpose robustness | **ipopt** --- decades of development |\n",
     "\n",
+    "Anything you cannot express as one of the two names above is not a third\n",
+    "choice: `\"ipm\"` and `\"sparse_ipm\"` both land on POUNCE.\n",
+    "\n",
     "**Drawbacks of POUNCE:**\n",
     "\n",
-    "- Dense linear algebra only --- no sparse KKT factorization yet, so\n",
-    "  performance degrades on large problems.\n",
     "- Evaluation overhead from PyO3 callbacks (each `f(x)`, `grad(x)`,\n",
     "  etc. crosses the Python/Rust boundary).\n",
     "- Fewer algorithmic refinements than Ipopt (e.g., no adaptive barrier\n",
-    "  strategy, no inertia-free regularization)."
+    "  strategy, no inertia-free regularization).\n",
+    "- Its sparse LDL^T backend is young next to HSL MA57, which is what the\n",
+    "  large-problem row of the table above is about."
    ]
   },
   {
@@ -685,8 +745,8 @@
    "source": [
     "## Exercise\n",
     "\n",
-    "Formulate a 10-variable constrained NLP and compare POUNCE to the\n",
-    "JAX IPM node backend. The problem:\n",
+    "Formulate a 10-variable constrained NLP and compare POUNCE to Ipopt.\n",
+    "The problem:\n",
     "\n",
     "$$\n",
     "\\min_{x} \\quad \\sum_{i=0}^{9} (x_i - t_i)^4\n",
@@ -695,19 +755,22 @@
     "x_i \\in [-3, 3].\n",
     "$$\n",
     "\n",
-    "where $t_i = \\sin(i)$."
+    "where $t_i = \\sin(i)$.\n",
+    "\n",
+    "Both backends should report the same objective; the printed difference\n",
+    "between them is the check."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 12,
    "id": "exercise-skeleton",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-11T02:54:10.532332Z",
-     "iopub.status.busy": "2026-08-11T02:54:10.532269Z",
-     "iopub.status.idle": "2026-08-11T02:54:10.533983Z",
-     "shell.execute_reply": "2026-08-11T02:54:10.533670Z"
+     "iopub.execute_input": "2026-08-15T17:24:59.602190Z",
+     "iopub.status.busy": "2026-08-15T17:24:59.602104Z",
+     "iopub.status.idle": "2026-08-15T17:24:59.603864Z",
+     "shell.execute_reply": "2026-08-15T17:24:59.603509Z"
     }
    },
    "outputs": [],
@@ -721,8 +784,8 @@
     "# 3. Minimize sum_i (x[i] - targets[i])^4\n",
     "# 4. Add equality constraint: sum(x) == 5\n",
     "# 5. Solve with nlp_solver=\"pounce\" and time it\n",
-    "# 6. Solve with nlp_solver=\"ipm\" and time it\n",
-    "# 7. Print both objectives and times"
+    "# 6. Solve with nlp_solver=\"ipopt\" and time it\n",
+    "# 7. Print both objectives and times, and check they agree"
    ]
   },
   {
@@ -738,14 +801,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 13,
    "id": "exercise-solution",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-11T02:54:10.534823Z",
-     "iopub.status.busy": "2026-08-11T02:54:10.534767Z",
-     "iopub.status.idle": "2026-08-11T02:54:10.545583Z",
-     "shell.execute_reply": "2026-08-11T02:54:10.545213Z"
+     "iopub.execute_input": "2026-08-15T17:24:59.604793Z",
+     "iopub.status.busy": "2026-08-15T17:24:59.604742Z",
+     "iopub.status.idle": "2026-08-15T17:24:59.655642Z",
+     "shell.execute_reply": "2026-08-15T17:24:59.655208Z"
     }
    },
    "outputs": [
@@ -754,11 +817,18 @@
      "output_type": "stream",
      "text": [
       "Backend    | Status     |    Objective |     Time\n",
-      "------------------------------------------------\n",
-      "pounce     | optimal    |     0.085947 |   0.0043s\n",
-      "ipm        | optimal    |     0.085947 |   0.0037s\n",
+      "******************************************************************************\n",
+      "This program contains Ipopt, a library for large-scale nonlinear optimization.\n",
+      " Ipopt is released as open source code under the Eclipse Public License (EPL).\n",
+      "         For more information visit https://github.com/coin-or/Ipopt\n",
+      "******************************************************************************\n",
       "\n",
-      "Objective difference: 0.00e+00\n"
+      "\n",
+      "------------------------------------------------\n",
+      "pounce     | optimal    |     0.085947 |   0.0040s\n",
+      "ipopt      | optimal    |     0.085947 |   0.0442s\n",
+      "\n",
+      "Objective difference: 1.39e-17\n"
      ]
     }
    ],
@@ -771,23 +841,23 @@
     "    return m\n",
     "\n",
     "\n",
-    "# Solve with pounce\n",
-    "m_rip = build_quartic_model()\n",
+    "# Solve with POUNCE\n",
+    "m_pounce = build_quartic_model()\n",
     "t0 = time.perf_counter()\n",
-    "r_rip = m_rip.solve(nlp_solver=\"pounce\")\n",
-    "t_rip = time.perf_counter() - t0\n",
+    "r_pounce = m_pounce.solve(nlp_solver=\"pounce\")\n",
+    "t_pounce = time.perf_counter() - t0\n",
     "\n",
-    "# Solve with JAX IPM\n",
-    "m_ipm = build_quartic_model()\n",
+    "# Solve with Ipopt\n",
+    "m_ipopt = build_quartic_model()\n",
     "t0 = time.perf_counter()\n",
-    "r_ipm = m_ipm.solve(nlp_solver=\"ipm\")\n",
-    "t_ipm = time.perf_counter() - t0\n",
+    "r_ipopt = m_ipopt.solve(nlp_solver=\"ipopt\")\n",
+    "t_ipopt = time.perf_counter() - t0\n",
     "\n",
     "print(f\"{'Backend':<10s} | {'Status':<10s} | {'Objective':>12s} | {'Time':>8s}\")\n",
     "print(\"-\" * 48)\n",
-    "print(f\"{'pounce':<10s} | {r_rip.status:<10s} | {r_rip.objective:12.6f} | {t_rip:8.4f}s\")\n",
-    "print(f\"{'ipm':<10s} | {r_ipm.status:<10s} | {r_ipm.objective:12.6f} | {t_ipm:8.4f}s\")\n",
-    "print(f\"\\nObjective difference: {abs(r_rip.objective - r_ipm.objective):.2e}\")"
+    "print(f\"{'pounce':<10s} | {r_pounce.status:<10s} | {r_pounce.objective:12.6f} | {t_pounce:8.4f}s\")\n",
+    "print(f\"{'ipopt':<10s} | {r_ipopt.status:<10s} | {r_ipopt.objective:12.6f} | {t_ipopt:8.4f}s\")\n",
+    "print(f\"\\nObjective difference: {abs(r_pounce.objective - r_ipopt.objective):.2e}\")"
    ]
   },
   {
@@ -808,23 +878,24 @@
     "In this tutorial you learned to:\n",
     "\n",
     "- **Select** the POUNCE backend with `m.solve(nlp_solver=\"pounce\")`.\n",
-    "- **Understand** the Rust IPM architecture: compiled `.so`, PyO3 bindings,\n",
-    "  Python evaluation callbacks.\n",
+    "- **Understand** the Rust IPM architecture: a compiled `pounce` extension,\n",
+    "  PyO3 bindings, Python evaluation callbacks.\n",
     "- **Configure** solver options (time limit, tolerance, verbosity).\n",
-    "- **Compare** POUNCE against the pure-JAX IPM and Ipopt backends on\n",
-    "  small-to-medium NLPs.\n",
+    "- **Compare** POUNCE against Ipopt on small-to-medium NLPs.\n",
+    "- **Recognize** `\"ipm\"` and `\"sparse_ipm\"` as compatibility aliases that\n",
+    "  resolve to POUNCE --- shown above by bit-identical objectives, not asserted.\n",
     "- **Use** POUNCE as the NLP subsolver inside Branch-and-Bound for MINLPs.\n",
     "\n",
     "POUNCE is the right choice when you need a dependency-free NLP solver\n",
     "for deployment, or when you want single-threaded Rust performance\n",
-    "without the GIL. For large-scale problems or when sparse linear\n",
-    "algebra is critical, Ipopt remains the stronger option\n",
-    "{cite:p}`Wachter2006`. For batch solving or differentiable optimization,\n",
-    "the pure-JAX IPM is preferred {cite:p}`Nocedal2006`.\n",
+    "without the GIL. For large-scale problems, Ipopt's linear algebra remains\n",
+    "the more mature option {cite:p}`Wachter2006`. Both implement the same\n",
+    "primal-dual interior-point framework {cite:p}`Nocedal2006`, which is why\n",
+    "they agree so closely on the problems above.\n",
     "\n",
     "**See also:**\n",
     "\n",
-    "- [IPM vs Ipopt comparison](ipm_vs_ipopt.ipynb) --- detailed benchmarks\n",
+    "- [POUNCE vs Ipopt comparison](ipm_vs_ipopt.ipynb) --- detailed benchmarks\n",
     "- [Advanced features](advanced_features.ipynb) --- solver configuration guide"
    ]
   }

--- a/python/discopt/solvers/gdpopt_loa.py
+++ b/python/discopt/solvers/gdpopt_loa.py
@@ -744,8 +744,12 @@ def _solve_master_milp(
         solve_milp = get_milp_solver(backend=milp_solver)
     except ImportError as e:
         raise ImportError(
+            # HiGHS was removed from the MILP path in #356; get_milp_solver
+            # accepts only auto/pounce/simplex/gurobi, so `pip install highspy`
+            # was a dead hint. The simplex backend is in-tree and needs no
+            # install, which is why it is not listed here.
             "LOA solver requires a MILP backend for the master. Install one of: "
-            "pip install highspy  |  pip install pounce-solver  |  pip install gurobipy"
+            "pip install pounce-solver  |  pip install gurobipy"
         ) from e
 
     # Determine master problem dimensions


### PR DESCRIPTION
`tutorial_solver_pounce.ipynb` swept `nlp_solver` over `["ipm", "pounce", "ipopt"]` and presented the first two as separate engines. They are not — `"ipm"` is a compatibility alias that resolves to POUNCE, so the committed table was **POUNCE against POUNCE**, and the prose explained the (identical) numbers with a JIT-compilation story about a solver that is no longer on the path.

Fixing that needs a real run, not hand-edited outputs. The notebook was re-executed end to end in a worktree with the extension built there.

## Ground truth first

Entry experiment before any edit (CLAUDE.md §4). 27 executed assertions, counted and printed, exiting non-zero at zero (§6); nothing caught (§7); `discopt.__file__` and the loaded extension's `feral-0.16.0` marker asserted (§8).

| | check | result |
|---|---|---|
| **A** | `"ipm"` / `"sparse_ipm"` vs `"pounce"` on all five of the notebook's own problems | objectives **bit-identical** — 20 comparisons on exact float equality, not printed digits; same status |
| **B** | accepted selectors, read off the solver's own error text | `cyipopt`, `ipm`, `ipopt`, `pounce`, `simplex`, `sparse_ipm` |
| **C** | `jax` in `sys.modules` after import, and after a solve | **False, False** — there is no JIT compilation for the timing prose to attribute cost to |

## What changed in the notebook

- **The sweep is now POUNCE vs Ipopt**, two engines, which is what exists. Objective and timing tables regenerated from the run.
- **A new cell demonstrates the alias rather than asserting it** — `pounce`, `ipm`, `sparse_ipm` on the same model, objectives printed at full `repr` precision and compared with `==`:

  ```
  selector     | status     | objective (repr, full precision)
  --------------------------------------------------------------
  pounce       | optimal    | 0.002063987656113868
  ipm          | optimal    | 0.002063987656113868
  sparse_ipm   | optimal    | 0.002063987656113868

  ipm == pounce         (exact): True
  sparse_ipm == pounce  (exact): True
  ```

  This is the `ipm_vs_ipopt.ipynb` approach the issue points at — identical columns as evidence — kept as one focused cell rather than a third column inside a two-engine comparison.
- **The JIT timing note is gone.** The replacement says plainly that nothing is traced or compiled on this path, so a repeat solve is not systematically cheaper than the first.
- **The "when to choose" table no longer recommends `ipm` for two scenarios.** Batch solving → POUNCE (no compilation step to amortize). Differentiable optimization → POUNCE, because that is the documented default in `discopt._relax.differentiable`, which differentiates through the solve via the envelope theorem.
- **The exercise** compared POUNCE to "the JAX IPM node backend" — POUNCE to POUNCE, and its committed output duly showed a difference of `0.00e+00`. It now compares POUNCE to Ipopt (`1.39e-17` on the re-executed run).

### Two claims that were false, not merely stale

Found while checking the rest of the notebook against the tree, per the issue's "while you are re-executing, also check":

- The architecture diagram routed through **`discopt._rust.solve_POUNCE`, which does not exist** (`hasattr` → `False`). POUNCE is a separate compiled package (`pounce` 0.10.0); discopt drives it through `nlp_pounce.py` onto `pounce.Problem`, which is shape-compatible with `cyipopt.Problem`.
- **"Dense linear algebra only --- no sparse KKT factorization yet"** was listed as a POUNCE drawback. POUNCE's default backend is FERAL, a pure-Rust **sparse** symmetric LDLᵀ factorization. The drawback is now stated as the true one: that backend is young next to HSL MA57.

Cell 1 also no longer sets `JAX_PLATFORMS` / `JAX_ENABLE_X64` — per (C) those configured a library the notebook never loads.

## Also

- `docs/notebooks/estimation.md` said `estimate_parameters()` "solves it with discopt's NLP solvers (Ipopt or pure-JAX IPM)". #1028 missed this one; it is POUNCE by default, or Ipopt.
- `python/discopt/solvers/gdpopt_loa.py` told users to `pip install highspy` when no MILP backend was available. HiGHS was removed from the MILP path in #356 and `get_milp_solver` accepts only `auto`/`pounce`/`simplex`/`gurobi`, so that hint sent people to install a package the code cannot use. It now matches `lp_backend`'s own message. The issue named this as adjacent-but-worth-doing.

`docs/notebooks/llm_integration.ipynb:198` is left alone deliberately: it is captured output from a recorded LLM run, and editing it would be forging a transcript.

## Gate

`grep -rn "pure-JAX IPM" docs/` returns only deliberate mentions — five that say the solver has been retired (`mip_nlp.md`, `tutorial_solver_selection`, `ipm_vs_ipopt`, `advanced_features`, and this notebook's own alias cell), the `pounce-only-roadmap` design doc recording the deletion, and the untouched captured LLM output.

## Verification

- notebook re-executed with `nbclient`, all 13 code cells, `allow_errors=False`, kernel's `discopt.__file__` asserted inside the worktree before any cell ran
- `jupyter-book build docs/` — **zero warnings** (run twice, before and after a final prose tightening)
- `ruff check python/` + `ruff format --check python/` — clean
- `test_gdpopt_heuristics_core_units.py` — **123 passed, 2 xpassed** (it asserts on the message that changed)
- `pytest -m smoke` — **1028 passed**, 1 skipped, 2 xpassed
- `pytest -m slow python/tests/test_adversarial_recent_fixes.py` — **10 passed**
- No Rust touched, so `cargo test` was not required.

Closes #1029

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017PQaiDVuY5Rs3tga98tnNo
