### PR TITLE
fix(gdp): #1043 make the hull perspective exact at both integer faces

### DIFF
--- a/docs/references.bib
+++ b/docs/references.bib
@@ -657,6 +657,17 @@
   doi       = {10.1016/S0098-1354(00)00581-0},
 }
 
+@article{Furman2020,
+  author    = {Furman, Kevin C. and Sawaya, Nicolas W. and Grossmann, Ignacio E.},
+  title     = {A computationally useful algebraic representation of nonlinear disjunctive convex sets using the perspective function},
+  journal   = {Computational Optimization and Applications},
+  volume    = {76},
+  number    = {2},
+  pages     = {589--614},
+  year      = {2020},
+  doi       = {10.1007/s10589-020-00176-0},
+}
+
 @article{Raman1994,
   author    = {Raman, Ramesh and Grossmann, Ignacio E.},
   title     = {Modelling and computational techniques for logic based integer programming},

--- a/python/discopt/_relax/gdp_reformulate.py
+++ b/python/discopt/_relax/gdp_reformulate.py
@@ -11,6 +11,7 @@ original model is returned unchanged (zero overhead).
 from __future__ import annotations
 
 import logging
+from collections.abc import Callable
 
 import numpy as np
 
@@ -1077,24 +1078,46 @@ def _reformulate_disjunction_hull(
                 )
                 rhs_expr = _wrap(con.rhs) * y_k
             else:
-                # Nonlinear: perspective form with clamped y_k
-                # f(v_k / y_clamp) * y_clamp where y_clamp = y_k + eps.
+                # Nonlinear: the Furman-Sawaya-Grossmann eps-perspective
+                # (Furman2020 in docs/references.bib), for g(x) = body - rhs <= 0:
                 #
-                # The eps clamp avoids division by zero at y_k = 0 but makes the
-                # perspective only an O(eps) approximation at the integer faces:
-                # at y_k = 0 the disaggregated vars are pinned to 0 by the
-                # bound-linking constraints, yet the body evaluates to
-                # f(0) * eps != 0 instead of exactly 0. The constraints are kept
-                # exact here (so KKT verification sees them tight at the optimum);
-                # the eps-scale residual is absorbed downstream by the feasibility
-                # tolerance in constraint-based bound tightening, which must not
-                # certify infeasibility from a violation below the solver's
-                # feasibility tolerance (issue #27a).
-                y_clamp = y_k + _wrap(eps)
+                #     yhat * g(v_k / yhat) - eps * g(0) * (1 - y_k) <= 0,
+                #     yhat = (1 - eps) * y_k + eps.
+                #
+                # Both pieces are load-bearing, and the previous form
+                # (``yhat = y_k + eps`` with no g(0) term) had NEITHER, so it was
+                # exact at NEITHER integer face:
+                #
+                #   y_k = 0: the disaggregated vars are pinned to 0 by the bound
+                #     linking rows, so the body evaluates to eps * g(0), not 0.
+                #     Whenever g(0) != 0 that is a HARD violation of a row the
+                #     model states as an equality -- the "off" disjunct can never
+                #     actually be off. The -eps*g(0)*(1-y_k) term cancels it
+                #     exactly.
+                #   y_k = 1: yhat was 1 + eps, so the row read
+                #     g(v/(1+eps)) * (1+eps) -- an O(eps) DISTORTION of the
+                #     selected disjunct's own constraint. Scaling eps into the
+                #     y_k coefficient makes yhat exactly 1 there.
+                #
+                # #1043: this is not a tolerance nicety. The residuals make the
+                # reformulated model infeasible in exact arithmetic, and the
+                # rigorous machinery downstream (FBBT / the McCormick LP, which
+                # must be exact to be sound) then proves it empty and reports
+                # ``infeasible`` for a feasible model -- the worst-class error.
+                # Measured on ``max x s.t. if_else(x>=0, exp(x)-1, log(-x+3)) <= 1,
+                # x in [-10,10]``: at the true optimum x = log 2 the old rows are
+                # violated by 1.0986e-08 = eps*log(3) (the off disjunct) and
+                # 3.86e-09 (the on disjunct). Shrinking eps does not help --
+                # the model is still exactly infeasible at eps = 1e-14 -- which is
+                # why only cancelling the terms, not making them small, fixes it.
+                g0 = _body_at_zero(con.body, all_vars) - float(np.max(con.rhs))
+                y_clamp = _wrap(1.0 - eps) * y_k + _wrap(eps)
                 persp_map = {vname: disagg[k][vname] / y_clamp for vname in all_vars}
                 subst_body = _substitute_vars(con.body, persp_map)
                 hull_body = subst_body * y_clamp
-                rhs_expr = _wrap(con.rhs) * y_k
+                if g0 != 0.0:
+                    hull_body = hull_body - _wrap(eps * g0) * (_wrap(1.0) - y_k)
+                rhs_expr = _wrap(con.rhs) * y_clamp
 
             if con.sense == "<=":
                 new_cons.append(
@@ -1133,6 +1156,101 @@ def _reformulate_disjunction_hull(
                 )
 
     return new_vars, new_cons
+
+
+class HullPerspectiveOriginError(ValueError):
+    """``g(0)`` is not finite, so the hull perspective cannot be formed.
+
+    Raised by :func:`_body_at_zero`. See its docstring for why this is a refusal
+    rather than a fallback value.
+    """
+
+
+def _body_at_zero(expr: Expression, all_vars: dict[str, Variable]) -> float:
+    """Evaluate a disjunct constraint body with every disjunct variable at 0.
+
+    The Furman-Sawaya-Grossmann perspective needs ``g(0)`` to cancel the residual
+    the eps clamp leaves on a de-selected disjunct (#1043). ``g(0)`` is a property
+    of the *function*, not of the box: at ``y_k = 0`` the bound-linking rows pin
+    every disaggregated variable to exactly 0, so ``g(0)`` is the value the row
+    actually takes there, whether or not 0 lies inside the disjunct's own bounds.
+
+    Refuses loudly (CLAUDE.md §3) when the body is not finite at the origin --
+    ``log(0)``, ``1/0``, ``sqrt`` of a negative -- because there is no sound
+    numeric substitute. A fabricated finite ``g(0)`` would leave an uncancelled
+    eps-scale residual on the off disjunct, which is exactly the false-infeasible
+    class this function exists to close. The old formulation did not refuse: it
+    emitted ``f(0) * eps`` = NaN/-inf straight into the row.
+    """
+    _UN: dict[str, Callable[[float], float]] = {
+        "neg": lambda a: -a,
+        "-": lambda a: -a,
+        "abs": abs,
+        "exp": np.exp,
+        "log": np.log,
+        "sqrt": np.sqrt,
+        "sin": np.sin,
+        "cos": np.cos,
+        "tan": np.tan,
+        "tanh": np.tanh,
+    }
+    _BIN: dict[str, Callable[[float, float], float]] = {
+        "+": lambda a, b: a + b,
+        "-": lambda a, b: a - b,
+        "*": lambda a, b: a * b,
+        "/": lambda a, b: a / b,
+        "**": lambda a, b: a**b,
+        "^": lambda a, b: a**b,
+    }
+    _NARY: dict[str, Callable[..., float]] = {"max": max, "min": min}
+
+    def _walk(e: Expression) -> float:
+        if isinstance(e, Variable):
+            if e.name not in all_vars:
+                raise HullPerspectiveOriginError(
+                    f"variable {e.name!r} appears in a disjunct body but was not "
+                    "collected as a disjunct variable"
+                )
+            return 0.0
+        if isinstance(e, Constant):
+            return float(np.max(e.value))
+        if isinstance(e, IndexExpression):
+            return _walk(e.base)
+        if isinstance(e, UnaryOp):
+            if e.op not in _UN:
+                raise HullPerspectiveOriginError(f"unsupported unary op {e.op!r}")
+            return float(_UN[e.op](_walk(e.operand)))
+        if isinstance(e, BinaryOp):
+            if e.op not in _BIN:
+                raise HullPerspectiveOriginError(f"unsupported binary op {e.op!r}")
+            return float(_BIN[e.op](_walk(e.left), _walk(e.right)))
+        if isinstance(e, FunctionCall):
+            args = [_walk(a) for a in e.args]
+            if e.func_name in _NARY:
+                return float(_NARY[e.func_name](*args))
+            if e.func_name not in _UN or len(args) != 1:
+                raise HullPerspectiveOriginError(f"unsupported function {e.func_name!r}")
+            return float(_UN[e.func_name](args[0]))
+        raise HullPerspectiveOriginError(f"unsupported expression node {type(e).__name__}")
+
+    with np.errstate(all="raise"):
+        try:
+            val = _walk(expr)
+        except (FloatingPointError, ValueError, ZeroDivisionError, OverflowError) as exc:
+            if isinstance(exc, HullPerspectiveOriginError):
+                raise
+            raise HullPerspectiveOriginError(
+                f"the disjunct body is not finite at the origin ({exc}); the hull "
+                "perspective needs g(0) to cancel the eps residual on a de-selected "
+                "disjunct. Reformulate this disjunction with method='big-m'."
+            ) from exc
+    if not np.isfinite(val):
+        raise HullPerspectiveOriginError(
+            f"the disjunct body evaluates to {val} at the origin; the hull "
+            "perspective needs a finite g(0) to cancel the eps residual on a "
+            "de-selected disjunct. Reformulate this disjunction with method='big-m'."
+        )
+    return val
 
 
 def _hull_linear_substitute(

--- a/python/tests/test_issue1043_hull_perspective.py
+++ b/python/tests/test_issue1043_hull_perspective.py
@@ -1,0 +1,357 @@
+"""#1043(a): the hull perspective must be exact at both integer faces.
+
+The GDP ``hull`` reformulation writes each nonlinear disjunct row in perspective
+form.  The pre-#1043 form was ``g(v_k / (y_k + eps)) * (y_k + eps) <= rhs * y_k``,
+which is exact at *neither* integer face:
+
+* ``y_k = 0`` -- the bound-linking rows pin every disaggregated variable of a
+  de-selected disjunct to exactly 0, so the row body collapses to ``eps * g(0)``
+  rather than 0.  For an **equality** row with ``g(0) != 0`` that is a hard,
+  unsatisfiable violation: the reformulated model is empty in exact arithmetic,
+  and the rigorous FBBT / McCormick-LP machinery correctly proves it empty.  The
+  solver then returns ``infeasible`` for a model with a perfectly good optimum --
+  a false infeasible, the worst class of error under CLAUDE.md 1.
+* ``y_k = 1`` -- ``y_clamp`` was ``1 + eps``, so the selected disjunct's own row
+  read ``g(v / (1 + eps)) * (1 + eps)``, an O(eps) distortion of the constraint
+  the user actually wrote.
+
+The fix is the Furman-Sawaya-Grossmann eps-perspective (``Furman2020`` in
+``docs/references.bib``; the same form Pyomo.GDP's ``hull`` transformation uses)::
+
+    yhat * g(v_k / yhat) - eps * g(0) * (1 - y_k) <= 0,   yhat = (1 - eps) * y_k + eps
+
+which is exact at both faces: 0 at ``y_k = 0``, and ``g(v)`` at ``y_k = 1``.
+
+Shrinking ``eps`` does not fix the old form -- the repro below is still exactly
+infeasible at ``eps = 1e-14`` -- so these tests assert *cancellation*, not
+smallness.
+"""
+
+import math
+
+import discopt.modeling as dm
+import numpy as np
+import pytest
+from discopt._relax.gdp_reformulate import (
+    HullPerspectiveOriginError,
+    _body_at_zero,
+    reformulate_gdp,
+)
+from discopt.modeling.core import (
+    BinaryOp,
+    Constant,
+    Constraint,
+    FunctionCall,
+    UnaryOp,
+    Variable,
+    VarType,
+)
+
+# ---------------------------------------------------------------------------
+# Shared model builders
+# ---------------------------------------------------------------------------
+
+#: Nonlinear bodies for the *de-selected* disjunct, each with ``g(0) != 0``.
+#:
+#: ``g(0) != 0`` is the whole trigger: it is what the ``y_k = 0`` face leaves
+#: behind as ``eps * g(0)``.  The set spans the unary operators the perspective
+#: has to survive (log, exp, a power, a trig function), because the fix computes
+#: ``g(0)`` by walking the expression DAG and a missing operator there is a
+#: refusal, not a wrong number.
+OFF_BRANCHES = [
+    # (id, f_b, f_b(0), max f_b over x in [-2, 2])
+    ("log", lambda x: dm.log(x + 3.0), math.log(3.0), math.log(5.0)),
+    ("exp", lambda x: dm.exp(x) - 3.0, -2.0, math.exp(2.0) - 3.0),
+    ("cube", lambda x: x**3 + 1.0, 1.0, 9.0),
+    ("cos", lambda x: dm.cos(x) + 1.0, 2.0, 2.0),
+]
+
+#: Bodies with ``g(0) == 0`` -- the control.  The ``y_k = 0`` residual is
+#: ``eps * g(0) == 0`` even in the old formulation, so these must pass *before*
+#: and after the fix.  Without them a green suite could just mean "something
+#: changed", not "the defect is closed".
+OFF_BRANCHES_ZERO_AT_ORIGIN = [
+    ("cube0", lambda x: x**3, 0.0, 8.0),
+    ("expm1", lambda x: dm.exp(x) - 1.0, 0.0, math.exp(2.0) - 1.0),
+    ("sin", lambda x: dm.sin(x), 0.0, math.sin(1.0)),
+]
+
+#: The *selected* branch.  ``exp(x) + 2`` peaks at ``e^2 + 2 ~ 9.389`` on
+#: ``[-2, 2]``, above every ``max f_b`` above, so disjunct 0 is the optimal
+#: choice in every case and the expected objective is analytic.  Its own
+#: ``g(0) = -2 != 0`` also exercises the ``y_k = 1`` face, where the old
+#: ``yhat = 1 + eps`` distorted the row.
+ON_BRANCH_MAX = math.exp(2.0) + 2.0
+
+
+def _two_branch_model(name: str, f_b) -> dm.Model:
+    """``max y`` subject to ``(y == exp(x) + 2) or (y == f_b(x))``, x in [-2, 2].
+
+    Both disjuncts carry a nonlinear **equality**, which is what makes the
+    de-selected one's eps residual a hard violation rather than something a
+    feasibility tolerance can absorb.
+    """
+    m = dm.Model(name)
+    x = m.continuous("x", lb=-2.0, ub=2.0)
+    y = m.continuous("y", lb=-10.0, ub=20.0)
+    m.maximize(y)
+    m.either_or(
+        [
+            [Constraint(body=y - (dm.exp(x) + 2.0), sense="==", rhs=0.0)],
+            [Constraint(body=y - f_b(x), sense="==", rhs=0.0)],
+        ],
+        name="br",
+    )
+    return m
+
+
+# ---------------------------------------------------------------------------
+# The end-to-end regression: no false infeasible
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.slow
+@pytest.mark.timeout(300)
+class TestNoFalseInfeasible:
+    def test_minimal_repro(self):
+        """The issue's reproduction verbatim: ``infeasible`` before, ``log 2`` after.
+
+        ``if_else`` is one producer of the trigger shape -- it emits the branch
+        value as an equality on an auxiliary variable, and both branches here are
+        nonlinear with ``g(0) != 0``.
+        """
+        m = dm.Model("issue1043")
+        x = m.continuous("x", lb=-10.0, ub=10.0)
+        m.maximize(x)
+        m.subject_to(dm.if_else(x >= 0, dm.exp(x) - 1, dm.log(-x + 3)) <= 1.0)
+
+        r = m.solve()
+        assert r.status == "optimal", (
+            f"#1043(a): hull perspective reported {r.status!r} for a model whose "
+            f"optimum is log 2 = {math.log(2.0)!r}"
+        )
+        assert r.objective == pytest.approx(math.log(2.0), abs=1e-6)
+
+    @pytest.mark.parametrize(
+        ("case", "f_b", "g0", "max_b"),
+        OFF_BRANCHES,
+        ids=[c[0] for c in OFF_BRANCHES],
+    )
+    def test_deselected_nonlinear_equality(self, case, f_b, g0, max_b):
+        """A de-selected disjunct with ``g(0) != 0`` must not empty the model."""
+        assert g0 != 0.0, "this case is supposed to trigger the eps residual"
+        assert max_b < ON_BRANCH_MAX, "disjunct 0 must be the optimal choice"
+
+        r = _two_branch_model(f"off_{case}", f_b).solve(gdp_method="hull")
+        assert r.status == "optimal", (
+            f"#1043(a): {case} de-selected branch reported {r.status!r}; the "
+            f"eps residual on the y_k = 0 face is eps * {g0!r}"
+        )
+        assert r.objective == pytest.approx(ON_BRANCH_MAX, rel=1e-6)
+
+    @pytest.mark.parametrize(
+        ("case", "f_b", "g0", "max_b"),
+        OFF_BRANCHES_ZERO_AT_ORIGIN,
+        ids=[c[0] for c in OFF_BRANCHES_ZERO_AT_ORIGIN],
+    )
+    def test_control_zero_at_origin(self, case, f_b, g0, max_b):
+        """Control: ``g(0) == 0`` leaves no residual, so this passes either way."""
+        assert g0 == 0.0
+        assert max_b < ON_BRANCH_MAX
+
+        r = _two_branch_model(f"ctl_{case}", f_b).solve(gdp_method="hull")
+        assert r.status == "optimal"
+        assert r.objective == pytest.approx(ON_BRANCH_MAX, rel=1e-6)
+
+
+# ---------------------------------------------------------------------------
+# The general contract: exactness at both integer faces
+# ---------------------------------------------------------------------------
+
+_UNARY = {
+    "neg": lambda a: -a,
+    "-": lambda a: -a,
+    "abs": abs,
+    "exp": math.exp,
+    "log": math.log,
+    "sqrt": math.sqrt,
+    "sin": math.sin,
+    "cos": math.cos,
+    "tan": math.tan,
+    "tanh": math.tanh,
+}
+_BINARY = {
+    "+": lambda a, b: a + b,
+    "-": lambda a, b: a - b,
+    "*": lambda a, b: a * b,
+    "/": lambda a, b: a / b,
+    "**": lambda a, b: a**b,
+    "^": lambda a, b: a**b,
+}
+
+
+def _evaluate(expr, values: dict[str, float], counter: list[int]) -> float:
+    """Evaluate an expression DAG at ``values``.
+
+    Deliberately total: an unknown variable raises ``KeyError`` and an unknown
+    operator raises ``KeyError`` too.  A probe that swallowed either would report
+    "0 violations" for rows it never actually evaluated (CLAUDE.md 6, 7).
+    """
+    counter[0] += 1
+    if isinstance(expr, Variable):
+        return values[expr.name]
+    if isinstance(expr, Constant):
+        return float(np.asarray(expr.value).ravel()[0])
+    if isinstance(expr, UnaryOp):
+        return float(_UNARY[expr.op](_evaluate(expr.operand, values, counter)))
+    if isinstance(expr, BinaryOp):
+        return float(
+            _BINARY[expr.op](
+                _evaluate(expr.left, values, counter),
+                _evaluate(expr.right, values, counter),
+            )
+        )
+    if isinstance(expr, FunctionCall):
+        args = [_evaluate(a, values, counter) for a in expr.args]
+        return float(_UNARY[expr.func_name](*args))
+    raise TypeError(f"unhandled node {type(expr).__name__}: {expr!r}")
+
+
+def _hull_point(reformulated: dm.Model, origin: dict[str, float], active: int) -> dict:
+    """Build the hull-space point that corresponds to ``origin`` with disjunct
+    ``active`` selected.
+
+    Names are *discovered* from the reformulated model rather than hardcoded per
+    instance, so this works for any single-disjunction model (CLAUDE.md 2).
+    """
+    values = dict(origin)
+    selectors, disaggregated = 0, 0
+    for v in reformulated._variables:
+        if v.name in values:
+            continue
+        stem, _, k_text = v.name.rpartition("_")
+        k = int(k_text)
+        if v.var_type == VarType.BINARY:
+            values[v.name] = 1.0 if k == active else 0.0
+            selectors += 1
+            continue
+        original = next((n for n in origin if stem.endswith(f"_v_{n}")), None)
+        if original is None:
+            raise AssertionError(f"unclassified hull variable {v.name!r}")
+        values[v.name] = origin[original] if k == active else 0.0
+        disaggregated += 1
+    assert selectors >= 2, f"discovered only {selectors} selector binaries"
+    assert disaggregated >= 2, f"discovered only {disaggregated} disaggregated vars"
+    return values
+
+
+def _max_violation(reformulated: dm.Model, values: dict[str, float]) -> tuple[float, str, int]:
+    """Largest constraint violation of ``values``, with the row that attains it."""
+    worst, worst_row, checked, nodes = 0.0, "", 0, [0]
+    for con in reformulated._constraints:
+        residual = _evaluate(con.body, values, nodes) - float(np.asarray(con.rhs).ravel()[0])
+        if con.sense == "<=":
+            violation = max(0.0, residual)
+        elif con.sense == ">=":
+            violation = max(0.0, -residual)
+        else:
+            violation = abs(residual)
+        checked += 1
+        if violation > worst:
+            worst, worst_row = violation, con.name or "<unnamed>"
+    assert checked > 0 and nodes[0] > 0, "PROBE FIRED NOTHING: no rows were evaluated"
+    return worst, worst_row, checked
+
+
+@pytest.mark.parametrize(
+    ("case", "f_b", "g0", "max_b"),
+    OFF_BRANCHES,
+    ids=[c[0] for c in OFF_BRANCHES],
+)
+def test_hull_rows_exact_at_both_integer_faces(case, f_b, g0, max_b):
+    """The reformulation must not cut off any point the disjunction admits.
+
+    This is the contract the end-to-end tests observe indirectly, asserted
+    directly on the rows: for each disjunct ``k``, the hull point built from a
+    genuinely feasible ``(x, y)`` of disjunct ``k`` must satisfy *every*
+    reformulated row.  Before the fix the de-selected disjunct's row was violated
+    by ``eps * |g(0)|`` and the selected one by an O(eps) distortion.
+    """
+    reformulated = reformulate_gdp(_two_branch_model(f"faces_{case}", f_b), method="hull")
+    assert reformulated is not None
+
+    checks = 0
+    for active, f in ((0, lambda t: math.exp(t) + 2.0), (1, None)):
+        x_value = 0.5
+        if active == 0:
+            y_value = f(x_value)
+        else:
+            # Evaluate the parametrized branch numerically through the DAG.
+            probe = dm.Model("probe")
+            xv = probe.continuous("x", lb=-2.0, ub=2.0)
+            y_value = _evaluate(f_b(xv), {"x": x_value}, [0])
+        origin = {"x": x_value, "y": y_value}
+        worst, row, n_rows = _max_violation(reformulated, _hull_point(reformulated, origin, active))
+        assert worst <= 1e-9, (
+            f"#1043(a): disjunct {active} face of {case} violates {row} by {worst:.6e} "
+            f"({n_rows} rows checked); a feasible point of the original disjunction "
+            f"must satisfy every hull row"
+        )
+        checks += 1
+    assert checks == 2, "PROBE FIRED NOTHING: neither integer face was checked"
+
+
+# ---------------------------------------------------------------------------
+# g(0): the value, and the refusal
+# ---------------------------------------------------------------------------
+
+
+def _named(expr_fn):
+    m = dm.Model("g0")
+    x = m.continuous("x", lb=-5.0, ub=5.0)
+    y = m.continuous("y", lb=-5.0, ub=5.0)
+    return expr_fn(x, y), {"x": x, "y": y}
+
+
+class TestBodyAtZero:
+    @pytest.mark.parametrize(
+        ("case", "build", "expected"),
+        [
+            ("affine", lambda x, y: 2.0 * x - 3.0 * y + 7.0, 7.0),
+            ("exp", lambda x, y: dm.exp(x) - 1.0, 0.0),
+            ("log", lambda x, y: dm.log(x + 3.0), math.log(3.0)),
+            ("power", lambda x, y: x**3 + 1.0, 1.0),
+            ("cos", lambda x, y: dm.cos(x) + 1.0, 2.0),
+            ("product", lambda x, y: x * y + 4.0, 4.0),
+            ("quotient", lambda x, y: (x + 2.0) / (y + 4.0), 0.5),
+            ("nested", lambda x, y: dm.exp(dm.sin(x) + y) - 2.0, -1.0),
+        ],
+    )
+    def test_value(self, case, build, expected):
+        expr, variables = _named(build)
+        assert _body_at_zero(expr, variables) == pytest.approx(expected, abs=1e-12)
+
+    @pytest.mark.parametrize(
+        ("case", "build"),
+        [
+            ("log_at_zero", lambda x, y: dm.log(x)),
+            ("divide_by_zero", lambda x, y: 1.0 / x),
+            ("sqrt_negative", lambda x, y: dm.sqrt(x - 1.0)),
+        ],
+        ids=["log_at_zero", "divide_by_zero", "sqrt_negative"],
+    )
+    def test_refuses_when_not_finite_at_origin(self, case, build):
+        """No finite ``g(0)`` means no sound perspective -- refuse, do not guess.
+
+        Fabricating a value here would leave an uncancelled eps residual on the
+        de-selected disjunct, which is precisely the false-infeasible class this
+        function exists to close (CLAUDE.md 3).
+        """
+        expr, variables = _named(build)
+        with pytest.raises(HullPerspectiveOriginError):
+            _body_at_zero(expr, variables)
+
+    def test_refuses_unknown_variable(self):
+        expr, variables = _named(lambda x, y: x + y)
+        with pytest.raises(HullPerspectiveOriginError, match="not collected"):
+            _body_at_zero(expr, {"x": variables["x"]})


### PR DESCRIPTION
Closes defect **(a)** of #1043 — the false infeasible on `nlp_mi_006_010`. Defect (b), the three uncertified-`optimal` points, is still open, so this is `Contributes to` rather than `Closes`.

## The defect

The nonlinear branch of the GDP hull reformulation wrote each disjunct row as

```
g(v_k / (y_k + eps)) * (y_k + eps) <= rhs * y_k
```

which is exact at **neither** integer face:

| face | what the row actually said | should have been |
|---|---|---|
| `y_k = 0` | `eps * g(0)` — the linking rows pin every disaggregated variable to exactly 0 | `0` |
| `y_k = 1` | `g(v/(1+eps)) * (1+eps)` — an O(eps) distortion | `g(v)` |

The old comment called the residual something "absorbed downstream by the feasibility tolerance". It is not. When the row is an **equality** and `g(0) != 0` — which is exactly what `if_else` emits, one equality per branch on the branch-value variable — `eps * g(0) != 0` is a hard violation. The reformulated model is then empty in exact arithmetic, and the rigorous machinery downstream (FBBT, the McCormick LP, both of which must be exact to be sound) correctly proves it empty and reports `infeasible` for a model with a perfectly good optimum.

Shrinking `eps` does not help — the repro is still exactly infeasible at `eps = 1e-14` — which is why the fix has to *cancel* the terms, not make them small.

## The fix

The Furman–Sawaya–Grossmann eps-perspective (`Furman2020`, added to `docs/references.bib`; the same form Pyomo.GDP's `hull` transformation uses), for `g(x) = body - rhs <= 0`:

```
yhat * g(v_k / yhat) - eps * g(0) * (1 - y_k) <= 0,    yhat = (1 - eps) * y_k + eps
```

Both pieces are load-bearing and the old form had neither. At `y_k = 0` the `-eps*g(0)*(1-y_k)` term cancels the residual exactly; at `y_k = 1` folding `eps` into the `y_k` coefficient makes `yhat` exactly 1, so the selected disjunct's row is the user's constraint verbatim.

`g(0)` comes from a new `_body_at_zero`, which walks the body with every disjunct variable at 0. It is a property of the *function*, not of the box: at `y_k = 0` the linking rows pin the disaggregated variables to exactly 0, so `g(0)` is the value the row actually takes there whether or not 0 lies inside the disjunct's own bounds. When the body is not finite at the origin — `log(0)`, `1/0`, `sqrt` of a negative — it raises `HullPerspectiveOriginError` and points at `method='big-m'` rather than inventing a value (CLAUDE.md §3): a fabricated `g(0)` would leave an uncancelled residual, which is the exact class this function exists to close. The old code did not refuse — it emitted `f(0)*eps` = NaN/-inf straight into the row.

## Measured

Main tree vs this branch, 16 behavioural assertions (`scratchpad/p1043_before.py`, marker-gated per CLAUDE.md §8 so each arm proves which tree it loaded):

**before 12 of 16 fail → after 0 of 16 fail**

And the failures are not only false infeasibles — the old form also returns `optimal` with a **wrong objective**:

| case | before | after |
|---|---|---|
| minimal repro | `infeasible` | `0.693147177` (log 2) |
| off-branch `log(x+3)` | `optimal` **9.344527669** (wrong) | 9.389056094 |
| off-branch `exp(x)-3` | `infeasible` | 9.389056132 |
| off-branch `cos(x)+1` | `optimal` **3.000000012** (wrong) | 9.389056098 |
| off-branch `x**3+1` | ok | ok |
| 8 × integer-face row checks | violated 2.8e-08 / 3.0e-08 | **0.0 exactly** |

The three `g(0) = 0` controls pass on **both** arms, so the suite is measuring this defect and not a general change.

## Tests

`python/tests/test_issue1043_hull_perspective.py` (24):

* the issue's repro verbatim;
* a parametrized family of de-selected nonlinear equalities spanning `log`, `exp`, a power and a trig body — the class, not the instance (§2), and the operator span matters because `_body_at_zero` walks the DAG and a missing operator there is a refusal;
* the `g(0) = 0` controls described above;
* the general contract asserted directly on the rows: a point feasible for the original disjunction must satisfy **every** hull row, checked at both integer faces, with hull variable names *discovered* from the reformulated model rather than hardcoded, and a counter so a discovery that classified nothing fails loudly (§6);
* `_body_at_zero` values on 8 bodies and its three refusal paths.

## Verified

* `test_minlptests.py` **4 failed / 121 passed → 3 failed / 122 passed**. `nlp_mi_006_010` fixed, **0 new failures**. Both arms run with the module path and the `_body_at_zero` marker asserted (present / absent) — a first attempt silently imported `discopt` from the main tree (§8) and measured the baseline twice before this was caught.
* GDP suites (`test_gdp`, `test_gdp_advisor`, `test_gdp1_gdp2_bigm_soundness`, `test_disjunctive_config_bound`, `test_gdpopt_heuristics_core_units`, `test_gdpopt_loa`, `test_gdpopt_loa_issue756`, `test_issue1004_gdp_config_start`, `test_issue823_gdp_config_primal`, `test_issue993_gdp_config_dive`) plus the new file: **1 failed / 328 passed / 2 xpassed**. The one failure, `test_gdpopt_loa.py::test_disjunct_block_with_loa` (LOA returns `unknown` on an all-linear disjunct block), fails **identically on main** — pre-existing, an untouched code path, and deselected by the default marker filter so CI never ran it (#1034).
* `pytest -m smoke`: 1028 passed, 1 skipped, 2 xpassed.
* `pytest -m slow python/tests/test_adversarial_recent_fixes.py`: 19 passed.
* `ruff check` / `ruff format --check` clean.
* No Rust touched, so `cargo test -p discopt-core` was not run.

Contributes to #1043

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017PQaiDVuY5Rs3tga98tnNo
