### PR TITLE
fix(release): #1055 ship abi3 wheels and honor the declared 3.10 floor

### DIFF
--- a/.github/scripts/check_wheel_coverage.py
+++ b/.github/scripts/check_wheel_coverage.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+"""Assert the built distribution actually covers every platform we promise.
+
+Run against the collected ``dist/`` directory *before* uploading to PyPI.
+
+v0.8.0 shipped with ``requires-python = ">=3.10"`` while macOS and Windows had
+wheels for 3.12 only (#1055): the release workflow's macOS/Windows jobs never
+passed an interpreter list, so maturin built against the runner's ``setup-python``
+version alone. Every job was green and the upload succeeded -- the gap was
+invisible because nothing checked *what* got published, only that publishing
+worked. A Mac user on 3.11 fell through to the sdist and hit a Rust toolchain
+error that reads as a broken package.
+
+The fix was ``abi3``: one wheel per platform, valid for the whole supported
+range. This script is the guard that keeps it that way. It fails the release if
+a platform is missing, if a wheel is not ``abi3``, or if the ``abi3`` floor has
+drifted away from ``requires-python`` -- that last one is the silent failure the
+next person would otherwise hit, because bumping ``requires-python`` without
+bumping the ``abi3-pyXY`` feature in ``Cargo.toml`` publishes wheels that claim
+support for versions they were never built against.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+import tomllib
+from pathlib import Path
+
+# Platform tag -> a human name for the error message. Every one of these must be
+# represented by at least one wheel in dist/.
+REQUIRED_PLATFORMS: dict[str, str] = {
+    r"manylinux.*_x86_64": "Linux x86_64",
+    r"manylinux.*_aarch64": "Linux aarch64",
+    r"macosx_.*_x86_64": "macOS x86_64",
+    r"macosx_.*_arm64": "macOS arm64",
+    r"win_amd64": "Windows x64",
+}
+
+
+def main() -> int:
+    repo = Path(__file__).resolve().parents[2]
+    dist = Path(sys.argv[1] if len(sys.argv) > 1 else "dist")
+
+    with (repo / "pyproject.toml").open("rb") as fh:
+        pyproject = tomllib.load(fh)
+    requires_python = pyproject["project"]["requires-python"]
+    m = re.fullmatch(r">=\s*3\.(\d+)", requires_python.strip())
+    if not m:
+        print(
+            f"FAIL: cannot parse requires-python {requires_python!r}. This script "
+            "understands '>=3.N' only; teach it the new form rather than deleting "
+            "the check.",
+            file=sys.stderr,
+        )
+        return 1
+    floor_minor = int(m.group(1))
+    expected_abi_tag = f"cp3{floor_minor}-abi3"
+
+    wheels = sorted(p.name for p in dist.glob("*.whl"))
+    sdists = sorted(p.name for p in dist.glob("*.tar.gz"))
+
+    failures: list[str] = []
+    checks = 0
+
+    # 1. Something was actually built. Without this, an empty dist/ would sail
+    #    through every loop below and report a clean pass.
+    checks += 1
+    if not wheels:
+        failures.append(f"no wheels found in {dist}/")
+
+    # 2. Exactly one sdist.
+    checks += 1
+    if len(sdists) != 1:
+        failures.append(f"expected exactly 1 sdist, found {len(sdists)}: {sdists}")
+
+    # 3. Every promised platform has a wheel.
+    for pattern, label in REQUIRED_PLATFORMS.items():
+        checks += 1
+        if not any(re.search(pattern, w) for w in wheels):
+            failures.append(f"no wheel for {label} (no filename matches /{pattern}/)")
+
+    # 4. Every wheel is abi3 at exactly the requires-python floor.
+    for w in wheels:
+        checks += 1
+        if expected_abi_tag not in w:
+            failures.append(
+                f"{w} is not tagged {expected_abi_tag}. requires-python is "
+                f"{requires_python}, so the pyo3 'abi3-py3{floor_minor}' feature in "
+                "Cargo.toml must match it."
+            )
+
+    print(f"dist:            {dist}")
+    print(f"requires-python: {requires_python}  ->  expecting {expected_abi_tag}")
+    print(f"sdists:          {len(sdists)}")
+    print(f"wheels:          {len(wheels)}")
+    for w in wheels:
+        print(f"  {w}")
+    print(f"EXECUTED CHECKS: {checks}")
+
+    if checks == 0:
+        print("FAIL: PROBE NEVER FIRED -- zero checks executed", file=sys.stderr)
+        return 1
+    if failures:
+        print(f"\nFAIL: {len(failures)} coverage problem(s):", file=sys.stderr)
+        for f in failures:
+            print(f"  - {f}", file=sys.stderr)
+        return 1
+    print("\nOK: wheel coverage complete.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,11 @@ jobs:
         uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.platform.target }}
-          args: --release --out dist -i python3.10 python3.11 python3.12 python3.13
+          # One abi3 wheel per platform covers every supported interpreter --
+          # see the abi3-py310 note in Cargo.toml. No `-i` list: an explicit
+          # interpreter list here would silently define coverage per platform,
+          # which is exactly how #1055 happened.
+          args: --release --out dist
           manylinux: auto
       - name: Upload wheels
         uses: actions/upload-artifact@v4
@@ -106,11 +110,20 @@ jobs:
     permissions:
       id-token: write
     steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
       - uses: actions/download-artifact@v4
         with:
           pattern: wheels-*
           merge-multiple: true
           path: dist
+      # Green build jobs are not evidence of coverage: v0.8.0 published with
+      # eight of twelve platform/version combinations missing and every job
+      # passed. Check the artifact list itself, before the upload.
+      - name: Verify wheel coverage
+        run: python .github/scripts/check_wheel_coverage.py dist
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,72 @@ The release procedure that produces these entries is documented in
 
 ## [Unreleased]
 
+### Fixed
+
+- **macOS and Windows wheels covered only Python 3.12** (`fix(release)`, #1056,
+  closes #1055). `pyproject.toml` declares `requires-python = ">=3.10"`, but the
+  release workflow's macOS and Windows jobs passed no interpreter list, so maturin
+  built against the runner's `setup-python` version alone. v0.8.0 published 11
+  wheels covering 4 of 12 platform/version combinations off Linux; `pip install
+  discopt` on macOS or Windows under 3.10, 3.11 or 3.13 fell through to the sdist
+  and failed on a missing Rust toolchain, which reads as a broken package rather
+  than a missing wheel. Present since at least v0.7.0, whose file list has the
+  identical shape.
+
+  Fixed with `abi3` rather than by extending the interpreter matrix: pyo3 gains
+  `abi3-py310`, so **one** wheel per platform serves every supported interpreter.
+  The artifact count drops 12 → 6 and the build matrix shrinks instead of
+  quadrupling. Verified by building a single `cp310-abi3` wheel and solving the
+  same model on 3.10, 3.11, 3.12 and 3.13 — identical objective to the bit on all
+  four.
+
+  The stable ABI routes the Python↔Rust boundary through the limited API, and this
+  solver crosses that boundary per B&B node, so the cost was measured rather than
+  assumed: 5 interleaved reps over a 6-instance panel plus 3 reps on
+  `clay0303hfsg`. Node counts are identical on every instance (bound-neutral, per
+  `CLAUDE.md` verification regime 1); wall-clock difference is within noise. Full
+  numbers in #1056.
+
+- **The release could publish an incomplete artifact set with every job green**
+  (`fix(release)`, #1056). Nothing checked *what* was built, only that building
+  and uploading succeeded — which is why the gap above survived a release.
+  `.github/scripts/check_wheel_coverage.py` now runs on the collected artifacts
+  before the PyPI upload and fails if a platform is missing, if a wheel is not
+  `abi3`, or if the `abi3` floor has drifted from `requires-python` (bumping one
+  without the other would publish wheels claiming support they were never built
+  against). The guard was tested against the real v0.8.0 file list, which it
+  rejects, and against this release's, which it accepts.
+
+- **`discopt install-skills` crashed on Python 3.10** (`fix(skills)`, #1056).
+  `discopt/skills/__init__.py` imported `Traversable` from
+  `importlib.resources.abc`, which exists only on 3.11+, so `import
+  discopt.skills` raised `ModuleNotFoundError` on the 3.10 floor
+  `requires-python` promises. The name is used only in annotations and the module
+  already has `from __future__ import annotations`, so the import moved under
+  `if TYPE_CHECKING:` with a `sys.version_info` split (3.10 reaches the same class
+  as `importlib.abc.Traversable`). Found while fixing the wheel gap above: until
+  the `abi3` change, no macOS or Windows user could install on 3.10 at all, so a
+  3.10-only crash could not surface there.
+
+- **The correctness tier could not be collected on Python 3.10** (`fix(tests)`,
+  #1056). `python/tests/_optima.py` — the reference-optima oracle shared by every
+  soundness suite — did a bare `import tomllib` (3.11+), making six test modules
+  collection errors on 3.10. It now falls back to `tomli`, matching
+  `discopt/profiles.py`, and raises a pointed error if neither parser is present
+  rather than degrading to an empty registry, which would silently turn every
+  soundness assertion into a no-op. `tomli` is now declared in the `dev` extra
+  under a `python_version < "3.11"` marker.
+
+- **Nothing checked that shipped code runs on the oldest supported Python**
+  (`test`, #1056). Both 3.10 breaks above survived because all seven CI jobs run
+  3.12. `python/tests/test_requires_python_floor.py` AST-scans `python/discopt/`
+  and `python/tests/` for module-scope imports of stdlib modules or names newer
+  than the `requires-python` floor, ignoring those guarded by `try`/`except`,
+  `TYPE_CHECKING`, or a `sys.version_info` branch. It runs on any interpreter, so
+  it does not need a 3.10 job to catch the next one. A companion test feeds the
+  scanner a known violation plus three correctly-guarded imports, so a broken
+  scanner cannot pass vacuously.
+
 ## [0.8.0] - 2026-08-16
 
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,5 +9,9 @@ license = "EPL-2.0"
 repository = "https://github.com/discopt-org/discopt"
 
 [workspace.dependencies]
-pyo3 = { version = "0.23", features = ["extension-module"] }
+# abi3-py310 builds against CPython's stable ABI, so ONE wheel per platform
+# covers every supported interpreter. The floor must track `requires-python` in
+# pyproject.toml -- if that moves to >=3.11, this becomes abi3-py311.
+# `.github/scripts/check_wheel_coverage.py` fails the release if the two drift.
+pyo3 = { version = "0.23", features = ["extension-module", "abi3-py310"] }
 numpy = "0.23"

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -147,9 +147,16 @@ directly; always re-export from org.
 - [ ] `git checkout main && git pull`.
 - [ ] `git tag -a vX.Y.Z -m "discopt vX.Y.Z"` -- annotated tag on the merge commit.
 - [ ] `git push origin vX.Y.Z` -- this triggers `.github/workflows/release.yml`.
-- [ ] Watch the release workflow: wheels build for Linux (x86_64 + aarch64), macOS (x86_64 + aarch64), and Windows (x64); sdist built; PyPI upload succeeds.
-- [ ] Verify on PyPI that `https://pypi.org/project/discopt/X.Y.Z/` exists and lists the expected wheels.
-- [ ] In a clean virtualenv: `pip install discopt==X.Y.Z` then `python -c "import discopt; print(discopt.__version__)"`.
+- [ ] Watch the release workflow: one `abi3` wheel builds per platform -- Linux (x86_64 + aarch64), macOS (x86_64 + aarch64), Windows (x64) -- sdist built; the **Verify wheel coverage** step passes; PyPI upload succeeds.
+- [ ] Verify on PyPI that `https://pypi.org/project/discopt/X.Y.Z/` exists and lists **6 files**: five `cp3NN-abi3` wheels plus the sdist.
+      *Green build jobs are not evidence of coverage.* v0.8.0 published with macOS
+      and Windows wheels for 3.12 only against `requires-python = ">=3.10"`, and
+      every job was green (#1055). The workflow now runs
+      `.github/scripts/check_wheel_coverage.py` on the collected artifacts before
+      uploading; if that step is ever removed or skipped, check the file list by
+      hand:
+      `curl -s -H "User-Agent: <you>" https://pypi.org/pypi/discopt/X.Y.Z/json | python -c "import json,sys; [print(u['filename']) for u in json.load(sys.stdin)['urls']]"`
+- [ ] In a clean virtualenv: `pip install discopt==X.Y.Z` then `python -c "import discopt; print(discopt.__version__)"`. Do this on the **oldest** supported Python, not the newest -- an ABI gap shows up there first.
 
 ## 11. GitHub Release
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,6 +89,12 @@ dev = [
     # (Also in the `gams` extra, for gamsconfig.yaml merging.)
     "pyyaml>=6",
     "pytest-xdist",
+    # `python/tests/_optima.py` -- the reference-optima oracle for every
+    # correctness suite -- needs a TOML parser, and stdlib `tomllib` is 3.11+.
+    # Without this the correctness tier is a *collection error* on the 3.10 floor
+    # that `requires-python` promises, which is how #1055 stayed invisible: no
+    # CI job runs 3.10, so nothing ever tried.
+    "tomli>=2; python_version < '3.11'",
     # Pin the lint/typecheck toolchain to the exact versions in
     # .pre-commit-config.yaml (the single source of truth CI also runs), so a
     # local `pip install -e .[dev]` cannot drift from CI.

--- a/python/discopt/skills/__init__.py
+++ b/python/discopt/skills/__init__.py
@@ -19,9 +19,22 @@ Examples
 
 from __future__ import annotations
 
+import sys
 from importlib.resources import files
-from importlib.resources.abc import Traversable
-from typing import Iterator
+from typing import TYPE_CHECKING, Iterator
+
+if TYPE_CHECKING:
+    # ``Traversable`` appears here only in annotations, and PEP 563 (the
+    # ``__future__`` import above) makes those strings -- so this never executes
+    # at runtime. It has to be guarded because ``importlib.resources.abc`` is
+    # 3.11+, while ``requires-python`` promises 3.10: until #1055 this was an
+    # unconditional import, and ``import discopt.skills`` (hence
+    # ``discopt install-skills``) raised ModuleNotFoundError on 3.10. On 3.10 the
+    # same class is reachable as ``importlib.abc.Traversable``.
+    if sys.version_info >= (3, 11):
+        from importlib.resources.abc import Traversable
+    else:
+        from importlib.abc import Traversable
 
 _PACKAGE = "discopt.skills"
 

--- a/python/tests/_optima.py
+++ b/python/tests/_optima.py
@@ -22,7 +22,22 @@ from functools import lru_cache
 from pathlib import Path
 from typing import Any
 
-import tomllib
+try:
+    import tomllib
+except ModuleNotFoundError:  # Python 3.10 -- stdlib tomllib arrived in 3.11.
+    try:
+        import tomli as tomllib  # type: ignore[no-redef]
+    except ModuleNotFoundError as exc:  # pragma: no cover - env misconfiguration
+        # Deliberately fatal rather than degrading to an empty registry: this
+        # module feeds the *reference optima* to the correctness suites, and a
+        # silently empty registry turns every soundness assertion into a no-op
+        # that reports a pass (CLAUDE.md 6). `tomli` is in the `dev` extra.
+        raise ModuleNotFoundError(
+            "the reference-optima registry needs a TOML parser: Python < 3.11 has "
+            "no stdlib `tomllib`, and `tomli` is not installed. Install the dev "
+            "extra (`pip install -e '.[dev]'`) -- do not skip these tests, they "
+            "are the correctness oracle."
+        ) from exc
 
 _REGISTRY_PATH = Path(__file__).parent / "data" / "known_optima.toml"
 

--- a/python/tests/test_requires_python_floor.py
+++ b/python/tests/test_requires_python_floor.py
@@ -1,0 +1,195 @@
+"""No shipped module may need a newer Python than ``requires-python`` promises.
+
+``pyproject.toml`` declares ``requires-python = ">=3.10"`` and, since #1055, the
+release publishes a single ``abi3`` wheel per platform that pip will happily
+install on 3.10. That makes the floor a real promise for the first time -- and it
+was already broken in two places when the wheels were fixed:
+
+* ``discopt/skills/__init__.py`` did ``from importlib.resources.abc import
+  Traversable`` at module scope. That submodule is 3.11+, so ``import
+  discopt.skills`` -- and therefore ``discopt install-skills`` -- raised
+  ``ModuleNotFoundError`` on 3.10.
+* ``python/tests/_optima.py`` did a bare ``import tomllib`` (3.11+), which turned
+  the *entire correctness tier* into a collection error on 3.10, since that
+  module is the reference-optima oracle.
+
+Neither was caught by CI: every job runs 3.12, so nothing ever executed an import
+on the floor. This test does it statically instead, on whatever interpreter is
+running, and covers the class rather than those two files -- the next 3.11-only
+import added anywhere under ``python/`` fails here.
+
+A guarded import is fine: inside ``try``/``except``, inside ``if TYPE_CHECKING``,
+or inside a ``sys.version_info`` branch. Only an unconditional module-scope
+import is a violation.
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_PYPROJECT = _REPO_ROOT / "pyproject.toml"
+_SCAN_ROOTS = (_REPO_ROOT / "python" / "discopt", _REPO_ROOT / "python" / "tests")
+
+# Stdlib module -> the first Python version that has it.
+_NEW_MODULES: dict[str, tuple[int, int]] = {
+    "tomllib": (3, 11),
+    "importlib.resources.abc": (3, 11),
+    "asyncio.taskgroups": (3, 11),
+    "wsgiref.types": (3, 11),
+    "importlib.metadata.diagnose": (3, 13),
+    "dbm.sqlite3": (3, 13),
+    "compression": (3, 14),
+    "annotationlib": (3, 14),
+}
+
+# (module, imported name) -> the first Python version that has the name.
+_NEW_NAMES: dict[tuple[str, str], tuple[int, int]] = {
+    ("typing", "Self"): (3, 11),
+    ("typing", "Never"): (3, 11),
+    ("typing", "LiteralString"): (3, 11),
+    ("typing", "assert_never"): (3, 11),
+    ("typing", "assert_type"): (3, 11),
+    ("typing", "reveal_type"): (3, 11),
+    ("typing", "TypeVarTuple"): (3, 11),
+    ("typing", "Unpack"): (3, 11),
+    ("typing", "dataclass_transform"): (3, 11),
+    ("typing", "get_overloads"): (3, 11),
+    ("typing", "override"): (3, 12),
+    ("typing", "TypeAliasType"): (3, 12),
+    ("typing", "ReadOnly"): (3, 13),
+    ("typing", "TypeIs"): (3, 13),
+    ("enum", "StrEnum"): (3, 11),
+    ("enum", "ReprEnum"): (3, 11),
+    ("enum", "EnumCheck"): (3, 11),
+    ("enum", "verify"): (3, 11),
+    ("enum", "member"): (3, 11),
+    ("enum", "nonmember"): (3, 11),
+    ("datetime", "UTC"): (3, 11),
+    ("asyncio", "TaskGroup"): (3, 11),
+    ("asyncio", "Runner"): (3, 11),
+    ("asyncio", "timeout"): (3, 11),
+    ("asyncio", "timeout_at"): (3, 11),
+    ("contextlib", "chdir"): (3, 11),
+    ("hashlib", "file_digest"): (3, 11),
+    ("itertools", "batched"): (3, 12),
+    ("pathlib", "UnsupportedOperation"): (3, 13),
+    ("warnings", "deprecated"): (3, 13),
+    ("os", "process_cpu_count"): (3, 13),
+}
+
+
+def _floor() -> tuple[int, int]:
+    """The ``requires-python`` floor, as a version tuple."""
+    text = _PYPROJECT.read_text()
+    m = re.search(r'requires-python\s*=\s*"[^"]*?>=\s*(\d+)\.(\d+)', text)
+    assert m, "could not read requires-python from pyproject.toml"
+    return int(m.group(1)), int(m.group(2))
+
+
+def _is_guarded(node: ast.AST, parents: dict[ast.AST, ast.AST]) -> bool:
+    """True if ``node`` sits under try/except, ``TYPE_CHECKING``, or a version check."""
+    cur = parents.get(node)
+    while cur is not None:
+        if isinstance(cur, ast.Try):
+            return True
+        if isinstance(cur, ast.If):
+            test = ast.dump(cur.test)
+            if "TYPE_CHECKING" in test or "version_info" in test:
+                return True
+        cur = parents.get(cur)
+    return False
+
+
+def _violations(floor: tuple[int, int]) -> tuple[list[str], int]:
+    """Return (violation messages, number of imports actually examined)."""
+    found: list[str] = []
+    examined = 0
+
+    for root in _SCAN_ROOTS:
+        assert root.is_dir(), f"scan root missing: {root}"
+        for path in sorted(root.rglob("*.py")):
+            tree = ast.parse(path.read_text(), filename=str(path))
+            parents: dict[ast.AST, ast.AST] = {}
+            for parent in ast.walk(tree):
+                for child in ast.iter_child_nodes(parent):
+                    parents[child] = parent
+
+            for node in ast.walk(tree):
+                if isinstance(node, ast.Import):
+                    targets = [(alias.name, None) for alias in node.names]
+                elif isinstance(node, ast.ImportFrom) and node.level == 0:
+                    mod = node.module or ""
+                    targets = [(mod, None)] + [(mod, a.name) for a in node.names]
+                else:
+                    continue
+
+                guarded = _is_guarded(node, parents)
+                rel = path.relative_to(_REPO_ROOT)
+                for mod, name in targets:
+                    examined += 1
+                    need = _NEW_MODULES.get(mod) if name is None else _NEW_NAMES.get((mod, name))
+                    if need is None or need <= floor or guarded:
+                        continue
+                    what = f"from {mod} import {name}" if name else f"import {mod}"
+                    found.append(
+                        f"{rel}:{node.lineno}: {what} needs Python "
+                        f"{need[0]}.{need[1]}, but requires-python floor is "
+                        f"{floor[0]}.{floor[1]}"
+                    )
+    return found, examined
+
+
+@pytest.mark.smoke
+def test_no_unguarded_imports_above_requires_python_floor():
+    floor = _floor()
+    violations, examined = _violations(floor)
+
+    # Prove the probe fired (CLAUDE.md §6). A refactor that moves the package or
+    # breaks the AST walk would otherwise report a clean pass having read nothing.
+    assert examined > 1000, (
+        f"only {examined} imports examined across {[str(r) for r in _SCAN_ROOTS]} -- "
+        "the scan is not reaching the source tree"
+    )
+
+    assert not violations, (
+        f"{len(violations)} import(s) require a newer Python than the "
+        f"{floor[0]}.{floor[1]} floor that pyproject.toml promises and the abi3 "
+        "wheel delivers:\n  " + "\n  ".join(violations) + "\n"
+        "Guard with try/except, `if TYPE_CHECKING:`, or `if sys.version_info >= "
+        "(3, N):` -- or raise the floor in pyproject.toml (and the abi3-pyXY "
+        "feature in Cargo.toml with it)."
+    )
+
+
+@pytest.mark.smoke
+def test_the_floor_scanner_detects_a_known_violation(tmp_path, monkeypatch):
+    """The scanner must fail on a real violation, not just pass on clean code.
+
+    Without this, a typo in `_NEW_MODULES` or a broken guard check would make the
+    test above vacuous while still reporting green.
+    """
+    bad = tmp_path / "pkg"
+    bad.mkdir()
+    (bad / "unguarded.py").write_text("import tomllib\n")
+    (bad / "guarded_try.py").write_text("try:\n    import tomllib\nexcept ImportError:\n    pass\n")
+    (bad / "guarded_version.py").write_text(
+        "import sys\nif sys.version_info >= (3, 11):\n    import tomllib\n"
+    )
+    (bad / "guarded_typing.py").write_text(
+        "from typing import TYPE_CHECKING\nif TYPE_CHECKING:\n"
+        "    from importlib.resources.abc import Traversable\n"
+    )
+    monkeypatch.setattr(sys.modules[__name__], "_SCAN_ROOTS", (bad,))
+    monkeypatch.setattr(sys.modules[__name__], "_REPO_ROOT", tmp_path)
+
+    violations, examined = _violations((3, 10))
+    # 6 `import X` / bare-module entries plus 2 from-import names.
+    assert examined == 8, f"expected 8 import targets examined, got {examined}"
+    assert len(violations) == 1, f"expected exactly the unguarded one, got {violations}"
+    assert "unguarded.py" in violations[0]


### PR DESCRIPTION
Closes #1055.

## The bug

`pyproject.toml` declares `requires-python = ">=3.10"`. v0.8.0 published:

| Platform | Wheels published | Should cover |
|---|---|---|
| Linux x86_64 / aarch64 | 3.10, 3.11, 3.12, 3.13 | 4 |
| macOS x86_64 / arm64 | **3.12 only** | 4 |
| Windows x64 | **3.12 only** | 2 |

Off Linux that is 4 of 12 platform/version combinations. The release workflow's
macOS and Windows jobs passed no `-i` interpreter list, so maturin built against
the runner's `setup-python` version alone. **Every job was green** — nothing
inspected what got built, only that building and uploading succeeded. A macOS
user on 3.11 falls through to the sdist and hits a Rust toolchain error, which
reads as a broken package rather than a missing wheel. v0.7.0's file list has the
identical shape, so this has been present since at least then.

## The fix: abi3, not a bigger matrix

Extending the interpreter list to four versions × five platforms is the obvious
fix and the wrong one — it quadruples build time and leaves the same trap for the
next Python release. `pyo3` gains `abi3-py310`, so **one wheel per platform**
covers every supported interpreter. Artifacts drop 12 → 6, the matrix shrinks,
and adding Python 3.14 support becomes a no-op.

The stable ABI routes the Python↔Rust boundary through the limited API, and this
solver crosses that boundary per B&B node, so I measured rather than assumed.

**Functional equivalence** — one `cp310-abi3` wheel, four interpreters:

| Python | Objective | Status |
|---|---|---|
| 3.10.16 | −9.999999990908268 | optimal |
| 3.11 | −9.999999990908268 | optimal |
| 3.12.11 | −9.999999990908268 | optimal |
| 3.13 | −9.999999990908268 | optimal |

**Cost** — interleaved A/B, 5 reps × 6 light instances + 3 reps × `clay0303hfsg`,
66 raw rows, load average 4.46 → 6.22 across the run (CLAUDE.md §9):

| Instance | control (s) | abi3 (s) | Δ |
|---|---|---|---|
| `alan` | 0.023 ± 0.001 | 0.023 ± 0.001 | −0.4% |
| `ex1221` | — | — | +1.4% |
| `ex1222` | — | — | −4.0% |
| `ex1224` | — | — | +2.5% |
| `ex1225` | — | — | +0.4% |
| `ex1226` | — | — | −0.5% |
| `clay0303hfsg` | 17.584 ± 0.136 | 17.765 ± 0.239 | +1.0% |
| **total wall** | **61.35** | **61.97** | **+1.0%** |

Signs go both ways and every per-instance delta is inside its own spread. Per
CLAUDE.md verification regime 1 (bound-neutral), the binding check is not wall
but exactness: **0 node-count mismatches and 0 objective mismatches** across all
7 instances.

## The guard

The gap survived a release because nothing checked coverage.
`.github/scripts/check_wheel_coverage.py` runs on the collected artifacts
*before* the PyPI upload and fails if a platform is missing, if a wheel is not
`abi3`, or if the `abi3` floor has drifted from `requires-python` — that last one
is the silent trap, since bumping `requires-python` without bumping
`abi3-pyXY` in `Cargo.toml` publishes wheels claiming support they were never
built against.

Tested both directions: it **rejects** the real v0.8.0 file list (11 problems, 18
checks executed) and **accepts** this one (12 checks, exit 0). It prints an
executed-check count and fails on zero (CLAUDE.md §6).

## Two things 3.10 never actually supported

Making 3.10 installable exposed code that had never run there. Both survived
because **all seven CI jobs run 3.12**.

1. **`discopt install-skills` crashed on 3.10.** `discopt/skills/__init__.py`
   imported `Traversable` from `importlib.resources.abc`, which is 3.11+, so
   `import discopt.skills` raised `ModuleNotFoundError`. This is shipped code, not
   test scaffolding. The name is annotation-only and the module already has
   `from __future__ import annotations`, so it moves under `if TYPE_CHECKING:`
   with a `sys.version_info` split (3.10 reaches the same class as
   `importlib.abc.Traversable`).

2. **The correctness tier could not even be collected on 3.10.**
   `python/tests/_optima.py` — the reference-optima oracle shared by every
   soundness suite — did a bare `import tomllib` (3.11+), making six modules
   collection errors. It now falls back to `tomli` (matching
   `discopt/profiles.py`) and **raises loudly** if neither parser is present
   rather than degrading to an empty registry, which would silently turn every
   soundness assertion into a no-op (CLAUDE.md §6). `tomli` is declared in the
   `dev` extra under `python_version < "3.11"`.

## Regression test

`python/tests/test_requires_python_floor.py` fixes the *class* rather than those
two files (CLAUDE.md §2). It AST-scans `python/discopt/` and `python/tests/` for
module-scope imports of stdlib modules or names newer than the `requires-python`
floor, ignoring anything guarded by `try`/`except`, `TYPE_CHECKING`, or a
`sys.version_info` branch. It runs on **any** interpreter, so catching the next
one does not require adding a 3.10 CI job.

Fails before / passes after, on the two real violations:

```
python/discopt/skills/__init__.py:23: import importlib.resources.abc needs Python 3.11, but requires-python floor is 3.10
python/tests/_optima.py:25: import tomllib needs Python 3.11, but requires-python floor is 3.10
1 failed, 1 passed
```
```
2 passed
```

A companion test feeds the scanner a known violation plus three correctly-guarded
imports and asserts it finds exactly one — so a typo in the version table or a
broken guard check cannot make the main test pass vacuously. The main test also
asserts it examined >1000 import targets (it sees 17,588) rather than silently
scanning nothing.

## Verification

- `pytest python/tests/ -m smoke` on **Python 3.10.16**, against the abi3 wheel:
  **1026 passed, 16 skipped, 2 xpassed** (113 s). Before this PR: **6 collection
  errors**, suite could not run.
- `pytest python/tests/ -m smoke` on **Python 3.12.11**, same wheel: **1026
  passed, 16 skipped, 2 xpassed** (120 s) — identical counts on both
  interpreters.
- `pytest -m slow python/tests/test_adversarial_recent_fixes.py`: see comment
  below.
- `cargo test -p discopt-core`: **618 passed, 0 failed**.
- `ruff check` / `ruff format --check` / `mypy`: clean (also via pre-commit on the
  commit).
- Provenance asserted before every measurement (CLAUDE.md §8): each run checks
  `sys.version_info`, that `discopt.__file__` resolves inside the target venv, and
  that `discopt._rust.__file__` ends in `.abi3.so`.

## RELEASE.md

§10 now says to expect **6 files** (five `cp3NN-abi3` wheels + sdist), to treat
green build jobs as no evidence of coverage, and to run the clean-venv install
check on the **oldest** supported Python — an ABI gap shows up there first.
