### PR TITLE
fix(duals): #1037 report multipliers of the declared model, not the presolved one

### DIFF
--- a/python/discopt/_dual_recovery.py
+++ b/python/discopt/_dual_recovery.py
@@ -1,0 +1,273 @@
+"""Active-set multiplier recovery (least squares), shared by the examiner and
+the solver's dual reporting.
+
+Given a point ``x``, a box, and the constraint rows, this builds the
+first-order stationarity system over the ACTIVE set
+
+    ∇f + Σ_act μ_i ∇g_i − λ_lb + λ_ub = 0,    μ ≥ 0 (inequalities), λ ≥ 0
+
+and solves it with :func:`scipy.optimize.lsq_linear` under those sign bounds.
+Integer columns are dropped: fixing the discrete variables and running
+continuous KKT is exactly what omitting their columns does (the GAMS Examiner
+"fix and re-check" convention).
+
+Why this lives in its own module rather than inside the examiner
+----------------------------------------------------------------
+Two callers need the same arithmetic, and they must not drift apart:
+
+* :mod:`discopt.validation.examiner` wraps it in ``CheckResult`` reporting;
+* :mod:`discopt.solver` uses it to report duals against the box the USER
+  DECLARED when presolve solved a tightened one (#1037). A bound the
+  tightening introduced is not a bound of the user's model, so a multiplier
+  sitting on it is not a multiplier of the user's model; the fit has to be
+  redone against the declared active set, and this is the fit that does it.
+
+The module is deliberately dependency-light (numpy + scipy only) so both the
+validation layer and the solver can import it without a cycle.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+import numpy as np
+from scipy.optimize import lsq_linear
+
+# Distance within which a point counts as sitting ON a bound / row. Matches
+# ``examiner.ACTIVE_TOL``; kept here so the solver does not have to import the
+# validation layer just to name a tolerance.
+ACTIVE_TOL = 1e-6
+
+
+def row_metadata(evaluator):
+    """``(sense_arr, rhs_arr, row_labels)`` for the evaluator's flat row order.
+
+    Vector-bodied constraints contribute ``sz`` rows that share the source
+    constraint's sense and rhs.
+    """
+    senses: list[str] = []
+    rhss: list[float] = []
+    labels: list[str] = []
+    for c, sz in zip(evaluator._source_constraints, evaluator._constraint_flat_sizes):
+        sz = int(sz)
+        senses.extend([c.sense] * sz)
+        rhss.extend([float(c.rhs)] * sz)
+        cname = getattr(c, "name", None) or repr(c.body)[:40]
+        if sz > 1:
+            labels.extend([f"{cname}[{i}]" for i in range(sz)])
+        else:
+            labels.append(str(cname))
+    return np.asarray(senses), np.asarray(rhss, dtype=float), labels
+
+
+@dataclass
+class DualRecovery:
+    """Outcome of an active-set multiplier fit.
+
+    ``ok`` is False only when ``lsq_linear`` itself raised; a large residual is
+    reported, not hidden, and is the caller's decision to act on (CLAUDE.md §7 —
+    an instrument must not swallow the thing it is measuring).
+    """
+
+    ok: bool
+    detail: str = ""
+    # Index arrays, all into the FLAT variable / row vectors.
+    cont_idx: np.ndarray = None  # type: ignore[assignment]
+    row_select: np.ndarray = None  # type: ignore[assignment]
+    lb_active: np.ndarray = None  # type: ignore[assignment]  # indices into cont_idx
+    ub_active: np.ndarray = None  # type: ignore[assignment]  # indices into cont_idx
+    # Fitted multipliers, in active-set order.
+    mu_act: np.ndarray = None  # type: ignore[assignment]
+    lam_lb_act: np.ndarray = None  # type: ignore[assignment]
+    lam_ub_act: np.ndarray = None  # type: ignore[assignment]
+    # Full-length vectors aligned with the evaluator's row order and the flat
+    # variable order; zero off the active set.
+    mu_full: Optional[np.ndarray] = None
+    lam_lb_full: Optional[np.ndarray] = None
+    lam_ub_full: Optional[np.ndarray] = None
+    # Stationarity residual of the fit, over continuous columns.
+    stat_resid: np.ndarray = None  # type: ignore[assignment]
+    residual_max: float = float("inf")
+    residual_norm: float = float("inf")
+    # True when the active set was empty, so the "fit" is just ‖∇f‖ at x.
+    empty_active_set: bool = False
+
+    @property
+    def n_active_cons(self) -> int:
+        return 0 if self.row_select is None else int(self.row_select.size)
+
+    @property
+    def n_active_bounds(self) -> int:
+        n_lb = 0 if self.lb_active is None else int(self.lb_active.size)
+        n_ub = 0 if self.ub_active is None else int(self.ub_active.size)
+        return n_lb + n_ub
+
+
+def recover_multipliers(
+    *,
+    grad: np.ndarray,
+    jac: np.ndarray,
+    body: np.ndarray,
+    sense_arr: np.ndarray,
+    rhs_arr: np.ndarray,
+    x_flat: np.ndarray,
+    lb: np.ndarray,
+    ub: np.ndarray,
+    is_continuous: np.ndarray,
+    active_tol: float = ACTIVE_TOL,
+) -> DualRecovery:
+    """Fit KKT multipliers at ``x_flat`` against the box ``(lb, ub)``.
+
+    ``lb``/``ub`` decide which bounds are active, and therefore which
+    multipliers are allowed to be nonzero — this is the whole reason the caller
+    gets to choose the box (#1037). Pass the DECLARED bounds to obtain duals of
+    the user's model; pass a tightened box and you get duals of the tightened
+    problem, which is a different problem.
+
+    ``jac`` rows follow ``body``/``sense_arr``/``rhs_arr``; the returned
+    ``mu_full`` uses the Lagrangian convention μ ≥ 0 for "<=", μ ≤ 0 for ">=".
+    """
+    cont_idx = np.where(is_continuous)[0]
+    if cont_idx.size == 0:
+        return DualRecovery(
+            ok=True,
+            detail="no continuous columns",
+            cont_idx=cont_idx,
+            row_select=np.zeros(0, dtype=int),
+            lb_active=np.zeros(0, dtype=int),
+            ub_active=np.zeros(0, dtype=int),
+            mu_act=np.zeros(0),
+            lam_lb_act=np.zeros(0),
+            lam_ub_act=np.zeros(0),
+            mu_full=np.zeros(jac.shape[0]) if jac.size else np.zeros(0),
+            lam_lb_full=np.zeros(x_flat.size),
+            lam_ub_full=np.zeros(x_flat.size),
+            stat_resid=np.zeros(0),
+            residual_max=0.0,
+            residual_norm=0.0,
+            empty_active_set=True,
+        )
+
+    grad_c = grad[cont_idx]
+    jac_c = jac[:, cont_idx] if jac.size else np.empty((0, cont_idx.size))
+    lb_c = lb[cont_idx]
+    ub_c = ub[cont_idx]
+    x_c = x_flat[cont_idx]
+
+    if body.size:
+        signed = body - rhs_arr
+        is_le = sense_arr == "<="
+        is_ge = sense_arr == ">="
+        is_eq = sense_arr == "=="
+        active_le = is_le & (np.abs(signed) <= active_tol)
+        active_ge = is_ge & (np.abs(signed) <= active_tol)
+        row_select = np.where(active_le | active_ge | is_eq)[0]
+    else:
+        row_select = np.zeros(0, dtype=int)
+
+    lb_active = np.where(np.isfinite(lb_c) & (x_c - lb_c <= active_tol))[0]
+    ub_active = np.where(np.isfinite(ub_c) & (ub_c - x_c <= active_tol))[0]
+
+    n_mu = int(row_select.size)
+    n_llb = int(lb_active.size)
+    n_lub = int(ub_active.size)
+
+    if n_mu + n_llb + n_lub == 0:
+        max_r = float(np.max(np.abs(grad_c))) if grad_c.size else 0.0
+        return DualRecovery(
+            ok=True,
+            detail="no active set; ‖∇f‖∞ at returned x",
+            cont_idx=cont_idx,
+            row_select=row_select,
+            lb_active=lb_active,
+            ub_active=ub_active,
+            mu_act=np.zeros(0),
+            lam_lb_act=np.zeros(0),
+            lam_ub_act=np.zeros(0),
+            mu_full=np.zeros(jac.shape[0]) if jac.size else np.zeros(0),
+            lam_lb_full=np.zeros(x_flat.size),
+            lam_ub_full=np.zeros(x_flat.size),
+            stat_resid=grad_c,
+            residual_max=max_r,
+            residual_norm=float(np.linalg.norm(grad_c)),
+            empty_active_set=True,
+        )
+
+    cols = []
+    var_lb_y: list[float] = []
+    var_ub_y: list[float] = []
+    if n_mu:
+        sub_sense = sense_arr[row_select]
+        sub_jac = jac_c[row_select, :].copy()
+        flip = sub_sense == ">="
+        sub_jac[flip, :] *= -1.0
+        cols.append(sub_jac.T)
+        for s in sub_sense:
+            var_lb_y.append(-np.inf if s == "==" else 0.0)
+            var_ub_y.append(np.inf)
+    if n_llb:
+        I_lb = np.zeros((cont_idx.size, n_llb))
+        for k, j in enumerate(lb_active):
+            I_lb[j, k] = -1.0
+        cols.append(I_lb)
+        var_lb_y.extend([0.0] * n_llb)
+        var_ub_y.extend([np.inf] * n_llb)
+    if n_lub:
+        I_ub = np.zeros((cont_idx.size, n_lub))
+        for k, j in enumerate(ub_active):
+            I_ub[j, k] = 1.0
+        cols.append(I_ub)
+        var_lb_y.extend([0.0] * n_lub)
+        var_ub_y.extend([np.inf] * n_lub)
+
+    A = np.concatenate(cols, axis=1) if cols else np.zeros((cont_idx.size, 0))
+    b = -grad_c
+
+    try:
+        y = lsq_linear(A, b, bounds=(np.asarray(var_lb_y), np.asarray(var_ub_y))).x
+    except Exception as e:  # pragma: no cover - scipy failure path
+        return DualRecovery(
+            ok=False,
+            detail=f"dual recovery failed: {e}",
+            cont_idx=cont_idx,
+            row_select=row_select,
+            lb_active=lb_active,
+            ub_active=ub_active,
+            stat_resid=np.zeros(0),
+        )
+
+    stat_resid = A @ y - b
+    mu_act = y[:n_mu] if n_mu else np.zeros(0)
+    lam_lb_act = y[n_mu : n_mu + n_llb] if n_llb else np.zeros(0)
+    lam_ub_act = y[n_mu + n_llb :] if n_lub else np.zeros(0)
+
+    mu_full = np.zeros(jac.shape[0]) if jac.size else np.zeros(0)
+    if n_mu:
+        # mu_act is in "flipped to ≤ form"; un-flip ">=" rows back to original sign.
+        mu_signed = mu_act.copy()
+        mu_signed[sense_arr[row_select] == ">="] *= -1.0
+        mu_full[row_select] = mu_signed
+    lam_lb_full = np.zeros(x_flat.size)
+    lam_ub_full = np.zeros(x_flat.size)
+    for k, j in enumerate(lb_active):
+        lam_lb_full[cont_idx[j]] = lam_lb_act[k]
+    for k, j in enumerate(ub_active):
+        lam_ub_full[cont_idx[j]] = lam_ub_act[k]
+
+    return DualRecovery(
+        ok=True,
+        cont_idx=cont_idx,
+        row_select=row_select,
+        lb_active=lb_active,
+        ub_active=ub_active,
+        mu_act=mu_act,
+        lam_lb_act=lam_lb_act,
+        lam_ub_act=lam_ub_act,
+        mu_full=mu_full,
+        lam_lb_full=lam_lb_full,
+        lam_ub_full=lam_ub_full,
+        stat_resid=stat_resid,
+        residual_max=float(np.max(np.abs(stat_resid))) if stat_resid.size else 0.0,
+        residual_norm=float(np.linalg.norm(stat_resid)),
+    )

--- a/python/discopt/_dual_recovery.py
+++ b/python/discopt/_dual_recovery.py
@@ -160,9 +160,21 @@ def recover_multipliers(
         is_le = sense_arr == "<="
         is_ge = sense_arr == ">="
         is_eq = sense_arr == "=="
-        active_le = is_le & (np.abs(signed) <= active_tol)
-        active_ge = is_ge & (np.abs(signed) <= active_tol)
-        row_select = np.where(active_le | active_ge | is_eq)[0]
+        # Row activity is judged RELATIVE to the row's own scale, using the same
+        # row_scale the examiner uses for scaled primal feasibility:
+        # max(1, |rhs|, max|J_row| * max(1, |x|)). An absolute test measures the
+        # row in whatever units it happens to be written in, so multiplying a
+        # constraint through by 1000 -- which changes nothing about the problem
+        # -- makes a binding row read as inactive: the NLP's own convergence
+        # slack is scaled up with it. That empties the active set and the
+        # multiplier of a genuinely binding row is lost.
+        if jac.size:
+            jac_scale = np.max(np.abs(jac) * np.maximum(1.0, np.abs(x_flat))[None, :], axis=1)
+        else:
+            jac_scale = np.zeros(body.size)
+        row_scale = np.maximum(np.maximum(np.abs(rhs_arr), jac_scale), 1.0)
+        near = np.abs(signed) <= active_tol * row_scale
+        row_select = np.where((is_le & near) | (is_ge & near) | is_eq)[0]
     else:
         row_select = np.zeros(0, dtype=int)
 

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -3952,6 +3952,206 @@ def _unpack_bound_duals(
     return out
 
 
+# Stationarity residual a declared-box refit must meet before its multipliers
+# are reported: the declared ``abs=1e-6``, with a relative forgiveness on the
+# gradient scale so a large-coefficient model is not refused for being large.
+_DECLARED_DUAL_STAT_TOL = 1e-6
+# Complementary-slackness budget for the reported multipliers, judged against
+# the box the model declares. Matches ``examiner.PRIMAL_CS_TOL`` — the check
+# that exposed #1037 — so the solver holds itself to what the examiner asserts.
+_DECLARED_DUAL_CS_TOL = 1e-7
+
+
+def _duals_against_declared_box(
+    *,
+    model: Model,
+    evaluator,
+    x_flat: np.ndarray,
+    declared_lb: np.ndarray,
+    declared_ub: np.ndarray,
+    solved_lb: np.ndarray,
+    solved_ub: np.ndarray,
+    constraint_duals: Optional[dict[str, np.ndarray]],
+    bound_duals_lower: Optional[dict[str, np.ndarray]],
+    bound_duals_upper: Optional[dict[str, np.ndarray]],
+    active_tol: float = 1e-6,
+) -> tuple[
+    Optional[dict[str, np.ndarray]],
+    Optional[dict[str, np.ndarray]],
+    Optional[dict[str, np.ndarray]],
+]:
+    """Report duals of the model the USER DECLARED, not of the presolved one (#1037).
+
+    The backends solve a box that presolve (FBBT / nonlinear tightening) may have
+    shrunk. When a *derived* bound is active at the returned point, the backend
+    hangs a bound multiplier on it — but that bound is not a constraint of the
+    user's model, so neither is its multiplier. The reported duals then satisfy
+    KKT for the tightened problem and violate it for the declared one:
+
+        min −x  s.t.  x²+y² ≤ 1,  x,y ∈ [−2,2]
+
+    FBBT derives x ∈ [−1,1]; the optimum x=1 sits on the derived bound, the split
+    ``2μ + z_U = 1`` is degenerate, and the backend returned μ=0.204, z_U=0.592.
+    On the declared box the answer is unique — x=1 is strictly interior to [−2,2],
+    so complementary slackness forces z_U=0 and hence μ=0.5. The error is not a
+    perturbation: which of the infinitely many degenerate splits comes back is
+    arbitrary, so μ can be off by any factor.
+
+    So: when the reported multipliers are not admissible for the declared model,
+    refit them against the DECLARED active set — the same routine the examiner
+    has been validating on exactly this question. When they are admissible they
+    are returned untouched, which is the common case and costs one O(n) pass.
+
+    The trigger is the defect itself, not its cause: a multiplier is admissible
+    for the declared model only if it satisfies complementary slackness against
+    the DECLARED bounds, ``|λ_j| · |x_j − bound_j| ≤ cs_tol``. That one test
+    catches every way a multiplier can end up on something the user did not
+    declare, and it is exactly the examiner check that exposed this issue. Two
+    causes are known to trip it:
+
+    * a presolve-derived bound, as above;
+    * the ±1e20 *infinity sentinel* standing in for "no bound at all". A
+      variable declared unbounded has no bound to price, so its multiplier is
+      exactly zero; the interior-point backends return residue there (measured:
+      λ=3.8e-05 on ``nlp_cvx_102_010``), and against a 1e20 "bound" that residue
+      is a CS violation of 3.8e+15. No sentinel special-case is needed — a point
+      1e20 away from a bound is not at it, so the refit's active set already
+      excludes it and the refitted multiplier is 0.
+
+    Refuses rather than guesses (CLAUDE.md §3): if the refit cannot meet
+    stationarity at the declared active set, all three families come back
+    ``None`` with a warning naming the variable. A dual that does not satisfy
+    the user's own KKT system is worse than no dual, because nothing downstream
+    can tell it is wrong.
+    """
+    if bound_duals_lower is None and bound_duals_upper is None:
+        # With no bound multipliers there is nothing that can sit on a bound the
+        # user did not declare, and the row duals alone cannot violate CS here.
+        return constraint_duals, bound_duals_lower, bound_duals_upper
+
+    declared_lb = np.asarray(declared_lb, dtype=float)
+    declared_ub = np.asarray(declared_ub, dtype=float)
+    x_flat = np.asarray(x_flat, dtype=float)
+    n = x_flat.size
+    if not (declared_lb.size == declared_ub.size == n):  # pragma: no cover - layout mismatch
+        return constraint_duals, bound_duals_lower, bound_duals_upper
+
+    is_int = np.zeros(n, dtype=bool)
+    offset = 0
+    for v in model._variables:
+        sz = int(v.size)
+        if v.var_type in (VarType.BINARY, VarType.INTEGER):
+            is_int[offset : offset + sz] = True
+        offset += sz
+    if offset != n:  # pragma: no cover - layout mismatch
+        return constraint_duals, bound_duals_lower, bound_duals_upper
+    is_continuous = ~is_int
+
+    def _flat(named):
+        if named is None:
+            return np.zeros(n)
+        parts = []
+        for v in model._variables:
+            if v.name not in named:
+                return None
+            arr = np.asarray(named[v.name], dtype=float).reshape(-1)
+            if arr.size != int(v.size):
+                return None
+            parts.append(arr)
+        return np.concatenate(parts) if parts else np.zeros(0)
+
+    lam_lb = _flat(bound_duals_lower)
+    lam_ub = _flat(bound_duals_upper)
+    if lam_lb is None or lam_ub is None or lam_lb.size != n or lam_ub.size != n:
+        # Cannot line the multipliers up with the variables, so cannot judge
+        # them; leave the caller's values alone rather than guess.
+        return constraint_duals, bound_duals_lower, bound_duals_upper
+
+    # Integer columns are excluded: their bound multipliers price the *fixing*
+    # of the integer, not bound activity in the declared model, and the callers
+    # already zero them (the examiner likewise drops them from stationarity).
+    cs_lb = np.where(is_continuous, np.abs(lam_lb) * np.abs(x_flat - declared_lb), 0.0)
+    cs_ub = np.where(is_continuous, np.abs(lam_ub) * np.abs(declared_ub - x_flat), 0.0)
+    bad_lb = cs_lb > _DECLARED_DUAL_CS_TOL
+    bad_ub = cs_ub > _DECLARED_DUAL_CS_TOL
+    if not (bad_lb.any() or bad_ub.any()):
+        return constraint_duals, bound_duals_lower, bound_duals_upper
+
+    from discopt._dual_recovery import recover_multipliers, row_metadata
+
+    sense_arr, rhs_arr, _labels = row_metadata(evaluator)
+    body = evaluator.evaluate_constraints(x_flat) if sense_arr.size else np.empty(0, dtype=float)
+    jac = evaluator.evaluate_jacobian(x_flat) if sense_arr.size else np.empty((0, n), dtype=float)
+    grad = evaluator.evaluate_gradient(x_flat)
+
+    rec = recover_multipliers(
+        grad=grad,
+        jac=jac,
+        body=np.asarray(body, dtype=float),
+        sense_arr=sense_arr,
+        rhs_arr=rhs_arr,
+        x_flat=x_flat,
+        lb=declared_lb,
+        ub=declared_ub,
+        is_continuous=is_continuous,
+        active_tol=active_tol,
+    )
+
+    # Name the offenders, and say whether presolve is the cause — that is the
+    # difference between "your bound was derived" and "you never had a bound".
+    flat_names: list[str] = []
+    for v in model._variables:
+        sz = int(v.size)
+        flat_names.extend([f"{v.name}[{i}]" if sz > 1 else v.name for i in range(sz)])
+    solved_lb = np.asarray(solved_lb, dtype=float)
+    solved_ub = np.asarray(solved_ub, dtype=float)
+    _has_solved_box = solved_lb.size == n and solved_ub.size == n
+
+    def _why(j: int, is_lower: bool) -> str:
+        declared = declared_lb[j] if is_lower else declared_ub[j]
+        cs = cs_lb[j] if is_lower else cs_ub[j]
+        cause = ""
+        if _has_solved_box:
+            derived = solved_lb[j] if is_lower else solved_ub[j]
+            if derived != declared:
+                cause = f", presolve derived {derived:.6g}"
+        return (
+            f"{flat_names[j]}.{'lb' if is_lower else 'ub'}"
+            f"(declared {declared:.6g}{cause}, CS {cs:.3e})"
+        )
+
+    names = [_why(int(j), True) for j in np.nonzero(bad_lb)[0]]
+    names += [_why(int(j), False) for j in np.nonzero(bad_ub)[0]]
+    where = ", ".join(names[:5]) + (" …" if len(names) > 5 else "")
+
+    tol = _DECLARED_DUAL_STAT_TOL * (1.0 + (float(np.max(np.abs(grad))) if grad.size else 0.0))
+    if not rec.ok or rec.residual_max > tol:
+        logger.warning(
+            "Duals withheld (#1037): the backend's multipliers violate complementary "
+            "slackness against the box your model declares at %s, so they are duals "
+            "of a different problem. Refitting against the declared active set did "
+            "not reach stationarity (residual %.3e > %.3e%s), so no duals are "
+            "reported rather than wrong ones.",
+            where,
+            rec.residual_max,
+            tol,
+            "" if rec.ok else f"; {rec.detail}",
+        )
+        return None, None, None
+
+    logger.info(
+        "Duals refitted against the declared box (#1037): the backend's multipliers "
+        "violated complementary slackness at %s; refit stationarity residual %.3e.",
+        where,
+        rec.residual_max,
+    )
+    return (
+        _unpack_constraint_duals(evaluator, rec.mu_full),
+        _unpack_bound_duals(model, rec.lam_lb_full),
+        _unpack_bound_duals(model, rec.lam_ub_full),
+    )
+
+
 def _strong_branch_lp(
     evaluator,
     solution: np.ndarray,
@@ -14034,6 +14234,25 @@ def _solve_continuous(
     bound_duals_lower = _unpack_bound_duals(model, nlp_result.bound_multipliers_lower)
     bound_duals_upper = _unpack_bound_duals(model, nlp_result.bound_multipliers_upper)
 
+    # #1037: the NLP above ran on ``lb``/``ub``, which the nonlinear tightening
+    # may have shrunk below what the model declares (``raw_lb``/``raw_ub``). A
+    # multiplier on a bound that only the tightening created is not a multiplier
+    # of the user's model; refit against the declared box when that happened.
+    # No-op when it did not, which is the usual case.
+    if nlp_result.x is not None:
+        constraint_duals, bound_duals_lower, bound_duals_upper = _duals_against_declared_box(
+            model=model,
+            evaluator=evaluator,
+            x_flat=np.asarray(nlp_result.x, dtype=float),
+            declared_lb=np.asarray(raw_lb, dtype=float),
+            declared_ub=np.asarray(raw_ub, dtype=float),
+            solved_lb=lb,
+            solved_ub=ub,
+            constraint_duals=constraint_duals,
+            bound_duals_lower=bound_duals_lower,
+            bound_duals_upper=bound_duals_upper,
+        )
+
     _gap_certified = True
 
     # Convex single-NLP certificate gate (issue #849). On the convexity-CERTIFIED
@@ -15403,6 +15622,29 @@ def _solve_nlp_bb(
                                 bound_duals_lower[v.name] = np.zeros_like(bound_duals_lower[v.name])
                             if bound_duals_upper is not None and v.name in bound_duals_upper:
                                 bound_duals_upper[v.name] = np.zeros_like(bound_duals_upper[v.name])
+
+                # #1037: the recover solve ran on the FBBT-tightened ``lb``/``ub``
+                # (with integers fixed). A multiplier sitting on a bound that only
+                # FBBT created is not a multiplier of the declared model, so refit
+                # against ``_declared_box`` when that happened. Integer columns are
+                # excluded by the helper, so the fixing above is not mistaken for a
+                # spurious tightening. No-op when presolve changed nothing.
+                (
+                    constraint_duals,
+                    bound_duals_lower,
+                    bound_duals_upper,
+                ) = _duals_against_declared_box(
+                    model=model,
+                    evaluator=evaluator,
+                    x_flat=sol_flat,
+                    declared_lb=_declared_box[:, 0],
+                    declared_ub=_declared_box[:, 1],
+                    solved_lb=lb,
+                    solved_ub=ub,
+                    constraint_duals=constraint_duals,
+                    bound_duals_lower=bound_duals_lower,
+                    bound_duals_upper=bound_duals_upper,
+                )
 
                 # The refined primal was already adopted above, from the
                 # incumbent-options solve, and this recover ran *at* that point —

--- a/python/discopt/validation/examiner.py
+++ b/python/discopt/validation/examiner.py
@@ -23,8 +23,8 @@ from dataclasses import dataclass, field
 from typing import Optional
 
 import numpy as np
-from scipy.optimize import lsq_linear
 
+from discopt._dual_recovery import recover_multipliers, row_metadata
 from discopt.modeling.core import Model, ObjectiveSense, VarType
 
 PRIMAL_FEAS_TOL = 1e-6
@@ -379,19 +379,8 @@ def assert_examined(result, model: Model, name: str, **kwargs) -> None:
 
 
 def _row_metadata(evaluator):
-    senses: list[str] = []
-    rhss: list[float] = []
-    labels: list[str] = []
-    for c, sz in zip(evaluator._source_constraints, evaluator._constraint_flat_sizes):
-        sz = int(sz)
-        senses.extend([c.sense] * sz)
-        rhss.extend([float(c.rhs)] * sz)
-        cname = getattr(c, "name", None) or repr(c.body)[:40]
-        if sz > 1:
-            labels.extend([f"{cname}[{i}]" for i in range(sz)])
-        else:
-            labels.append(str(cname))
-    return np.asarray(senses), np.asarray(rhss, dtype=float), labels
+    # Shared with the solver's declared-box dual reporting (#1037).
+    return row_metadata(evaluator)
 
 
 def _flatten_solver_duals(result, model: Model, evaluator):
@@ -778,37 +767,39 @@ def _recover_and_check_kkt(
             "residual": 0.0,
         }
 
-    grad_c = grad[cont_idx]
-    jac_c = jac[:, cont_idx] if jac.size else np.empty((0, cont_idx.size))
     lb_c = lb[cont_idx]
     ub_c = ub[cont_idx]
     x_c = x_flat[cont_idx]
     cont_names = [var_names[i] for i in cont_idx]
 
-    if body.size:
-        signed = body - rhs_arr
-        is_le = sense_arr == "<="
-        is_ge = sense_arr == ">="
-        is_eq = sense_arr == "=="
-        active_le = is_le & (np.abs(signed) <= active_tol)
-        active_ge = is_ge & (np.abs(signed) <= active_tol)
-        active_rows = active_le | active_ge | is_eq
-        row_select = np.where(active_rows)[0]
-    else:
-        row_select = np.zeros(0, dtype=int)
-
-    lb_active = np.where(np.isfinite(lb_c) & (x_c - lb_c <= active_tol))[0]
-    ub_active = np.where(np.isfinite(ub_c) & (ub_c - x_c <= active_tol))[0]
-
+    # The fit itself lives in :mod:`discopt._dual_recovery`; this function is the
+    # reporting wrapper around it. The solver calls the same routine to report
+    # duals against the box the user DECLARED when presolve solved a tightened
+    # one (#1037) — one implementation, so the two cannot drift apart.
+    rec = recover_multipliers(
+        grad=grad,
+        jac=jac,
+        body=body,
+        sense_arr=sense_arr,
+        rhs_arr=rhs_arr,
+        x_flat=x_flat,
+        lb=lb,
+        ub=ub,
+        is_continuous=is_continuous,
+        active_tol=active_tol,
+    )
+    row_select = rec.row_select
+    lb_active = rec.lb_active
+    ub_active = rec.ub_active
     n_mu = row_select.size
     n_llb = lb_active.size
     n_lub = ub_active.size
     n_unknowns = n_mu + n_llb + n_lub
 
     if n_unknowns == 0:
-        residual = grad_c
-        max_r = float(np.max(np.abs(residual))) if residual.size else 0.0
-        norm_r = float(np.linalg.norm(residual))
+        max_r = rec.residual_max
+        norm_r = rec.residual_norm
+        residual = rec.stat_resid
         worst = int(np.argmax(np.abs(residual))) if residual.size else 0
         return {
             "checks": [
@@ -831,41 +822,8 @@ def _recover_and_check_kkt(
             "recovered_lam_ub_full": np.zeros(x_flat.size),
         }
 
-    cols = []
-    var_lb_y: list[float] = []
-    var_ub_y: list[float] = []
-    if n_mu:
-        sub_sense = sense_arr[row_select]
-        sub_jac = jac_c[row_select, :].copy()
-        flip = sub_sense == ">="
-        sub_jac[flip, :] *= -1.0
-        cols.append(sub_jac.T)
-        for s in sub_sense:
-            var_lb_y.append(-np.inf if s == "==" else 0.0)
-            var_ub_y.append(np.inf)
-    if n_llb:
-        I_lb = np.zeros((cont_idx.size, n_llb))
-        for k, j in enumerate(lb_active):
-            I_lb[j, k] = -1.0
-        cols.append(I_lb)
-        var_lb_y.extend([0.0] * n_llb)
-        var_ub_y.extend([np.inf] * n_llb)
-    if n_lub:
-        I_ub = np.zeros((cont_idx.size, n_lub))
-        for k, j in enumerate(ub_active):
-            I_ub[j, k] = 1.0
-        cols.append(I_ub)
-        var_lb_y.extend([0.0] * n_lub)
-        var_ub_y.extend([np.inf] * n_lub)
-
-    A = np.concatenate(cols, axis=1) if cols else np.zeros((cont_idx.size, 0))
-    b = -grad_c
-
-    try:
-        sol = lsq_linear(A, b, bounds=(np.asarray(var_lb_y), np.asarray(var_ub_y)))
-        y = sol.x
-    except Exception as e:
-        msg = f"dual recovery failed: {e}"
+    if not rec.ok:
+        msg = rec.detail
         return {
             "checks": [
                 CheckResult(
@@ -896,9 +854,9 @@ def _recover_and_check_kkt(
             "recovered_lam_ub_full": None,
         }
 
-    stat_resid = A @ y - b
-    stat_max = float(np.max(np.abs(stat_resid))) if stat_resid.size else 0.0
-    stat_norm = float(np.linalg.norm(stat_resid))
+    stat_resid = rec.stat_resid
+    stat_max = rec.residual_max
+    stat_norm = rec.residual_norm
     worst_var = int(np.argmax(np.abs(stat_resid))) if stat_resid.size else 0
     stationarity = CheckResult(
         name=f"stationarity{suffix}",
@@ -913,9 +871,9 @@ def _recover_and_check_kkt(
         ),
     )
 
-    mu = y[:n_mu] if n_mu else np.zeros(0)
-    lam_lb = y[n_mu : n_mu + n_llb] if n_llb else np.zeros(0)
-    lam_ub = y[n_mu + n_llb :] if n_lub else np.zeros(0)
+    mu = rec.mu_act
+    lam_lb = rec.lam_lb_act
+    lam_ub = rec.lam_ub_act
 
     cs_p = np.zeros(cont_idx.size)
     for k, j in enumerate(lb_active):
@@ -952,30 +910,16 @@ def _recover_and_check_kkt(
     else:
         dual_cs = CheckResult(name=f"dual_cs{suffix}", passed=True, tolerance=dual_cs_tol)
 
-    # Pack recovered duals into full-length vectors aligned with the
-    # evaluator's row order and the model's variable order, so the cross-check
-    # against solver-supplied duals can compare element-wise.
-    mu_full = np.zeros(jac.shape[0]) if jac.size else np.zeros(0)
-    if n_mu:
-        # mu_act is in "flipped to ≤ form"; un-flip ">=" rows back to original sign.
-        sub_sense = sense_arr[row_select]
-        mu_signed = mu.copy()
-        mu_signed[sub_sense == ">="] *= -1.0
-        mu_full[row_select] = mu_signed
-    lam_lb_full = np.zeros(x_flat.size)
-    lam_ub_full = np.zeros(x_flat.size)
-    for k, j in enumerate(lb_active):
-        lam_lb_full[cont_idx[j]] = lam_lb[k]
-    for k, j in enumerate(ub_active):
-        lam_ub_full[cont_idx[j]] = lam_ub[k]
-
+    # The full-length vectors (aligned with the evaluator's row order and the
+    # model's variable order, so the cross-check against solver-supplied duals
+    # can compare element-wise) are packed by the shared recovery routine.
     return {
         "checks": [stationarity, primal_cs, dual_cs],
         "n_active_cons": int(n_mu),
         "n_active_bounds": int(n_llb + n_lub),
         "recovered": True,
         "residual": stat_norm,
-        "recovered_mu_full": mu_full,
-        "recovered_lam_lb_full": lam_lb_full,
-        "recovered_lam_ub_full": lam_ub_full,
+        "recovered_mu_full": rec.mu_full,
+        "recovered_lam_lb_full": rec.lam_lb_full,
+        "recovered_lam_ub_full": rec.lam_ub_full,
     }

--- a/python/tests/test_solver_duals.py
+++ b/python/tests/test_solver_duals.py
@@ -17,6 +17,40 @@ def _scalar(name: str, vec: dict[str, np.ndarray]) -> float:
     return float(np.asarray(vec[name]).ravel()[0])
 
 
+def _assert_cs_against_declared_box(model, res, tol: float = 1e-7) -> int:
+    """Every reported bound multiplier must satisfy complementary slackness
+    against the bounds the MODEL DECLARES (#1037).
+
+    This is the general contract, not a per-instance expectation: a nonzero
+    multiplier on a bound the point is not sitting on prices a constraint the
+    user never wrote. Returns the number of products actually checked so the
+    caller can assert the probe fired (CLAUDE.md §6).
+    """
+    if res.bound_duals_lower is None and res.bound_duals_upper is None:
+        return 0
+    checked = 0
+    for v in model._variables:
+        if v.var_type in (dm.VarType.BINARY, dm.VarType.INTEGER):
+            continue  # integer bound duals price the fixing, not the box
+        xv = np.asarray(res.x[v.name], dtype=float).ravel()
+        for bnd, duals, tag in (
+            (v.lb, res.bound_duals_lower, "lb"),
+            (v.ub, res.bound_duals_upper, "ub"),
+        ):
+            if duals is None or bnd is None or v.name not in duals:
+                continue
+            lam = np.asarray(duals[v.name], dtype=float).ravel()
+            slack = np.abs(xv - float(bnd))
+            prod = np.abs(lam) * slack
+            worst = int(np.argmax(prod))
+            assert prod[worst] <= tol, (
+                f"CS violated on {v.name}[{worst}].{tag}: declared bound={float(bnd):.6g}, "
+                f"x={xv[worst]:.6g}, lambda={lam[worst]:.6e}, product={prod[worst]:.6e}"
+            )
+            checked += lam.size
+    return checked
+
+
 # ── LP fast path ────────────────────────────────────────────────────────
 
 
@@ -183,3 +217,114 @@ def test_validate_true_on_milp_attaches_report():
     primal = [c for c in rep.checks if c.name.startswith("primal_")]
     assert primal, "expected at least one primal check"
     assert all(c.passed for c in primal), rep.summary(verbose=True)
+
+
+# ── duals belong to the DECLARED model, not the presolved one (#1037) ────
+
+
+def _circle_model(scale: float = 1.0, radius: float = 1.0, box: float = 2.0):
+    """min -x  s.t.  s*x^2 + s*y^2 <= s*r^2,  x,y in [-box, box].
+
+    Optimum x*=r, y*=0. Stationarity -1 + mu*2*s*r = 0 gives mu = 1/(2*s*r),
+    independent of the box. When box > r, presolve derives x in [-r, r] and the
+    derived bound is active at x*, making the split between the row multiplier
+    and the bound multiplier degenerate on the TIGHTENED box — but uniquely
+    determined on the declared one, where x* is strictly interior.
+
+    The scale is DISTRIBUTED over the terms on purpose. Writing the row as
+    ``s*(x**2 + y**2) <= s*r**2`` puts a multiply above the sum, FBBT cannot
+    derive x in [-r, r] through it, no tightening happens and the defect does
+    not arise — a model shaped that way is silently not a test of #1037.
+    """
+    m = dm.Model(f"circle_s{scale}_r{radius}_b{box}")
+    x = m.continuous("x", lb=-box, ub=box)
+    y = m.continuous("y", lb=-box, ub=box)
+    m.minimize(-x)
+    m.subject_to(scale * x**2 + scale * y**2 <= scale * radius**2, name="ball")
+    return m
+
+
+def test_derived_bound_does_not_steal_the_row_multiplier():
+    """The #1037 reproduction verbatim: mu must be 0.5, not the degenerate
+    split the backend returns against the presolve-tightened box."""
+    m = _circle_model()
+    res = m.solve()
+
+    assert res.status == "optimal"
+    assert _scalar("x", res.x) == pytest.approx(1.0, abs=1e-6)
+    assert res.constraint_duals is not None, "duals were withheld, not refitted"
+
+    assert _scalar("ball", res.constraint_duals) == pytest.approx(0.5, abs=1e-6)
+    # x* = 1 is strictly interior to the DECLARED box [-2, 2], so CS forces the
+    # upper-bound multiplier to zero. Before the fix this carried 5.92e-01; the
+    # tolerance is the examiner's CS budget, not the refit's noise floor (~1e-9).
+    assert _scalar("x", res.bound_duals_upper) == pytest.approx(0.0, abs=1e-7)
+    assert _assert_cs_against_declared_box(m, res) > 0
+
+
+@pytest.mark.parametrize("scale", [1e-3, 0.1, 1.0, 10.0, 1000.0, 1e5])
+def test_declared_box_duals_hold_across_row_scaling(scale):
+    """Same defect at every row scale — mu = 1/(2*scale). Fixing the class,
+    not the instance: the split the backend picks is arbitrary, and pre-fix it
+    varied with scale (mu/mu_true measured at 0.408 and 0.431 for scale 1 and
+    10). Multiplying a row through by a constant changes nothing about the
+    problem, so nothing about the duals may depend on it."""
+    m = _circle_model(scale=scale)
+    res = m.solve()
+
+    assert res.status == "optimal"
+    assert res.constraint_duals is not None, "duals were withheld, not refitted"
+    expected = 1.0 / (2.0 * scale)
+    mu = _scalar("ball", res.constraint_duals)
+    assert mu == pytest.approx(expected, rel=1e-5)
+    assert _assert_cs_against_declared_box(m, res) > 0
+
+
+def test_genuinely_active_declared_bound_keeps_its_multiplier():
+    """Control: the refit must not destroy a real bound multiplier. With
+    r = 10 the ball is slack at x* = 2 and the DECLARED upper bound is what
+    binds, so -1 + z_U = 0 → z_U = 1."""
+    m = _circle_model(radius=10.0, box=2.0)
+    res = m.solve()
+
+    assert res.status == "optimal"
+    assert _scalar("x", res.x) == pytest.approx(2.0, abs=1e-6)
+    assert res.bound_duals_upper is not None
+    assert _scalar("x", res.bound_duals_upper) == pytest.approx(1.0, abs=1e-5)
+    assert _scalar("ball", res.constraint_duals) == pytest.approx(0.0, abs=1e-6)
+    assert _assert_cs_against_declared_box(m, res) > 0
+
+
+def test_unbounded_variable_carries_no_bound_multiplier():
+    """The second cause the issue did not name: the +/-1e20 sentinel standing
+    in for "no bound at all". A variable with no declared bound has no bound to
+    price, so any residue the backend leaves there is a CS violation of ~1e15.
+
+    A guard, not a regression test — this small model gets clean zeros on the
+    pre-fix code too. The residue is backend- and instance-dependent (measured
+    lam_ub = 3.84e-05 on nlp_cvx_102_010); the regression coverage for it is
+    test_minlptests.py, where that bucket went from failing to passing.
+    """
+    m = dm.Model("free_vars")
+    x = m.continuous("x")
+    y = m.continuous("y")
+    m.minimize((x - 3.0) ** 2 + (y + 1.0) ** 2)
+    m.subject_to(x + y >= 1.0, name="c1")
+
+    res = m.solve()
+    assert res.status == "optimal"
+    assert _scalar("x", res.x) == pytest.approx(3.0, abs=1e-5)
+    assert _scalar("y", res.x) == pytest.approx(-1.0, abs=1e-5)
+    assert _assert_cs_against_declared_box(m, res) > 0
+
+
+def test_examiner_accepts_the_reported_duals_on_the_declared_box():
+    """End-to-end: the examiner's primal_cs check on the solver's own duals is
+    what exposed #1037. It must now pass on the reproduction."""
+    m = _circle_model()
+    res = m.solve(validate=True)
+
+    rep = res.validation_report
+    assert rep is not None
+    assert rep.solver_duals_used, "the refit must feed the solver-duals branch"
+    assert rep.passed, rep.summary(verbose=True)


### PR DESCRIPTION
## The defect

`SolveResult.constraint_duals` / `bound_duals_*` were the duals of the box **presolve actually solved**, handed back against the model **the user wrote**. When a presolve-derived bound is active at the returned point, the backend hangs a multiplier on it — but that bound is not a constraint of the user's model, so neither is its multiplier.

```
min -x  s.t.  x^2 + y^2 <= 1,  x, y in [-2, 2]
```

FBBT derives `x in [-1,1]`; at `x*=1` the derived bound's gradient is parallel to the row's, so the split `2*mu + z_U = 1` is degenerate on the *tightened* box and the backend returned `mu=0.204, z_U=0.592`. On the **declared** box `x*=1` is strictly interior to `[-2,2]`, so complementary slackness forces `z_U=0` and `mu=0.5` **uniquely**. This is not a perturbation — which degenerate split comes back is arbitrary, and it varied with row scale (`mu/mu_true` measured at 0.408 and 0.431).

## The fix

**The trigger is the defect, not its cause.** A multiplier is admissible for the declared model only if it satisfies CS against the **declared** bounds, `|lam_j| * |x_j - bound_j| <= 1e-7` — the same `examiner.PRIMAL_CS_TOL` check that exposed this.

That generality earned its keep immediately: it catches a second cause the issue did not name — the **±1e20 infinity sentinel** standing in for "no bound at all". An unbounded variable has no bound to price, so its multiplier is exactly zero; the IPM backends leave residue there (measured `lam=3.8e-05` on `nlp_cvx_102_010`), and against a 1e20 "bound" that residue is a CS violation of 3.8e+15. A first attempt that triggered on a presolve-diff instead fixed only 10 of 79 tests; the CS trigger fixes 75. No sentinel special-case is needed — a point 1e20 away from a bound is not at it, so the refit's active set already excludes it.

When the reported multipliers are inadmissible they are **refitted** against the declared active set, at the already-reported point; when they are admissible they pass through untouched (one O(n) pass). A refit rather than a re-solve on the widened box, because re-solving a nonconvex problem can wander to a different point and leave the duals inconsistent with the reported primal.

If the refit cannot reach stationarity the duals are **withheld with a warning naming the variable and the bound**, rather than reported wrong (CLAUDE.md §3) — a dual that fails the user's own KKT system is worse than no dual, because nothing downstream can tell it is wrong.

The refit is the examiner's least-squares active-set recovery, which the issue established already computes the right answer on all 79 instances. Rather than duplicate it, it moved to `discopt/_dual_recovery.py` and both callers use it, so solver and examiner cannot drift apart. The examiner keeps its `CheckResult` reporting and is otherwise unchanged.

Wired into `_solve_continuous` (nonlinear tightening) and `_solve_nlp_bb` (root FBBT). Integer columns are excluded throughout: their bound multipliers price the fixing of the integer, not bound activity in the declared model.

### Second commit: row activity is now relative to row scale

Writing the regression tests exposed a real weakness in the recovery. The active-set test compared `|body - rhs|` against an **absolute** 1e-6, which measures a row in whatever units it happens to be written in. Multiplying a constraint through by 1000 changes nothing about the problem, but it scales the NLP's own convergence slack up with it, so a binding row read as inactive, the active set came out empty, and the refit could not reach stationarity (residual 1.0 = `|grad f|`) — duals of a genuinely binding row withheld. Row activity now uses the same `row_scale` the examiner already applies to scaled primal feasibility. Bound activity stays absolute on purpose (see the commit message).

## Verification

**Baseline measured both ways**, not assumed:

| | `test_minlptests.py` |
|---|---|
| `main` | **79 failed**, 46 passed |
| this branch | **4 failed**, 121 passed |
| new failures introduced | **0** |
| fixed | **75** |

The entire `primal_cs (solver duals)` bucket — the #1037 signature — is gone. The panel is **unchanged by the row-scale commit** (4 failed / 121 passed, 0 new), which matters because that code is shared with the examiner.

The 4 that remain — `nlp_001_010`, `nlp_008_010`, `nlp_008_011`, `nlp_mi_006_010` — are all in the baseline's 79, i.e. **pre-existing**, and are a different defect: all report `solver_duals_used=False` and fail the examiner's *own* `stationarity (recovered)` check by 1.3e-06..2.0e-04, at a point the NLP did not converge tightly enough on (POUNCE logged "refusing a termination certificate masked by an extreme objective scale" on these). That is primal convergence accuracy, not dual reporting; a follow-up issue will track it.

Also run:

- `python/tests/test_solver_duals.py` + `test_examiner.py` — **34 passed**
- `pytest -m smoke` — **1028 passed**, 1 skipped, 2 xpassed
- `pytest -m slow python/tests/test_adversarial_recent_fixes.py` — **19 passed**
- No Rust touched, so `cargo test -p discopt-core` was not required.

### Regression tests

18 tests in `python/tests/test_solver_duals.py`, of which **7 fail on the pre-fix tree and pass on this one** (verified by restoring `main`'s files in place and asserting the fix marker absent, per CLAUDE.md §8):

- the issue's reproduction verbatim — `mu == 0.5`, `lambda_ub[x] == 0`;
- the same model swept over **six row scales**, asserting `mu == 1/(2*scale)`;
- an examiner end-to-end assertion that the reported duals pass the `primal_cs` check that exposed the issue;
- `_assert_cs_against_declared_box` — the general contract rather than a per-instance expectation, applied in every case and returning a count so the caller can assert it actually checked something;
- two **controls** that must pass before *and* after: a genuinely active declared bound keeps its multiplier (`x*=2`, `z_U=1` — the refit does not destroy real bound multipliers), and an unbounded variable carries none.

One note worth keeping: the first draft of the scaled family wrote the row as `s*(x**2 + y**2) <= s*r**2` and **passed on the pre-fix tree**. Grouped that way the multiply sits above the sum, FBBT cannot derive `x in [-r, r]` through it, no tightening happens and the defect never arises — the test was silently not a test of #1037. The scale is now distributed over the terms, and the reason is recorded in the builder's docstring so it is not reintroduced.

Closes #1037

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017PQaiDVuY5Rs3tga98tnNo
