### PR TITLE
fix(oa): #1062 the master must not spend the budget OA needs for an incumbent

### DIFF
--- a/python/discopt/solvers/oa.py
+++ b/python/discopt/solvers/oa.py
@@ -22,6 +22,7 @@ References:
 from __future__ import annotations
 
 import logging
+import math
 import time
 import warnings
 from collections import Counter
@@ -46,6 +47,40 @@ if TYPE_CHECKING:
     from discopt._relax.nlp_evaluator import NLPEvaluator
 
 logger = logging.getLogger(__name__)
+
+#: While OA holds no incumbent, the fraction of the remaining budget the master
+#: MILP is allowed to consume (#1062). OA's product with no incumbent is nothing
+#: at all, and the master is entitled to stop at its own time limit and still
+#: return a perfectly good integer assignment — but the fixed-integer NLP that
+#: turns that assignment into an incumbent runs *after* the candidate loop's
+#: ``elapsed >= time_limit`` check. Handing the master 100% of the budget
+#: therefore makes OA discard the answer it is holding. Measured on ``rsyn0840m``
+#: at 60 s: master 60.34 s (100% of the solve), fixed-NLP calls 0, obj None —
+#: against ``rsyn0805m`` on the same route, whose master takes 0.14 s and which
+#: reaches a proved optimum in 1.2 s.
+_MASTER_NO_INCUMBENT_BUDGET_FRAC = 0.9
+
+
+def _master_time_budget(remaining: float, *, has_incumbent: bool) -> float:
+    """Time limit for one master MILP solve, reserving room for the fixed NLP.
+
+    Once an incumbent exists OA has something to return, so the master may use
+    everything that is left. Until then it may not, or a master that exhausts
+    the budget leaves OA reporting ``status=unknown, obj=None`` while a usable
+    integer assignment sits in ``master_result.x``.
+
+    The reserve is a *fraction* rather than a constant so it never starves as
+    the budget shrinks, and it is a no-op whenever the master finishes early —
+    which is the common case. Stopping the master early costs only master
+    optimality, not soundness: a MILP master truncated at its time limit still
+    yields a valid dual bound for a relaxation of the MINLP.
+    """
+    if has_incumbent:
+        return remaining
+    if not math.isfinite(remaining) or remaining <= 0.0:
+        return remaining
+    return remaining * _MASTER_NO_INCUMBENT_BUDGET_FRAC
+
 
 _INIT_STRATEGIES = frozenset({"rNLP", "initial_binary", "max_binary", "fp"})
 _REGULARIZATION_MODES = {
@@ -6550,7 +6585,9 @@ def solve_oa(
             decomp.obj_coeffs,
             decomp.obj_is_linear,
             master_bound_valid,
-            time_limit=time_limit - elapsed,
+            time_limit=_master_time_budget(
+                time_limit - elapsed, has_incumbent=incumbent is not None
+            ),
             gap_tolerance=gap_tolerance,
             add_slack=add_slack,
             max_slack=max_slack,

--- a/python/tests/test_issue1062_oa_master_budget.py
+++ b/python/tests/test_issue1062_oa_master_budget.py
@@ -1,0 +1,112 @@
+"""Regression test for #1062: OA must not let the master eat the whole budget.
+
+`solve_oa` handed the master MILP ``time_limit - elapsed`` — every second that
+was left. A master that runs to its own time limit still returns a usable
+integer assignment, but the fixed-integer NLP subproblem that turns that
+assignment into an incumbent lives *after* the candidate loop's
+``elapsed >= time_limit`` check, so it never ran. OA then reported
+``status=unknown, obj=None`` while holding the answer.
+
+Measured on MINLPLib ``rsyn0840m`` at 60 s with the #1059 convex route on:
+
+    master  60.34 s (100 % of the solve)   fixed-NLP calls 0   obj None
+
+against ``rsyn0805m``, whose master takes 0.14 s and which the same route drives
+to a proved optimum in 1.2 s in three iterations. Capping the master's budget
+made three fixed-NLP subproblems run (0.02-0.03 s each) and produced a feasible
+incumbent on the instance that had returned none.
+
+The integration test below reproduces that shape without depending on a
+particular instance's difficulty (§2): it wraps the master so that it consumes
+exactly the budget it is given, which is what a hard MILP does. Before the fix
+the model comes back with no objective; after it, an incumbent is returned.
+"""
+
+from __future__ import annotations
+
+import time
+
+import discopt.modeling as dm
+import discopt.solvers.oa as oa
+import pytest
+
+
+def test_master_budget_reserves_time_while_there_is_no_incumbent():
+    """The unit rule: no incumbent means the master cannot have everything."""
+    # With an incumbent in hand OA has something to return, so the master is
+    # welcome to the whole remaining budget.
+    assert oa._master_time_budget(10.0, has_incumbent=True) == 10.0
+
+    # Without one, it must leave room for the subproblem that creates it.
+    budget = oa._master_time_budget(10.0, has_incumbent=False)
+    assert budget < 10.0
+    assert budget > 0.0
+
+    # The reserve is a fraction, so it survives repeated shrinking rather than
+    # collapsing to zero and starving the subproblem late in a solve.
+    assert oa._master_time_budget(1e-3, has_incumbent=False) > 0.0
+
+    # Degenerate budgets pass through untouched rather than being scaled into
+    # something stranger.
+    assert oa._master_time_budget(0.0, has_incumbent=False) == 0.0
+    assert oa._master_time_budget(float("inf"), has_incumbent=False) == float("inf")
+
+
+def _small_convex_minlp():
+    """A convex MINLP with a genuine fixed-integer NLP subproblem to solve."""
+    m = dm.Model("oa_budget")
+    y = m.binary("y", 3)
+    x = m.continuous("x", 3, lb=0.0, ub=5.0)
+    m.subject_to(y[0] + y[1] + y[2] == 2, name="pick_two")
+    for i in range(3):
+        m.subject_to(x[i] <= 5.0 * y[i], name=f"link{i}")
+    m.subject_to(x[0] + x[1] + x[2] >= 4.0, name="demand")
+    m.minimize(sum(x[i] * x[i] for i in range(3)) + 2.0 * (y[0] + y[1] + y[2]))
+    return m
+
+
+@pytest.mark.smoke
+def test_oa_returns_an_incumbent_when_the_master_exhausts_its_budget(monkeypatch):
+    """A master that uses all the time it is given must not cost OA its answer."""
+    real_master = oa._solve_master_milp
+    observed: dict[str, int] = {"master": 0, "fixed_nlp": 0}
+
+    def greedy_master(*args, **kwargs):
+        """Consume the whole allotted budget, then return the real solution.
+
+        This is what a hard MILP master does; simulating it keeps the test
+        independent of any particular instance being slow enough on the day.
+        """
+        observed["master"] += 1
+        budget = kwargs.get("time_limit")
+        result = real_master(*args, **kwargs)
+        if budget is not None and budget > 0:
+            deadline = time.perf_counter() + float(budget)
+            while time.perf_counter() < deadline:
+                time.sleep(0.01)
+        return result
+
+    real_nlp = oa._solve_nlp_subproblem
+
+    def counting_nlp(*args, **kwargs):
+        observed["fixed_nlp"] += 1
+        return real_nlp(*args, **kwargs)
+
+    monkeypatch.setattr(oa, "_solve_master_milp", greedy_master)
+    monkeypatch.setattr(oa, "_solve_nlp_subproblem", counting_nlp)
+
+    result = _small_convex_minlp().solve(solver="mip-nlp", mip_nlp_method="oa", time_limit=3.0)
+
+    # §6: the test is only meaningful if the wrapped master actually ran.
+    assert observed["master"] > 0, "the master wrapper never fired — test measured nothing"
+
+    # This is the defect: the subproblem is what manufactures the incumbent, and
+    # before the fix it was unreachable once the master had spent the budget.
+    assert observed["fixed_nlp"] > 0, (
+        "the master consumed the whole budget and OA never ran a fixed-integer "
+        "NLP subproblem, so it could not produce an incumbent"
+    )
+    assert result.objective is not None, (
+        f"OA returned no incumbent (status={result.status}) despite having "
+        "solved a master to a usable integer assignment"
+    )


### PR DESCRIPTION
## The defect

`solve_oa` handed the master MILP `time_limit - elapsed` — every second that was
left. That is fine once OA holds an incumbent. Before it holds one it is not:
the master is entitled to stop at its own time limit and still return a
perfectly usable integer assignment, but the fixed-integer NLP subproblem that
turns that assignment into an incumbent runs *after* the candidate loop's
`elapsed >= time_limit` check. A master that spends the budget therefore makes
OA throw away the answer it is holding and report `status=unknown, obj=None`.

## The measurement

MINLPLib `rsyn0840m`, 60 s, `DISCOPT_CONVEX_MINLP_ROUTE=1`, with
`_solve_master_milp` / `_solve_nlp_subproblem` wrapped to record calls and wall:

| instance | master | fixed-NLP calls | result |
|---|---|---|---|
| `rsyn0805m` (control) | 0.14 s, 0.35 s, 0.41 s | 3, at 0.01 s each | **optimal** 1296.1206 in 1.2 s |
| `rsyn0840m` | **60.34 s — 100 % of the solve** | **0** | `status=unknown`, `obj=None` |

and OA's own log line on the failing instance is
`OA: Time limit reached during iteration 0`.

Entry experiment before writing any code, with the kill criterion stated first
(*if a capped-master run still returns `obj=None`, the mechanism is wrong and no
reserve gets built*). Both arms interleaved in one process:

| arm | status | objective | fixed-NLP calls |
|---|---|---|---|
| master capped to 90 % of remaining | **feasible**, −11.413 | 3 subproblems, 0.02–0.03 s each | 3 |
| unchanged | `unknown` | `None` | **0** |

The kill criterion did not fire: the subproblems run and an incumbent appears
where there was none.

## The change

One helper and one call site. While `incumbent is None`, the master may use
90 % of the remaining budget instead of all of it.

Why a fraction and not a constant: it never starves as the budget shrinks, and
it is a **no-op whenever the master finishes early**, which is the common case —
`rsyn0805m`'s master takes 0.14 s of the same 60 s, so the cap is never binding
there. The change fires only in the situation that produces the bug.

Soundness: stopping a MILP master at a shorter limit costs master optimality,
not validity. A truncated master still yields a valid dual bound for a
relaxation of the MINLP, so `LB` remains sound (CLAUDE.md §1).

## Scope of the benefit — stated plainly

This converts "no answer at all" into "an answer" on `rsyn0840m`. It does **not**
make that incumbent good: −11.413 against a published optimum of 325.55, and the
default spatial path returns 37.587 on the same budget. So the #1059 convex
route still is not graduation-ready on this instance; this removes the
`obj=None` failure mode, not the primal-quality gap.

Cross-checked against #1064's `squfl` family, where the same "no incumbent"
signature was reported. There the cap is a measured **no-op**, which is the
safety property this change is supposed to have:

| instance | capped | unchanged |
|---|---|---|
| `squfl020-150` | feasible 1614.1130688, bound 226.3485246 | feasible 1614.1130688, bound 226.3485246 |
| `squfl025-040` | feasible 423.9799722, bound 76.8720441 | feasible 423.9799722, bound 76.8720441 |

Identical objective and bound on both, because those masters are not the
bottleneck — they return in 0.2–8.4 s and 8–19 subproblems run either way.
(Separately worth noting on #1064: both instances return a feasible incumbent on
the current tree, where that issue recorded `unknown` / "no solution found" for
`squfl020-150`. Still 115–189 % off, so #1064's real complaint stands.)

Reported rather than omitted: the measured *benefit* rests on one instance. The
general claim rests on the mechanism, which the regression test exercises
directly rather than through any instance's difficulty.

## Tests

`python/tests/test_issue1062_oa_master_budget.py`:

* a unit test of the budget rule itself (incumbent → full budget; no incumbent →
  strictly less but positive; degenerate `0.0`/`inf` budgets pass through);
* an integration test that wraps the master so it consumes exactly the budget it
  is given — what a hard MILP does — and asserts a fixed-NLP subproblem still
  runs and an incumbent still comes back. No instance name, no dependence on any
  model being slow on the day (§2).

Verified load-bearing: with the call site reverted the integration test fails
with `the master consumed the whole budget and OA never ran a fixed-integer NLP
subproblem`, and passes with the change.

Suites run on this branch (worktree `wt1062b`):

- `pytest -m smoke python/tests` — **1039 passed, 1 skipped, 2 xpassed** (125.34 s)
- `pytest -m slow python/tests/test_adversarial_recent_fixes.py` — **19 passed** (155.01 s)
- Rust untouched, so `cargo test -p discopt-core` does not apply.

`python/tests/test_1060_native_single_tree.py` is deselected from the smoke
number: it fails in this worktree with `SimplexBackendUnavailable` from a stale
compiled extension, both with and without this change. CI builds fresh and runs
it there.

Contributes to #1062.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017PQaiDVuY5Rs3tga98tnNo

