### PR TITLE
docs(release): changelog entries for the four post-cut fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 The release procedure that produces these entries is documented in
 [`RELEASE.md`](RELEASE.md).
 
-## [0.8.0] - 2026-08-15
+## [0.8.0] - 2026-08-16
 
 ### Changed
 
@@ -57,7 +57,53 @@ The release procedure that produces these entries is documented in
   No default moved. Details and the falsification record in
   `docs/dev/performance-plan.md` §18f.
 
+### Removed
+
+- **The inert `superposition` knob** (`fix(relax)`, #1046, closes #1035).
+  `build_milp_relaxation` accepted a `superposition` parameter and never read
+  it — the #632 uniform-factorable cutover stopped consuming it — so
+  `relaxation_arithmetic="superposition"` quietly returned the plain McCormick
+  relaxation. The generator behind it, `discopt._relax.superposition`, was
+  reachable only from its own tests. Per `CLAUDE.md` §3 (*no dead flags*) the
+  switch is deleted rather than re-wired: an accepted-and-ignored knob is worse
+  than no knob, because a measurement taken with it set reads as a measurement
+  of the feature. `relaxation_arithmetic` itself is unaffected — its live values
+  (`mccormick`, `chebyshev`, `taylor`, `ellipsoidal`, `alphabb`) never included
+  `superposition`. One consequence recorded in `docs/dev/performance-plan.md`
+  §6: the `superposition cuts` row of the ex1252 lever table measured the
+  baseline and is retracted.
+
 ### Fixed
+
+- **A GDP disjunction could be declared `infeasible` when it was not**
+  (`fix(gdp)`, #1044, closes part of #1043). The hull reformulation's perspective
+  function was not exact at both integer faces, so a disjunct that admitted a
+  feasible point could have it cut away and the root node returned
+  `infeasible` in a single node. A false `infeasible` is a hard-gate violation
+  under `CLAUDE.md` §1 — the certificate is wrong, not merely loose — and this
+  was the most serious defect fixed in this release.
+
+- **The solver reported multipliers of the presolved model, not the declared
+  one** (`fix(duals)`, #1042, closes #1037). Bound and row multipliers were
+  handed back in the presolved space, so a user reading `result` got duals that
+  did not correspond to the model they wrote. Row activity is now judged
+  relative to row scale as well. This took `python/tests/test_minlptests.py`
+  from **79 failed / 46 passed to 4 failed / 121 passed**.
+
+- **The reported incumbent could be a barrier-interior point rather than a
+  stationary one** (`fix(correctness)`, #1045, closes #1043). Two causes, both
+  in the terminal incumbent polish: the polish ran in the *reduced*
+  (FBBT/OBBT/root) box, where a reduction can place a bound exactly on the
+  optimum; and an interior-point method stops a distance `~ mu/lambda` inside a
+  *weakly* active bound, which the periodicity reduction creates systematically
+  (it maps a doubly-infinite periodic-only variable to exactly `[-pi, pi]`, and
+  a periodic function attains its extrema at the period boundary). The polish
+  now runs over the declared box for free columns and crosses over onto weakly
+  active bounds, guarded by feasibility, objective-not-worse, and a dual-bound
+  floor so the `bound <= incumbent` invariant binds the polish too. Measured:
+  stationarity 1.331e-06 -> 7.84e-10 on `nlp_008_010`, and 2.037e-04 -> 1.22e-16
+  on `nlp_001_010`. With #1042 and #1044 this brings `test_minlptests.py` to
+  **125/125**.
 
 - **The primal simplex could return a false `Unbounded` on a bounded LP**
   (`fix(lp)`, #1008). The ratio test now certifies the primal ray before the

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -10,7 +10,7 @@ For each release, fill in:
 - `vX.Y.Z` -- the target version
 - `vA.B.C` -- the previous released version
 
-The next planned release is **`v0.6.0`** (minor bump on top of `v0.5.0`).
+The next planned release is **`v0.8.0`** (minor bump on top of `v0.7.0`).
 
 ---
 


### PR DESCRIPTION
## Why

The `## [0.8.0]` changelog section was written when the release branch was cut on **2026-08-15**. The four correctness fixes that gated this release all landed *after* that, so none of them appear in it — the section has 45 entries and mentions #1037, #1043 and #1035 zero times. Tagging with the changelog in that state would ship a release whose headline fixes are undocumented.

## What

Adds the four fixes, moves the section date to `2026-08-16`, and corrects one stale line in `RELEASE.md`.

**New `### Removed` section** (the 0.8.0 block had none):
- #1035 / #1046 — the inert `superposition` knob, with the retracted ex1252 lever-table row noted

**Added to `### Fixed`**, ordered by severity:
- #1043 / #1044 — a GDP disjunction could be declared `infeasible` when it was not (a `CLAUDE.md` §1 hard-gate violation, the most serious defect in this release)
- #1037 / #1042 — multipliers were reported in the presolved space, not the declared model's; took `test_minlptests.py` from 79 failed / 46 passed to 4 failed / 121 passed
- #1043 / #1045 — the reported incumbent could be a barrier-interior point rather than a stationary one, with the measured stationarity numbers (1.331e-06 → 7.84e-10, 2.037e-04 → 1.22e-16) and the resulting 125/125 panel

**`RELEASE.md`**: line 13 still read *"The next planned release is `v0.6.0` (minor bump on top of `v0.5.0`)"* — two releases stale. Now `v0.8.0` on top of `v0.7.0`.

## Verification

Docs only — no code, no tests touched. pre-commit ran and skipped every hook (`no files to check` for ruff, ruff format, mypy, cargo fmt).

Note that PRs targeting `release/**` receive **no CI at all** — `ci.yml` triggers on `pull_request: branches: [main, feature/mip-nlp-solver]`. That is a real gap (I hit it on #1047, where "no checks reported" read as green), but it is not a concern for this PR, which changes only Markdown.

Contributes to the v0.8.0 release; leaves #1041 open.
