### PR TITLE
fix(correctness): #1038 a callback-vetoed point could be returned as optimal

### DIFF
--- a/crates/discopt-core/src/bnb/tree_manager.rs
+++ b/crates/discopt-core/src/bnb/tree_manager.rs
@@ -10,6 +10,12 @@ use crate::bnb::branching::{
 use crate::bnb::node::{Node, NodeId, NodeStatus};
 use crate::bnb::pool::{NodePool, SelectionStrategy};
 
+/// Any imported bound at or above this is the orchestrator's *failure/exclusion
+/// sentinel* (`INFEASIBILITY_SENTINEL = 1e30` in `python/discopt/constants.py`),
+/// not a bound the relaxation proved. Mirrors `SENTINEL_THRESHOLD` there; keep
+/// the two in sync.
+pub(crate) const SENTINEL_THRESHOLD: f64 = 1e29;
+
 /// A batch of nodes exported for relaxation evaluation.
 #[derive(Debug)]
 pub struct ExportBatch {
@@ -469,7 +475,10 @@ impl TreeManager {
                 // and the floored `local_lower_bound` is only the inherited
                 // parent bound (valid for pruning, but the solution is an
                 // untrusted placeholder). See `PendingResult::bound_trusted`.
-                bound_trusted: r.lower_bound.is_finite(),
+                // The `1e30` failure/exclusion sentinel is finite but is equally
+                // not a proved bound (#1038) — a point carrying it must never be
+                // promoted to the incumbent, so it is untrusted here too.
+                bound_trusted: r.lower_bound.is_finite() && r.lower_bound < SENTINEL_THRESHOLD,
                 certified_infeasible: r.certified_infeasible,
             }));
     }
@@ -545,6 +554,20 @@ impl TreeManager {
             // subtree, and promoting it would inject a FALSE incumbent whose
             // "objective" is the parent's lower bound at an unverified point;
             // #598.)
+            // A node the orchestrator SENTINELLED (`INFEASIBILITY_SENTINEL` =
+            // 1e30) carries no bound its relaxation proved — it is how the Python
+            // side says "this node is excluded": the relaxation failed, or a user
+            // callback (`lazy_constraints` cut / `incumbent_callback` returning
+            // False) rejected the integer point it found. That exclusion is
+            // handled through `bound_trusted` (see `import_results`), NOT here:
+            // `trusted` governs ROUTING (branch vs fathom-as-unresolved), and a
+            // sentinelled node must keep routing exactly as before — it still
+            // spatially branches, and it must not flip `bound_unresolved`, which
+            // would discard the whole tree bound where the Python orchestrator
+            // deliberately keeps it via `_taint_floor_internal` (solver.py's
+            // "instead of discarding the entire tree bound", DECOMP-1). Widening
+            // `trusted` was measured to cost `m3` its certificate (bound
+            // 37.7999997 → none) for no soundness gain.
             let trusted = node_lb.is_finite();
             let int_feasible = trusted
                 && (result.is_feasible
@@ -580,6 +603,15 @@ impl TreeManager {
                     // path described above. Fall through to branching; if no
                     // branch direction remains, the no-decision arm below
                     // fathoms it into `unresolved_floor` (#598).
+                    //
+                    // #1038 routes here too: a node the orchestrator sentinelled
+                    // because a user callback VETOED its integer point is
+                    // `bound_trusted == false`, so it can neither be fathomed
+                    // here nor promoted below. Before that, 1e30 was *finite* and
+                    // read as a proved bound, and step 1 above cannot cut it
+                    // before the first incumbent exists (`1e30 >= +inf` is
+                    // false) — so the vetoed point became the incumbent and was
+                    // reported `optimal`.
                 }
             }
 
@@ -824,7 +856,7 @@ impl TreeManager {
                 // trusted (finite-bound) node here IS resolved and stays certifiable.
                 if !trusted {
                     self.bound_unresolved = true;
-                } else if !result.bound_trusted {
+                } else if !result.bound_trusted && node_lb < SENTINEL_THRESHOLD {
                     // The node's own relaxation FAILED (raw import -inf) but a
                     // valid finite bound for its box was inherited from an
                     // ancestor (`import_results` floor), and no branch direction
@@ -834,6 +866,16 @@ impl TreeManager {
                     // close if this removed subtree is provably within tolerance
                     // of the incumbent, which keeps a gap-closed exit rigorous
                     // without pinning the whole tree bound at -inf.
+                    //
+                    // A SENTINELLED node (#1038) is excluded from this floor: its
+                    // `node_lb` is 1e30, not a bound anything proved, and
+                    // `update_global_lower_bound` caps the floor at the incumbent
+                    // — so flooring at 1e30 would collapse the global bound ONTO
+                    // the incumbent and certify the very subtree that was removed
+                    // without proof. The orchestrator already accounts for these
+                    // nodes rigorously, flooring the reported bound at their
+                    // pop-time bound (`_taint_floor_internal`, solver.py) and
+                    // barring an `infeasible` verdict (`_nonrigorous_fathom`).
                     self.unresolved_floor = self.unresolved_floor.min(node_lb);
                 }
                 self.pool.get_mut(result.node_id).status = NodeStatus::Fathomed;
@@ -1237,6 +1279,77 @@ mod tests {
         }]);
         let stats = tm.process_evaluated();
         assert_eq!(stats.pruned, 0, "an UNPROVEN sentinel must not prune");
+    }
+
+    /// #1038: a sentinelled node whose solution happens to be integer-feasible
+    /// must never be promoted to the incumbent, even with no incumbent yet.
+    ///
+    /// This is how a `incumbent_callback` veto (and a `lazy_constraints` cut) is
+    /// communicated: the orchestrator rewrites the node's bound to 1e30. That
+    /// value is finite, so the node used to pass the `trusted`/`bound_trusted`
+    /// checks and — because `1e30 >= +inf` is false, so the bound-cut in step 1
+    /// could not fire before the first incumbent — was fathomed AND promoted,
+    /// making the VETOED point the incumbent and reporting it `optimal`.
+    #[test]
+    fn sentinelled_integer_node_is_never_promoted_to_the_incumbent() {
+        let mut tm = TreeManager::new(
+            1,
+            vec![0.0],
+            vec![10.0],
+            vec![VarBranchInfo {
+                offset: 0,
+                size: 1,
+                is_integer: true,
+            }],
+            SelectionStrategy::BestFirst,
+        );
+        tm.initialize();
+        let batch = tm.export_batch(1);
+        assert_eq!(tm.incumbent_value, f64::INFINITY, "no incumbent yet");
+
+        tm.import_results(&[NodeResult {
+            node_id: batch.node_ids[0],
+            lower_bound: 1e30,   // the orchestrator's exclusion sentinel
+            solution: vec![3.0], // INTEGER-feasible, and the excluded point
+            is_feasible: true,
+            certified_infeasible: false,
+        }]);
+        let stats = tm.process_evaluated();
+
+        assert_eq!(
+            stats.incumbent_updates, 0,
+            "a sentinelled (callback-excluded) point must not become the incumbent"
+        );
+        assert!(
+            tm.incumbent_solution.is_none(),
+            "no incumbent solution may be recorded from a sentinelled node, got {:?}",
+            tm.incumbent_solution
+        );
+        assert_eq!(
+            tm.incumbent_value,
+            f64::INFINITY,
+            "the sentinel must not become the incumbent value"
+        );
+        // The fix is confined to TRUST, not routing: the node still branches, so
+        // its subtree is explored rather than silently removed (#927), and the
+        // tree bound is not discarded — the orchestrator's `_taint_floor_internal`
+        // is what keeps a sentinelled node's bound honest.
+        assert_eq!(
+            stats.fathomed, 1,
+            "every integer variable is fixed here, so the node has no branch direction \
+             and is fathomed — the point is that it is fathomed WITHOUT being promoted"
+        );
+        assert!(
+            !tm.bound_unresolved,
+            "a sentinelled node must not discard the whole tree bound (measured: it costs \
+             m3 its certificate); the Python taint floor accounts for it"
+        );
+        assert_eq!(
+            tm.unresolved_floor,
+            f64::INFINITY,
+            "the 1e30 sentinel must never enter the unresolved floor — capped at the \
+             incumbent it would certify the unproven subtree"
+        );
     }
 
     #[test]

--- a/python/discopt/modeling/core.py
+++ b/python/discopt/modeling/core.py
@@ -4763,7 +4763,32 @@ class Model:
                         else:
                             result.bound = max(result.bound, _fb.bound)
                     result.node_count = (result.node_count or 0) + _fb.node_count
-                if _fb is not None and _fb.objective is not None:
+                # #1038: ``solve_lp_spatial_bb`` neither receives nor consults
+                # ``lazy_constraints``/``incumbent_callback``, so its primal is
+                # unscreened by the user's gate. "Only ever fills in a MISSING
+                # incumbent" is exactly the hole when a callback is in play: the
+                # incumbent may be missing *because the user vetoed every point
+                # the primary found*, and this branch then reinstated the vetoed
+                # point as ``optimal`` — the #748 defect, one layer above the
+                # tree (measured on the #748 reproduction: the primary correctly
+                # returned ``unknown``/no incumbent and this branch overwrote it
+                # with the rejected x=1). Take the fallback's BOUND (merged
+                # above — a dual bound over the un-cut relaxation is still valid
+                # for the more constrained problem) but never its primal.
+                if (
+                    _fb is not None
+                    and _fb.objective is not None
+                    and (lazy_constraints is not None or incumbent_callback is not None)
+                ):
+                    import logging as _logging
+
+                    _logging.getLogger(__name__).info(
+                        "#844 LP-spatial fallback found a primal, but a "
+                        "lazy_constraints/incumbent_callback is active and that engine "
+                        "cannot consult it — discarding the unscreened primal (#1038); "
+                        "its dual bound is kept."
+                    )
+                elif _fb is not None and _fb.objective is not None:
                     from discopt.solver import _unpack_solution
 
                     result.status = _fb.status

--- a/python/tests/test_callbacks.py
+++ b/python/tests/test_callbacks.py
@@ -991,3 +991,59 @@ class TestIssue748MilpMiqpCallbackDispatch:
         assert not (res.status == "infeasible" and res.gap_certified), (
             "feasible model falsely certified infeasible"
         )
+
+    def test_vetoed_root_is_never_certified_optimal(self):
+        """#1038: the veto must survive BOTH re-entry paths, not just the tree.
+
+        The same reproduction, pinned harder. Two independent defects let the
+        rejected point back out and each is invisible to the assertion above
+        whenever the other is fixed:
+
+        1. The Rust tree treated the orchestrator's ``1e30`` exclusion sentinel
+           as a *trusted* bound (1e30 is finite). Before the first incumbent the
+           bound-cut cannot fire (``1e30 >= +inf`` is false), so the sentinelled,
+           integer-feasible node was fathomed AND promoted — the vetoed point
+           became the incumbent with objective 1e30, reported as ``optimal``.
+        2. ``Model.solve``'s #844 no-incumbent LP-spatial fallback re-solved the
+           model with an engine that never sees the callback and overwrote the
+           honest ``unknown`` with the same vetoed point.
+
+        A run that returns no ``x`` passes the sibling test vacuously, so assert
+        the certificate directly: a solve whose only cheap optimum was vetoed may
+        not come back ``optimal``, and may not come back certified.
+        """
+        m = discopt.Model("milp1038_veto_root")
+        x = m.binary("x")
+        y = m.binary("y")
+        m.minimize(x + 2 * y)
+        m.subject_to(x + y >= 1)
+
+        seen = []
+
+        def veto_x1(ctx, model, sol):
+            xv = float(np.ravel(sol["x"])[0])
+            seen.append(xv)
+            return xv < 0.5
+
+        res = m.solve(incumbent_callback=veto_x1, time_limit=30)
+
+        # The gate must actually have run — otherwise this test proves nothing
+        # (CLAUDE.md §6).
+        assert seen, "incumbent_callback was never invoked; the test measured nothing"
+        assert any(v > 0.5 for v in seen), (
+            f"the callback never saw the x=1 point it exists to veto: {seen}"
+        )
+
+        if res.x is not None:
+            assert round(float(np.ravel(res.x["x"])[0])) == 0, (
+                f"vetoed x=1 point returned (status {res.status}, obj {res.objective})"
+            )
+            return  # an accepted point WAS found; certifying it is legitimate
+
+        # No accepted incumbent: the result must be honest about it.
+        assert res.status != "optimal", (
+            f"no acceptable incumbent exists, yet status is optimal (obj {res.objective})"
+        )
+        assert not res.gap_certified, (
+            "a callback rejection is a non-rigorous fathom — it can never certify"
+        )


### PR DESCRIPTION
A user callback that rejects an integer point could still have that exact point
returned as `optimal`, with `gap_certified=True`. This is the #748 defect
re-opened through a path #748 did not cover: the case where the veto leaves the
solver with **no incumbent at all**.

Closes #1038.

## Two independent defects, both measured

### 1. The Rust tree trusted the exclusion sentinel (`tree_manager.rs`)

The orchestrator signals "discard this node" by writing
`INFEASIBILITY_SENTINEL = 1e30` into `result_lbs[i]`
(`_invoke_pre_import_callbacks`, solver.py:3620). Normally the tree disposes of
such a node at step 1, by bound: `1e30 >= incumbent`.

Before the first incumbent exists, `incumbent_value` is `+inf`, so
`1e30 >= +inf` is **false** and that cut never fires. `1e30` is also *finite*,
so `bound_trusted` (`r.lower_bound.is_finite()`) accepted it as a bound the
relaxation had proved. A sentinelled node whose solution was integer-feasible —
i.e. exactly the point the callback had just vetoed — therefore reached the
convex fathom/promote arm and became the incumbent, carrying `1e30` as its
"objective".

Measured before the fix, on the #748 reproduction:

```
tree.incumbent() after solve = (array([9.99999993e-01, 3.39638055e-09]), 1e+30)
```

That is the vetoed `x=1` point, installed as the incumbent.

The fix is confined to **trust**, not routing: `bound_trusted` now also requires
`lower_bound < SENTINEL_THRESHOLD` (1e29, mirroring `constants.py`). That denies
a sentinelled node both promotion sites and the convex fathom, while leaving it
to branch normally — a failure sentinel must not silently remove its subtree
(#927), and the existing test
`uncertified_sentinel_still_branches_without_an_incumbent` holds.

One related guard: a sentinelled node reaching the no-branch-direction arm is
excluded from `unresolved_floor`. `update_global_lower_bound` caps that floor at
the incumbent, so flooring at `1e30` would collapse the global bound *onto* the
incumbent and certify the very subtree that was removed without proof. The
orchestrator already accounts for these nodes rigorously
(`_taint_floor_internal` floors the reported bound at their pop-time bound;
`_nonrigorous_fathom` bars an `infeasible` verdict).

### 2. `Model.solve`'s #844 fallback reinstated the vetoed point (`core.py`)

With the tree fixed, the reproduction still returned `optimal / 1.0`. Probing
showed exactly one `SolveResult` is constructed (solver.py:13654) with
`status=unknown obj=None x=None`, and that same object (`inst is res` → True)
reads back as `optimal / 1.0`. The mutation is `core.py:4769`.

`solve_lp_spatial_bb` neither receives nor consults
`lazy_constraints`/`incumbent_callback`, so its primal is unscreened. The
branch's stated contract — "only ever fills in a MISSING incumbent" — is exactly
the hole when a callback is in play: the incumbent may be missing *because the
user vetoed every point the primary found*.

The fallback's **bound** is still taken (a dual bound over the un-cut relaxation
is valid for the more constrained problem); its **primal** is discarded, with an
`info` log, whenever either callback is active.

## Verification

Reproduction, before → after:

| | status | objective | x | gap_certified |
|---|---|---|---|---|
| before | `optimal` | 1.0 | vetoed `x=1` | True |
| after | `unknown` | None | None | False |

with the callback confirmed invoked 3× (the test asserts it fired and asserts it
actually saw the `x=1` point it exists to veto — CLAUDE.md §6).

- New Rust unit test `sentinelled_integer_node_is_never_promoted_to_the_incumbent`
  fails pre-fix (`incumbent_updates` 1, expected 0), passes post-fix.
- New Python regression test `test_vetoed_root_is_never_certified_optimal`
  covers both re-entry paths.
- `cargo test -p discopt-core --lib` → **613 passed, 0 failed**.
- `pytest python/tests/test_callbacks.py -m ""` → **46 passed**, including the
  previously-failing `test_reproduction_sketch_never_returns_vetoed_point`.

### Differential panel (bound-changing change — CLAUDE.md §5 regime 2)

66 in-repo MINLPLib instances, `time_limit=15`, baseline vs fixed, build marker
asserted on both arms:

| metric | baseline → fixed |
|---|---|
| instances compared | 66 |
| status changes | **0** |
| certification lost / gained | **0 / 0** |
| objective drift | none |
| bound changes | 2 — `4stufen` 20940.80 → 21012.22 (tighter), `tanksize` 1.2640921 → 1.2640433 (looser; both are time-limited and both flipped in the fixed-vs-fixed control) |
| node-count changes | 3 — `heatexch_gen1` 31→29, `m3` 51→53, `tanksize` 6296→6258 |

Certificate invariant swept over the fixed arm: **59 `bound <= objective` checks
executed, 0 violations** (the check prints its executed count and fails at zero,
per CLAUDE.md §6). No bound rose above its instance's objective; no incumbent
changed.

A first, broader attempt gated the tree's `trusted` flag (routing) on the
sentinel as well. That was **measured to lose `m3` its certificate** (bound
37.7999997 → none, cert True → False, reproduced deterministically in panel
context on both arms via a 29-instance prefix harness, and *not* reproducible
standalone). Root cause: it flipped `bound_unresolved` on sentinelled nodes,
discarding the whole tree bound where the orchestrator deliberately keeps it
(DECOMP-1 "instead of discarding the entire tree bound"). Narrowing the fix to
`bound_trusted` restores `m3` to `bound=37.799999670024405, cert=True`. The
falsification is recorded in the test's assertions so it cannot be re-widened
silently.

Note on panel noise (CLAUDE.md §9): a fixed-vs-fixed repeat of this panel
differs on 6 of 66 instances at `time_limit=15`, including a certification flip
on `clay0303hfsg`. Diffs at that magnitude are read as noise unless, like `m3`,
they reproduce under a controlled prefix.
