### PR TITLE
chore(release): post-v0.8.0 housekeeping (RELEASE.md §12)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,6 +103,13 @@ docs/notebooks/*.xlsx
 # stray solver listing files (GAMS/BARON .lst) — not part of the repo
 *.lst
 
+# GAMS scratch directories. A `gams` invocation creates one per run in the CWD,
+# named <pid-ish digits><letter> (225a, 225b, ...), and it contains `gamslice.dat`
+# — the machine's GAMS *license file*. A blanket `git add -A` after a BARON run
+# stages it. Ignore the whole shape, and the license file by name wherever it lands.
+[0-9][0-9][0-9][a-z]/
+gamslice.dat
+
 # scratchpad run logs (keep the harnesses, drop the outputs)
 scratchpad/*_out*.txt
 scratchpad/*.log

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 The release procedure that produces these entries is documented in
 [`RELEASE.md`](RELEASE.md).
 
+## [Unreleased]
+
 ## [0.8.0] - 2026-08-16
 
 ### Changed

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -10,7 +10,7 @@ For each release, fill in:
 - `vX.Y.Z` -- the target version
 - `vA.B.C` -- the previous released version
 
-The next planned release is **`v0.8.0`** (minor bump on top of `v0.7.0`).
+The next planned release is **`v0.9.0`** (minor bump on top of `v0.8.0`).
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "discopt"
-version = "0.8.0"
+version = "0.8.1.dev0"
 description = "MINLP solver with a Rust core: spatial branch and bound over convex relaxations"
 requires-python = ">=3.10"
 authors = [{name = "John Kitchin"}]

--- a/python/discopt/__init__.py
+++ b/python/discopt/__init__.py
@@ -25,7 +25,7 @@ solvers
     NLP solver backends: POUNCE (pure-Rust Ipopt port, the default) and cyipopt (Ipopt).
 """
 
-__version__ = "0.8.0"
+__version__ = "0.8.1.dev0"
 
 # Allow external distributions (e.g. the ``discopt-aggregation`` plugin) to
 # contribute submodules under the ``discopt`` namespace from a separate location


### PR DESCRIPTION
`RELEASE.md` §12, run now that `v0.8.0` is tagged on `deba4ce8` and the release
workflow has published.

## Version

`pyproject.toml` and `python/discopt/__init__.py` move to `0.8.1.dev0`.
`CITATION.cff` stays at `0.8.0` on purpose — §8 requires it to match the tag, and
it cites the released artifact, not the development tip. The Rust crates
(`discopt-core` 0.2.0, `discopt-python` 0.2.3) version independently of the Python
package and are untouched.

## Changelog

A fresh `## [Unreleased]` header above `## [0.8.0]`. The
`[Unreleased]: .../compare/v0.8.0...HEAD` footnote was already pointing at the new
tag, so no link edit was needed. `RELEASE.md`'s "next planned release" line moves
to `v0.9.0`.

## GAMS license file, nearly committed

Included here because it surfaced during this release's benchmarking and is a
one-line guard rather than its own PR.

Each `gams` invocation creates a scratch directory in the working directory named
`<digits><letter>` — `225a`, `225b`, … — and that directory contains
`gamslice.dat`, **this machine's GAMS license file**. Running the BARON
head-to-head left one in a worktree, and a `git add -A` while preparing this
commit staged all three files in it. It was caught at `git status` before any
commit.

The file has never been tracked and is not in history — `git ls-files | grep -i
gamslice` and `git log --all -- '**/gamslice.dat'` are both empty. Nothing needs
scrubbing. But the failure mode is silent and repeatable, so `.gitignore` now
covers both the directory shape and the license file by name, verified with
`git check-ignore` on all three paths.

## Verification

`pre-commit run` on the commit: ruff, ruff format, mypy all pass. The change is a
version string, a markdown header, and ignore rules; no code path is touched.
