### PR TITLE
feat(mip-nlp): #1060 single-tree LP/NLP-BB on the in-house MILP driver

### DIFF
--- a/crates/discopt-core/src/bnb/milp_driver.rs
+++ b/crates/discopt-core/src/bnb/milp_driver.rs
@@ -11,7 +11,7 @@
 //! Python by a single PyO3 entry. MINLP/MIQP/NLP are untouched (they keep the
 //! POUNCE/JAX path); only linear MILP reaches here.
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 
 use crate::bnb::branching::VarBranchInfo;
 use crate::bnb::node::NodeId;
@@ -72,6 +72,20 @@ pub struct MilpResult {
     pub nodes: usize,
     /// Total simplex pivots across all node solves.
     pub lp_iters: usize,
+    /// Number of times a [`MilpLazyHook`] separator was actually invoked.
+    ///
+    /// Zero whenever no hook was attached. With a hook attached it is the
+    /// anti-vacuity counter (CLAUDE.md §6): a caller that wires a separator in
+    /// and gets `lazy_calls == 0` back learns that the separator never saw a
+    /// point, which is a different failure from "the separator accepted
+    /// everything" and must not be reported as one.
+    pub lazy_calls: usize,
+    /// Number of times a node was re-queued because the separator vetoed its
+    /// integral relaxation solution. Zero without a hook. Together with
+    /// `lazy_calls` this distinguishes "the separator accepted everything" from
+    /// "the separator re-searched boxes", which is the signal the OA caller
+    /// needs to tell a converged single-tree run from a vacuous one.
+    pub lazy_requeues: usize,
 }
 
 /// A node-lifecycle checkpoint fired to an attached [`MilpDebugHook`].
@@ -146,6 +160,53 @@ pub trait MilpDebugHook: Sync {
     /// end the search gracefully.
     fn checkpoint(&self, state: &MilpDebugState<'_>) -> MilpDebugControl;
 }
+
+/// What a [`MilpLazyHook`] says about an integer-feasible point.
+#[derive(Debug, Clone)]
+pub enum MilpLazyVerdict {
+    /// No lazy constraint is violated: adopt the point exactly as an unhooked
+    /// search would.
+    Accept,
+    /// The point violates a lazy constraint. Each returned row is a
+    /// **globally valid** `coeffs · x ≥ rhs` (coefficients indexed by
+    /// structural column; trailing columns are implicitly zero) that cuts this
+    /// point off. Never empty — an empty separation is [`Self::Accept`].
+    Reject(Vec<GomoryCut>),
+    /// The separator itself failed (e.g. the Python callable raised). The
+    /// search stops and the result is reported uncertified. A failed separator
+    /// must never be treated as "no cut" — that silently drops a constraint
+    /// the caller believes is being enforced (CLAUDE.md §7).
+    Failed,
+}
+
+/// A lazy-constraint separator attached to the Rust MILP search: the native
+/// equivalent of a Gurobi `MIPSOL` callback, and the mechanism single-tree
+/// LP/NLP branch-and-bound (`mip_nlp_method="lp_nlp_bb"`) runs on (#1060).
+///
+/// `separate` is called with each integer-feasible **structural** point the
+/// search finds — a node relaxation that came out integral, a primal
+/// heuristic's candidate, or a caller-supplied seed — *before* that point can
+/// become the incumbent. Must be `Sync`: the solve runs under
+/// `Python::allow_threads`, and the Python adapter re-acquires the GIL.
+///
+/// **Zero effect when absent:** every fire-site is gated on `Option::is_some`,
+/// so a `None` hook leaves the search bit-for-bit identical (bound-neutral).
+pub trait MilpLazyHook: Sync {
+    /// Separate `x` (length `n_struct`) against the caller's lazy constraints.
+    fn separate(&self, x: &[f64]) -> MilpLazyVerdict;
+}
+
+/// How many times one node may be re-solved after a lazy veto before the search
+/// gives up on refining it.
+///
+/// Each veto folds in a cut that provably separates the vetoed point, so a
+/// node's re-solve cannot return the same point and the loop terminates on any
+/// well-behaved separator (finite outer approximation). The cap only bounds a
+/// pathological one — a separator that vetoes without separating. Exhausting it
+/// sentinels the node, which is a *non-rigorous* fathom, so the driver also
+/// drops certification (see the call site): the result may then be `Feasible`,
+/// never a false `Optimal`.
+const LAZY_REQUEUE_CAP: u32 = 1000;
 
 /// Options for the MILP driver.
 pub struct MilpOptions {
@@ -309,6 +370,30 @@ pub fn solve_milp(lp: &LpView<'_>, b: &[f64], obj_const: f64, opts: &MilpOptions
 /// solve (all fire-sites short-circuit).
 #[allow(clippy::too_many_arguments)]
 pub fn solve_milp_hooked(
+    csc_w: SparseCols,
+    m: usize,
+    n: usize,
+    c: &[f64],
+    l: &[f64],
+    u: &[f64],
+    b: &[f64],
+    obj_const: f64,
+    opts: &MilpOptions,
+    hook: Option<&dyn MilpDebugHook>,
+) -> MilpResult {
+    solve_milp_lazy_hooked(csc_w, m, n, c, l, u, b, obj_const, opts, hook, None)
+}
+
+/// [`solve_milp_hooked`] plus an optional lazy-constraint separator (#1060).
+///
+/// `lazy` turns the driver into a single-tree lazy-cut engine: every
+/// integer-feasible point is offered to the separator before it can become the
+/// incumbent, and the globally-valid rows a veto returns are folded into the
+/// shared matrix at the batch boundary — the same mechanism the node cut pool
+/// already uses. A vetoed node is **re-queued**, not fathomed. When `lazy` is
+/// `None` this is exactly [`solve_milp_hooked`].
+#[allow(clippy::too_many_arguments)]
+pub fn solve_milp_lazy_hooked(
     mut csc_w: SparseCols,
     m: usize,
     n: usize,
@@ -319,6 +404,7 @@ pub fn solve_milp_hooked(
     obj_const: f64,
     opts: &MilpOptions,
     hook: Option<&dyn MilpDebugHook>,
+    lazy: Option<&dyn MilpLazyHook>,
 ) -> MilpResult {
     crate::profile::init_from_env();
     crate::profile::reset();
@@ -362,6 +448,8 @@ pub fn solve_milp_hooked(
                 bound: f64::INFINITY,
                 nodes: 0,
                 lp_iters: 0,
+                lazy_calls: 0,
+                lazy_requeues: 0,
             };
         }
         (pr.l, pr.u)
@@ -384,6 +472,38 @@ pub fn solve_milp_hooked(
     let mut m_w = m;
     let mut n_w = n;
 
+    // --- Lazy separation state (only live when `lazy` is Some) ---
+    // Cuts a lazy separator produced, awaiting the next batch-boundary fold.
+    // Kept apart from the node-cut pool because a lazy cut is not optional: it
+    // is the only thing that stops the vetoed point from coming back, so it is
+    // exempt from the pool's `node_cut_cap` budget.
+    let mut lazy_pending: Vec<GomoryCut> = Vec::new();
+    let mut lazy_sigs: HashSet<Vec<(u32, i64)>> = HashSet::new();
+    // Per-node lazy re-solve counts, against `LAZY_REQUEUE_CAP`.
+    let mut lazy_requeues: HashMap<NodeId, u32> = HashMap::new();
+    // Set when the separator itself failed; the search stops uncertified.
+    let mut lazy_failed = false;
+    // Executed separator calls, for the caller's anti-vacuity check (§6).
+    let mut lazy_calls: usize = 0;
+    // Total re-queue events across all nodes (the per-node counts above are
+    // consumed by the cap; this one is reported).
+    let mut lazy_requeue_events: usize = 0;
+    // Dedup + record a batch of separator rows into `lazy_pending`. Returns how
+    // many were new (a fully-duplicate veto cannot make progress, so the caller
+    // counts on the re-queue cap to break the loop).
+    macro_rules! stage_lazy_cuts {
+        ($cuts:expr) => {{
+            let mut fresh = 0usize;
+            for cut in $cuts {
+                if lazy_sigs.insert(cut_signature(&cut)) {
+                    lazy_pending.push(cut);
+                    fresh += 1;
+                }
+            }
+            fresh
+        }};
+    }
+
     // --- Caller-seeded incumbent: validate, then inject before the search ---
     // Runs on the pre-cut matrix (all rows are original rows here) with the
     // presolve-tightened bounds (FBBT never cuts a feasible point, so a
@@ -394,7 +514,32 @@ pub fn solve_milp_hooked(
         if let Some((sx, sobj)) =
             validate_seed_incumbent(seed, ns, &is_int, &csc_w, &b_w, &c_w, &l_w, &u_w, m_w, n_w)
         {
-            tm.inject_incumbent(sx, sobj + obj_const);
+            // A seed is an integer-feasible point like any other, so it goes to
+            // the separator first: seeding an incumbent the caller's lazy
+            // constraints exclude would prune the tree against a point that is
+            // not actually feasible. A vetoed seed is simply not seeded (seeding
+            // is an optimization), but its cuts are kept — they are globally
+            // valid and the first batch boundary folds them in.
+            let accept = match lazy {
+                None => true,
+                Some(h) => {
+                    lazy_calls += 1;
+                    match h.separate(&sx) {
+                        MilpLazyVerdict::Accept => true,
+                        MilpLazyVerdict::Reject(cuts) => {
+                            let _ = stage_lazy_cuts!(cuts);
+                            false
+                        }
+                        MilpLazyVerdict::Failed => {
+                            lazy_failed = true;
+                            false
+                        }
+                    }
+                }
+            };
+            if accept {
+                tm.inject_incumbent(sx, sobj + obj_const);
+            }
         }
     }
 
@@ -778,7 +923,7 @@ pub fn solve_milp_hooked(
 
         // --- sequential reduce: apply tree mutations in batch order ---
         let mut hit_unbounded = false;
-        for (k, out) in outputs.into_iter().enumerate() {
+        for (k, mut out) in outputs.into_iter().enumerate() {
             let id = batch.node_ids[k];
             lp_iters += out.iters;
             if out.deferred {
@@ -821,7 +966,31 @@ pub fn solve_milp_hooked(
                 tm.set_node_basis(id, Some(basis));
             }
             if let Some((cand, cobj)) = out.incumbent {
-                tm.inject_incumbent(cand, cobj);
+                // A heuristic candidate is an integer-feasible point, so it goes
+                // through the separator on the same terms as a node's own
+                // integral relaxation. Nothing to re-queue here: the candidate is
+                // not this node's LP solution, so vetoing it leaves the node's
+                // own result (fractional, or handled below) untouched.
+                let accept = match lazy {
+                    None => true,
+                    Some(h) => {
+                        lazy_calls += 1;
+                        match h.separate(&cand) {
+                            MilpLazyVerdict::Accept => true,
+                            MilpLazyVerdict::Reject(cuts) => {
+                                let _ = stage_lazy_cuts!(cuts);
+                                false
+                            }
+                            MilpLazyVerdict::Failed => {
+                                lazy_failed = true;
+                                false
+                            }
+                        }
+                    }
+                };
+                if accept {
+                    tm.inject_incumbent(cand, cobj);
+                }
             }
             if let Some(v) = out.branch_hint {
                 tm.set_branch_hint(id, v);
@@ -842,7 +1011,69 @@ pub fn solve_milp_hooked(
             if !out.found_cuts.is_empty() && pool_sigs.len() < node_cut_cap {
                 pending_cuts.extend(dedup_new_cuts(out.found_cuts, &mut pool_sigs, node_cut_cap));
             }
+            // Lazy separation of this node's OWN relaxation solution. The point
+            // has to be screened here, before `import_results`, because
+            // `process_evaluated` fathoms an integer-feasible node and promotes
+            // its solution to the incumbent in one step — after that the point
+            // is already the answer.
+            //
+            // The predicate must match the one `process_evaluated` uses
+            // (`result.is_feasible || is_integer_feasible(solution)`), or a point
+            // it treats as integral would slip past unseparated.
+            if let Some(h) = lazy {
+                let integral = out.result.lower_bound.is_finite()
+                    && (out.result.is_feasible
+                        || solution_is_integral(&out.result.solution, &is_int));
+                if integral {
+                    lazy_calls += 1;
+                    match h.separate(&out.result.solution) {
+                        MilpLazyVerdict::Accept => {}
+                        MilpLazyVerdict::Reject(cuts) => {
+                            let _ = stage_lazy_cuts!(cuts);
+                            let seen = lazy_requeues.entry(id).or_insert(0);
+                            *seen += 1;
+                            if *seen <= LAZY_REQUEUE_CAP {
+                                lazy_requeue_events += 1;
+                                // Re-open the node instead of importing a result.
+                                // The cuts fold in at this batch's boundary, so
+                                // the re-solve runs against a matrix that
+                                // excludes the vetoed point. The node keeps its
+                                // parent-inherited bound meanwhile — valid, just
+                                // not sharpened by this evaluation.
+                                // The node's optimal basis was already
+                                // stored above, so the re-solve warm-starts from
+                                // it through the dual simplex once the new cut
+                                // rows are appended (`extend_basis`).
+                                tm.requeue_node(id);
+                                continue;
+                            }
+                            // Cap exhausted: a separator that keeps vetoing
+                            // without making progress. Fall back to the sentinel
+                            // (the node is excluded) — which is a NON-RIGOROUS
+                            // fathom, so certification is dropped: this run may
+                            // report `Feasible`, never a false `Optimal`.
+                            out.result.lower_bound = INFEAS_SENTINEL;
+                            out.result.is_feasible = false;
+                            gap_certified = false;
+                            search_incomplete = true;
+                        }
+                        MilpLazyVerdict::Failed => {
+                            lazy_failed = true;
+                        }
+                    }
+                }
+            }
             results.push(out.result);
+        }
+        if lazy_failed {
+            // A separator that raised leaves constraints unenforced; continuing
+            // would report a result built against a model the caller did not
+            // ask for. Stop, uncertified (CLAUDE.md §7).
+            gap_certified = false;
+            search_incomplete = true;
+            tm.import_results(&results);
+            tm.process_evaluated();
+            break 'search;
         }
         if hit_unbounded {
             unbounded = true;
@@ -867,6 +1098,14 @@ pub fn solve_milp_hooked(
             break 'search;
         }
         dbg_iter += 1;
+
+        // Lazy cuts join the fold unconditionally — after the node-cut dedup
+        // above and outside the `node_cut_cap` budget, because dropping one
+        // would leave the vetoed point in the relaxation and the node would be
+        // re-queued forever against a matrix that never changed.
+        if !lazy_pending.is_empty() {
+            pending_cuts.append(&mut lazy_pending);
+        }
 
         // Fold this batch's newly-found global cuts into the shared matrix.
         // Stored node bases are extended lazily on their next solve, so children
@@ -925,6 +1164,8 @@ pub fn solve_milp_hooked(
         bound,
         nodes: stats.total_nodes,
         lp_iters,
+        lazy_calls,
+        lazy_requeues: lazy_requeue_events,
     }
 }
 
@@ -2432,6 +2673,37 @@ fn frac(v: f64) -> f64 {
     f.min(1.0 - f)
 }
 
+/// Integrality screen for the lazy separator, deliberately identical to the one
+/// `TreeManager::process_evaluated` applies (`branching::is_integer_feasible`
+/// over the tree's `integer_vars`, tolerance `INTEGRALITY_TOL`).
+///
+/// It is re-derived here over the structural mask rather than borrowed from the
+/// tree because `int_info` is moved into `TreeManager::new`. The two must agree:
+/// a point the tree treats as integer-feasible but this screen skips would be
+/// promoted to the incumbent without ever reaching the separator. The driver's
+/// `is_int` is built from the same `opts.integer_cols`, and every `VarBranchInfo`
+/// the driver constructs has `size == 1`, so the predicates coincide.
+///
+/// `INT_TOL` here and `branching::INTEGRALITY_TOL` there are both 1e-5; the
+/// latter is private to that module, so the agreement is pinned by
+/// `lazy_screen_matches_tree_integrality_predicate` in the tests below rather
+/// than by a shared constant.
+fn solution_is_integral(solution: &[f64], is_int: &[bool]) -> bool {
+    for (j, &it) in is_int.iter().enumerate() {
+        if !it {
+            continue;
+        }
+        // Matches `is_integer_feasible`'s short-circuit on a truncated solution.
+        if j >= solution.len() {
+            return false;
+        }
+        if frac(solution[j]) > INT_TOL {
+            return false;
+        }
+    }
+    true
+}
+
 fn midpoint(lb: &[f64], ub: &[f64]) -> Vec<f64> {
     lb.iter()
         .zip(ub)
@@ -3773,5 +4045,294 @@ mod sparse_milp_diff {
             let (_col_ptr, _row_idx, vals) = sp.raw();
             assert_eq!(vals.len(), dense_nnz, "{}: csc nnz != dense nnz", case.name);
         }
+    }
+}
+
+/// #1060: the lazy-constraint separator hook that makes single-tree LP/NLP-BB
+/// possible without a commercial MILP backend.
+///
+/// The properties pinned here are the ones the OA caller depends on: a vetoed
+/// point never becomes the answer, a vetoed node stays in the search instead of
+/// being fathomed, a separator that cannot make progress costs the certificate
+/// rather than producing a false one, and `lazy: None` is inert.
+#[cfg(test)]
+mod lazy_separation {
+    use super::*;
+    use crate::bnb::branching::is_integer_feasible;
+    use crate::lp::simplex::sparse::SparseCols;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    /// Binary knapsack: `min -10x0 -9x1 -8x2 -x3` s.t. `5(x0+x1+x2+x3) + s = 9`,
+    /// all four structural columns binary. The budget admits exactly one item,
+    /// so the unconstrained optimum is `x0 = 1`, obj `-10`; with `x0` excluded
+    /// it is `x1 = 1`, obj `-9`.
+    struct Knapsack {
+        a: Vec<f64>,
+        m: usize,
+        n: usize,
+        c: Vec<f64>,
+        l: Vec<f64>,
+        u: Vec<f64>,
+        b: Vec<f64>,
+    }
+
+    impl Knapsack {
+        fn new() -> Self {
+            Knapsack {
+                a: vec![5.0, 5.0, 5.0, 5.0, 1.0],
+                m: 1,
+                n: 5,
+                c: vec![-10.0, -9.0, -8.0, -1.0, 0.0],
+                l: vec![0.0; 5],
+                u: vec![1.0, 1.0, 1.0, 1.0, INF],
+                b: vec![9.0],
+            }
+        }
+
+        fn opts(&self) -> MilpOptions {
+            MilpOptions {
+                n_struct: 4,
+                integer_cols: vec![0, 1, 2, 3],
+                max_nodes: 100_000,
+                time_limit_s: None,
+                gap_tol: 1e-9,
+                root_cuts: 16,
+                cut_rounds: 3,
+                gmi_cuts: true,
+                cut_select: true,
+                node_cuts: true,
+                max_pool_cuts: 500,
+                heuristics: true,
+                presolve: true,
+                strong_branch: true,
+                node_propagation: true,
+                reduced_cost_fixing: true,
+                sb_max_cands: 8,
+                sb_node_budget: 1024,
+                initial_incumbent: None,
+                simplex: SimplexOptions::default(),
+            }
+        }
+
+        fn solve_with(&self, lazy: Option<&dyn MilpLazyHook>) -> MilpResult {
+            solve_milp_lazy_hooked(
+                SparseCols::from_dense(&self.a, self.m, self.n),
+                self.m,
+                self.n,
+                &self.c,
+                &self.l,
+                &self.u,
+                &self.b,
+                0.0,
+                &self.opts(),
+                None,
+                lazy,
+            )
+        }
+    }
+
+    /// Rejects any point that uses item 0, returning the globally valid row
+    /// `x0 ≤ 0` in the driver's `coeffs · x ≥ rhs` form (`-x0 ≥ 0`).
+    struct VetoItemZero {
+        calls: AtomicUsize,
+    }
+
+    impl MilpLazyHook for VetoItemZero {
+        fn separate(&self, x: &[f64]) -> MilpLazyVerdict {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            if x.first().copied().unwrap_or(0.0) > 0.5 {
+                let mut coeffs = vec![0.0; 4];
+                coeffs[0] = -1.0;
+                MilpLazyVerdict::Reject(vec![GomoryCut { coeffs, rhs: 0.0 }])
+            } else {
+                MilpLazyVerdict::Accept
+            }
+        }
+    }
+
+    /// Rejects every point and returns nothing that separates it — the
+    /// pathological separator the re-queue cap exists for.
+    struct VetoEverythingUselessly {
+        calls: AtomicUsize,
+    }
+
+    impl MilpLazyHook for VetoEverythingUselessly {
+        fn separate(&self, _x: &[f64]) -> MilpLazyVerdict {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            MilpLazyVerdict::Reject(Vec::new())
+        }
+    }
+
+    /// A separator that raised on the Python side.
+    struct SeparatorFails {
+        calls: AtomicUsize,
+    }
+
+    impl MilpLazyHook for SeparatorFails {
+        fn separate(&self, _x: &[f64]) -> MilpLazyVerdict {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            MilpLazyVerdict::Failed
+        }
+    }
+
+    /// The headline behaviour: the separator sees the MILP optimum, vetoes it,
+    /// and the driver returns the best point that survives the cut — still with
+    /// a certificate, because the veto was resolved by a genuine cut and not by
+    /// removing a box.
+    #[test]
+    fn veto_of_the_optimum_returns_the_next_best_certified_point() {
+        let k = Knapsack::new();
+        let baseline = k.solve_with(None);
+        assert_eq!(baseline.status, MilpStatus::Optimal, "baseline status");
+        assert!(
+            (baseline.obj - (-10.0)).abs() < 1e-6,
+            "baseline obj {}",
+            baseline.obj
+        );
+        assert_eq!(
+            baseline.lazy_calls, 0,
+            "no hook must mean no separator call"
+        );
+
+        let hook = VetoItemZero {
+            calls: AtomicUsize::new(0),
+        };
+        let r = k.solve_with(Some(&hook));
+        assert_eq!(r.status, MilpStatus::Optimal, "vetoed solve status");
+        assert!((r.obj - (-9.0)).abs() < 1e-6, "vetoed solve obj {}", r.obj);
+        assert!(
+            r.x[0] < 0.5,
+            "the vetoed item is still in the answer: {:?}",
+            r.x
+        );
+        // Anti-vacuity (CLAUDE.md §6): a pass here must mean the separator ran.
+        let fired = hook.calls.load(Ordering::SeqCst);
+        assert!(fired > 0, "separator never fired");
+        assert_eq!(r.lazy_calls, fired, "reported lazy_calls != actual calls");
+        assert!(
+            r.lazy_requeues > 0,
+            "the node fire-site never re-queued: the veto was resolved somewhere \
+             else, so this test does not exercise the mechanism it claims to"
+        );
+        assert_eq!(baseline.lazy_requeues, 0, "no hook must mean no re-queue");
+    }
+
+    /// A separator that keeps vetoing without ever separating must cost the
+    /// certificate, never produce a false `Optimal`. This is the property that
+    /// makes the re-queue cap safe (CLAUDE.md §1).
+    #[test]
+    fn a_separator_that_never_makes_progress_loses_the_certificate() {
+        let k = Knapsack::new();
+        let hook = VetoEverythingUselessly {
+            calls: AtomicUsize::new(0),
+        };
+        let r = k.solve_with(Some(&hook));
+        assert_ne!(
+            r.status,
+            MilpStatus::Optimal,
+            "a search that excluded a box it never proved empty must not certify"
+        );
+        assert!(
+            hook.calls.load(Ordering::SeqCst) > 0,
+            "separator never fired"
+        );
+        assert_eq!(r.lazy_calls, hook.calls.load(Ordering::SeqCst));
+        assert!(
+            r.lazy_requeues >= LAZY_REQUEUE_CAP as usize,
+            "the cap was never reached ({} re-queues), so this test did not \
+             exercise the exhaustion path",
+            r.lazy_requeues
+        );
+    }
+
+    /// A separator failure is surfaced, not swallowed (CLAUDE.md §7): the search
+    /// stops and returns uncertified rather than reporting a result computed
+    /// against constraints that were never enforced.
+    #[test]
+    fn separator_failure_stops_the_search_uncertified() {
+        let k = Knapsack::new();
+        let hook = SeparatorFails {
+            calls: AtomicUsize::new(0),
+        };
+        let r = k.solve_with(Some(&hook));
+        assert_ne!(
+            r.status,
+            MilpStatus::Optimal,
+            "failed separator must not certify"
+        );
+        assert!(
+            hook.calls.load(Ordering::SeqCst) > 0,
+            "separator never fired"
+        );
+    }
+
+    /// `lazy: None` must be inert — same status, objective, bound and node count
+    /// as the plain CSC entry point (CLAUDE.md §5, bound-neutral regime).
+    #[test]
+    fn lazy_none_is_bound_neutral() {
+        let k = Knapsack::new();
+        let with_none = k.solve_with(None);
+        let plain = solve_milp_csc(
+            &SparseCols::from_dense(&k.a, k.m, k.n),
+            k.m,
+            k.n,
+            &k.c,
+            &k.l,
+            &k.u,
+            &k.b,
+            0.0,
+            &k.opts(),
+        );
+        assert_eq!(with_none.status, plain.status, "status drift");
+        assert_eq!(with_none.nodes, plain.nodes, "node-count drift");
+        assert!((with_none.obj - plain.obj).abs() < 1e-12, "obj drift");
+        assert!((with_none.bound - plain.bound).abs() < 1e-12, "bound drift");
+    }
+
+    /// The separator's integrality screen must agree with the one
+    /// `TreeManager::process_evaluated` uses, or a point the tree promotes to
+    /// the incumbent could bypass separation entirely. Compared directly against
+    /// `branching::is_integer_feasible` on the same mask.
+    #[test]
+    fn lazy_screen_matches_tree_integrality_predicate() {
+        let is_int = vec![true, false, true, true];
+        let vars: Vec<VarBranchInfo> = (0..is_int.len())
+            .filter(|&j| is_int[j])
+            .map(|j| VarBranchInfo {
+                offset: j,
+                size: 1,
+                is_integer: true,
+            })
+            .collect();
+        // Integral, fractional on an integer column, fractional only on the
+        // continuous column, at-tolerance either side, and negative values.
+        let points: Vec<Vec<f64>> = vec![
+            vec![0.0, 0.5, 1.0, 3.0],
+            vec![0.5, 0.5, 1.0, 3.0],
+            vec![0.0, 0.5, 1.4, 3.0],
+            vec![1.0 - 1e-6, 0.5, 1.0, 3.0],
+            vec![1.0 + 1e-6, 0.5, 1.0, 3.0],
+            vec![1.0 - 1e-3, 0.5, 1.0, 3.0],
+            vec![-2.0, -0.25, -3.0, 0.0],
+            vec![-2.25, 0.0, 0.0, 0.0],
+        ];
+        let mut compared = 0usize;
+        for p in &points {
+            assert_eq!(
+                solution_is_integral(p, &is_int),
+                is_integer_feasible(p, &vars),
+                "screen disagrees with the tree on {p:?}"
+            );
+            compared += 1;
+        }
+        // A truncated solution is rejected by both.
+        let short = vec![0.0, 0.5];
+        assert_eq!(
+            solution_is_integral(&short, &is_int),
+            is_integer_feasible(&short, &vars),
+            "screen disagrees with the tree on a truncated solution"
+        );
+        compared += 1;
+        assert_eq!(compared, 9, "integrality-screen comparison count");
     }
 }

--- a/crates/discopt-core/src/bnb/pool.rs
+++ b/crates/discopt-core/src/bnb/pool.rs
@@ -185,6 +185,42 @@ impl NodePool {
             .count()
     }
 
+    /// Return an already-exported node to the open frontier so it is selected
+    /// and re-evaluated again.
+    ///
+    /// This exists for the lazy-constraint separator (#1060). When a user
+    /// separator VETOES the integer point a node's relaxation found, the node
+    /// must be re-solved against the cut-augmented matrix — **not** excluded.
+    /// Excluding it is the `_INFEASIBILITY_SENTINEL` path, a documented
+    /// *non-rigorous* fathom (#748): it removes a box that was never proven to
+    /// contain no acceptable point, so single-tree outer approximation built on
+    /// it would silently drop the optimum. Re-opening keeps the box in the
+    /// search; the cut that vetoed the point is globally valid and is folded
+    /// into the shared matrix before the next selection, so the re-solve cannot
+    /// return the same point.
+    ///
+    /// `select_next` consumed this node's heap entry, so a fresh one is pushed.
+    /// Any stale entry left behind is skipped by the usual lazy-deletion rule
+    /// once the node leaves `Pending` again.
+    pub fn reopen(&mut self, id: NodeId) {
+        let node = &mut self.nodes[id.0];
+        node.status = NodeStatus::Pending;
+        let lower_bound = node.local_lower_bound;
+        let estimate = if node.best_estimate.is_finite() {
+            node.best_estimate
+        } else {
+            lower_bound
+        };
+        let depth = node.depth;
+        self.open.push(HeapEntry {
+            node_id: id,
+            lower_bound,
+            estimate,
+            depth,
+            strategy: self.strategy,
+        });
+    }
+
     /// Mark a node as pruned.
     pub fn prune(&mut self, id: NodeId) {
         self.nodes[id.0].status = NodeStatus::Pruned;

--- a/crates/discopt-core/src/bnb/tree_manager.rs
+++ b/crates/discopt-core/src/bnb/tree_manager.rs
@@ -1119,6 +1119,22 @@ impl TreeManager {
         }
     }
 
+    /// Return an exported node to the open frontier without importing a result.
+    ///
+    /// The single-tree lazy-constraint path (#1060) calls this when a user
+    /// separator vetoes the integer point a node's relaxation found: the node
+    /// keeps its (parent-inherited) lower bound and is re-solved against the
+    /// cut-augmented matrix on a later batch. The caller MUST NOT also import a
+    /// `NodeResult` for it — `import_results` asserts `Evaluated` status and
+    /// would queue a `PendingResult` for a node that is open again.
+    ///
+    /// Re-opening rather than sentinelling is what keeps this sound: the veto
+    /// says "this *point* is not acceptable", never "this *box* is empty", and
+    /// the sentinel spells the latter (see `NodePool::reopen`).
+    pub fn requeue_node(&mut self, node_id: NodeId) {
+        self.pool.reopen(node_id);
+    }
+
     /// Inject an externally-found incumbent (e.g. from a primal heuristic).
     ///
     /// Updates the incumbent only if `obj_val` is strictly better than the

--- a/crates/discopt-core/src/lp/gomory.rs
+++ b/crates/discopt-core/src/lp/gomory.rs
@@ -50,6 +50,7 @@ const FRAC_MIN: f64 = 1e-3;
 const MAX_ABS_COEFF: f64 = 1e7;
 
 /// A generated cut `coeffs · x ≥ rhs` over the standard-form variables.
+#[derive(Debug, Clone)]
 pub struct GomoryCut {
     /// Dense length-`n` coefficient vector.
     pub coeffs: Vec<f64>,

--- a/crates/discopt-python/src/lib.rs
+++ b/crates/discopt-python/src/lib.rs
@@ -58,6 +58,7 @@ fn _rust(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(lp_bindings::solve_lp_batch_py, m)?)?;
     m.add_function(wrap_pyfunction!(lp_bindings::solve_milp_py, m)?)?;
     m.add_function(wrap_pyfunction!(lp_bindings::solve_milp_csc_py, m)?)?;
+    m.add_function(wrap_pyfunction!(lp_bindings::solve_milp_lazy_csc_py, m)?)?;
     m.add_function(wrap_pyfunction!(
         decomp_bindings::decomp_connected_components,
         m

--- a/crates/discopt-python/src/lp_bindings.rs
+++ b/crates/discopt-python/src/lp_bindings.rs
@@ -12,13 +12,13 @@
 #![allow(clippy::too_many_arguments, clippy::type_complexity)]
 
 use discopt_core::bnb::milp_driver::{
-    solve_milp_hooked as core_solve_milp_hooked, MilpCheckpoint, MilpDebugControl, MilpDebugHook,
-    MilpDebugState, MilpOptions, MilpStatus,
+    solve_milp_lazy_hooked as core_solve_milp_lazy_hooked, MilpCheckpoint, MilpDebugControl,
+    MilpDebugHook, MilpDebugState, MilpLazyHook, MilpLazyVerdict, MilpOptions, MilpStatus,
 };
 use discopt_core::lp::aggregation::separate_aggregation_mir;
 use discopt_core::lp::basis::{recover_basis, Basis, BASIC};
 use discopt_core::lp::crossover::{crossover_to_vertex, LpView};
-use discopt_core::lp::gomory::separate_gomory;
+use discopt_core::lp::gomory::{separate_gomory, GomoryCut};
 use discopt_core::lp::mir::separate_mir;
 use discopt_core::lp::simplex::{
     solve_lp as simplex_solve_lp, solve_lp_batch, solve_lp_warm, solve_lp_warm_csc,
@@ -915,6 +915,95 @@ impl MilpDebugHook for PyMilpHook {
     }
 }
 
+/// Python-side lazy-constraint separator for the MILP driver (#1060).
+///
+/// This is what makes single-tree LP/NLP branch-and-bound possible without a
+/// commercial MILP backend: the driver offers every integer-feasible point to
+/// `callback` before it can become the incumbent, and folds the rows a veto
+/// returns into the shared matrix.
+///
+/// **Callback contract.** `callback(x: np.ndarray) -> list[(coeffs, rhs)]`,
+/// where `x` has length `n_struct` and each returned row means
+/// `coeffs · x <= rhs` and must be **globally valid** — it is added to the
+/// shared relaxation, not to one node. An empty list accepts the point.
+///
+/// The driver's internal cut form is `coeffs · x >= rhs`, so each row is
+/// negated on the way in.
+///
+/// A callback that raises, or returns something that does not match the
+/// contract, yields [`MilpLazyVerdict::Failed`]: the search stops uncertified
+/// and the error is stashed in `pending` for `run_milp_hooked` to re-raise.
+/// Constraints the caller asked for but that were never enforced must not be
+/// silently dropped (CLAUDE.md §7) — unlike the debug hook, which is
+/// inspection-only and can safely continue after an error.
+struct PyMilpLazyHook {
+    callback: Py<PyAny>,
+    /// Structural width; a returned row may not be longer (a longer row would
+    /// spill into the driver's slack columns and mean something else entirely).
+    n_struct: usize,
+    pending: std::sync::Mutex<Option<PyErr>>,
+}
+
+impl PyMilpLazyHook {
+    /// Record the first failure only — later ones are consequences of it.
+    fn fail(&self, e: PyErr) -> MilpLazyVerdict {
+        let mut slot = self.pending.lock().unwrap();
+        if slot.is_none() {
+            *slot = Some(e);
+        }
+        MilpLazyVerdict::Failed
+    }
+}
+
+impl MilpLazyHook for PyMilpLazyHook {
+    fn separate(&self, x: &[f64]) -> MilpLazyVerdict {
+        Python::with_gil(|py| {
+            let arr = PyArray1::from_slice(py, x);
+            let ret = match self.callback.bind(py).call1((arr,)) {
+                Ok(r) => r,
+                Err(e) => return self.fail(e),
+            };
+            // `list[(coeffs, rhs)]`; a numpy row extracts through the sequence
+            // protocol, so both plain lists and arrays are accepted.
+            let rows: Vec<(Vec<f64>, f64)> = match ret.extract() {
+                Ok(r) => r,
+                Err(e) => {
+                    return self.fail(PyValueError::new_err(format!(
+                        "lazy_callback must return a sequence of (coeffs, rhs) pairs \
+                         meaning `coeffs @ x <= rhs`; got {ret:?} ({e})"
+                    )))
+                }
+            };
+            if rows.is_empty() {
+                return MilpLazyVerdict::Accept;
+            }
+            let mut cuts = Vec::with_capacity(rows.len());
+            for (coeffs, rhs) in rows {
+                if coeffs.len() > self.n_struct {
+                    return self.fail(PyValueError::new_err(format!(
+                        "lazy_callback returned a row of length {} over {} structural \
+                         columns; a longer row would address the driver's slack columns",
+                        coeffs.len(),
+                        self.n_struct
+                    )));
+                }
+                if !rhs.is_finite() || coeffs.iter().any(|v| !v.is_finite()) {
+                    return self.fail(PyValueError::new_err(
+                        "lazy_callback returned a row with a non-finite entry; such a \
+                         row cannot be added to the relaxation soundly",
+                    ));
+                }
+                // `coeffs @ x <= rhs`  ==>  `(-coeffs) @ x >= -rhs`.
+                cuts.push(GomoryCut {
+                    coeffs: coeffs.iter().map(|v| -v).collect(),
+                    rhs: -rhs,
+                });
+            }
+            MilpLazyVerdict::Reject(cuts)
+        })
+    }
+}
+
 #[pyfunction]
 #[pyo3(signature = (c, a, b, lb, ub, integer_cols, n_struct, obj_const=0.0,
                     max_nodes=1_000_000, gap_tol=1e-6, tol=1e-9, root_cuts=16,
@@ -978,7 +1067,7 @@ pub fn solve_milp_py<'py>(
     // Fully sparse driver (T3b5): build the working CSC from the dense numpy matrix
     // once and delegate. The CSC entry `solve_milp_csc_py` skips this densify.
     let csc = SparseCols::from_dense(&a_owned, m, n);
-    run_milp_hooked(
+    let (status, x, obj, bound, nodes, lp_iters, _lazy_calls, _lazy_requeues) = run_milp_hooked(
         py,
         csc,
         m,
@@ -1009,7 +1098,12 @@ pub fn solve_milp_py<'py>(
         initial_incumbent,
         time_limit_s,
         debug_hook,
-    )
+        // No lazy separator on this entry point: it keeps the historical
+        // 6-tuple return and the driver's untouched path. `solve_milp_lazy_csc_py`
+        // is the entry that takes one.
+        None,
+    )?;
+    Ok((status, x, obj, bound, nodes, lp_iters))
 }
 
 /// CSC-input MILP entry (docs/dev/sparse-milp-plan.md T4): the constraint matrix is
@@ -1074,6 +1168,141 @@ pub fn solve_milp_csc_py<'py>(
         .map(|&v| v as usize)
         .collect();
     let csc = SparseCols::from_csc(col_ptr_v, row_idx_v, vals_v);
+    let (status, x, obj, bound, nodes, lp_iters, _lazy_calls, _lazy_requeues) = run_milp_hooked(
+        py,
+        csc,
+        m,
+        n,
+        c_owned,
+        l_owned,
+        u_owned,
+        b_owned,
+        int_cols,
+        n_struct,
+        obj_const,
+        max_nodes,
+        gap_tol,
+        tol,
+        root_cuts,
+        cut_rounds,
+        gmi_cuts,
+        cut_select,
+        node_cuts,
+        max_pool_cuts,
+        heuristics,
+        presolve,
+        strong_branch,
+        node_propagation,
+        reduced_cost_fixing,
+        sb_max_cands,
+        sb_node_budget,
+        initial_incumbent,
+        time_limit_s,
+        debug_hook,
+        // No lazy separator on this entry point: it keeps the historical
+        // 6-tuple return and the driver's untouched path. `solve_milp_lazy_csc_py`
+        // is the entry that takes one.
+        None,
+    )?;
+    Ok((status, x, obj, bound, nodes, lp_iters))
+}
+
+/// CSC-input MILP entry **with a lazy-constraint separator** (#1060).
+///
+/// Identical to [`solve_milp_csc_py`] except that `lazy_callback` is called with
+/// every integer-feasible point the search finds, before that point can become
+/// the incumbent:
+///
+/// ```text
+/// lazy_callback(x: np.ndarray) -> list[(coeffs, rhs)]      # coeffs @ x <= rhs
+/// ```
+///
+/// An empty return accepts the point. A non-empty return **rejects** it: the
+/// rows are added to the shared relaxation (they must be globally valid) and the
+/// node is put back in the search — not fathomed, since a veto is not a proof
+/// that the box is empty. This is what lets the Python OA layer run a
+/// Quesada-Grossmann single tree on the in-house simplex instead of requiring a
+/// commercial backend's lazy-constraint callbacks.
+///
+/// A callback that raises propagates out of this function, and the search stops
+/// without a certificate rather than returning a result built against
+/// constraints that were never enforced.
+///
+/// Returns [`solve_milp_csc_py`]'s tuple plus `(lazy_calls, lazy_requeues)` —
+/// the anti-vacuity counters (CLAUDE.md §6). `lazy_calls == 0` means the
+/// separator never saw a point, which is NOT the same as it having accepted
+/// everything and must not be reported as convergence.
+#[pyfunction]
+#[pyo3(signature = (c, m, n, col_ptr, row_idx, vals, b, lb, ub, integer_cols, n_struct,
+                    lazy_callback,
+                    obj_const=0.0, max_nodes=1_000_000, gap_tol=1e-6, tol=1e-9, root_cuts=16,
+                    cut_rounds=1, gmi_cuts=true, cut_select=false, node_cuts=false,
+                    max_pool_cuts=128, heuristics=true, presolve=true, strong_branch=true,
+                    node_propagation=false, reduced_cost_fixing=true,
+                    sb_max_cands=6, sb_node_budget=48,
+                    initial_incumbent=None, time_limit_s=None, debug_hook=None))]
+#[allow(clippy::too_many_arguments)]
+pub fn solve_milp_lazy_csc_py<'py>(
+    py: Python<'py>,
+    c: PyReadonlyArray1<'py, f64>,
+    m: usize,
+    n: usize,
+    col_ptr: PyReadonlyArray1<'py, i64>,
+    row_idx: PyReadonlyArray1<'py, i64>,
+    vals: PyReadonlyArray1<'py, f64>,
+    b: PyReadonlyArray1<'py, f64>,
+    lb: PyReadonlyArray1<'py, f64>,
+    ub: PyReadonlyArray1<'py, f64>,
+    integer_cols: PyReadonlyArray1<'py, i64>,
+    n_struct: usize,
+    lazy_callback: Py<PyAny>,
+    obj_const: f64,
+    max_nodes: usize,
+    gap_tol: f64,
+    tol: f64,
+    root_cuts: usize,
+    cut_rounds: usize,
+    gmi_cuts: bool,
+    cut_select: bool,
+    node_cuts: bool,
+    max_pool_cuts: usize,
+    heuristics: bool,
+    presolve: bool,
+    strong_branch: bool,
+    node_propagation: bool,
+    reduced_cost_fixing: bool,
+    sb_max_cands: usize,
+    sb_node_budget: usize,
+    initial_incumbent: Option<PyReadonlyArray1<'py, f64>>,
+    time_limit_s: Option<f64>,
+    debug_hook: Option<Py<PyAny>>,
+) -> PyResult<(
+    String,
+    Bound<'py, PyArray1<f64>>,
+    f64,
+    f64,
+    usize,
+    usize,
+    usize,
+    usize,
+)> {
+    if !lazy_callback.bind(py).is_callable() {
+        return Err(PyValueError::new_err("lazy_callback must be callable"));
+    }
+    let col_ptr_v: Vec<usize> = col_ptr.as_slice()?.iter().map(|&x| x as usize).collect();
+    check_box_not_nan(lb.as_slice()?, ub.as_slice()?)?;
+    let row_idx_v: Vec<usize> = row_idx.as_slice()?.iter().map(|&x| x as usize).collect();
+    let vals_v: Vec<f64> = vals.as_slice()?.to_vec();
+    let c_owned: Vec<f64> = c.as_slice()?.to_vec();
+    let b_owned: Vec<f64> = b.as_slice()?.to_vec();
+    let l_owned: Vec<f64> = lb.as_slice()?.to_vec();
+    let u_owned: Vec<f64> = ub.as_slice()?.to_vec();
+    let int_cols: Vec<usize> = integer_cols
+        .as_slice()?
+        .iter()
+        .map(|&v| v as usize)
+        .collect();
+    let csc = SparseCols::from_csc(col_ptr_v, row_idx_v, vals_v);
     run_milp_hooked(
         py,
         csc,
@@ -1105,6 +1334,7 @@ pub fn solve_milp_csc_py<'py>(
         initial_incumbent,
         time_limit_s,
         debug_hook,
+        Some(lazy_callback),
     )
 }
 
@@ -1144,7 +1374,17 @@ fn run_milp_hooked<'py>(
     initial_incumbent: Option<PyReadonlyArray1<'py, f64>>,
     time_limit_s: Option<f64>,
     debug_hook: Option<Py<PyAny>>,
-) -> PyResult<(String, Bound<'py, PyArray1<f64>>, f64, f64, usize, usize)> {
+    lazy_callback: Option<Py<PyAny>>,
+) -> PyResult<(
+    String,
+    Bound<'py, PyArray1<f64>>,
+    f64,
+    f64,
+    usize,
+    usize,
+    usize,
+    usize,
+)> {
     let opts = MilpOptions {
         n_struct,
         integer_cols: int_cols,
@@ -1193,9 +1433,17 @@ fn run_milp_hooked<'py>(
         pending: std::sync::Mutex::new(None),
     });
     let hook_ref: Option<&dyn MilpDebugHook> = hook.as_ref().map(|h| h as &dyn MilpDebugHook);
+    // Same shape for the lazy separator (#1060): absent means the driver runs
+    // its untouched, bound-neutral path.
+    let lazy = lazy_callback.map(|cb| PyMilpLazyHook {
+        callback: cb,
+        n_struct,
+        pending: std::sync::Mutex::new(None),
+    });
+    let lazy_ref: Option<&dyn MilpLazyHook> = lazy.as_ref().map(|h| h as &dyn MilpLazyHook);
     let res = py.allow_threads(|| {
-        let r = core_solve_milp_hooked(
-            csc, m, n, &c_owned, &l_owned, &u_owned, &b_owned, obj_const, &opts, hook_ref,
+        let r = core_solve_milp_lazy_hooked(
+            csc, m, n, &c_owned, &l_owned, &u_owned, &b_owned, obj_const, &opts, hook_ref, lazy_ref,
         );
         // Emit the per-phase / pivot profile to stderr when DISCOPT_PROFILE is set
         // (no-op otherwise). solve_milp has returned, so its function-scoped phase
@@ -1208,6 +1456,14 @@ fn run_milp_hooked<'py>(
     // then propagates as the exception the caller expects, instead of being
     // silently converted into a normal-looking partial result.
     if let Some(h) = hook.as_ref() {
+        if let Some(err) = h.pending.lock().unwrap().take() {
+            return Err(err);
+        }
+    }
+    // A separator that raised (or broke its contract) propagates: the search
+    // already stopped uncertified, and returning its partial result as a normal
+    // one would hide constraints that were never enforced (CLAUDE.md §7).
+    if let Some(h) = lazy.as_ref() {
         if let Some(err) = h.pending.lock().unwrap().take() {
             return Err(err);
         }
@@ -1226,5 +1482,7 @@ fn run_milp_hooked<'py>(
         res.bound,
         res.nodes,
         res.lp_iters,
+        res.lazy_calls,
+        res.lazy_requeues,
     ))
 }

--- a/python/discopt/modeling/core.py
+++ b/python/discopt/modeling/core.py
@@ -4241,8 +4241,9 @@ class Model:
             family. Current implemented ``mip_nlp_method`` values are ``"oa"``,
             ``"ecp"``, ``"fp"``, ``"goa"``, and ``"lp_nlp_bb"``; ``"roa"``
             is reserved until its dedicated implementation lands. The
-            LP/NLP-BB method uses single-tree lazy OA cuts and currently
-            requires ``milp_solver="gurobi"``. Top-level OA/ECP options such
+            LP/NLP-BB method uses single-tree lazy OA cuts and runs on
+            ``milp_solver="simplex"`` (the default via ``"auto"``) or
+            ``"gurobi"``. Top-level OA/ECP options such
             as ``equality_relaxation``,
             ``ecp_mode``, ``feasibility_cuts``, ``heuristic_nonconvex``,
             ``add_slack``, ``max_slack``, ``oa_penalty_factor``,

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -6116,10 +6116,12 @@ def solve_model(
         plus initialization option ``init_strategy`` may be passed as top-level
         aliases and take precedence over duplicate keys in ``mip_nlp_options``.
         ``solution_pool``
-        currently requires ``milp_solver="gurobi"``. For
-        ``mip_nlp_method="lp_nlp_bb"``, ``milp_solver="gurobi"`` is also
-        required because the single-tree LP/NLP branch-and-bound variant uses
-        lazy master callbacks.
+        currently requires ``milp_solver="gurobi"``.
+        ``mip_nlp_method="lp_nlp_bb"`` runs on ``milp_solver="simplex"``
+        (also reached by ``"auto"``) or ``"gurobi"``: the single tree needs a
+        lazy-constraint callback, which those two backends provide and
+        ``"pounce"`` does not. Combining it with ``mip_nlp_profile="shot"``
+        still requires ``"gurobi"`` for the fractional-node (MIPNODE) cuts.
         Experimental SHOT-parity controls are accepted only with
         ``mip_nlp_profile="shot"`` and include ``tree_strategy``,
         ``cut_strategy``, ``objective_epigraph``, ``anti_epigraph``,

--- a/python/discopt/solvers/milp_simplex.py
+++ b/python/discopt/solvers/milp_simplex.py
@@ -19,7 +19,8 @@ from __future__ import annotations
 
 import logging
 import time
-from typing import NamedTuple, Optional, Union, cast
+from collections.abc import Iterable
+from typing import Callable, NamedTuple, Optional, Union, cast
 
 import numpy as np
 import scipy.sparse as sp
@@ -529,31 +530,43 @@ def _farkas_certified_std(
     return False
 
 
-def solve_milp(
-    c: np.ndarray,
-    A_ub: Optional[Union[np.ndarray, sp.spmatrix]] = None,
-    b_ub: Optional[np.ndarray] = None,
-    A_eq: Optional[Union[np.ndarray, sp.spmatrix]] = None,
-    b_eq: Optional[np.ndarray] = None,
-    bounds: Optional[list[tuple[float, float]]] = None,
-    integrality: Optional[np.ndarray] = None,
-    time_limit: Optional[float] = None,
-    gap_tolerance: float = 1e-4,
-    max_nodes: int = 1_000_000,
-) -> MILPResult:
-    """Solve ``min c^T x  s.t.  A_ub x <= b_ub, A_eq x == b_eq, bounds, integrality``
-    with the Rust warm-started-simplex B&B.
+class _StdForm(NamedTuple):
+    """The engine's standard form ``[A_ub | I] z = b``, built column-major.
 
-    Mirrors :func:`discopt.solvers.milp_pounce.solve_milp`. The returned
-    ``objective`` is the engine's dual lower bound (see module docstring).
+    ``n`` structural columns come first, then one slack per row; ``lb``/``ub``/``c``
+    are over all ``n + m`` columns. ``lp_kwargs`` carries the pure-LP
+    short-circuit described in :func:`_marshal_std_form`.
     """
-    try:
-        from discopt._rust import solve_milp_csc_py
-    except ImportError as err:  # pragma: no cover - exercised via the selector
-        raise SimplexBackendUnavailable(
-            "discopt._rust.solve_milp_csc_py is unavailable; build the Rust extension"
-        ) from err
 
+    m: int
+    n: int
+    col_ptr: np.ndarray
+    row_idx: np.ndarray
+    vals: np.ndarray
+    b: np.ndarray
+    lb: np.ndarray
+    ub: np.ndarray
+    c: np.ndarray
+    int_cols: np.ndarray
+    lp_kwargs: dict
+
+
+def _marshal_std_form(
+    c: np.ndarray,
+    A_ub: Optional[Union[np.ndarray, sp.spmatrix]],
+    b_ub: Optional[np.ndarray],
+    A_eq: Optional[Union[np.ndarray, sp.spmatrix]],
+    b_eq: Optional[np.ndarray],
+    bounds: Optional[list[tuple[float, float]]],
+    integrality: Optional[np.ndarray],
+) -> _StdForm:
+    """Marshal ``A_ub x <= b_ub, A_eq x == b_eq`` into the driver's CSC standard form.
+
+    Shared verbatim by :func:`solve_milp` and :func:`solve_milp_with_lazy_cuts` so
+    the two entry points cannot drift: a lazy-cut row is written in the *caller's*
+    ``x`` space, which only means anything if both paths lay the columns out the
+    same way (structural first, then one slack per row).
+    """
     c_arr = np.asarray(c, dtype=np.float64).ravel()
     n = c_arr.shape[0]
 
@@ -617,10 +630,6 @@ def solve_milp(
     else:
         int_cols = np.zeros(0, dtype=np.int64)
 
-    # Interactive debugger: install the Rust checkpoint hook only when a debugger
-    # is attached now, so the pure-Rust search stays bound-neutral otherwise.
-    from discopt import debug as _debug
-
     # Pure-LP short-circuit (THRU-2b): when there are no integer columns this is a
     # plain LP, yet the MILP driver still runs its integer-search machinery — root
     # cut rounds, GMI, primal heuristics, strong branching. With no integer
@@ -647,18 +656,67 @@ def solve_milp(
         if _pure_lp
         else {}
     )
+    return _StdForm(
+        m=m,
+        n=n,
+        col_ptr=csc_col_ptr,
+        row_idx=csc_row_idx,
+        vals=csc_vals,
+        b=np.ascontiguousarray(b_vec),
+        lb=np.ascontiguousarray(lb_std),
+        ub=np.ascontiguousarray(ub_std),
+        c=np.ascontiguousarray(c_std),
+        int_cols=np.ascontiguousarray(int_cols),
+        lp_kwargs=_lp_kwargs,
+    )
+
+
+def solve_milp(
+    c: np.ndarray,
+    A_ub: Optional[Union[np.ndarray, sp.spmatrix]] = None,
+    b_ub: Optional[np.ndarray] = None,
+    A_eq: Optional[Union[np.ndarray, sp.spmatrix]] = None,
+    b_eq: Optional[np.ndarray] = None,
+    bounds: Optional[list[tuple[float, float]]] = None,
+    integrality: Optional[np.ndarray] = None,
+    time_limit: Optional[float] = None,
+    gap_tolerance: float = 1e-4,
+    max_nodes: int = 1_000_000,
+) -> MILPResult:
+    """Solve ``min c^T x  s.t.  A_ub x <= b_ub, A_eq x == b_eq, bounds, integrality``
+    with the Rust warm-started-simplex B&B.
+
+    Mirrors :func:`discopt.solvers.milp_pounce.solve_milp`. The returned
+    ``objective`` is the engine's dual lower bound (see module docstring).
+    """
+    try:
+        from discopt._rust import solve_milp_csc_py
+    except ImportError as err:  # pragma: no cover - exercised via the selector
+        raise SimplexBackendUnavailable(
+            "discopt._rust.solve_milp_csc_py is unavailable; build the Rust extension"
+        ) from err
+
+    c_arr = np.asarray(c, dtype=np.float64).ravel()
+    n = c_arr.shape[0]
+    std = _marshal_std_form(c, A_ub, b_ub, A_eq, b_eq, bounds, integrality)
+    m = std.m
+    _lp_kwargs = std.lp_kwargs
+
+    # Interactive debugger: install the Rust checkpoint hook only when a debugger
+    # is attached now, so the pure-Rust search stays bound-neutral otherwise.
+    from discopt import debug as _debug
 
     status, x_full, obj, bound, nodes, _iters = solve_milp_csc_py(
-        np.ascontiguousarray(c_std),
+        std.c,
         m,
         n + m,  # total columns: structural + one slack per row
-        csc_col_ptr,
-        csc_row_idx,
-        csc_vals,
-        np.ascontiguousarray(b_vec),
-        np.ascontiguousarray(lb_std),
-        np.ascontiguousarray(ub_std),
-        np.ascontiguousarray(int_cols),
+        std.col_ptr,
+        std.row_idx,
+        std.vals,
+        std.b,
+        std.lb,
+        std.ub,
+        std.int_cols,
         n,  # n_struct: structural columns precede the slacks
         0.0,  # obj_const: caller (MilpRelaxationModel) applies its own offset
         int(max_nodes),
@@ -699,6 +757,211 @@ def solve_milp(
         objective=float(obj) if np.isfinite(obj) else None,
         bound=float(bound) if np.isfinite(bound) else None,
         node_count=int(nodes),
+    )
+
+
+def solve_milp_with_lazy_cuts(
+    c: np.ndarray,
+    A_ub: Optional[Union[np.ndarray, sp.spmatrix]] = None,
+    b_ub: Optional[np.ndarray] = None,
+    A_eq: Optional[Union[np.ndarray, sp.spmatrix]] = None,
+    b_eq: Optional[np.ndarray] = None,
+    bounds: Optional[list[tuple[float, float]]] = None,
+    integrality: Optional[np.ndarray] = None,
+    time_limit: Optional[float] = None,
+    gap_tolerance: float = 1e-4,
+    max_nodes: int = 1_000_000,
+    lazy_callback: Optional[Callable[[np.ndarray], object]] = None,
+    node_callback: Optional[Callable[[np.ndarray], object]] = None,
+    terminate_callback: Optional[Callable[[dict[str, object]], bool]] = None,
+    mip_start: Optional[np.ndarray] = None,
+) -> MILPResult:
+    """Single-tree MILP solve with a lazy-constraint separator, on the Rust simplex.
+
+    The in-house counterpart of :func:`discopt.solvers.gurobi.solve_milp_with_lazy_cuts`
+    (issue #1060): ``lazy_callback`` is called with every integer-feasible point the
+    search finds, before that point can become the incumbent, and returns an iterable
+    of ``(coefficients, rhs)`` rows in ``coefficients @ x <= rhs`` form. An empty
+    return (or ``None``) accepts the point; a non-empty return rejects it, adds the
+    rows to the shared relaxation, and puts the node **back in the search** — a veto
+    is not a proof that the box is empty, so the node is re-queued rather than
+    fathomed.
+
+    Not supported here, and refused rather than silently dropped:
+
+    ``node_callback``
+        Gurobi's MIPNODE user cuts fire at *fractional* node relaxations. The Rust
+        driver's hook fires only at integer-feasible points, so there is nothing to
+        map it onto; accepting and ignoring it would silently disable the caller's
+        cut strategy.
+    ``terminate_callback``
+        The driver enforces ``time_limit`` itself. A callback that can never fire
+        would make ``callback_stats["terminated"]`` a lie.
+
+    ``callback_stats`` reports ``mipsol_calls`` (separator invocations),
+    ``lazy_cuts`` (rows the separator returned), ``driver_lazy_calls`` (the same
+    count as the driver saw it) and ``lazy_requeues`` (vetoed nodes put back in
+    the search). ``mipsol_calls == 0`` means the separator never saw a point — NOT
+    that it accepted everything (CLAUDE.md §6).
+    """
+    try:
+        from discopt._rust import solve_milp_lazy_csc_py
+    except ImportError as err:  # pragma: no cover - exercised via the selector
+        raise SimplexBackendUnavailable(
+            "discopt._rust.solve_milp_lazy_csc_py is unavailable; build the Rust extension"
+        ) from err
+
+    if lazy_callback is None:
+        raise ValueError(
+            "solve_milp_with_lazy_cuts requires lazy_callback; use solve_milp for a "
+            "plain MILP solve"
+        )
+    if node_callback is not None:
+        raise NotImplementedError(
+            "the simplex lazy-cut backend has no MIPNODE equivalent: its separator "
+            "fires only at integer-feasible points, so node_callback (fractional "
+            "user cuts) cannot be honoured. Use milp_solver='gurobi' for that."
+        )
+    if terminate_callback is not None:
+        raise NotImplementedError(
+            "the simplex lazy-cut backend enforces time_limit in the driver and has "
+            "no callback-termination hook; pass time_limit instead of "
+            "terminate_callback."
+        )
+
+    c_arr = np.asarray(c, dtype=np.float64).ravel()
+    n = c_arr.shape[0]
+    std = _marshal_std_form(c, A_ub, b_ub, A_eq, b_eq, bounds, integrality)
+    m = std.m
+
+    # Separator invocations and vetoes, counted on this side too so the caller's
+    # anti-vacuity check does not depend on the binding's bookkeeping alone.
+    stats: dict[str, object] = {
+        "mipsol_calls": 0,
+        "mipnode_calls": 0,
+        "lazy_cuts": 0,
+        "node_cuts": 0,
+        "terminated": False,
+        "terminate_context": None,
+    }
+
+    def _separate(x_full: np.ndarray) -> list[tuple[np.ndarray, float]]:
+        stats["mipsol_calls"] = int(cast(int, stats["mipsol_calls"])) + 1
+        # The driver works in standard form and hands over `[structural | slacks]`.
+        # The caller's contract is the master's own variable vector, exactly as the
+        # Gurobi wrapper delivers it, so trim the slacks rather than leaking a
+        # layout the caller never declared.
+        x_arr = np.asarray(x_full, dtype=np.float64).ravel()
+        if x_arr.shape[0] < n:
+            raise ValueError(
+                f"driver returned a {x_arr.shape[0]}-vector for a master with {n} "
+                "structural columns"
+            )
+        rows = lazy_callback(x_arr[:n])
+        if rows is None:
+            return []
+        if not isinstance(rows, Iterable):
+            raise TypeError(
+                "lazy_callback must return None or an iterable of (coefficients, rhs) "
+                f"rows, got {type(rows).__name__}"
+            )
+        out: list[tuple[np.ndarray, float]] = []
+        for coeffs, rhs in rows:
+            row = np.asarray(coeffs, dtype=np.float64).ravel()
+            if row.shape[0] != n:
+                raise ValueError(
+                    f"lazy_callback returned a row with {row.shape[0]} coefficients "
+                    f"but the master has {n} variables"
+                )
+            out.append((row, float(rhs)))
+        stats["lazy_cuts"] = int(cast(int, stats["lazy_cuts"])) + len(out)
+        return out
+
+    # A caller-supplied start is a plain incumbent candidate: the driver validates
+    # it against the constraints AND offers it to the separator before seeding, so
+    # an infeasible or lazily-excluded start cannot prune the true optimum.
+    seed = None
+    if mip_start is not None:
+        seed_arr = np.asarray(mip_start, dtype=np.float64).ravel()
+        if seed_arr.shape[0] == n:
+            seed = np.ascontiguousarray(np.concatenate([seed_arr, np.zeros(m)]))
+
+    from discopt import debug as _debug
+
+    t0 = time.perf_counter()
+    (
+        status,
+        x_full,
+        obj,
+        bound,
+        nodes,
+        _iters,
+        lazy_calls,
+        lazy_requeues,
+    ) = solve_milp_lazy_csc_py(
+        std.c,
+        m,
+        n + m,
+        std.col_ptr,
+        std.row_idx,
+        std.vals,
+        std.b,
+        std.lb,
+        std.ub,
+        std.int_cols,
+        n,
+        _separate,
+        0.0,  # obj_const
+        int(max_nodes),
+        float(gap_tolerance),
+        time_limit_s=None if time_limit is None else max(0.0, float(time_limit)),
+        initial_incumbent=seed,
+        debug_hook=_debug.rust_hook(),
+        **std.lp_kwargs,
+    )
+    wall_time = time.perf_counter() - t0
+    # The binding counts calls the driver actually made; this side counts calls it
+    # actually served. A mismatch means a call was lost between the two and the
+    # separator's veto may not have been applied — report the driver's count and
+    # let the discrepancy surface rather than papering over it.
+    stats["driver_lazy_calls"] = int(lazy_calls)
+    stats["lazy_requeues"] = int(lazy_requeues)
+
+    if status == "infeasible":
+        return MILPResult(
+            status=SolveStatus.INFEASIBLE,
+            node_count=int(nodes),
+            wall_time=wall_time,
+            callback_stats=stats,
+        )
+    if status == "unbounded":
+        return MILPResult(
+            status=SolveStatus.UNBOUNDED,
+            node_count=int(nodes),
+            wall_time=wall_time,
+            callback_stats=stats,
+        )
+
+    x_struct = np.asarray(x_full, dtype=np.float64)[:n]
+    if status == "optimal":
+        return MILPResult(
+            status=SolveStatus.OPTIMAL,
+            x=x_struct,
+            objective=float(obj),
+            bound=float(obj),
+            gap=0.0,
+            node_count=int(nodes),
+            wall_time=wall_time,
+            callback_stats=stats,
+        )
+    return MILPResult(
+        status=SolveStatus.ITERATION_LIMIT,
+        x=x_struct,
+        objective=float(obj) if np.isfinite(obj) else None,
+        bound=float(bound) if np.isfinite(bound) else None,
+        node_count=int(nodes),
+        wall_time=wall_time,
+        callback_stats=stats,
     )
 
 

--- a/python/discopt/solvers/oa.py
+++ b/python/discopt/solvers/oa.py
@@ -27,7 +27,7 @@ import warnings
 from collections import Counter
 from collections.abc import Mapping
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any, Optional, cast
+from typing import TYPE_CHECKING, Any, Callable, Optional, cast
 
 import numpy as np
 
@@ -3773,14 +3773,42 @@ def solve_feasibility_pump(
     )
 
 
-def _require_lp_nlp_bb_gurobi_backend(milp_solver: str) -> None:
-    if not isinstance(milp_solver, str) or milp_solver.strip().lower() != "gurobi":
+def _resolve_lp_nlp_bb_backend(milp_solver: str, *, shot_profile: bool) -> str:
+    """Pick the single-tree MILP backend for LP/NLP branch-and-bound.
+
+    Returns ``"gurobi"`` or ``"simplex"``. Until #1060 this raised for anything
+    but Gurobi, because the single tree needs a *persistent lazy-constraint
+    callback* and only Gurobi's had one. The in-house Rust MILP driver now has
+    one too (``solve_milp_lazy_csc_py``), so ``"auto"`` and ``"simplex"`` resolve
+    to it and the method no longer requires a commercial license.
+
+    ``"pounce"`` still refuses: the POUNCE matrix-MILP B&B exposes no separator
+    hook, and silently substituting a different backend would hide that the
+    caller's choice was ignored.
+
+    The SHOT profile also still requires Gurobi. Its ESH/hyperplane strategy adds
+    user cuts at *fractional* node relaxations (Gurobi MIPNODE); the Rust hook
+    fires only at integer-feasible points, so there is nothing to map it onto,
+    and accepting the request while dropping those cuts would report a SHOT run
+    that never ran SHOT's cut generation.
+    """
+    backend = milp_solver.strip().lower() if isinstance(milp_solver, str) else ""
+    if backend == "gurobi":
+        return "gurobi"
+    if shot_profile:
         raise RuntimeError(
-            "mip_nlp_method='lp_nlp_bb' requires milp_solver='gurobi' because "
-            "LP/NLP branch-and-bound uses single-tree lazy constraint callbacks. "
-            "Backends 'auto', 'pounce', and 'simplex' do not expose the "
-            "required persistent lazy-cut capability."
+            "mip_nlp_method='lp_nlp_bb' with mip_nlp_profile='shot' requires "
+            "milp_solver='gurobi': the SHOT profile separates hyperplanes at "
+            "fractional node relaxations (MIPNODE user cuts), which the in-house "
+            f"simplex backend does not expose. Got milp_solver={milp_solver!r}."
         )
+    if backend in {"auto", "simplex"}:
+        return "simplex"
+    raise RuntimeError(
+        "mip_nlp_method='lp_nlp_bb' requires a MILP backend with a lazy-constraint "
+        "callback: 'gurobi' or 'simplex' (also reachable as 'auto'). Backend "
+        f"{milp_solver!r} exposes no separator hook."
+    )
 
 
 def _format_lazy_master_cut(
@@ -3819,7 +3847,7 @@ def solve_lp_nlp_bb(
     oa_penalty_factor: float = 1000.0,
     add_no_good_cuts: bool = False,
     feasibility_norm: str = "L_infinity",
-    milp_solver: str = "gurobi",
+    milp_solver: str = "auto",
     integer_to_binary: bool = False,
     mip_nlp_profile: str = "default",
     mip_nlp_shot_config: Optional[MIPNLPShotConfig] = None,
@@ -3828,12 +3856,16 @@ def solve_lp_nlp_bb(
     """Solve a convex MINLP with the LP/NLP branch-and-bound variant.
 
     This is a single-tree OA method: the MILP master is solved once, and each
-    integer incumbent triggers a fixed-integer NLP solve inside a Gurobi lazy
+    integer incumbent triggers a fixed-integer NLP solve inside a lazy
     constraint callback. Lazy rows are generated through the same OA and
     feasibility-cut helpers used by the multi-tree OA method. ``max_iterations``
     only caps the optional feasibility-pump initializer on this path; the main
-    single-tree search is delegated to Gurobi and is controlled by
+    single-tree search is delegated to the MILP backend and is controlled by
     ``time_limit`` and ``gap_tolerance``.
+
+    ``milp_solver`` selects that backend: ``"simplex"`` (the in-house Rust MILP
+    driver, also reached by the default ``"auto"``) or ``"gurobi"``. See
+    :func:`_resolve_lp_nlp_bb_backend` for what each one supports.
     """
     if kwargs:
         raise ValueError(
@@ -3845,8 +3877,13 @@ def solve_lp_nlp_bb(
             "max_slack, milp_solver, mip_nlp_profile, mip_nlp_shot_config, "
             "oa_penalty_factor."
         )
-    _require_lp_nlp_bb_gurobi_backend(milp_solver)
     t_start = time.perf_counter()
+    shot_config = mip_nlp_shot_config if mip_nlp_profile == "shot" else None
+    shot_profile = shot_config is not None
+    shot_cut_strategy = shot_config.cut_strategy if shot_config is not None else "oa"
+    # Resolve (and refuse) the single-tree backend before any model work, so an
+    # unsupported request costs a message rather than a decomposition.
+    lazy_backend = _resolve_lp_nlp_bb_backend(milp_solver, shot_profile=shot_profile)
     init_strategy = _normalize_init_strategy(init_strategy)
     feasibility_norm = _normalize_feasibility_norm(feasibility_norm)
     fp_config = _normalize_fp_config(
@@ -3893,9 +3930,6 @@ def solve_lp_nlp_bb(
             "disabling certified bound/gap reporting and skipping objective OA cuts"
         )
     master_bound_valid = decomp.master_bound_valid and not heuristic_nonconvex
-    shot_config = mip_nlp_shot_config if mip_nlp_profile == "shot" else None
-    shot_profile = shot_config is not None
-    shot_cut_strategy = shot_config.cut_strategy if shot_config is not None else "oa"
     cut_provenance = MIPNLPCutProvenance()
     callback_events: list[dict[str, object]] = []
 
@@ -4283,8 +4317,17 @@ def solve_lp_nlp_bb(
         )
         return rows
 
-    from discopt.solvers import SolveStatus
-    from discopt.solvers.gurobi import solve_milp_with_lazy_cuts
+    from discopt.solvers import MILPResult, SolveStatus
+
+    solve_milp_with_lazy_cuts: Callable[..., MILPResult]
+    if lazy_backend == "gurobi":
+        from discopt.solvers.gurobi import (
+            solve_milp_with_lazy_cuts as solve_milp_with_lazy_cuts,
+        )
+    else:
+        from discopt.solvers.milp_simplex import (
+            solve_milp_with_lazy_cuts as solve_milp_with_lazy_cuts,
+        )
 
     master_mip_start = None
     if shot_profile and incumbent is not None:
@@ -4298,7 +4341,7 @@ def solve_lp_nlp_bb(
     def callback_terminate(_snapshot: dict[str, object]) -> bool:
         return (time.perf_counter() - t_start) >= float(time_limit)
 
-    master_result = solve_milp_with_lazy_cuts(
+    lazy_kwargs: dict[str, object] = dict(
         c=master.c,
         A_ub=master.A_ub,
         b_ub=master.b_ub,
@@ -4309,10 +4352,14 @@ def solve_lp_nlp_bb(
         time_limit=remaining,
         gap_tolerance=gap_tolerance,
         lazy_callback=lazy_callback,
-        node_callback=node_callback if shot_profile else None,
-        terminate_callback=callback_terminate,
         mip_start=master_mip_start,
     )
+    if lazy_backend == "gurobi":
+        # MIPNODE user cuts and the wall-clock poll are Gurobi-only; the native
+        # driver has no fractional-node hook and enforces `time_limit` itself.
+        lazy_kwargs["node_callback"] = node_callback if shot_profile else None
+        lazy_kwargs["terminate_callback"] = callback_terminate
+    master_result = solve_milp_with_lazy_cuts(**lazy_kwargs)  # type: ignore[arg-type]
     wall_time = time.perf_counter() - t_start
 
     bound = None
@@ -4354,6 +4401,7 @@ def solve_lp_nlp_bb(
         "schema_version": 1,
         "solver": "mip-nlp",
         "method": "lp_nlp_bb",
+        "milp_backend": lazy_backend,
         "profile": mip_nlp_profile,
         "shot_options": (
             mip_nlp_shot_config.as_trace_dict() if mip_nlp_shot_config is not None else {}

--- a/python/tests/test_1060_native_single_tree.py
+++ b/python/tests/test_1060_native_single_tree.py
@@ -1,0 +1,212 @@
+"""#1060 — LP/NLP branch-and-bound without a Gurobi license.
+
+Before this change ``mip_nlp_method="lp_nlp_bb"`` raised for every MILP backend
+but ``"gurobi"``, because the single tree needs a persistent lazy-constraint
+callback. The Rust MILP driver now exposes one (``solve_milp_lazy_csc_py``), so
+``"auto"``/``"simplex"`` run the same algorithm in-house.
+
+Every end-to-end test here asserts the separator actually fired
+(``mipsol_calls``/``lazy_requeues``) — a single-tree run that never calls the
+callback would still report ``optimal`` on these models by solving the initial
+linearization, and would read as a pass while testing nothing (CLAUDE.md §6).
+"""
+
+import discopt.modeling as dm
+import numpy as np
+import pytest
+import scipy.sparse as sp
+from discopt import Model
+from discopt.solvers import SolveStatus
+from discopt.solvers.milp_simplex import solve_milp, solve_milp_with_lazy_cuts
+from discopt.solvers.oa import _resolve_lp_nlp_bb_backend
+
+
+def _build_convex_minlp(n: int = 6) -> Model:
+    """A convex MINLP whose first integer incumbent is *not* optimal.
+
+    The knapsack-style cardinality limit plus the big-M links make the initial
+    linearization loose enough that the separator has to reject several integer
+    points, so the requeue path is exercised rather than just the accept path.
+    """
+    m = Model("convex_minlp_1060")
+    x = [m.continuous(f"x{i}", lb=0.0, ub=5.0) for i in range(n)]
+    b = [m.binary(f"b{i}") for i in range(n)]
+    for i in range(n):
+        m.subject_to(x[i] <= 5.0 * b[i])
+    m.subject_to(sum(b) <= 3)
+    m.subject_to(sum(x) >= 6.0)
+    obj = 0
+    for i in range(n):
+        obj = obj + dm.exp(0.4 * x[i]) + (x[i] - float(i) * 0.5) ** 2 - 6.0 * b[i]
+    m.minimize(obj)
+    return m
+
+
+def _callback_stats(result) -> dict:
+    return dict(result.mip_nlp_trace["summary"]["callback_stats"])
+
+
+# --------------------------------------------------------------------------
+# backend resolution
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.smoke
+@pytest.mark.parametrize(
+    "requested,expected",
+    [("auto", "simplex"), ("simplex", "simplex"), ("SIMPLEX", "simplex"), ("gurobi", "gurobi")],
+)
+def test_lazy_backend_resolution(requested, expected):
+    assert _resolve_lp_nlp_bb_backend(requested, shot_profile=False) == expected
+
+
+@pytest.mark.smoke
+def test_pounce_backend_is_refused_not_silently_substituted():
+    # POUNCE's matrix MILP has no separator hook. Substituting a different
+    # backend would hide that the caller's choice was ignored.
+    with pytest.raises(RuntimeError, match="no separator hook"):
+        _resolve_lp_nlp_bb_backend("pounce", shot_profile=False)
+
+
+@pytest.mark.smoke
+def test_shot_profile_still_requires_gurobi():
+    # SHOT separates hyperplanes at fractional node relaxations (MIPNODE); the
+    # native hook only fires at integer-feasible points.
+    with pytest.raises(RuntimeError, match="MIPNODE"):
+        _resolve_lp_nlp_bb_backend("simplex", shot_profile=True)
+    assert _resolve_lp_nlp_bb_backend("gurobi", shot_profile=True) == "gurobi"
+
+
+# --------------------------------------------------------------------------
+# end to end
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.smoke
+def test_lp_nlp_bb_runs_on_the_native_backend():
+    """The regression: this raised RuntimeError before #1060."""
+    result = _build_convex_minlp().solve(
+        solver="mip-nlp",
+        mip_nlp_method="lp_nlp_bb",
+        milp_solver="simplex",
+        time_limit=120,
+    )
+    assert result.status == "optimal"
+    assert result.objective is not None
+    assert result.mip_nlp_trace["milp_backend"] == "simplex"
+
+    stats = _callback_stats(result)
+    # Anti-vacuity: the separator ran, rejected points, and those rejections
+    # were served by re-queueing rather than fathoming.
+    assert stats["mipsol_calls"] > 0
+    assert stats["driver_lazy_calls"] >= stats["mipsol_calls"]
+    assert stats["lazy_cuts"] > 0
+    assert stats["lazy_requeues"] > 0
+
+
+@pytest.mark.smoke
+def test_native_single_tree_agrees_with_multi_tree_oa_and_global_bb():
+    single = _build_convex_minlp().solve(
+        solver="mip-nlp", mip_nlp_method="lp_nlp_bb", milp_solver="simplex", time_limit=120
+    )
+    multi = _build_convex_minlp().solve(
+        solver="mip-nlp", mip_nlp_method="oa", milp_solver="simplex", time_limit=120
+    )
+    spatial = _build_convex_minlp().solve(time_limit=180)
+
+    assert _callback_stats(single)["lazy_requeues"] > 0, "separator never vetoed; test is vacuous"
+    for name, other in (("oa", multi), ("bb", spatial)):
+        assert other.objective is not None, name
+        assert single.objective == pytest.approx(other.objective, rel=1e-6, abs=1e-6), name
+
+
+@pytest.mark.smoke
+def test_auto_backend_reaches_the_native_single_tree():
+    result = _build_convex_minlp(4).solve(
+        solver="mip-nlp", mip_nlp_method="lp_nlp_bb", time_limit=120
+    )
+    assert result.mip_nlp_trace["milp_backend"] == "simplex"
+    assert _callback_stats(result)["mipsol_calls"] > 0
+
+
+# --------------------------------------------------------------------------
+# the native lazy wrapper itself
+# --------------------------------------------------------------------------
+
+
+def _knapsack():
+    # min -10 x0 - 9 x1 - 8 x2 - x3  s.t.  5(x0+x1+x2+x3) <= 9, x binary
+    c = np.array([-10.0, -9.0, -8.0, -1.0])
+    A_ub = sp.csr_matrix(np.full((1, 4), 5.0))
+    b_ub = np.array([9.0])
+    bounds = [(0.0, 1.0)] * 4
+    integrality = np.ones(4, dtype=np.int64)
+    return c, A_ub, b_ub, bounds, integrality
+
+
+@pytest.mark.smoke
+def test_accept_all_separator_is_bound_neutral():
+    c, A_ub, b_ub, bounds, integrality = _knapsack()
+    calls = {"n": 0}
+
+    def accept_everything(_x):
+        calls["n"] += 1
+        return []
+
+    baseline = solve_milp(c, A_ub, b_ub, None, None, bounds, integrality)
+    lazy = solve_milp_with_lazy_cuts(
+        c, A_ub, b_ub, None, None, bounds, integrality, lazy_callback=accept_everything
+    )
+    assert calls["n"] > 0, "separator never fired; neutrality claim is vacuous"
+    assert lazy.status == baseline.status
+    assert lazy.objective == pytest.approx(baseline.objective, rel=0, abs=0)
+    assert lazy.node_count == baseline.node_count
+
+
+@pytest.mark.smoke
+def test_veto_of_the_optimum_returns_the_next_best_point():
+    c, A_ub, b_ub, bounds, integrality = _knapsack()
+
+    def veto_x0(x):
+        if x[0] > 0.5:
+            return [(np.array([1.0, 0.0, 0.0, 0.0]), 0.0)]  # x0 <= 0
+        return []
+
+    result = solve_milp_with_lazy_cuts(
+        c, A_ub, b_ub, None, None, bounds, integrality, lazy_callback=veto_x0
+    )
+    assert result.status == SolveStatus.OPTIMAL
+    assert result.objective == pytest.approx(-9.0)
+    assert result.x[0] < 0.5
+    assert result.callback_stats["lazy_requeues"] > 0
+
+
+@pytest.mark.smoke
+def test_separator_exception_propagates_rather_than_being_swallowed():
+    c, A_ub, b_ub, bounds, integrality = _knapsack()
+
+    def boom(_x):
+        raise ZeroDivisionError("separator blew up")
+
+    with pytest.raises(Exception, match="separator blew up"):
+        solve_milp_with_lazy_cuts(
+            c, A_ub, b_ub, None, None, bounds, integrality, lazy_callback=boom
+        )
+
+
+@pytest.mark.smoke
+def test_unsupported_callbacks_are_refused_loudly():
+    c, A_ub, b_ub, bounds, integrality = _knapsack()
+    kw = dict(
+        c=c, A_ub=A_ub, b_ub=b_ub, A_eq=None, b_eq=None, bounds=bounds, integrality=integrality
+    )
+
+    with pytest.raises(ValueError, match="lazy_callback"):
+        solve_milp_with_lazy_cuts(**kw, lazy_callback=None)
+    # Accepting these while ignoring them would report cuts that were never added.
+    with pytest.raises(NotImplementedError, match="node_callback"):
+        solve_milp_with_lazy_cuts(**kw, lazy_callback=lambda _x: [], node_callback=lambda _x: [])
+    with pytest.raises(NotImplementedError, match="terminate_callback"):
+        solve_milp_with_lazy_cuts(
+            **kw, lazy_callback=lambda _x: [], terminate_callback=lambda _s: False
+        )

--- a/python/tests/test_mip_nlp.py
+++ b/python/tests/test_mip_nlp.py
@@ -2633,11 +2633,22 @@ def test_mip_nlp_reserved_methods_raise(method, issue):
         solve_mip_nlp(_binary_model(f"{method}_reserved"), method=method)
 
 
-def test_mip_nlp_method_lp_nlp_bb_requires_gurobi_backend():
+def test_mip_nlp_method_lp_nlp_bb_runs_on_the_native_simplex_backend():
+    """#1060: the single-tree path no longer requires Gurobi.
+
+    This asserted ``RuntimeError: requires milp_solver='gurobi'`` until the
+    in-house simplex grew a lazy-cut callback; the restriction it guarded is
+    gone, so the test now pins the replacement behavior (the request is served,
+    not refused).
+    """
     from discopt.solvers.mip_nlp import solve_mip_nlp
 
-    with pytest.raises(RuntimeError, match="requires milp_solver='gurobi'"):
-        solve_mip_nlp(_binary_model("lp_nlp_bb_backend"), method="lp_nlp_bb", milp_solver="simplex")
+    result = solve_mip_nlp(
+        _binary_model("lp_nlp_bb_backend"), method="lp_nlp_bb", milp_solver="simplex"
+    )
+
+    assert result.status == "optimal"
+    assert result.objective == pytest.approx(0.0, abs=1e-6)
 
 
 def test_mip_nlp_method_lp_nlp_bb_alias_routes_to_single_tree_solver(monkeypatch):


### PR DESCRIPTION
Contributes to #1060. Leaves #1060 open — the capability it asks for is
delivered, but its numeric acceptance criterion is not met, for a reason
measured below that lives in a different subsystem.

## The defect

`mip_nlp_method="lp_nlp_bb"` — single-tree LP/NLP branch-and-bound, the fastest
convex-MINLP algorithm in the tree — refused to run on anything but Gurobi:

```
mip_nlp_method='lp_nlp_bb' requires milp_solver='gurobi' because LP/NLP
branch-and-bound uses single-tree lazy constraint callbacks. Backends 'auto',
'pounce', and 'simplex' do not expose the required persistent lazy-cut capability.
```

The refusal was accurate — no in-house backend had a separator hook — and it is
why #1059 had to route convex MINLPs to the slower multi-tree `oa`. This PR
gives the in-house Rust MILP driver the missing hook.

## The change

A lazy-separation hook in the Rust MILP driver, surfaced through PyO3 and wired
into the OA layer.

**Rust (`bnb/milp_driver.rs`).** `MilpLazyHook::separate(&[f64]) -> MilpLazyVerdict`
(`Accept` / `Reject(Vec<GomoryCut>)` / `Failed`), consumed by the new
`solve_milp_lazy_hooked`. `solve_milp_hooked` delegates to it with `lazy = None`,
which is the same code path as before.

The soundness argument is where the work is:

- **The hook fires in the sequential reduce**, after `solve_node` and *before*
  `import_results`, so a vetoed point can never be promoted to incumbent. Firing
  at `IncumbentFound` would be post-adoption and too late to veto.
- **The screen matches the tree's own integrality predicate.** `solution_is_integral`
  mirrors `TreeManager::process_evaluated` (re-derived because `int_info` is moved
  into `TreeManager::new`); a test asserts agreement with `branching::is_integer_feasible`
  over 9 executed comparisons, so the two tolerances cannot silently drift apart.
- **A vetoed node is re-queued, never sentinelled.** Sentinelling is the #748
  non-rigorous fathom — sound for the Python `lazy_constraints` path's purposes,
  wrong here: a veto says "this point is not admissible", not "this box is empty".
  `TreeManager::requeue_node` puts the node back with its stored basis, so the
  child warm-starts through the dual simplex against the augmented matrix.
- **Lazy cuts bypass `node_cut_cap`** (they are signature-deduped, but never
  dropped) at the batch boundary. Dropping one would leave the vetoed point in the
  relaxation and re-queue the node forever against a matrix that never changed.
- **`LAZY_REQUEUE_CAP = 1000` per node** bounds a separator that never makes
  progress. Exhaustion sentinels the node *and* clears `gap_certified` / sets
  `search_incomplete`, so `decide_status` can return neither `Optimal` (needs
  `gap_closed && gap_certified`) nor `Infeasible` (needs `!search_incomplete`) —
  it degrades to a limit status.
- **A `Failed` separator stops the search uncertified** and the Python exception
  is re-raised on the way out; it is never swallowed (§7).

**PyO3 (`lp_bindings.rs`).** `PyMilpLazyHook` follows the existing `PyMilpDebugHook`
pattern (GIL-reacquiring, first-error-wins stash). It validates the returned rows —
width `<= n_struct` (a longer row would address the driver's slack columns and mean
something else), all entries finite — and converts the caller's `coeffs @ x <= rhs`
into the driver's `coeffs · x >= rhs`. New `solve_milp_lazy_csc_py`; the existing
`solve_milp_py`/`solve_milp_csc_py` are unchanged externally.

**Python.** `milp_simplex.solve_milp_with_lazy_cuts` is the in-house counterpart of
`gurobi.solve_milp_with_lazy_cuts` with the same `(coefficients, rhs)` contract and
the same `callback_stats` keys. It refuses `node_callback` (Gurobi MIPNODE fires at
*fractional* relaxations; the native hook only sees integer-feasible points) and
`terminate_callback` (the driver enforces `time_limit`, so a hook that can never
fire would make `callback_stats["terminated"]` a lie) rather than accepting and
ignoring them.

`oa.py`'s `_require_lp_nlp_bb_gurobi_backend` becomes `_resolve_lp_nlp_bb_backend`:
`"auto"`/`"simplex"` → the native driver, `"gurobi"` → unchanged, `"pounce"` →
still refused (no separator hook; substituting a different backend would hide that
the caller's choice was ignored), and `mip_nlp_profile="shot"` → still requires
Gurobi, because SHOT's ESH strategy separates at fractional nodes. `solve_lp_nlp_bb`'s
`milp_solver` default moves from `"gurobi"` to `"auto"`. The chosen backend is
recorded on the trace as `milp_backend`.

**No default changes.** `Model.solve()` still resolves `mip_nlp_method` to `"oa"`
when unspecified (`solver.py:6554`), so `lp_nlp_bb` remains opt-in and #1059's
auto-route is untouched. This PR removes a refusal; it does not flip a default,
so §5's *net-positive* bar does not gate it — the soundness bar does, and that is
what the panels below check.

## Verification

**Suites.**

| suite | result |
|---|---|
| `cargo test -p discopt-core` | 624 + 4 + 1 passed |
| `pytest -m smoke python/tests` | 1047 passed, 1 skipped, 2 xpassed |
| `pytest -m slow python/tests/test_adversarial_recent_fixes.py` | 19 passed |
| `pytest python/tests/test_1060_native_single_tree.py` | 13 passed |
| `ruff check` / `ruff format --check` / `mypy python/discopt/` | clean |

**New tests** (`python/tests/test_1060_native_single_tree.py`, 13). The
end-to-end ones each assert the separator actually fired — a single tree that
never calls the callback still reports `optimal` on these models by solving the
initial linearization, and would read as a pass while testing nothing (§6):

- `test_lp_nlp_bb_runs_on_the_native_backend` — the regression proper; raised
  `RuntimeError` before this change.
- `test_native_single_tree_agrees_with_multi_tree_oa_and_global_bb` — same
  objective from `lp_nlp_bb`, `oa` and spatial B&B, with
  `lazy_requeues > 0` asserted first so agreement is not vacuous.
- `test_accept_all_separator_is_bound_neutral` — §5 bound-neutral regime: an
  accept-everything separator leaves `node_count` and `objective` *exactly*
  unchanged versus plain `solve_milp` (`rel=0, abs=0`).
- `test_veto_of_the_optimum_returns_the_next_best_point` — vetoing the optimal
  knapsack item returns the true second-best point, not an infeasible or
  fathomed answer; `lazy_requeues > 0`.
- `test_separator_exception_propagates_rather_than_being_swallowed` (§7),
  `test_unsupported_callbacks_are_refused_loudly`,
  `test_pounce_backend_is_refused_not_silently_substituted`,
  `test_shot_profile_still_requires_gurobi`.

**Corpus panel.** `panel1060/` — 12 convex MINLPs selected mechanically, not by
name (§2): OA's own `_decompose_model` certificate (`oa_constraint_mask` all
true, objective linear or `oa_objective_is_convex`, `master_bound_valid`),
intersected with "has an oracle in `minlplib.solu`", `probtype` containing NLP,
`discrete > 0`, `nl_cons > 0`, `10 <= vars <= 2000`, `cons <= 3000`. Selected:
flay06h, flay06m, gams01, o9_ar4_1, portfol_roundlot, rsyn0830m02m, syn30m02m,
syn30m04m, syn40m04m, tls5, tls6, tls7.

Arms interleaved per instance (§9), 60 s each, both on `milp_solver="simplex"`.
Every arm is checked against the oracle for "incumbent does not beat the
reference" and "dual bound does not cross the reference", sense-aware; the
treatment arm additionally for `milp_backend == "simplex"` and
`mipsol_calls > 0`.

```
executed checks: 53; violations: 0        (12-instance panel)
executed checks: 28; violations: 0        (5-instance acceptance panel)
```

Outcome by instance:

| instance | `oa` | `lp_nlp_bb` (this PR) |
|---|---|---|
| flay06h | unknown, no incumbent | **feasible 108.16** |
| flay06m | feasible 66.93280218527 | feasible 66.93280218527 |
| gams01 | HARD_TIMEOUT | HARD_TIMEOUT |
| o9_ar4_1 | unknown | iteration_limit |
| portfol_roundlot | optimal 12.3 s | feasible |
| rsyn0830m02m | unknown, no incumbent | **feasible** |
| syn30m02m | unknown, no incumbent | **feasible** |
| syn30m04m | unknown, no incumbent | **feasible** |
| syn40m04m | unknown, no incumbent | **feasible** |
| tls5 / tls6 / tls7 | unknown | iteration_limit |

The single tree returns an incumbent on five instances where `oa` returns
nothing, and is worse on `portfol_roundlot` (where `oa` certifies in 12.3 s).
Neither result gates this PR — it changes no default — but both are recorded
rather than summarised as "helpful".

**Two instrument defects were found and fixed mid-run** (§6, §11), and the
earlier "0 violations" they produced is retracted:

1. The panel parsed only `=best=` from `minlplib.solu`. The five acceptance
   instances carry `=opt=`, so *every* oracle comparison silently did not run and
   the panel reported "executed checks: 10; violations: 0" — which was exactly
   the 5 backend + 5 anti-vacuity checks and no soundness at all. Fixed to parse
   both and to `SystemExit` if any requested instance lacks an oracle; the count
   rose to 28 on the same five instances, still 0 violations.
2. The panel trusted `time_limit`. `gams01` spent 7 m 1 s inside one cold XLA
   compile of `jit_batch_jvp` on the `oa` arm (#1063), which `time_limit` does
   not interrupt, and stalled the whole run for 13 minutes. Each (instance, arm)
   now runs in its own subprocess under a hard wall of 4x `time_limit`;
   `gams01` is reported as `HARD_TIMEOUT` on both arms, not dropped.

## The acceptance criterion is not met — and why

#1060 asks for: "`lp_nlp_bb` with `milp_solver` set to a free backend reaches
`optimal` on `rsyn0840m` and `rsyn0820m02m` inside 60 s". It does not:

| instance | `oa` (simplex) | `lp_nlp_bb` (simplex, this PR) | `lp_nlp_bb` (Gurobi, per #1060) |
|---|---|---|---|
| rsyn0805m | optimal 2.7 s | optimal 2.3 s | optimal 2.0 s |
| rsyn0820m02m | unknown, no incumbent | **feasible** 51.98 (opt 1092.09) | license limit |
| rsyn0840m | unknown, no incumbent | **feasible** −11.41 (opt 325.55) | optimal 3.4 s |
| syn20m02m | optimal 9.2 s | feasible 1748.40 (opt 1752.13) | optimal 2.3 s |
| syn40m | feasible 58.21 | feasible 61.93 (opt 67.71) | optimal 1.5 s |

The single tree is strictly better than `oa` where `oa` returns nothing
(`rsyn0820m02m`, `rsyn0840m`, and `flay06h` on the wider panel), and worse on
`syn20m02m`. Every arm is sound against the oracle.

**The gap is not the hook.** `panel1060/attribute.py` times the driver call and
the separator separately inside one process, at `time_limit=60`:

| instance | driver wall | separator | MILP search | search share |
|---|---|---|---|---|
| rsyn0840m | 56.89 s | 0.04 s (1 call) | 56.85 s | 99.9% |
| rsyn0820m02m | 53.94 s | 0.11 s (1 call) | 53.83 s | 99.8% |

Both runs end with `mipsol_calls = 1`: the in-house MILP B&B reaches one
integer-feasible point on these masters and then searches for ~55 s without
finding a second, so the separator has nothing to separate. Gurobi closes the
same master in ~3 s. The remaining distance to #1060's acceptance number is
in-house MILP throughput on rsyn-class synthesis masters, not in the lazy-cut
mechanism this PR adds — and it is pre-existing, since the `oa` arm fails on the
same two instances for the same reason.

That is why this PR says *Contributes to* rather than *Closes*: the capability
#1060 describes under "What done means" is delivered and sound, the numeric
acceptance bar it sets is not, and the work that would close it belongs to the
MILP driver.

## Measurement conditions

Darwin 25.5.0, 12 days uptime. `uptime` load average at panel start 4.2-4.9,
rising to 7.5-10.8 during the run; `ps` attributes the bulk to a Spotlight
`mds_stores` index at 141% CPU, not to the panel (which is single-threaded).

Because of that, **no timing claim is made in this PR.** The panel's claims are
status- and value-based (sound bound, sound incumbent, separator fired), which
load does not affect. The one quantitative claim — the 99.8-99.9% attribution
table — is a ratio of two components measured inside the same process during the
same interval, so contention scales both and cancels.

Run-to-run variance under that load is visible and worth stating: `syn40m`
returned `optimal` on both arms in one acceptance run and `feasible` on both in
the next. Both runs were sound; only the limit status moved.

`gams01` is the only instance excluded from the outcome table, by hard timeout on
*both* arms, and is listed explicitly in the panel output rather than filtered
out.
