### PR TITLE
fix(gdp): #1062 the config dive was unreachable whenever the wave succeeded

### DIFF
--- a/python/discopt/_relax/primal_heuristics.py
+++ b/python/discopt/_relax/primal_heuristics.py
@@ -1538,18 +1538,25 @@ def one_hot_config_subnlp(
     skips, and the whole path is additionally deadline-bounded — in practice the
     deadline, not ``max_configs``, is what stops it.
 
-    **When this search returns nothing, control passes to**
-    :func:`one_hot_config_dive` **with the remaining budget** (#993). Both searches
-    here rank disjuncts from one static point and never re-solve, which measurably
-    cannot reach the answer on the harder nonlinear GDPs: on syngas the proven
-    configuration is 3 demotions from the argmax (plan 743 of 256) and on
-    batch_processing 15 of 29 (C(29,15) ~ 7.7e7). The dive re-solves the relaxation
-    between choices, which is what makes those reachable. Ordering is deliberate —
-    the wave is far cheaper when it works (0.018 s/plan on cstr) so it goes first,
-    and the dive only pays for models the wave cannot solve. The wave hands over
+    **When this search finishes, control passes to** :func:`one_hot_config_dive`
+    **with whatever budget is left, and the two point sets are merged** (#993,
+    #1062). Both searches here rank disjuncts from one static point and never
+    re-solve, which measurably cannot reach the answer on the harder nonlinear
+    GDPs: on syngas the proven configuration is 3 demotions from the argmax (plan
+    743 of 256) and on batch_processing 15 of 29 (C(29,15) ~ 7.7e7). The dive
+    re-solves the relaxation between choices, which is what makes those reachable.
+    Ordering is deliberate — the wave is far cheaper when it works (0.018 s/plan on
+    cstr) so it goes first, and the dive gets the remainder. The wave hands over
     after ``_WAVE_SOLVE_CAP`` sub-NLP solves: measured, an uncapped wave consumes
     the entire grant on precisely the models the dive is for, so the two searches
     would compete for one budget and the cheaper-but-useless one would always win.
+
+    The handover is **not** conditioned on the wave having failed. It was until
+    #1062, and that gate is what made the dive unreachable in practice: on the
+    syn/rsyn family the wave always returns a feasible-but-poor plan, so
+    "the wave found nothing" never fired and the better search never ran. Merging
+    rather than substituting means the caller can only end up with a superset of
+    the candidates it had before.
 
     ``max_configs`` is deliberately large. Measured on cstr, a fixed-integer
     sub-NLP here costs **0.018 s** (384 plans in 7 s), and the feasible plans sit
@@ -1733,23 +1740,50 @@ def one_hot_config_subnlp(
         stop,
         len(results),
     )
-    if results or not groups:
+    if not groups:
         return results
-    # The wave found nothing. Spend what is left of the budget on the dive, which
-    # re-solves between choices and can therefore reach configurations no wave
-    # around a single point can (see this function's docstring, #993). Called from
-    # HERE rather than from the solver's three call sites so that no path can be
-    # left unwired — that omission is exactly how #823 shipped a flag that was dead
-    # on the model class it targeted.
-    return one_hot_config_dive(
-        model,
-        x_relax,
-        backend=backend,
-        nlp_options=nlp_options,
-        evaluator=evaluator,
-        integer_tol=integer_tol,
-        deadline=deadline,
+    # Spend what is left of the budget on the dive, which re-solves between choices
+    # and can therefore reach configurations no wave around a single point can (see
+    # this function's docstring, #993). Called from HERE rather than from the
+    # solver's three call sites so that no path can be left unwired — that omission
+    # is exactly how #823 shipped a flag that was dead on the model class it
+    # targeted.
+    #
+    # This used to be gated on the wave having found *nothing* (``if results or not
+    # groups``). That gate made the dive unreachable on the class it was written
+    # for: the wave nearly always returns a feasible-but-poor plan, so "the wave
+    # found nothing" almost never happens, and the better search never ran (#1062).
+    # Measured on syn/rsyn at the production envelope (9 s shared by both searches,
+    # i.e. what ``_gdp_config_deadline`` grants at a 60 s limit), wave best vs. the
+    # two of them together, internal minimise convention:
+    #
+    #   rsyn0805m  -321.96 -> -1267.38 (dive 6.9 s)
+    #   syn40m       +0.95 ->   -23.16 (dive 3.1 s)
+    #   rsyn0840m   -11.06 ->   -92.11 (dive 5.5 s)
+    #   syn20m02m  -636.72 ->  -636.72 (wave used the whole envelope; dive got 0 s)
+    #
+    # The dive is *added*, never substituted: its points are appended to the wave's
+    # and the caller keeps the best, so this can only widen the candidate set. Both
+    # searches return points from :func:`subnlp`, which re-verifies integer- and
+    # constraint-feasibility, so neither can propose an infeasible incumbent and
+    # neither touches the dual bound.
+    #
+    # Cost is bounded by the caller's own ``deadline`` — the dive gets what the wave
+    # left and nothing more, so the heuristic's total budget is unchanged. When the
+    # wave spends the whole envelope the dive polls the expired deadline and returns
+    # immediately, which is the syn20m02m row above.
+    results.extend(
+        one_hot_config_dive(
+            model,
+            x_relax,
+            backend=backend,
+            nlp_options=nlp_options,
+            evaluator=evaluator,
+            integer_tol=integer_tol,
+            deadline=deadline,
+        )
     )
+    return results
 
 
 def one_hot_config_dive(

--- a/python/tests/test_issue1062_config_dive_reachable.py
+++ b/python/tests/test_issue1062_config_dive_reachable.py
@@ -1,0 +1,138 @@
+"""Regression test for #1062: the GDP config DIVE must not be gated on wave failure.
+
+``one_hot_config_subnlp`` reached ``one_hot_config_dive`` through::
+
+    if results or not groups:
+        return results
+
+so the dive ran *only when the wave returned nothing*. On the syn/rsyn family the
+wave always returns a feasible-but-poor plan, so that branch never fired and the
+search written for exactly those models was unreachable.
+
+Measured at the production envelope (9 s shared by both searches, i.e. what
+``_gdp_config_deadline`` grants at a 60 s limit), best objective in the solver's
+internal minimise convention, wave alone vs. wave + dive:
+
+    rsyn0805m   -321.96  ->  -1267.38      syn40m      +0.95  ->   -23.16
+    rsyn0840m    -11.06  ->    -92.11      syn20m02m  -636.72 ->  -636.72 (tie)
+
+For reference the published optima are 1296.12 / 67.71 / 325.55 / 1752.13 in the
+models' own maximise sense, and a full 60 s solve before this change returned
+1116.46 / 33.20 / 37.59 / 636.72.
+
+The tests below assert the *mechanism* — the dive is reached even when the wave
+succeeds, and its points are merged rather than discarded — on a small one-hot
+model, so nothing here depends on a named instance or on any model being hard
+enough on the day (CLAUDE.md §2).
+"""
+
+from __future__ import annotations
+
+import discopt.modeling as dm
+import numpy as np
+import pytest
+from discopt._relax import primal_heuristics as ph
+
+
+def _one_hot_model():
+    """A model whose disjunction the one-hot scanner actually recognises.
+
+    ``_scan_one_hot_rows`` requires an ``==`` row of unit-coefficient binaries
+    summing to 1, so this is a genuine structural match rather than a stand-in.
+    """
+    m = dm.Model("config_dive")
+    y = m.binary("y", 3)
+    x = m.continuous("x", 3, lb=0.0, ub=4.0)
+    m.subject_to(y[0] + y[1] + y[2] == 1, name="pick_one")
+    for i in range(3):
+        m.subject_to(x[i] <= 4.0 * y[i], name=f"link{i}")
+    m.subject_to(x[0] + x[1] + x[2] >= 1.0, name="demand")
+    m.minimize(sum((i + 1) * x[i] * x[i] for i in range(3)) + y[0] + 2.0 * y[1] + 3.0 * y[2])
+    return m
+
+
+def _seed_for(model):
+    from discopt._relax.nlp_evaluator import NLPEvaluator
+
+    evaluator = NLPEvaluator(model)
+    lb, ub = evaluator.variable_bounds
+    lb = np.asarray(lb, dtype=np.float64)
+    ub = np.asarray(ub, dtype=np.float64)
+    return evaluator, 0.5 * (lb + ub)
+
+
+@pytest.mark.smoke
+def test_one_hot_groups_are_detected(monkeypatch):
+    """§6 guard: without a recognised disjunction the tests below are vacuous."""
+    model = _one_hot_model()
+    int_mask = ph._get_integer_mask(model)
+    groups = ph._scan_one_hot_rows(model, int_mask, int(int_mask.size))
+    assert groups, "no one-hot group detected — the dive tests would prove nothing"
+
+
+@pytest.mark.smoke
+def test_dive_runs_even_when_the_wave_found_points(monkeypatch):
+    """The defect: a successful wave used to make the dive unreachable."""
+    from discopt.solvers.nlp_backend import get_nlp_solver
+
+    model = _one_hot_model()
+    evaluator, seed = _seed_for(model)
+
+    calls: list[int] = []
+    sentinel_obj = -12345.0
+    sentinel_x = np.zeros(int(np.asarray(seed).size), dtype=np.float64)
+
+    def spy_dive(*args, **kwargs):
+        calls.append(1)
+        return [(sentinel_x.copy(), sentinel_obj)]
+
+    monkeypatch.setattr(ph, "one_hot_config_dive", spy_dive)
+
+    results = ph.one_hot_config_subnlp(
+        model,
+        seed,
+        backend=get_nlp_solver("auto"),
+        evaluator=evaluator,
+        deadline=None,
+    )
+
+    # The wave has to have succeeded, or this test is measuring the old
+    # empty-wave branch and proves nothing about the change (§6).
+    wave_points = [r for r in results if float(r[1]) != sentinel_obj]
+    assert wave_points, "the wave found nothing — this test did not exercise the fix"
+
+    assert calls, (
+        "one_hot_config_dive was never called even though the wave succeeded — "
+        "the dive is still gated behind wave failure (#1062)"
+    )
+    # Merged, not substituted: the wave's own points must survive alongside it.
+    assert any(float(o) == sentinel_obj for _, o in results), (
+        "the dive ran but its points were discarded rather than merged"
+    )
+
+
+@pytest.mark.smoke
+def test_dive_still_runs_when_the_wave_finds_nothing(monkeypatch):
+    """The pre-existing #993 path must keep working — this is not a swap."""
+    from discopt.solvers.nlp_backend import get_nlp_solver
+
+    model = _one_hot_model()
+    evaluator, seed = _seed_for(model)
+
+    calls: list[int] = []
+
+    def spy_dive(*args, **kwargs):
+        calls.append(1)
+        return []
+
+    monkeypatch.setattr(ph, "one_hot_config_dive", spy_dive)
+    # A deadline already in the past stops the wave before its first sub-NLP, which
+    # is the "wave returned nothing" state #993 wired the dive up for.
+    ph.one_hot_config_subnlp(
+        model,
+        seed,
+        backend=get_nlp_solver("auto"),
+        evaluator=evaluator,
+        deadline=-1.0,
+    )
+    assert calls, "the dive is no longer reached on the empty-wave path (#993 regression)"


### PR DESCRIPTION
## The defect

`one_hot_config_subnlp` reached `one_hot_config_dive` through one gate:

```python
if results or not groups:
    return results
# The wave found nothing. Spend what is left of the budget on the dive ...
```

So the dive ran **only when the wave returned nothing**. The wave ranks disjuncts
from one static relaxation point and never re-solves; the dive re-solves the
relaxation between choices, and its own docstring records why that matters —
against BARON's proven configuration the answer sits 3 demotions from the argmax
on `syngas` (plan 743 of a 256-plan wave) and 15 of 29 on `batch_processing`
(C(29,15) ~ 7.7e7). Neither is reachable by any wave around a single point.

But on the `syn`/`rsyn` family the wave nearly always returns a
*feasible-but-poor* plan, so "the wave found nothing" almost never fires. The
better search was unreachable on a large part of the class it was written for.

## Entry experiment

Kill criterion stated before any code (§4): *if the dive is not strictly better
than the wave on at least 3 of the 4 instances, the suppression is not the
limiter and nothing gets built.* Both searches called directly on the same root
seed, 30 s each, one instance per fresh process. Internal minimise convention:

| instance | wave best | dive best | as max-sense objective |
|---|---|---|---|
| rsyn0805m | −321.96 | **−1267.38** | 321.96 → **1267.38** |
| syn40m | +0.95 | **−23.16** | −0.95 → **23.16** |
| rsyn0840m | −11.06 | **−210.44** | 11.06 → **210.44** |
| syn20m02m | −636.72 | −636.72 | tie |

3 of 4; the criterion did not fire.

## Design experiment: does it survive the *production* budget?

The entry experiment granted 30 s. Production grants both searches together
`_gdp_config_deadline` = `min(0.15 · remaining, 15 s)` — **9 s** at a 60 s limit —
and the wave alone consumes 2.1–9.9 s of it. So "run the dive too" could have
reduced to "run the dive for 0 s". Three wirings measured under one shared 9 s
envelope, so no arm can outspend another:

| instance | A (today: dive gated) | B (dive gets the remainder) | C (wave capped to half) |
|---|---|---|---|
| rsyn0805m | −321.96 | **−1267.38** | −1267.38 |
| syn40m | +0.95281 | **−23.1601** | −23.1601 |
| rsyn0840m | −11.0603 | **−92.1135** | −92.1135 |
| syn20m02m | −636.72 | −636.72 | −636.72 |

B and C are identical on all four, so the reservation logic in C buys nothing and
is not built — B is the change below. (On `syn20m02m` the wave spends the whole
envelope, the dive polls an expired deadline and returns immediately, and C's
half-and-half split still only ties. That instance is why C was measured at all.)

## The change

`if results or not groups:` becomes `if not groups:`, and the dive's points are
**appended** to the wave's rather than replacing them. One call site, no new
flag, no new budget.

* **Budget is unchanged.** The dive gets what the wave left of the caller's
  existing deadline and nothing more.
* **Soundness is structural, not argued.** Both searches return points from
  `subnlp`, which re-verifies integer- and constraint-feasibility, and the caller
  injects each through `_inject_incumbent`. Neither search touches the dual
  bound, so this cannot produce a false bound or a false `optimal` (§1).
* **Merged, not substituted** — the candidate set can only widen.

## End-to-end confirmation, 60 s, interleaved, one process per (instance, arm)

| instance | old | **new** | published optimum | primal gap old → new |
|---|---|---|---|---|
| rsyn0805m | 1116.458 | **1206.208** | 1296.121 | 13.86 % → **6.94 %** |
| rsyn0840m | 37.587 | **211.020** | 325.555 | 88.45 % → **35.18 %** |
| syn40m | 33.197 | 33.197 | 67.714 | 50.97 % (tie) |
| syn20m02m | 636.720 | 636.720 | 1752.134 | 63.66 % (tie) |

## §5 graduation panel — structural population, not a named list

The change can only alter behaviour for models where `_scan_one_hot_rows` finds
disjoint unit-coefficient `sum(binaries) == 1` rows; every other model returns at
`if not groups` on a byte-identical path. So the population was found by
scanning, not chosen by name: **162 of 550** corpus instances
(`problems_short` + `problems_medium`) carry that structure, across ~20 families
— `batch`, `clay`, `slay`, `flay`, `fac`, `enpro`, `graphpart`, `sssd`, `p_ball`,
`sfacloc`, `netmod`, `gastrans582`, `lip`, `ravempb`, `spring`, `supplychain`,
`wastepaper`, `crudeoil_pooling`, `feedtray`, `maxcsp` — and only then sampled
across them.

24 instances, both arms, 60 s each, one process per (instance, arm):

| | count |
|---|---|
| config heuristic actually ran (the change can act) | 15 |
| **better** | **1** (`sfacloc2_3_90`: 18.4488 → 17.853, opt 15.0945) |
| **worse** | **0** |
| unchanged | 14 |
| heuristic never ran — identical code path | 9 |

Combined with the four `syn`/`rsyn` instances above: **3 better, 0 worse, 16
unchanged** over 19 instances where the change can act.

*Cert-clean.* 116 certificate assertions executed over both arms of the panel and
the end-to-end runs — dual bound never crosses its incumbent, never crosses the
published optimum, and every `status=optimal` matches the published optimum —
with **0 violations**. That is structural rather than lucky: both searches return
points from `subnlp`, which re-verifies feasibility, and neither touches the
bound.

*Noise floor, reported rather than hidden.* Two instances in the never-ran set
(`netmod_kar1`, `slay10m`) show small drift in nodes and bound (0.4 % and 0.08 %)
despite executing provably identical code, because these are wall-clock-limited
runs. That is the run-to-run variance of the measurement, and it calibrates how
much of the "unchanged" column to trust: the 14 unchanged instances above match
to the last digit in objective, which is well inside it.

## Scope of the benefit — stated plainly

The large wins are concentrated in the `syn`/`rsyn` family, and one instance
outside it improved. Nothing regressed, and the cost is bounded by a budget that
was already allocated. This is a real but partial step on #1062: `rsyn0840m` goes
from 88 % off to 35 % off, which does not make it good — SCIP proves that
instance optimal in 0.66 s. The remaining gap is the sub-NLP seeding question
recorded in the issue comment, not this gate.

## Tests

`python/tests/test_issue1062_config_dive_reachable.py`:

* a §6 guard asserting the test model's disjunction is actually recognised by
  `_scan_one_hot_rows`, so the other two tests cannot pass vacuously;
* the defect itself — with the wave succeeding, `one_hot_config_dive` must still
  be called and its points must appear in the merged result;
* a non-regression guard that the #993 empty-wave path still reaches the dive,
  since this is a widening and not a swap.

No instance name and no dependence on any model being hard (§2). Verified
load-bearing: with the source change reverted the middle test fails with
`one_hot_config_dive was never called even though the wave succeeded — the dive
is still gated behind wave failure (#1062)`.

Suites run on this branch (worktree `wt1062b`):

- `pytest -m smoke python/tests` — **1042 passed, 1 skipped, 2 xpassed** (108 s)
- `pytest -m slow python/tests/test_adversarial_recent_fixes.py` — **19 passed** (155 s)
- `ruff check` / `ruff format --check` clean; Rust untouched, so
  `cargo test -p discopt-core` does not apply.

`python/tests/test_1060_native_single_tree.py` is deselected from the smoke
number: it fails in this worktree with `SimplexBackendUnavailable` from a stale
compiled extension, both with and without this change. CI builds fresh.

Contributes to #1062.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017PQaiDVuY5Rs3tga98tnNo
