### PR TITLE
chore(bench): record the 3-way head-to-head procedure and add time columns

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -202,6 +202,56 @@ python discopt_benchmarks/run_benchmarks.py --gate phase1     # Check phase gate
 python discopt_benchmarks/run_benchmarks.py --suite comparison --solvers discopt,baron
 ```
 
+#### The 3-way head-to-head (discopt vs BARON vs SCIP) — run it THIS way
+
+This is the standard pre-release comparison. It has been re-derived from scratch
+several times and gotten wrong the same way each time, so the procedure is fixed
+here. **BARON and SCIP do not go through the same harness.** There is no single
+command that produces a valid three-way table.
+
+**Step 1 — discopt and SCIP, via the benchmark runner.** SCIP is fully licensed
+and reads `.nl` directly, so it runs in-harness:
+
+```bash
+python -u discopt_benchmarks/run_benchmarks.py --suite global50 \
+    --solvers discopt,scip --report --output <out>.json
+```
+
+**Step 2 — BARON, via GAMS only.** `/Applications/AMPL/baron` is **DEMO-LICENSED
+(10 variables, 10 constraints)** and silently refuses anything larger. The full
+CMU floating-network license lives inside GAMS, which reads `.gms`, not `.nl`:
+
+```bash
+python -u -m discopt_benchmarks.scripts.global_opt_baron_vs_discopt \
+    --time-limit 60 --instances "<comma-separated names>" --out-dir <dir>
+```
+
+That script fetches `minlplib.org/gms/<name>.gms` (the canonical GAMS source, so
+there is no `.nl → .gms` conversion-fidelity risk), runs
+`gams <name>.gms minlp=baron optcr=0 optca=1e-9 reslim=<T>`, parses the `.lst`,
+and runs **discopt interleaved on the same instances** — so its discopt column is
+the one to compare BARON against, not the column from step 1.
+
+**The failure signature to watch for.** Demo-licensed BARON returns in ~0.03 s
+with `nodes=0` and no objective. A panel run against it reports something like
+"BARON 31/50" — which reads as a solver result but is just "19 instances exceeded
+10 variables". The 31 successes are a size-biased subset, not a comparison. Before
+believing any BARON number, confirm the license is not demo:
+
+```bash
+grep "Floating Network License" <run>.lst   # full license
+# vs. "Sorry, a demo license is limited to 10 variables and 10 constraints"
+```
+
+Measured 2026-08-16 on the global50 panel at 60 s/instance: demo BARON solved
+31/50; the same binary under GAMS with the full license solved `flay03m`
+(26 vars, 24 cons) to optimality in 0.32 s after the demo had refused it outright.
+
+Report **median time over solved instances** and **total wall over all
+instances** alongside SGM — a solved-only statistic flatters whichever solver
+times out most, since its slowest instances leave the population. Both columns
+are in the runner's summary table.
+
 **Benchmark instance corpus**: `~/Dropbox/projects/discopt-minlp-benchmark/` holds
 the full MINLPLib snapshot — ~4,800 `.nl` instances (`minlplib/nl/`), reference
 optima/dual bounds (`minlplib.solu`), problem-type/size metadata

--- a/discopt_benchmarks/config/benchmarks.toml
+++ b/discopt_benchmarks/config/benchmarks.toml
@@ -432,10 +432,15 @@ GAMS.framework/Resources/baron, which reads only `.bar` and answers a `.nl` \
 argument with a usage message and rc=0. CAVEAT: the AMPL bundle's BARON is \
 DEMO-LICENSED (10 variables, 10 constraints) -- it refuses anything larger, \
 which `_reject_non_result` now records as ERROR rather than a silent non-solve. \
-BARON at corpus scale is available only through GAMS (fully licensed here), and \
-that needs a .nl -> .gms bridge which does not exist yet; until it does, \
-`geomean_ratio_vs_baron` and `root_gap_ratio_vs_baron` are NOT producible on \
-this machine and must not be reported as measured."""
+BARON at corpus scale is available only through GAMS (fully licensed here). \
+DO NOT use this entry for a BARON comparison -- it yields a size-biased subset \
+(demo BARON "solved" 31/50 on global50, where the other 19 merely exceeded 10 \
+variables) that reads like a solver result. The bridge to full-license BARON \
+EXISTS: `discopt_benchmarks/scripts/global_opt_baron_vs_discopt.py` fetches the \
+canonical `minlplib.org/gms/<name>.gms` and drives `gams ... minlp=baron`, so \
+no .nl -> .gms conversion is involved. `geomean_ratio_vs_baron` and \
+`root_gap_ratio_vs_baron` are producible ONLY through that script, never through \
+this entry. See the 3-way head-to-head procedure in CLAUDE.md."""
 
 [solvers.couenne]
 command = "/Applications/AMPL/couenne"

--- a/discopt_benchmarks/run_benchmarks.py
+++ b/discopt_benchmarks/run_benchmarks.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import statistics
 import sys
 from datetime import datetime
 from pathlib import Path
@@ -555,10 +556,10 @@ def _run_benchmark(args):
 
     n_instances = len(results.get_instances())
     print(f"\nSuite: {args.suite} ({n_instances} instances, {time_limit}s limit)")
-    print("-" * 70)
+    print("-" * 88)
     print(f"{'Solver':<15s} {'Solved':>8s} {'Proved':>8s} {'Incorrect':>10s} "
-          f"{'SGM(s)':>10s} {'Med Gap':>10s}")
-    print("-" * 70)
+          f"{'SGM(s)':>10s} {'Med(s)':>10s} {'Total(s)':>10s} {'Med Gap':>10s}")
+    print("-" * 88)
     for solver_name in results.get_solvers():
         solver_results = results.get_results(solver_name)
         n_solved = solved_count(solver_results)
@@ -569,15 +570,25 @@ def _run_benchmark(args):
         gap_stats = final_gap_stats(solver_results)
         med_gap = gap_stats["median"]
 
+        # Med(s) is over SOLVED instances only -- same population as SGM, so the
+        # two columns are comparable. Total(s) is over EVERY instance including
+        # timeouts and errors: it answers "how long did this panel cost", which a
+        # solved-only statistic hides precisely when a solver times out most.
+        med_time = statistics.median(times) if times else float("nan")
+        total_time = sum(r.wall_time for r in solver_results)
+
         sgm_str = f"{sgm:.2f}" if sgm < 1e6 else "inf"
+        med_time_str = f"{med_time:.2f}" if med_time == med_time else "N/A"
+        total_str = f"{total_time:.1f}"
         gap_str = f"{med_gap:.2%}" if med_gap == med_gap else "N/A"
         solved_str = f"{n_solved}/{n_instances}"
         proved_str = f"{n_proved}/{n_instances}"
         print(
             f"{solver_name:<15s} {solved_str:>8s} {proved_str:>8s}"
-            f" {n_incorrect:>10d} {sgm_str:>10s} {gap_str:>10s}"
+            f" {n_incorrect:>10d} {sgm_str:>10s} {med_time_str:>10s}"
+            f" {total_str:>10s} {gap_str:>10s}"
         )
-    print("-" * 70)
+    print("-" * 88)
 
     # Append to history
     try:


### PR DESCRIPTION
Records the discopt/BARON/SCIP head-to-head procedure so it stops being
re-derived, and adds the two time columns the summary table was missing.

## Why

The 3-way comparison gets rebuilt from scratch each time it is needed, and fails
the same way each time. `/Applications/AMPL/baron` is **demo-licensed (10
variables, 10 constraints)**. It refuses anything larger in ~0.03s with
`nodes=0` and no objective, and the harness records that as a non-solve.

Run on the global50 panel at 60s/instance today, that produced:

```
Solver            Solved   Proved  Incorrect     SGM(s)    Med Gap
discopt            48/50    48/50          0       0.70      0.00%
baron              31/50    31/50          0       0.12        N/A
scip               44/50    44/50          0       0.38      0.00%
```

"BARON 31/50" reads as a solver result. It is really "19 of these instances have
more than 10 variables". The 31 are a size-biased subset and the row is
meaningless as a comparison.

## Changes

**`CLAUDE.md`** — the fixed procedure, under Benchmarking. The load-bearing fact
is that BARON and SCIP do not share a harness, so there is no single command
that yields a valid three-way table: SCIP is fully licensed and reads `.nl`, so
it runs in-harness; BARON must go through GAMS via
`scripts/global_opt_baron_vs_discopt.py`, which fetches the canonical
`minlplib.org/gms/<name>.gms` and drives `gams ... minlp=baron`. Includes the
demo-license failure signature and the `grep` that separates it from a full
floating-network license.

**`benchmarks.toml`** — the `[solvers.baron]` note claimed the `.nl -> .gms`
bridge "does not exist yet", so `geomean_ratio_vs_baron` and
`root_gap_ratio_vs_baron` were "NOT producible on this machine". Both wrong now:
the script above is the bridge, and no conversion is involved because MINLPLib
publishes the original `.gms`. The note now also says outright not to use that
entry for a comparison.

**`run_benchmarks.py`** — summary table gains `Med(s)` (median wall over solved
instances, same population as SGM) and `Total(s)` (total wall over every
instance, timeouts included). SGM and a solved-only median both flatter whichever
solver times out most, because its slowest instances leave the population; the
total does not.

## Verification

- `--suite smoke --solvers discopt` renders the new columns: `9/10 solved, SGM
  0.12, Med(s) 0.13, Total(s) 1.3`.
- Full-license BARON confirmed on `flay03m` (26 vars, 24 cons): demo BARON
  refused it outright; GAMS BARON solved it to optimality **48.9898 in 0.32s**.
- `benchmarks.toml` re-parses via `tomllib`.
- `ruff check` and `ruff format --check` report 3 errors and a reformat on
  `run_benchmarks.py` at lines 198/313/451 — all **pre-existing on `origin/main`**
  and none at an edit site in this PR (verified by running both against
  `git show origin/main:...`). `discopt_benchmarks/` is not covered by the
  pre-commit hooks, which is how it drifted; fixing that is out of scope here.

A full-license 3-way run is in flight and its numbers are not in this PR.
