### PR TITLE
fix(correctness): #1043 report a stationary incumbent, not a barrier-interior point

### DIFF
--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -2619,6 +2619,119 @@ def _check_constraint_feasibility(evaluator, x, cl_list, cu_list, tol=1e-4):
     return max_viol <= tol
 
 
+# Tolerance shared by the two conditions of :func:`_weakly_active_crossover` —
+# the repo's declared ``abs=1e-6`` (CLAUDE.md "Key Constraints"), which is also
+# the stationarity tolerance the examiner holds a reported point to.
+_CROSSOVER_TOL = 1e-6
+
+
+def _weakly_active_crossover(x, lb, ub, mult_lower, mult_upper, grad, tol=_CROSSOVER_TOL):
+    """Return ``{index: bound_value}`` for coordinates to place ON a bound (#1043).
+
+    An interior-point method stops a barrier distance ``d ~ mu / lambda`` inside
+    each active bound. Where the bound is only *weakly* active — the objective
+    gradient vanishes on it, so ``lambda -> 0`` — that distance is large even
+    though the IPM's own complementarity ``lambda * d`` is tiny and its
+    convergence test is satisfied. The returned point then carries a first-order
+    residual of order ``d`` in that coordinate while the solver correctly reports
+    ``Solve_Succeeded``: nothing is wrong with the NLP solve, the iterate is
+    simply not the vertex.
+
+    This is a class, not an instance quirk. The periodicity reduction in
+    ``_relax/nonlinear_bound_tightening.py`` maps a doubly-infinite periodic-only
+    variable to exactly ``[-pi, pi]``, and a periodic function attains its
+    extrema at the period boundary — so the reduction *systematically* places the
+    optimum ON the bound it creates, which is exactly the weakly-active case.
+    Measured on ``nlp_001_010`` (``min ... + cos(y)``, ``y`` reduced to
+    ``[-pi, pi]``): the polish stopped at ``y = -3.14138899`` with
+    ``lambda = 2.037e-04`` and ``d = 2.037e-04`` — complementarity 4.15e-08
+    (converged), stationarity 2.037e-04 (the examiner's only failing check).
+
+    The repair is a crossover: put the coordinate on the bound. Three conditions,
+    each load-bearing:
+
+    1. ``lambda > 0`` and ``lambda * d <= tol`` — the IPM's own certificate that
+       the bound is active; it is precisely the quantity its complementarity test
+       measured. Note this is *nearly* vacuous at convergence, since an inactive
+       finite bound carries ``lambda ~ mu / d`` and therefore
+       ``lambda * d ~ mu``; what it rejects is an unconverged coordinate the
+       barrier is still pushing away from a strongly-priced bound.
+    2. ``|df/dx_j| * d <= tol`` — moving to the bound perturbs the objective by
+       a first-order-negligible amount. This also caps the move: with (3) it
+       forces ``d < tol / |df/dx_j| < 1``.
+    3. ``|df/dx_j| > tol`` — there is an actual stationarity defect at this
+       coordinate to repair. Without it, any variable absent from the objective
+       (``df/dx_j == 0``) satisfies (1) and (2) at *every* finite bound no matter
+       how distant, and would be relocated for no reason.
+
+    Condition 1 alone selects gross moves: at ``nlp_008_010``'s incumbent ``z``
+    sits 0.54 from its lower bound with ``lambda = 4.5e-09``, so
+    ``lambda * d = 2.4e-09`` passes (1) while snapping ``z`` would be a wholesale
+    relocation; (2) rejects it with ``|g| * d = 0.47``. On ``nlp_001_010``'s own
+    ``y``, (2) is what rejects the far side: the *upper* bound ``y <= pi`` also
+    passes (1) with ``lambda * d = 9.1e-09``, and only ``|g| * d = 1.3e-03``
+    rules it out. Measured selectivity: ``nlp_001_010 -> {1: -pi}``,
+    ``nlp_008_010 -> {}``.
+
+    The caller must still verify the snapped point (feasibility, objective not
+    worse) before adopting it — this function only nominates candidates.
+
+    Parameters
+    ----------
+    x : np.ndarray
+        The point returned by the NLP solve.
+    lb, ub : np.ndarray
+        The box that solve was given (so the multipliers refer to these bounds).
+    mult_lower, mult_upper : np.ndarray or None
+        Bound multipliers from the same solve. ``None`` disables the test.
+    grad : np.ndarray or None
+        Objective gradient at *x*. ``None`` disables the test.
+    tol : float
+        Shared threshold for both conditions.
+
+    Returns
+    -------
+    dict[int, float]
+        Index -> bound value, empty when no coordinate qualifies.
+    """
+    out: dict[int, float] = {}
+    if mult_lower is None or mult_upper is None or grad is None:
+        return out
+    xv = np.asarray(x, dtype=np.float64).ravel()
+    lo = np.asarray(lb, dtype=np.float64).ravel()
+    hi = np.asarray(ub, dtype=np.float64).ravel()
+    ml = np.asarray(mult_lower, dtype=np.float64).ravel()
+    mu = np.asarray(mult_upper, dtype=np.float64).ravel()
+    gv = np.asarray(grad, dtype=np.float64).ravel()
+    if not (xv.size == lo.size == hi.size == ml.size == mu.size == gv.size):
+        return out
+    if not (np.all(np.isfinite(xv)) and np.all(np.isfinite(gv))):
+        return out
+    for j in range(xv.size):
+        if abs(gv[j]) <= tol:
+            # (3): nothing to repair here — leave the coordinate where the NLP
+            # solve put it.
+            continue
+        for bnd, lam, sign in ((lo[j], ml[j], 1.0), (hi[j], mu[j], -1.0)):
+            # 1e15 mirrors the "infinite bound" convention used throughout the
+            # solver (the 1e20 sentinel and anything near it is not a bound).
+            if not np.isfinite(bnd) or abs(bnd) >= 1e15:
+                continue
+            d = sign * (xv[j] - bnd)
+            if not (d > tol):
+                # Already on the bound (nothing to do), or outside it (a bound
+                # relaxation the caller owns — never "snap" a point inward).
+                continue
+            if not (np.isfinite(lam) and lam > 0.0):
+                continue
+            if lam * d > tol:
+                continue
+            if abs(gv[j]) * d > tol:
+                continue
+            out[j] = float(bnd)
+    return out
+
+
 # The absolute tolerance the NLP-BB exit gate (#954) holds a returned incumbent
 # to: the repo's declared ``abs=1e-6`` (CLAUDE.md "Key Constraints"), the same
 # figure ``_matrix_solution_feasible`` enforces on the matrix paths (#952) and
@@ -13319,6 +13432,20 @@ def solve_model(
         # validation time; POUNCE (or cyipopt) converges them tightly. This is
         # a single solve at the end of the search. Best-effort and guarded so a
         # divergent re-solve can never change the reported optimum.
+        # #1043(b): the certificate invariant ``bound <= incumbent`` binds the
+        # polish too. Both mechanisms below can move the reported point (the
+        # widened box lets it leave the reduced region; the crossover snap moves
+        # it onto a bound), so no polished objective is adopted below the tree's
+        # rigorous dual bound — a super-optimal "improvement" is a defect being
+        # surfaced, never something to report. A missing/sentinel/non-finite
+        # bound imposes no floor.
+        _glb_polish = stats.get("global_lower_bound")
+        _min_accept_obj = -np.inf
+        if _glb_polish is not None:
+            _glb_polish = float(_glb_polish)
+            if np.isfinite(_glb_polish) and abs(_glb_polish) < _SENTINEL_THRESHOLD:
+                _min_accept_obj = _glb_polish - 1e-6 * (1.0 + abs(_glb_polish))
+
         try:
             _fix_lb = lb.copy()
             _fix_ub = ub.copy()
@@ -13327,6 +13454,28 @@ def solve_model(
                     _val = float(round(float(sol_flat[_off + _k])))
                     _fix_lb[_off + _k] = _val
                     _fix_ub[_off + _k] = _val
+            # #1043(b): the polish's product is the reported POINT, so it must be
+            # solved over the box the MODEL declares, not over ``lb``/``ub``,
+            # which carry FBBT/OBBT/root reductions. A reduction can place a
+            # bound exactly ON the optimum — the periodicity reduction maps a
+            # doubly-infinite periodic-only variable to ``[-pi, pi]``, and a
+            # periodic function attains its extrema at the period boundary — and
+            # an interior-point polish then stops a barrier distance inside it.
+            # Measured on ``nlp_008_010``: polishing in the declared box drops
+            # the examiner's stationarity residual from 1.331e-06 (fail) to
+            # 7.84e-10. Only free columns are widened, so the integer assignment
+            # fixed above is untouched. This is the primal analogue of #1037's
+            # ``_duals_against_declared_box``: a quantity pinned to a bound only
+            # bound tightening created is not a KKT quantity of the declared
+            # model. Where no such bound exists the widening is a no-op.
+            _decl_bounds = getattr(evaluator, "variable_bounds", None)
+            if _decl_bounds is not None:
+                _decl_lb = np.asarray(_decl_bounds[0], dtype=np.float64).ravel()
+                _decl_ub = np.asarray(_decl_bounds[1], dtype=np.float64).ravel()
+                if _decl_lb.size == _fix_lb.size and _decl_ub.size == _fix_ub.size:
+                    _free_cols = _fix_lb < _fix_ub  # integer-fixed columns have lb == ub
+                    _fix_lb = np.where(_free_cols, _decl_lb, _fix_lb)
+                    _fix_ub = np.where(_free_cols, _decl_ub, _fix_ub)
             _polish_opts = dict(opts)
             # The polished point IS the reported solution when it is adopted below,
             # so this is an incumbent producer and takes the incumbent options
@@ -13354,6 +13503,48 @@ def solve_model(
                 for _off, _sz in zip(int_offsets, int_sizes):
                     for _k in range(int(_sz)):
                         _refined[_off + _k] = round(float(sol_flat[_off + _k]))
+                # #1043(b): place the polished point ON any bound it stopped a
+                # barrier distance short of while the IPM's own complementarity
+                # certified that bound active (see ``_weakly_active_crossover``).
+                # Widening the box above removes the spurious bounds; this
+                # handles the ones the DECLARED model really has, where there is
+                # no wider box to move to — ``nlp_001_010``'s ``y >= -pi`` is
+                # written back into ``model._variables`` by the periodicity
+                # reduction, so it IS the declared bound by the time the polish
+                # runs. Adopted only when the snapped point is feasible, no
+                # worse, and not below the tree's rigorous dual bound; the move
+                # is first-order-negligible by construction (condition 2), so
+                # this can never be an "improvement" that hides an infeasible
+                # relocation. Measured: stationarity 2.037e-04 -> 1.22e-16.
+                _snap = _weakly_active_crossover(
+                    _refined,
+                    _fix_lb,
+                    _fix_ub,
+                    _polished.bound_multipliers_lower,
+                    _polished.bound_multipliers_upper,
+                    (
+                        evaluator.evaluate_gradient(_refined)
+                        if _polished.bound_multipliers_lower is not None
+                        and _polished.bound_multipliers_upper is not None
+                        else None
+                    ),
+                )
+                if _snap:
+                    _cand = _refined.copy()
+                    for _j, _bv in _snap.items():
+                        _cand[_j] = _bv
+                    _cobj = float(evaluator.evaluate_objective(_cand))
+                    if (
+                        np.isfinite(_cobj)
+                        and _cobj <= _pobj + 1e-12 * (1.0 + abs(_pobj))
+                        and _cobj >= _min_accept_obj
+                        and (
+                            not cl_list
+                            or _check_constraint_feasibility(evaluator, _cand, cl_list, cu_list)
+                        )
+                    ):
+                        _refined = _cand
+                        _pobj = _cobj
                 # Two reasons to adopt the integer-fixed continuous completion:
                 #   (a) purification — objective ~unchanged, just tighter continuous
                 #       values (the original behavior, always safe), and
@@ -13378,13 +13569,16 @@ def solve_model(
                 # fractional power of a ratio jumped 176.17 -> 0.0). There we keep
                 # only the always-safe purification (unchanged objective).
                 _improved = _model_is_convex and _pobj < obj_val - 1e-9 * (1.0 + abs(obj_val))
-                _accept = _unchanged or (
-                    _improved
-                    and (
-                        not cl_list
-                        or _check_constraint_feasibility(evaluator, _refined, cl_list, cu_list)
+                _accept = (
+                    _unchanged
+                    or (
+                        _improved
+                        and (
+                            not cl_list
+                            or _check_constraint_feasibility(evaluator, _refined, cl_list, cu_list)
+                        )
                     )
-                )
+                ) and _pobj >= _min_accept_obj
                 if _accept:
                     sol_flat = _refined
                     x_dict = _unpack_solution(model, sol_flat)

--- a/python/tests/test_issue1043_incumbent_crossover.py
+++ b/python/tests/test_issue1043_incumbent_crossover.py
@@ -1,0 +1,225 @@
+"""#1043(b): the reported incumbent must be stationary, not a barrier-interior point.
+
+The terminal incumbent polish in ``solve_model`` re-solves the continuous part of
+the incumbent with a KKT-accurate NLP solve.  Two defects made that polish return
+a point the examiner's ``stationarity`` check rejects, on a solve that is
+otherwise fully converged and certified ``optimal``:
+
+* **The polish ran in the reduced box.**  ``lb``/``ub`` at that point carry
+  FBBT/OBBT/root reductions.  A reduction can place a bound exactly ON the
+  optimum, and an interior-point polish then stops a barrier distance inside it.
+  Measured on ``nlp_008_010``: stationarity 1.331e-06 (fail, tol 1e-6) in the
+  reduced box, 7.84e-10 in the declared box.
+* **A weakly active bound is approached slowly.**  An IPM leaves the iterate
+  ``d ~ mu / lambda`` inside an active bound; where the objective gradient
+  vanishes on the bound, ``lambda -> 0`` and ``d`` is large while the
+  complementarity ``lambda * d`` the solver tests stays tiny.  The periodicity
+  reduction (``_relax/nonlinear_bound_tightening.py``) maps a doubly-infinite
+  periodic-only variable to exactly ``[-pi, pi]``, and a periodic function
+  attains its extrema at the period boundary -- so it *systematically* creates
+  this case.  Measured on ``nlp_001_010`` (``min ... + cos(y)``): the polish
+  stopped at ``y = -3.14138899``, ``lambda = 2.037e-04``, complementarity
+  4.15e-08 (converged), stationarity 2.037e-04.  POUNCE is right about the box
+  it was given; the point is simply not the vertex.
+
+The repairs are (i) polish over the declared box for free columns, and (ii) a
+crossover that puts the point on a weakly active bound, guarded by feasibility,
+objective-not-worse, and the dual bound.
+
+The unit tests below pin each of the three conditions of the crossover rule with
+the measured numbers.  All three are load-bearing: (1) the IPM's complementarity
+certificate is nearly vacuous at convergence (an inactive finite bound carries
+``lambda ~ mu / d``), (2) rejects the gross moves (1) nominates, and (3) keeps a
+variable absent from the objective -- which passes (1) and (2) at every finite
+bound -- from being relocated for no reason.
+"""
+
+import discopt.modeling as dm
+import numpy as np
+import pytest
+from discopt.solver import _weakly_active_crossover
+from discopt.validation.examiner import assert_examined, examine
+
+# ── measured inputs, from the polish subsolves of the two instances ──────────
+
+# nlp_001_010: min x*exp(x) + cos(y) + z^3 - z^2, z >= 1.  ``y`` is reduced to
+# [-pi, pi] by the periodicity pass, and cos attains its minimum at -pi.
+NLP001_X = np.array([-1.0, -3.1413889875324084, 1.0000000090909087])
+NLP001_LB = np.array([-9.999e19, -np.pi, 1.0])
+NLP001_UB = np.array([9.999e19, np.pi, 9.999e19])
+NLP001_MULT_L = np.array([0.0, 2.03667508e-04, 1.00000004])
+NLP001_MULT_U = np.array([0.0, 1.44691002e-09, 0.0])
+NLP001_GRAD = np.array([0.0, 2.0366605597687062e-04, 1.0000000363636348])
+
+# nlp_008_010: z sits 0.54 from its lower bound with a tiny multiplier, so its
+# complementarity passes condition (1).  Snapping it would be a wholesale
+# relocation; condition (2) must reject it.
+NLP008_X = np.array([-0.59315858, 0.24404795, 0.54062715])
+NLP008_LB = np.array([-9.999e19, -9.999e19, 0.0])
+NLP008_UB = np.array([9.999e19, 9.999e19, 1.0])
+NLP008_MULT_L = np.array([0.0, 0.0, 4.532566e-09])
+NLP008_MULT_U = np.array([0.0, 0.0, 5.638838e-09])
+NLP008_GRAD = np.array([1.0, 0.4880959, 0.8768331459513673])
+
+
+class TestCrossoverRule:
+    """The three-condition rule, on the measurements that motivated it."""
+
+    def test_selects_the_weakly_active_periodic_bound(self):
+        cand = _weakly_active_crossover(
+            NLP001_X, NLP001_LB, NLP001_UB, NLP001_MULT_L, NLP001_MULT_U, NLP001_GRAD
+        )
+        assert cand == {1: pytest.approx(-np.pi)}, (
+            f"the weakly active y >= -pi bound must be nominated; got {cand}"
+        )
+
+    def test_snapping_recovers_stationarity(self):
+        """The whole point: on the bound, the residual is machine zero."""
+        cand = _weakly_active_crossover(
+            NLP001_X, NLP001_LB, NLP001_UB, NLP001_MULT_L, NLP001_MULT_U, NLP001_GRAD
+        )
+        assert cand
+        y = cand[1]
+        # d(cos y)/dy = -sin(y); 2.037e-04 at the returned point, ~1e-16 at -pi.
+        assert abs(-np.sin(NLP001_X[1])) > 1e-6
+        assert abs(-np.sin(y)) < 1e-12
+
+    def test_rejects_a_distant_bound_that_passes_complementarity_alone(self):
+        """Condition (1) is not sufficient -- condition (2) is load-bearing."""
+        d = NLP008_X[2] - NLP008_LB[2]
+        assert NLP008_MULT_L[2] * d < 1e-6, "premise: complementarity does pass"
+        assert abs(NLP008_GRAD[2]) * d > 1e-2, "premise: the objective effect is gross"
+        cand = _weakly_active_crossover(
+            NLP008_X, NLP008_LB, NLP008_UB, NLP008_MULT_L, NLP008_MULT_U, NLP008_GRAD
+        )
+        assert cand == {}, f"no coordinate should be nominated here; got {cand}"
+
+    def test_rejects_the_far_side_of_the_same_variable(self):
+        """``y <= pi`` passes condition (1) too -- only (2) rules it out."""
+        d_up = NLP001_UB[1] - NLP001_X[1]
+        assert NLP001_MULT_U[1] * d_up < 1e-6, "premise: complementarity does pass"
+        assert abs(NLP001_GRAD[1]) * d_up > 1e-4, "premise: the objective effect is not negligible"
+        cand = _weakly_active_crossover(
+            NLP001_X, NLP001_LB, NLP001_UB, NLP001_MULT_L, NLP001_MULT_U, NLP001_GRAD
+        )
+        assert 1 in cand and cand[1] < 0.0, f"the upper bound must not win; got {cand}"
+
+    def test_rejects_a_strongly_active_bound(self):
+        """Condition (2) is not sufficient either -- condition (1) is load-bearing.
+
+        A coordinate the barrier is still pushing away from a strongly priced
+        bound is an unconverged iterate, not a weakly-active vertex; relocating
+        it is not the solver's business.
+        """
+        cand = _weakly_active_crossover(
+            np.array([0.5]),
+            np.array([0.0]),
+            np.array([1e20]),
+            np.array([10.0]),  # lam * d = 5.0, condition (1) fails
+            np.array([0.0]),
+            np.array([2e-6]),  # |g| * d = 1e-6, conditions (2) and (3) pass
+        )
+        assert cand == {}
+
+    def test_rejects_a_variable_absent_from_the_objective(self):
+        """Condition (3) is load-bearing.
+
+        A variable with no objective gradient satisfies (1) and (2) at EVERY
+        finite bound, however distant -- at convergence an inactive bound carries
+        ``lambda ~ mu / d``, so ``lambda * d ~ mu`` is always tiny. Without (3)
+        such a variable is relocated to a bound for no reason at all.
+        """
+        x = np.array([0.5])
+        lam = np.array([2e-9])  # mu / d with mu ~ 1e-9: an ordinary inactive bound
+        assert float(lam[0]) * 0.5 < 1e-6, "premise: complementarity passes at both bounds"
+        cand = _weakly_active_crossover(
+            x, np.array([0.0]), np.array([1.0]), lam, lam, np.array([0.0])
+        )
+        assert cand == {}, f"a variable not in the objective must not be moved; got {cand}"
+
+    def test_infinite_bounds_and_missing_multipliers_are_inert(self):
+        free = np.array([0.0])
+        g = np.array([1.0])
+        lam = np.array([1e-9])
+        assert (
+            _weakly_active_crossover(free, np.array([-1e20]), np.array([1e20]), lam, lam, g) == {}
+        )
+        assert _weakly_active_crossover(free, np.array([-1.0]), np.array([1.0]), None, lam, g) == {}
+        assert (
+            _weakly_active_crossover(free, np.array([-1.0]), np.array([1.0]), lam, lam, None) == {}
+        )
+
+    def test_a_point_already_on_its_bound_is_not_moved(self):
+        lam = np.array([1e-9])
+        cand = _weakly_active_crossover(
+            np.array([1.0]),
+            np.array([1.0]),
+            np.array([2.0]),
+            lam,
+            lam,
+            np.array([1.0]),  # a real gradient, so (3) passes
+        )
+        # The lower bound has d = 0 (nothing to do); the upper bound is 1.0 away
+        # with |g| * d = 1.0, which (2) rejects.
+        assert cand == {}
+
+    def test_mismatched_shapes_are_inert(self):
+        assert (
+            _weakly_active_crossover(
+                np.zeros(2), np.zeros(2), np.ones(2), np.zeros(1), np.zeros(2), np.ones(2)
+            )
+            == {}
+        )
+
+
+class TestReportedIncumbentIsStationary:
+    """End-to-end: both instances failed the examiner before this fix."""
+
+    def _solve(self, model):
+        return model.solve(time_limit=120.0, gap_tolerance=1e-6)
+
+    def test_periodic_reduction_instance(self):
+        """nlp_001_010 -- the weakly active bound the periodicity pass creates."""
+        m = dm.Model("issue1043b_periodic")
+        x = m.continuous("x")
+        y = m.continuous("y")
+        z = m.continuous("z", lb=1.0)
+        m.minimize(x * dm.exp(x) + dm.cos(y) + z**3 - z**2)
+        result = self._solve(m)
+        assert result.status in ("optimal", "feasible")
+        assert_examined(result, m, "issue1043b_periodic")
+        # The reported point is the vertex, not a barrier-interior neighbour.
+        y_val = float(np.ravel(result.x["y"])[0])
+        assert abs(abs(y_val) - np.pi) < 1e-9, f"y = {y_val!r} is not at the cos minimum"
+
+    def test_reduced_box_instance(self):
+        """nlp_008_010 -- the polish must run in the declared box."""
+        m = dm.Model("issue1043b_reduced_box")
+        x = m.continuous("x")
+        y = m.continuous("y")
+        z = m.continuous("z", lb=0.0, ub=1.0)
+        m.minimize(x + y**2 + z**3)
+        m.subject_to(y >= dm.exp(-x - 2) + dm.exp(-z - 2) - 2)
+        m.subject_to(x**2 <= y**2 + z**2)
+        m.subject_to(y >= x / 2 + z)
+        result = self._solve(m)
+        assert result.status in ("optimal", "feasible")
+        report = examine(result, m)
+        stat = next((c for c in report.checks if c.name == "stationarity"), None)
+        assert stat is not None, "the stationarity check must have run"
+        assert stat.passed, f"stationarity {stat.max_violation:.3e} > {stat.tolerance:.3e}"
+        assert result.objective == pytest.approx(-0.3755859312158738, abs=1e-6)
+
+    def test_certificate_invariant_holds(self):
+        """The polish must never report a point below the rigorous dual bound."""
+        m = dm.Model("issue1043b_cert")
+        x = m.continuous("x")
+        y = m.continuous("y")
+        z = m.continuous("z", lb=1.0)
+        m.minimize(x * dm.exp(x) + dm.cos(y) + z**3 - z**2)
+        result = self._solve(m)
+        assert result.bound is not None
+        assert result.objective is not None
+        assert result.bound <= result.objective + 1e-9 * (1.0 + abs(result.objective)), (
+            f"bound {result.bound!r} above incumbent {result.objective!r}"
+        )


### PR DESCRIPTION

Three MINLPTests NLP instances (nlp_001_010, nlp_008_010, nlp_008_011) returned
the right objective with an `optimal` certificate but failed the examiner's
`stationarity` check. Two independent defects in the terminal incumbent polish,
both root-caused by instrumenting every `pounce.Problem.solve` call.

1. The polish ran in the REDUCED box. `lb`/`ub` at that point carry FBBT/OBBT
   root reductions; a reduction can place a bound exactly on the optimum, and an
   interior-point polish then stops a barrier distance inside it. Free
   (non-integer-fixed) columns are now widened back to the model's declared box,
   so the polish's product -- the reported POINT -- is a KKT point of the
   declared model. Primal analogue of #1037's `_duals_against_declared_box`.

2. A WEAKLY active bound is approached slowly. An IPM leaves the iterate
   d ~ mu/lambda inside an active bound; where the objective gradient vanishes on
   the bound, lambda -> 0 and d is large while the complementarity lambda*d the
   solver tests stays tiny. This is a class, not an instance quirk: the
   periodicity reduction maps a doubly-infinite periodic-only variable to exactly
   [-pi, pi], and a periodic function attains its extrema at the period boundary,
   so the reduction systematically places the optimum ON the bound it creates.
   `_weakly_active_crossover` puts such a coordinate on its bound.

POUNCE is not at fault in either case: on nlp_001_010 it reported
final_unscaled_kkt_error = 4.148e-08, which is exactly the complementarity
lambda*d = 2.0367e-04 * 2.0366e-04 of the box it was given. Correct for that box;
simply not the vertex.

The crossover rule has three conditions, all load-bearing (see the unit tests):

  (1) lambda > 0 and lambda*d <= tol -- the IPM's own activity certificate.
  (2) |df/dx_j| * d <= tol           -- first-order-negligible objective move.
  (3) |df/dx_j| > tol                -- there is a defect here to repair.

(1) alone nominates gross moves: nlp_008_010's z sits 0.54 from its lower bound
with lambda*d = 2.4e-09, and only (2) rejects it (|g|*d = 0.47). (1) is in fact
nearly vacuous at convergence, since an inactive finite bound carries
lambda ~ mu/d; without (3) any variable absent from the objective would be
relocated to a bound however distant. Measured selectivity:
nlp_001_010 -> {y: -pi}, nlp_008_010 -> {}.

A snap is adopted only wholesale and only when the snapped point is feasible,
no worse in objective, and not below the tree's rigorous dual bound. That last
floor is now applied to the whole polish adoption (CLAUDE.md 1): neither
mechanism may report a point that violates `bound <= incumbent`.

Measured (examiner stationarity, tol 1e-6):

  nlp_008_010   1.331e-06 (FAIL) -> 7.84e-10   (widened box)
  nlp_001_010   2.037e-04 (FAIL) -> 1.22e-16   (crossover; objective improves
                                                2.07e-08, stays above the bound)

Verification (all in a worktree, module path and a marker string asserted per
CLAUDE.md 8):

  pytest python/tests/test_minlptests.py -m ""    3 failed/122 passed -> 125 passed
  pytest python/tests/test_issue1043_incumbent_crossover.py   12 passed
    (the two end-to-end tests fail on main; confirmed against the main tree)
  pytest -m smoke python/tests                    1028 passed, 1 skipped, 2 xpassed
  pytest -m slow test_adversarial_recent_fixes    19 passed
  ruff check python/ ; ruff format --check        clean

No Rust touched, so `cargo test` was not run.

Closes #1043
