### PR TITLE
feat(solver): #1059 auto-route a convexity-certified MINLP to the MIP-NLP family (default-off)

### DIFF
--- a/python/discopt/modeling/core.py
+++ b/python/discopt/modeling/core.py
@@ -2047,6 +2047,11 @@ class SolveResult:
         True if the reported optimality gap is mathematically certified.
         False when NLP-BB is used on a nonconvex problem (heuristic mode),
         where the NLP objective is not a valid lower bound.
+    algorithm_route : Optional[str]
+        Why an algorithm other than the default branch-and-bound ran, when the
+        solver chose it automatically (#1059). ``None`` when no automatic
+        routing happened -- either the caller named ``solver=`` explicitly, or
+        the router declined and the default path ran.
     """
 
     status: str
@@ -2129,6 +2134,13 @@ class SolveResult:
     # Structured MIP-NLP decomposition trace. Populated by solver="mip-nlp"
     # paths when iteration/provenance data is available.
     mip_nlp_trace: Optional[dict[str, object]] = None
+
+    # Why an algorithm other than the default branch-and-bound ran (#1059).
+    # ``None`` means no automatic routing took place — either the caller named a
+    # solver explicitly, or the router declined and the default path ran. When
+    # populated it is a human-readable reason, e.g.
+    # ``"mip-nlp/oa: minlp certified convex at the root (DISCOPT_CONVEX_MINLP_ROUTE)"``.
+    algorithm_route: Optional[str] = None
 
     # Examiner-style validation report (populated if validate=True).
     validation_report: Optional[object] = None

--- a/python/discopt/result_io.py
+++ b/python/discopt/result_io.py
@@ -40,6 +40,7 @@ _SCALAR_FIELDS = (
     "subnlp_calls",
     "subnlp_feasible",
     "subnlp_incumbent_updates",
+    "algorithm_route",
 )
 _DICT_ARRAY_FIELDS = (
     "x",

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -4910,6 +4910,116 @@ def _classify_model_convexity(
     return result
 
 
+#: Problem classes the convex-MINLP auto-route (#1059) considers. Discrete AND
+#: nonlinear: a MILP has nothing for a MIP-NLP decomposition to decompose, and a
+#: continuous model is already served by the convex NLP fast path in
+#: ``solve_model``. MIQP/MIQCP/MIQCQP are included because a convex quadratic
+#: MINLP is exactly the class OA/LP-NLP-BB were designed for; whether the route
+#: actually pays there is what the §5 panel measures (see #1064).
+_CONVEX_MINLP_ROUTE_CLASSES = frozenset({"miqp", "miqcp", "miqcqp", "minlp"})
+
+
+def _convex_minlp_route_enabled() -> bool:
+    """Is the #1059 convexity-certified MINLP auto-route switched on?
+
+    **Default OFF.** Routing a model to a different algorithm is bound-changing
+    under CLAUDE.md §5 regime 2, so it ships behind ``DISCOPT_CONVEX_MINLP_ROUTE``
+    until a corpus-wide differential panel clears both bars (cert-clean AND
+    net-positive). ``DISCOPT_CONVEX_MINLP_ROUTE=0`` stays the opt-out after any
+    future graduation, and the spatial branch-and-bound path is left untouched
+    beneath it either way. Read per call, not cached at import, so a test can
+    flip it without reloading the module.
+    """
+    raw = os.environ.get("DISCOPT_CONVEX_MINLP_ROUTE")
+    if raw is None:
+        return False
+    return raw.strip() != "0"
+
+
+def _convex_minlp_auto_route(model: Model) -> tuple[Optional[str], str]:
+    """Decide whether ``model`` should be solved by the MIP-NLP family (#1059).
+
+    Returns ``(method, reason)`` where ``method`` is the ``mip_nlp_method`` to
+    use, or ``None`` to leave the model on the default spatial/NLP
+    branch-and-bound. ``reason`` always explains the verdict and is surfaced on
+    ``SolveResult.algorithm_route`` so the decision is never invisible.
+
+    Why this exists: discopt certifies models like the MINLPLib ``syn``/``rsyn``
+    family fully convex at the root in hundredths of a second (286/286
+    constraints on ``rsyn0805m``) and then discards the certificate, because
+    ``solver="mip-nlp"`` is reachable only through an explicit kwarg. The
+    default solve therefore runs the *spatial global* algorithm on a convex
+    MINLP — sound, but with a near-vacuous factorable relaxation (root bound
+    1833.9 against an optimum of 67.71 on ``syn40m``, 27x). Measured at 60 s per
+    instance, only the algorithm changed:
+
+    ==============  ======================  ====================
+    instance        default spatial path    ``mip_nlp_method="oa"``
+    ==============  ======================  ====================
+    ``rsyn0805m``   feasible, 13.9% off     optimal, 9.8 s
+    ``syn40m``      feasible, 51.0% off     optimal, 59.2 s
+    ``syn20m02m``   feasible, 63.7% off     optimal, 23.5 s
+    ==============  ======================  ====================
+
+    ``"oa"`` is the route target rather than the faster ``"lp_nlp_bb"``
+    (optimal on all three in 1.5-3.4 s) because ``lp_nlp_bb`` hard-requires a
+    Gurobi license — see #1060, which must land before that becomes selectable
+    automatically.
+
+    Every gate below is a *refusal* to route: an unknown convexity verdict, a
+    nonconvex model, a missing MILP backend, or an opaque ``dm.custom`` body all
+    leave the model on the sound default path. The route never fires on a model
+    whose convexity is merely unproven.
+    """
+    if not _convex_minlp_route_enabled():
+        return None, "disabled (DISCOPT_CONVEX_MINLP_ROUTE unset)"
+
+    if _is_pure_continuous(model):
+        # A convex *continuous* model is already served by solve_model's convex
+        # NLP fast path; there is no integrality for a decomposition to exploit.
+        return None, "not routed: model is pure continuous"
+
+    if _model_contains_custom_call(model):
+        # dm.custom is an opaque AD-only callable; the MILP master cannot
+        # linearize what it cannot read.
+        return None, "not routed: model contains an opaque dm.custom body"
+
+    try:
+        from discopt._relax.problem_classifier import ProblemClass, classify_problem
+
+        problem_class = classify_problem(model)
+    except Exception as exc:  # noqa: BLE001 - classification failure => stay put
+        logger.debug("convex-MINLP route: problem classification failed: %s", exc)
+        return None, "not routed: problem classification failed"
+
+    if not isinstance(problem_class, ProblemClass):  # pragma: no cover - defensive
+        return None, "not routed: problem classification returned an unknown value"
+    if problem_class.value not in _CONVEX_MINLP_ROUTE_CLASSES:
+        return None, f"not routed: problem class {problem_class.value} is not a discrete NLP"
+
+    known, is_convex, _mask = _classify_model_convexity(
+        model, failure_label="convex-MINLP route convexity detection failed"
+    )
+    if not known:
+        return None, "not routed: model convexity is unproven"
+    if not is_convex:
+        return None, "not routed: model is not convex"
+
+    # The OA master is a MILP. Refuse to route when no MILP backend can be
+    # loaded rather than routing into an import error (CLAUDE.md §3: a loud
+    # refusal beats a silent approximation, and staying on B&B is the sound
+    # answer here, not an approximation at all).
+    try:
+        import highspy  # noqa: F401
+    except ImportError:
+        return None, "not routed: no MILP backend for the OA master (highspy not installed)"
+
+    return "oa", (
+        f"mip-nlp/oa: {problem_class.value} certified convex at the root "
+        "(DISCOPT_CONVEX_MINLP_ROUTE)"
+    )
+
+
 # Size gate for the auto cut policy: above this many scalar variables the
 # per-node cut-separation overhead (eigh / extra LP re-solves) outweighs the
 # typical bound gain, so the policy declines to enable cuts (sound: a no-op).
@@ -6507,6 +6617,17 @@ def solve_model(
         )
     gurobi_options = kwargs.pop("gurobi_options", None) if _solver == "gurobi" else None
 
+    # --- #1059: auto-route a convexity-certified MINLP to the MIP-NLP family ---
+    # Only when the caller expressed no preference. An explicit solver= (including
+    # solver="bb") is always honoured, so this can never override a user's choice.
+    _auto_route_reason: Optional[str] = None
+    if _solver is None:
+        _auto_route_method, _auto_route_reason = _convex_minlp_auto_route(model)
+        if _auto_route_method is not None:
+            logger.info("Convex MINLP auto-route: %s", _auto_route_reason)
+            _solver = "mip-nlp"
+            kwargs.setdefault("mip_nlp_method", _auto_route_method)
+
     # --- MIP-NLP decomposition solver family ---
     if _solver == "mip-nlp":
         import warnings
@@ -6643,7 +6764,7 @@ def solve_model(
 
         model = reformulate_gdp(model, method=resolved_gdp_method)
 
-        return solve_mip_nlp(
+        _mip_nlp_result = solve_mip_nlp(
             model,
             method=mip_nlp_method,
             mip_nlp_options=mip_nlp_options,
@@ -6654,6 +6775,13 @@ def solve_model(
             initial_point=initial_point,
             **mip_nlp_kwargs,
         )
+        # #1059: record WHY this algorithm ran. Only set on the auto-route, so an
+        # explicit solver="mip-nlp" leaves the field None (the caller already
+        # knows what they asked for) and the field reads as "the router chose
+        # this" wherever it is populated.
+        if _auto_route_reason is not None and _mip_nlp_result is not None:
+            _mip_nlp_result.algorithm_route = _auto_route_reason
+        return _mip_nlp_result
 
     # --- Surrogate (model-based) derivative-free search (no certificate) ---
     #

--- a/python/tests/test_1059_convex_minlp_route.py
+++ b/python/tests/test_1059_convex_minlp_route.py
@@ -1,0 +1,143 @@
+"""#1059: auto-routing a convexity-certified MINLP to the MIP-NLP family.
+
+discopt certifies the MINLPLib ``syn``/``rsyn`` family fully convex at the root in
+hundredths of a second and then discards the certificate: ``solver="mip-nlp"``
+was reachable only through an explicit kwarg, so a default ``Model.solve()`` ran
+the *spatial global* algorithm on a convex MINLP. These tests pin the router's
+gates and the end-to-end effect.
+
+The route is bound-changing under CLAUDE.md §5 regime 2, so it ships default-OFF
+behind ``DISCOPT_CONVEX_MINLP_ROUTE``; every test here sets the variable
+explicitly rather than relying on the ambient default, so the file keeps testing
+what it says after any future graduation.
+"""
+
+from pathlib import Path
+
+import discopt.modeling as dm
+import pytest
+from discopt.modeling.core import Model, from_nl
+from discopt.solver import _convex_minlp_auto_route, _convex_minlp_route_enabled
+
+NL_DIR = Path(__file__).parent / "data" / "minlplib_nl"
+
+ROUTE_ENV = "DISCOPT_CONVEX_MINLP_ROUTE"
+
+
+def _load(name: str) -> Model:
+    path = NL_DIR / f"{name}.nl"
+    assert path.exists(), f"missing corpus instance {path}"
+    m = from_nl(str(path))
+    # Keep classification bounded so a slow box cannot turn a gate test into a
+    # timeout; every instance here classifies in well under 0.05 s.
+    m._convexity_time_budget = 10.0
+    return m
+
+
+@pytest.mark.unit
+class TestRouteFlag:
+    def test_default_is_off(self, monkeypatch):
+        """§5 regime 2: a bound-changing route ships default-OFF."""
+        monkeypatch.delenv(ROUTE_ENV, raising=False)
+        assert _convex_minlp_route_enabled() is False
+
+    def test_env_enables(self, monkeypatch):
+        monkeypatch.setenv(ROUTE_ENV, "1")
+        assert _convex_minlp_route_enabled() is True
+
+    def test_zero_is_the_opt_out(self, monkeypatch):
+        """``=0`` must stay a hard opt-out, so a graduation cannot strand users."""
+        monkeypatch.setenv(ROUTE_ENV, "0")
+        assert _convex_minlp_route_enabled() is False
+
+    def test_disabled_flag_declines_a_routable_model(self, monkeypatch):
+        """With the flag off the router declines a model it would otherwise take."""
+        monkeypatch.delenv(ROUTE_ENV, raising=False)
+        method, reason = _convex_minlp_auto_route(_load("gbd"))
+        assert method is None
+        assert "disabled" in reason
+
+
+@pytest.mark.unit
+class TestRouteGates:
+    """Every gate is a *refusal*: the route never fires on unproven convexity."""
+
+    def test_fires_on_convex_minlp(self, monkeypatch):
+        monkeypatch.setenv(ROUTE_ENV, "1")
+        method, reason = _convex_minlp_auto_route(_load("gbd"))
+        assert method == "oa"
+        assert "certified convex" in reason
+
+    def test_declines_pure_continuous(self, monkeypatch):
+        """A convex NLP is already served by the continuous convex fast path."""
+        monkeypatch.setenv(ROUTE_ENV, "1")
+        m = Model("convex_nlp")
+        x = m.continuous("x", lb=-5, ub=5)
+        m.minimize(dm.exp(x) + x**2)
+        m.subject_to(x >= -2)
+        method, reason = _convex_minlp_auto_route(m)
+        assert method is None
+        assert "pure continuous" in reason
+
+    def test_declines_milp(self, monkeypatch):
+        """A MILP has no nonlinearity for a MIP-NLP decomposition to decompose."""
+        monkeypatch.setenv(ROUTE_ENV, "1")
+        m = Model("milp")
+        x = m.continuous("x", lb=0, ub=10)
+        y = m.binary("y")
+        m.minimize(x + 2 * y)
+        m.subject_to(x + y >= 1)
+        method, reason = _convex_minlp_auto_route(m)
+        assert method is None
+        assert "not a discrete NLP" in reason
+
+    def test_declines_nonconvex_minlp(self, monkeypatch):
+        """A nonconvex MINLP must stay on the sound spatial path."""
+        monkeypatch.setenv(ROUTE_ENV, "1")
+        m = Model("nonconvex_minlp")
+        x = m.continuous("x", lb=-2, ub=2)
+        y = m.continuous("y", lb=-2, ub=2)
+        z = m.binary("z")
+        m.minimize(x * y + z)  # bilinear: nonconvex
+        m.subject_to(x + y + z >= 1)
+        method, reason = _convex_minlp_auto_route(m)
+        assert method is None
+        assert reason.startswith("not routed")
+
+    def test_declines_opaque_custom_body(self, monkeypatch):
+        """``dm.custom`` is AD-only; a MILP master cannot linearize it."""
+        monkeypatch.setenv(ROUTE_ENV, "1")
+        m = Model("custom")
+        x = m.continuous("x", lb=0, ub=5)
+        y = m.binary("y")
+        opaque = dm.custom(lambda v: v**2)
+        m.minimize(opaque(x) + y)
+        m.subject_to(x + y >= 1)
+        method, reason = _convex_minlp_auto_route(m)
+        assert method is None
+        assert "dm.custom" in reason
+
+
+@pytest.mark.smoke
+class TestRouteDispatch:
+    """The router must never override an explicit ``solver=``."""
+
+    def test_explicit_bb_is_honoured(self, monkeypatch):
+        monkeypatch.setenv(ROUTE_ENV, "1")
+        m = _load("gbd")
+        result = m.solve(solver="bb", time_limit=30)
+        assert result.algorithm_route is None
+
+    def test_auto_route_is_recorded_on_the_result(self, monkeypatch):
+        """The routing decision must be visible, not silent."""
+        monkeypatch.setenv(ROUTE_ENV, "1")
+        m = _load("gbd")
+        result = m.solve(time_limit=30)
+        assert result.algorithm_route is not None
+        assert "mip-nlp/oa" in result.algorithm_route
+
+    def test_route_off_leaves_the_field_unset(self, monkeypatch):
+        monkeypatch.delenv(ROUTE_ENV, raising=False)
+        m = _load("gbd")
+        result = m.solve(time_limit=30)
+        assert result.algorithm_route is None


### PR DESCRIPTION
Contributes to #1059.

## The defect

discopt certifies the MINLPLib `syn`/`rsyn` family fully convex at the root in
hundredths of a second — 286/286 constraints on `rsyn0805m`, 226/226 on
`syn40m` — and then throws the certificate away. `solver="mip-nlp"`, the
OA/ECP/FP/LP-NLP-BB family already implemented in `python/discopt/solvers/`, was
reachable only through an explicit kwarg:

```
solver.py:6484:    _solver = solver if solver is not None else kwargs.pop("solver", None)
solver.py:6511:    if _solver == "mip-nlp":
```

So a default `Model.solve()` ran the *spatial global* algorithm on a convex
MINLP. That is sound — every reported row carried `status=feasible`, never
`optimal`, and no dual bound crossed a reference optimum — but the factorable
relaxation on these big-M/GDP models is close to vacuous: the `syn40m` root
bound is **1833.9 against an optimum of 67.71, 27x**.

## The change

`_convex_minlp_auto_route(model)` in `solver.py`. When the caller named no
solver, a model that is **discrete AND nonlinear** (`MIQP`/`MIQCP`/`MIQCQP`/
`MINLP`) and that the existing classifier certifies convex is routed to
`mip_nlp_method="oa"`.

Every other branch is a **refusal**, leaving the model on the sound default
path: unproven convexity, a nonconvex model, a pure-continuous model (already
served by the convex NLP fast path), a MILP (nothing to decompose), an opaque
`dm.custom` body (a MILP master cannot linearize what it cannot read), or no
importable MILP backend for the OA master. An explicit `solver=` — including
`solver="bb"` — is always honoured, so the router can never override a choice.

`"oa"` is the target rather than the faster `"lp_nlp_bb"` because `lp_nlp_bb`
hard-requires a Gurobi license (#1060).

New `SolveResult.algorithm_route` records *why* a non-default algorithm ran, and
round-trips through `result_io`. It stays `None` on an explicit `solver=`.

**Default OFF** behind `DISCOPT_CONVEX_MINLP_ROUTE`, per CLAUDE.md §5 regime 2.
`=0` is the opt-out; the spatial path is untouched beneath it.

## §5 regime-2 differential panel: the flag does NOT graduate

Two arms, flag OFF vs ON, interleaved OFF-then-ON on the same instance (§9),
oracle = `minlplib.solu`. Both arms carry an anti-vacuity control (§6): the OFF
arm must NOT route and the ON arm MUST route, asserted per instance, so a panel
that measured nothing cannot read as a pass.

### Arm A — every in-repo instance the router fires on (23 of 66), 30 s each

**Bar 1, cert-clean: FAILS.** Soundness is clean — 0 incumbents beating a
reference optimum and 0 bounds crossing one, over 158 executed checks — but
there are **3 certification regressions** (`gap_certified` True → False):
`alan`, `clay0303hfsg`, `tls2`.

**Bar 2, net-positive: FAILS.** 0 status upgrades, **6 downgrades**, 17
unchanged. Total wall **42.4 s → 162.3 s**.

```
alan              optimal  -> feasible   wall  0.2 ->  30.0     (9-var MIQP)
clay0303hfsg      optimal  -> unknown    wall 17.2 ->  30.2
cvxnonsep_nsig30  optimal  -> feasible   wall  1.4 ->  30.2
cvxnonsep_psig30  optimal  -> feasible   wall  0.6 ->  30.0
fac2              optimal  -> feasible   wall  3.7 ->  30.2
tls2              optimal  -> feasible   wall 10.7 ->   2.3
```

The arm was run twice (the first run's oracle comparison was rebuilt after a
probe defect described below). Both runs give the same three certification
regressions, the same six downgrades and the same 17 unchanged rows; only the
wall figures move, by the amount §9 load variation predicts.

Per §5 and the `DISCOPT_CUT_INHERIT` precedent (sound ≠ helpful), the flag stays
OFF and the measurement is recorded rather than the bar being moved.

### Arm B — the class the issue is actually about, 60 s each

The in-repo corpus contains no `syn`/`rsyn` instance, so Arm A cannot see the
effect the report described. Drawn from the MINLPLib snapshot:

**Bar 1, cert-clean: PASSES.** 0 violations over 61 executed checks — no
incumbent beats a reference optimum, no bound crosses one, and no
`gap_certified=True` instance regresses.

**Bar 2, net-positive: PASSES.** 6 status upgrades, 1 downgrade, 2 unchanged;
gap-to-optimum 8 better / 0 worse; total wall **545.5 s → 280.4 s**.

```
rsyn0805m   feasible -> optimal    gap 13.86  -> 1.9e-08   wall 60.4 ->  3.1
rsyn0810m   feasible -> optimal    gap 10.45  -> 1.1e-08   wall 60.8 ->  3.5
rsyn0815m   feasible -> optimal    gap 19.46  -> 3.0e-08   wall 60.9 -> 25.2
rsyn0820m   feasible -> feasible   gap 22.48  -> 2.633     wall 60.6 -> 60.6
syn30m      feasible -> optimal    gap 12.21  -> 1.9e-07   wall 60.2 ->  2.5
syn40m      feasible -> optimal    gap 50.97  -> 4.6e-08   wall 60.2 -> 55.3
syn20m02m   feasible -> optimal    gap 63.66  -> 2.1e-08   wall 61.2 ->  9.0
rsyn0830m   feasible -> feasible   gap 47.62  -> 2.391     wall 61.0 -> 60.4
rsyn0840m   feasible -> unknown    gap 88.45  -> None      wall 60.2 -> 60.8
```

`gap` is the relative distance from the reported incumbent to the `minlplib.solu`
optimum. Six instances go from "a feasible point at a 10–64% gap after the full
60 s" to "certified optimal", three of them in under 10 s. `rsyn0840m` is the one
downgrade: OA finds no incumbent inside 60 s where the spatial path found a
distant one.

**Probe defect found and corrected here (§6/§11).** The first run of this arm
reported 22 soundness violations. They were an instrument bug, not a solver
result: the worker derived the objective sense with
`m._nl_repr.objective_sense == 1`, but that attribute returns the *string*
`'maximize'`/`'minimize'`, never the `.nl` integer code — so every maximization
instance was checked with minimization logic and every correct row read as a
violation. Corrected to read `m._objective.sense` with an assertion that the
value is legible at all, and both arms were re-run under the corrected probe;
the numbers above are from the corrected run. Arm A was audited for the same
defect: all 23 of its instances minimize, so its verdict never depended on the
broken branch, and its re-run confirms that.

### What the panel actually shows

The two arms disagree by instance size, not by soundness. Where the spatial path
already closes a small model in under a second, routing to OA is a large
regression; on the large convex MINLPs it is a large win. The Arm A downgrades
are not a routing tradeoff — OA failing to certify a 9-variable MIQP (`alan`) in
30 s where spatial B&B closes it in 0.2 s is an **OA weakness**, and it
generalises past the `squfl` family that #1064 was filed for. That is the work
that has to land before this flag can be flipped, and it is why this PR leaves
#1059 open.

## Verification

- `pytest -m smoke python/tests` — 1037 passed, 1 skipped, 2 xpassed
- `pytest -m slow python/tests/test_adversarial_recent_fixes.py` — 19 passed
- `pytest python/tests/test_1059_convex_minlp_route.py` — 12 passed (new)
- `ruff check` / `ruff format --check` / `mypy` — clean (pre-commit)
- Rust untouched, so no `cargo test`

New tests pin each refusal gate, the default-OFF flag and its `=0` opt-out, that
an explicit `solver="bb"` is honoured, and that the decision is recorded on
`SolveResult.algorithm_route`. They set `DISCOPT_CONVEX_MINLP_ROUTE` explicitly
rather than relying on the ambient default, so they keep testing what they say
after any future graduation.

## Measurement conditions

14-core machine, load average 3.6–7.9 across the panel runs (CLAUDE.md §9), so
absolute wall figures are indicative. The status and objective columns — which
carry the argument in both arms — are not load-sensitive. Probes assert
`module.__file__` contains the worktree path and that a marker unique to this
branch is present (§8); an earlier `pytest` run in this worktree silently
imported `discopt` from the main tree and failed collection, which is the
failure mode that assertion exists for.
