### PR TITLE
fix(bench): BARON resolved to the wrong binary and was parsed with Couenne's parser

### DIFF
--- a/discopt_benchmarks/benchmarks/_subprocess_worker.py
+++ b/discopt_benchmarks/benchmarks/_subprocess_worker.py
@@ -105,6 +105,14 @@ def _solve(
         bound=getattr(result, "bound", None),
         wall_time=float(getattr(result, "wall_time", time.monotonic() - start)),
         node_count=int(getattr(result, "node_count", 0) or 0),
+        # The in-process runner records this (runner.py) and this worker did
+        # not, so `--subprocess` -- the mode recommended for every large suite --
+        # silently produced `root_gap = None` on every row. That is the exact
+        # input `root_gap_populated_fraction` measures for `[gates.cert0]`, so
+        # the Phase-0 exit metric read 0.00 against a 0.90 floor purely because
+        # of how the suite was launched. Found on the 2026-08-15 global50 run,
+        # where it looked like a gate failure and was an instrumentation hole.
+        root_gap=getattr(result, "root_gap", None),
         rust_time_fraction=rust_frac,
         jax_time_fraction=jax_frac,
         python_time_fraction=py_frac,

--- a/discopt_benchmarks/benchmarks/runner.py
+++ b/discopt_benchmarks/benchmarks/runner.py
@@ -445,9 +445,10 @@ class BenchmarkRunner:
             elapsed = time.monotonic() - start_time
 
             # Parse solver output (solver-specific parsing)
-            return self._parse_external_output(
+            result = self._parse_external_output(
                 solver.name, instance, proc.stdout, proc.stderr, elapsed
             )
+            return self._reject_non_result(solver, instance, result, proc.stdout)
         except subprocess.TimeoutExpired:
             return SolveResult(
                 instance=instance,
@@ -461,6 +462,55 @@ class BenchmarkRunner:
                 solver=solver.name,
                 status=SolveStatus.ERROR,
             )
+
+    def _reject_non_result(
+        self,
+        solver: SolverConfig,
+        instance: str,
+        result: SolveResult,
+        stdout: str,
+    ) -> SolveResult:
+        """Turn a non-answer from an external solver into a loud ERROR.
+
+        This is the class fix for a defect found by the 2026-08 release audit
+        (CLAUDE.md §2: fix the class, not the instance). ``[solvers.baron]``
+        carried ``command = "baron"``, which resolves on PATH to whichever BARON
+        is installed; on a machine with GAMS that is the ``.bar``-only build,
+        which answers a ``.nl`` argument by printing a usage message and exiting
+        **rc = 0**. The parser saw no recognizable verdict, returned
+        ``status=UNKNOWN, objective=None``, and the run recorded it as an
+        instance BARON simply did not solve.
+
+        Nothing about that is loud, and the failure mode generalizes to any
+        wrong binary, unreadable format or refused license. Two shapes are
+        rejected here for every external solver:
+
+        * output containing a refusal/usage phrase -- the solver never read the
+          model;
+        * a claimed terminal success (``OPTIMAL``/``FEASIBLE``) with no
+          objective -- a status we cannot check against a known optimum, which
+          is exactly the input a correctness gate must never silently accept.
+        """
+        low = (stdout or "").lower()
+        reason = None
+        if any(p in low for p in self._EXTERNAL_REFUSAL_PHRASES):
+            reason = "refused the model (usage/license message, solver never read it)"
+        elif (
+            result.status in (SolveStatus.OPTIMAL, SolveStatus.FEASIBLE)
+            and result.objective is None
+        ):
+            reason = f"reported {result.status.value} with no objective"
+
+        if reason is None:
+            return result
+
+        print(f"    !! {solver.name} on {instance}: {reason} -- recorded as ERROR")
+        return SolveResult(
+            instance=instance,
+            solver=solver.name,
+            status=SolveStatus.ERROR,
+            wall_time=result.wall_time,
+        )
 
     def _build_command(self, solver: SolverConfig, instance: str) -> list[str]:
         """Build a solver command line for the .nl-interface external solvers.
@@ -554,8 +604,81 @@ class BenchmarkRunner:
             return self._parse_scip(instance, solver_name, stdout, elapsed)
         if name.startswith("highs"):
             return self._parse_highs(instance, solver_name, stdout, elapsed)
-        # Couenne / BARON / Bonmin and other AMPL-ASL solvers.
+        if name.startswith("baron"):
+            return self._parse_baron(instance, solver_name, stdout, elapsed)
+        # Couenne / Bonmin and other AMPL-ASL solvers.
         return self._parse_ampl_solver(instance, solver_name, stdout, elapsed)
+
+    # Phrases an external solver emits when it never looked at the model at all:
+    # a wrong binary invoked with an unreadable format, or a solver whose license
+    # refuses the instance size. Both used to parse to UNKNOWN with no objective,
+    # which is indistinguishable from "this solver tried and failed to solve it"
+    # -- so a systematically broken solver reads as a merely weak one, and every
+    # ratio computed against it flatters us. They are ERROR, loudly.
+    _EXTERNAL_REFUSAL_PHRASES = (
+        "demo license",
+        "license is limited",
+        "usage :",
+        "usage:",
+        "no license",
+        "licensing@",
+    )
+
+    def _parse_baron(
+        self, instance: str, solver_name: str, stdout: str, elapsed: float
+    ) -> SolveResult:
+        """Parse BARON's AMPL driver stdout.
+
+        BARON is NOT Couenne and must not share its parser. Two differences, both
+        verified against ``pointpack02`` (a maximize instance whose known optimum
+        is ``+2.0``):
+
+        * BARON reports ``Objective <value>`` in the model's **original** sense
+          (it printed ``+2.0``), whereas Couenne reports ``Lower bound:`` /
+          ``Upper bound:`` in *internal minimization* sense (it printed ``-2``).
+          Running BARON through :meth:`_parse_ampl_solver` therefore found no
+          objective at all -- it looks only for Couenne's bound lines -- and
+          returned ``status=OPTIMAL, objective=None``, so no correctness check
+          against a known optimum could fire.
+        * BARON's status line is ``BARON <version>: <n> iterations, <verdict>``,
+          which Couenne's ``^\\w+:`` verdict regex does not match (the version
+          string sits between the name and the colon).
+        """
+        low = stdout.lower()
+        if any(p in low for p in self._EXTERNAL_REFUSAL_PHRASES):
+            return SolveResult(
+                instance=instance,
+                solver=solver_name,
+                status=SolveStatus.ERROR,
+                wall_time=elapsed,
+            )
+
+        status = SolveStatus.UNKNOWN
+        if "infeasible" in low:
+            status = SolveStatus.INFEASIBLE
+        elif "unbounded" in low:
+            status = SolveStatus.UNBOUNDED
+        elif "optimal within tolerances" in low or "optimal solution found" in low:
+            status = SolveStatus.OPTIMAL
+        elif "max. allowable time" in low or "time limit" in low:
+            status = SolveStatus.TIME_LIMIT
+        elif "numerical difficulties" in low:
+            status = SolveStatus.NUMERICAL_ERROR
+        elif "max. allowable nodes" in low or "max. allowable iterations" in low:
+            status = SolveStatus.FEASIBLE
+
+        # Original sense -- deliberately NOT negated for maximize models.
+        objective = self._first_float(r"^Objective\s+([+\-0-9.eE]+)", stdout)
+        bound = self._first_float(r"Best possible:\s*([+\-0-9.eE]+)", stdout)
+        return SolveResult(
+            instance=instance,
+            solver=solver_name,
+            status=status,
+            objective=objective,
+            bound=bound,
+            wall_time=elapsed,
+            node_count=self._first_int(r"([0-9]+)\s+iterations", stdout),
+        )
 
     def _parse_scip(
         self, instance: str, solver_name: str, stdout: str, elapsed: float

--- a/discopt_benchmarks/config/benchmarks.toml
+++ b/discopt_benchmarks/config/benchmarks.toml
@@ -421,10 +421,21 @@ type = "internal"
 options = { threads = 1 }
 
 [solvers.baron]
-command = "baron"
+command = "/Applications/AMPL/baron"
 type = "external"
 nl_interface = true
 options = { threads = 1, epsa = 1e-6, epsr = 1e-4 }
+note = """BARON 25.12.10, the AMPL-ASL driver, which reads .nl directly. The path \
+is explicit on purpose: this entry used to say `command = "baron"`, and on a \
+machine with GAMS installed PATH resolves that to \
+GAMS.framework/Resources/baron, which reads only `.bar` and answers a `.nl` \
+argument with a usage message and rc=0. CAVEAT: the AMPL bundle's BARON is \
+DEMO-LICENSED (10 variables, 10 constraints) -- it refuses anything larger, \
+which `_reject_non_result` now records as ERROR rather than a silent non-solve. \
+BARON at corpus scale is available only through GAMS (fully licensed here), and \
+that needs a .nl -> .gms bridge which does not exist yet; until it does, \
+`geomean_ratio_vs_baron` and `root_gap_ratio_vs_baron` are NOT producible on \
+this machine and must not be reported as measured."""
 
 [solvers.couenne]
 command = "/Applications/AMPL/couenne"

--- a/discopt_benchmarks/tests/test_external_solver_parsing.py
+++ b/discopt_benchmarks/tests/test_external_solver_parsing.py
@@ -1,0 +1,160 @@
+"""Parsing and refusal-handling tests for external .nl solvers.
+
+These pin a defect found by the 2026-08 pre-release audit. ``[solvers.baron]``
+carried ``command = "baron"``; on a machine with GAMS installed, PATH resolves
+that to the GAMS build, which reads only ``.bar``. Handed a ``.nl`` it prints a
+usage message and exits **rc = 0**, so the run recorded "BARON did not solve
+this instance" rather than "BARON was never invoked correctly" -- and every
+ratio computed against a solver with zero solves flatters us.
+
+Fixing the path exposed a second bug underneath: BARON was being parsed by
+Couenne's parser, which reads only Couenne's ``Lower bound:`` / ``Upper bound:``
+lines. BARON prints ``Objective <value>`` instead, so it parsed to
+``status=OPTIMAL, objective=None`` -- a claimed success no correctness check
+could ever test against a known optimum.
+
+The stdout fixtures below are **verbatim captures** from the real binaries, not
+hand-written approximations; the sense convention in particular was established
+by running both solvers on ``pointpack02`` (known optimum ``+2.0``, maximize)
+and observing that BARON prints ``+2`` and Couenne prints ``-2``.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+import tomllib
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from benchmarks.metrics import SolveStatus
+from benchmarks.runner import BenchmarkConfig, BenchmarkRunner, SolverConfig
+
+pytestmark = pytest.mark.unit
+
+# Verbatim: /Applications/AMPL/baron pointpack02.nl  (maximize, true optimum +2.0)
+BARON_MAXIMIZE_STDOUT = (
+    "BARON 25.12.10 (2025.12.10): 0 iterations, numerical difficulties.\n"
+    "Objective 2.0000000007597647\n"
+)
+
+# Verbatim: /Applications/AMPL/baron ex3_1_2.nl  (minimize, true optimum -30665.5387)
+BARON_OPTIMAL_STDOUT = (
+    "BARON 25.12.10 (2025.12.10): 1 iterations, optimal within tolerances.\n"
+    "Objective -30665.53867365177\n"
+)
+
+# Verbatim: GAMS.framework/Versions/53/Resources/baron ex3_1_2.nl -- the wrong
+# binary, which exits rc=0.
+GAMS_BARON_USAGE_STDOUT = (
+    " Usage : /Library/Frameworks/GAMS.framework/Versions/53/Resources/baron"
+    " [-f] input(.bar)\n"
+    " Usage Contd. : The -f option prints the files\n"
+)
+
+# Verbatim: /Applications/AMPL/baron alkylation.nl -- 10 vars, 11 constraints.
+BARON_DEMO_REFUSAL_STDOUT = (
+    "\nSorry, a demo license is limited to 10 variables and\n"
+    "10 constraints and objectives.\n"
+    "You have 10 variables, 11 constraints, and 1 objective.\n\n"
+    "Contact us at <licensing@ampl.com> or https://discuss.ampl.com/\n"
+)
+
+# Verbatim: /Applications/AMPL/couenne pointpack02.nl -- same maximize instance,
+# reported in INTERNAL MINIMIZATION sense.
+COUENNE_MAXIMIZE_STDOUT = (
+    "couenne: Optimal\n"
+    "Lower bound:                                   -2\n"
+    "Upper bound:                                   -2  (gap: 0.00%)\n"
+    "Branch-and-bound nodes:                         0\n"
+)
+
+
+def _runner() -> BenchmarkRunner:
+    return BenchmarkRunner(BenchmarkConfig(suite_name="unit"))
+
+
+def _baron_cfg() -> SolverConfig:
+    return SolverConfig(name="baron", command="/Applications/AMPL/baron", solver_type="external")
+
+
+def test_baron_objective_is_parsed_at_all():
+    """The original bug: OPTIMAL with objective=None, so nothing could be checked."""
+    res = _runner()._parse_baron("ex3_1_2", "baron", BARON_OPTIMAL_STDOUT, 0.02)
+    assert res.status is SolveStatus.OPTIMAL
+    assert res.objective == pytest.approx(-30665.53867365177)
+
+
+def test_baron_objective_is_original_sense_on_a_maximize_model():
+    """BARON reports original sense; negating it would invert the answer.
+
+    ``bchoco06`` is vendored and maximizes, so ``_nl_is_maximize`` resolves
+    without the MINLPLib cache -- the negation path Couenne needs is live here,
+    and must still leave BARON's value alone.
+    """
+    r = _runner()
+    assert r._nl_is_maximize(r._find_nl_file("bchoco06")), (
+        "bchoco06 must parse as a maximize model or this test proves nothing"
+    )
+    res = r._parse_baron("bchoco06", "baron", BARON_MAXIMIZE_STDOUT, 0.02)
+    assert res.objective == pytest.approx(2.0000000007597647), (
+        "BARON's Objective line is original-sense and must not be negated"
+    )
+
+
+def test_couenne_bounds_are_still_negated_for_maximize():
+    """Guard the fix above did not disturb Couenne's (correct) convention."""
+    r = _runner()
+    res = r._parse_ampl_solver("bchoco06", "couenne", COUENNE_MAXIMIZE_STDOUT, 0.02)
+    assert res.objective == pytest.approx(2.0), (
+        "Couenne reports internal-minimization sense; -2 must come back as +2"
+    )
+
+
+@pytest.mark.parametrize(
+    "stdout,label",
+    [
+        (GAMS_BARON_USAGE_STDOUT, "wrong binary printing usage at rc=0"),
+        (BARON_DEMO_REFUSAL_STDOUT, "license refusing the instance size"),
+    ],
+)
+def test_a_solver_that_never_read_the_model_is_an_error(stdout, label):
+    r = _runner()
+    parsed = r._parse_external_output("baron", "ex3_1_2", stdout, "", 0.01)
+    res = r._reject_non_result(_baron_cfg(), "ex3_1_2", parsed, stdout)
+    assert res.status is SolveStatus.ERROR, f"{label} must be ERROR, got {res.status}"
+
+
+def test_claimed_success_without_an_objective_is_an_error():
+    """The class guard, exercised through a solver that is not BARON.
+
+    Any external adapter that reports OPTIMAL with nothing to check is rejected
+    -- that is the shape a correctness gate must never silently accept.
+    """
+    r = _runner()
+    parsed = r._parse_ampl_solver("ex3_1_2", "couenne", "couenne: Optimal\n", 0.01)
+    assert parsed.status is SolveStatus.OPTIMAL and parsed.objective is None
+    res = r._reject_non_result(
+        SolverConfig(name="couenne", command="couenne", solver_type="external"),
+        "ex3_1_2",
+        parsed,
+        "couenne: Optimal\n",
+    )
+    assert res.status is SolveStatus.ERROR
+
+
+def test_baron_command_is_an_absolute_path_not_a_bare_name():
+    """PATH resolution is the root cause; a bare name reintroduces it.
+
+    Machine-independent on purpose: it asserts the *shape* of the setting, not
+    the particular path this developer's AMPL bundle happens to live at.
+    """
+    cfg_path = Path(__file__).resolve().parents[1] / "config" / "benchmarks.toml"
+    cfg = tomllib.load(cfg_path.open("rb"))
+    command = cfg["solvers"]["baron"]["command"]
+    assert command.startswith("/"), (
+        f"[solvers.baron].command is {command!r}; a bare name resolves through "
+        "PATH, which on a GAMS machine finds the .bar-only build"
+    )


### PR DESCRIPTION
## Summary

Three silent defects in the benchmark harness's external-solver path, found
while trying to produce comparison metrics for the v0.8.0 release audit. Each
one degrades a measurement into something that still prints a plausible number.

### 1. BARON resolved through PATH to the wrong binary

`[solvers.baron].command` was the bare name `baron`. On a machine with GAMS
installed, PATH finds the GAMS build, which reads only `.bar`. Handed a `.nl`
it prints a usage line and **exits rc = 0**, so the harness recorded "BARON did
not solve this instance" rather than "BARON was never invoked correctly". Every
ratio computed against a solver with zero solves flatters discopt.

Now an absolute path to the AMPL-ASL driver, which reads `.nl` natively.

### 2. BARON was parsed with Couenne's parser

`_parse_ampl_solver` reads Couenne's `Lower bound:` / `Upper bound:` lines.
BARON prints `Objective <value>` instead, so BARON output parsed to
`status=OPTIMAL, objective=None` — a claimed success with nothing a correctness
check could ever test against a known optimum. Added `_parse_baron` and
dispatch on solver name.

The two solvers also **disagree on objective sense**, which is the part most
likely to produce a wrong-but-believable number:

| solver | line printed | sense |
|---|---|---|
| BARON (AMPL driver) | `Objective <v>` | **original** |
| Couenne | `Lower bound:` / `Upper bound:` | **internal minimization** |

Established empirically on `pointpack02` (known optimum **+2.0**, maximize):
BARON printed `+2`, Couenne printed `-2`. So Couenne's values must be negated
for a maximize model and BARON's must not. `_parse_baron` deliberately does not
negate, and there is a test pinning each side.

### 3. `--subprocess` never recorded `root_gap`

`_subprocess_worker.py` did not carry `root_gap` through, though the in-process
runner does (`runner.py:376`). `--subprocess` is the mode recommended for every
large suite, so it produced `root_gap = None` on **every** row — and that field
is exactly what `root_gap_populated_fraction` measures for `[gates.cert0]`.

The 2026-08-15 global50 run reported **0.00 against a 0.90 floor**. That looked
like a gate failure and was an instrumentation hole. After the fix the same
panel reads **45/50 = 0.90**, meeting the floor. This is the CLAUDE.md §6
failure mode — an instrument that measured nothing and was believed — so it is
worth noting it was caught only because the number was checked before being
reported.

### The class fix, not the BARON fix

Per CLAUDE.md §2, the guard is not keyed to BARON. `_reject_non_result` records
as `ERROR` any external solver that either

- emits a refusal/usage phrase (`demo license`, `usage :`, `no license`, …), or
- claims `OPTIMAL`/`FEASIBLE` with `objective is None`,

printing `!! {solver} on {instance}: {reason} -- recorded as ERROR`. The shape
being rejected — a success no oracle can check — is one a correctness gate must
never silently accept, whichever adapter produces it.

## Caveat, recorded in `benchmarks.toml` rather than worked around

The AMPL bundle's BARON is **DEMO-licensed** (10 variables, 10 constraints).
The fully-licensed GAMS BARON (25.12.10, via GAMS 53.2.0) reads only `.bar`,
and the corpus is `.nl`-only, so using it at scale would need a `.nl → .gms`
bridge that does not exist.

Therefore `geomean_ratio_vs_baron` and `root_gap_ratio_vs_baron` are **not
producible on this machine and must not be reported as measured.** This PR
fixes the plumbing and makes the refusal loud (CLAUDE.md §3); it does not
manufacture a number to fill the metric.

## Verification

- **New:** `discopt_benchmarks/tests/test_external_solver_parsing.py` — 7 tests,
  **6 of which fail without this change**.
  - stdout fixtures are **verbatim captures from the real binaries**, not
    hand-written approximations.
  - `test_baron_objective_is_original_sense_on_a_maximize_model` first *asserts*
    `_nl_is_maximize(bchoco06)` is true, so it cannot pass vacuously if the
    fixture instance ever stops being a maximize model.
  - `test_baron_command_is_an_absolute_path_not_a_bare_name` asserts the
    *shape* of the setting (`startswith("/")`), so it is machine-independent
    and does not pin this developer's AMPL location.
- `pytest discopt_benchmarks/tests/test_external_solver_parsing.py -q` → **7 passed**
- global50 re-run after the worker fix → `root_gap` populated **45/50 = 0.90**,
  `incorrect_count = 0` across 140 oracle checks.

### Lint state (checked, not assumed)

`ruff check discopt_benchmarks/` reports **565 pre-existing errors**, and both
edited files were **already unformatted at HEAD** — `.pre-commit-config.yaml`
scopes both ruff hooks to `^python/`, so this tree has never been gated. I
verified against `HEAD` that every remaining error and every `ruff format` hunk
in these two files predates this change (runner.py: 1 pre-existing `SIM105`;
_subprocess_worker.py: 2 pre-existing). The new test file is clean under both
`ruff check` and `ruff format`. I did not reformat wholesale, which would have
buried a 300-line fix in an unrelated diff.

No Rust was touched, so `cargo test` was not run.

## Related

Found during the v0.8.0 pre-release adversarial audit (PR #1031). Separately
noted there and **not addressed here**: CI never runs `discopt_benchmarks/tests/`
at all — every pytest invocation in `.github/workflows/ci.yml` targets
`python/tests/`. That is why 10 pre-existing failures in this tree are
invisible, and why the ruff state above was able to drift to 565.
