### PR TITLE
test(amp): #1072 patch the evaluator AMP actually builds, not the one it stopped building

### DIFF
--- a/python/tests/test_amp_integration.py
+++ b/python/tests/test_amp_integration.py
@@ -1969,25 +1969,42 @@ class TestCurrentCodeWeaknesses:
 
     def test_constraint_check_rejects_eval_failure(self, monkeypatch):
         """Constraint evaluation errors must reject the candidate point."""
-        import discopt._relax.nlp_evaluator as nlp_eval
+        import discopt._tape_nlp_evaluator as tape_eval
         from discopt.solvers import amp as amp_mod
+
+        # #1063/#1072: ``_check_constraints`` builds its evaluator through
+        # ``make_evaluator``, the canonical funnel, which returns the *tape*
+        # evaluator by default. Patching ``nlp_evaluator.NLPEvaluator`` -- as
+        # this test used to -- replaced a class AMP never instantiates, so
+        # ``BrokenEvaluator`` was never constructed, nothing raised, and the
+        # real evaluator happily reported the point feasible. The test then read
+        # as a failure of the code under test rather than of its own mock.
+        # Patch the funnel itself, and count the constructions so the patch
+        # cannot go un-exercised again (CLAUDE.md §6).
+        n_built = []
 
         class BrokenEvaluator:
             def __init__(self, model):
+                n_built.append(1)
                 self.n_constraints = 1
                 self.constraint_bounds = (np.array([0.0]), np.array([1.0]))
 
             def evaluate_constraints(self, x):
                 raise RuntimeError("boom")
 
-        monkeypatch.setattr(nlp_eval, "NLPEvaluator", BrokenEvaluator)
+        monkeypatch.setattr(tape_eval, "make_evaluator", lambda model, **kw: BrokenEvaluator(model))
 
         m = Model("broken_eval")
         x = m.continuous("x", lb=0, ub=1)
         m.subject_to(x >= 0)
         m.minimize(x)
 
-        assert amp_mod._check_constraints(np.array([0.5]), m) is False
+        result = amp_mod._check_constraints(np.array([0.5]), m)
+        assert n_built, (
+            "the broken evaluator was never constructed — the patch missed the "
+            "path under test and this assertion would pass for the wrong reason"
+        )
+        assert result is False
 
     def test_solve_model_signature_exposes_solver_parameter(self):
         """solve_model should expose the backend selector in its signature."""
@@ -2317,6 +2334,7 @@ class TestCurrentCodeWeaknesses:
     def test_amp_does_not_accept_start_with_nonfinite_objective(self, monkeypatch):
         """A finite start with NaN objective is not a valid AMP incumbent."""
         import discopt._relax.nlp_evaluator as nlp_eval
+        import discopt._tape_nlp_evaluator as tape_eval
         from discopt._relax.milp_relaxation import MilpRelaxationResult
         from discopt.solvers import amp as amp_mod
 
@@ -2324,11 +2342,21 @@ class TestCurrentCodeWeaknesses:
         x = m.continuous("x", lb=0.0, ub=1.0)
         m.minimize(x)
 
-        monkeypatch.setattr(
-            nlp_eval.NLPEvaluator,
-            "evaluate_objective",
-            lambda self, x_flat: np.nan,
-        )
+        # #1063/#1072: AMP goes through ``make_evaluator``, which hands back the
+        # tape evaluator, so patching only the JAX class silently patched a class
+        # this path never instantiates -- the NaN never appeared and the start
+        # was accepted, making the test read as a solver bug rather than a stale
+        # mock. Patch whichever backend the funnel returns, and count the calls
+        # so the patch cannot go un-exercised again (CLAUDE.md §6).
+        # ``test_amp.py`` carries the same fix for its copy of this test.
+        n_nan_evals = []
+
+        def _nan_objective(self, x_flat):
+            n_nan_evals.append(1)
+            return np.nan
+
+        monkeypatch.setattr(nlp_eval.NLPEvaluator, "evaluate_objective", _nan_objective)
+        monkeypatch.setattr(tape_eval.TapeNLPEvaluator, "evaluate_objective", _nan_objective)
         monkeypatch.setattr(
             amp_mod,
             "_solve_milp_with_oa_recovery",
@@ -2349,6 +2377,7 @@ class TestCurrentCodeWeaknesses:
             time_limit=1.0,
         )
 
+        assert n_nan_evals, "the NaN objective was never evaluated — this test asserted nothing"
         assert result.status == "error"
         assert result.objective is None
         assert result.x is None


### PR DESCRIPTION
## The failure

`amp-integration.yml`, job "AMP Alpine/incidence suite", step 1: `2 failed, 178
passed, 2 xpassed`. Red on every push to `main` since the #1070 merge run
(32095228445), and the workflow's own reporter filed #1072 minutes later.

```
test_constraint_check_rejects_eval_failure          AssertionError: assert True is False
test_amp_does_not_accept_start_with_nonfinite_objective  assert 'feasible' == 'error'
```

## Cause

PR #1070 (issue #1063, keeping JAX off the OA path) moved AMP's evaluator
construction from the JAX constructor to `make_evaluator`, the canonical funnel,
in `python/discopt/solvers/amp.py:1026` and `:2440`. `make_evaluator` returns a
`TapeNLPEvaluator` by default.

Both tests inject their failure by monkeypatching
`discopt._relax.nlp_evaluator.NLPEvaluator` — a class this path no longer
instantiates. So:

* `BrokenEvaluator` was never constructed, nothing raised, and the real
  evaluator found `x=0.5` satisfied the constraint, so `_check_constraints`
  returned `True`;
* the NaN `evaluate_objective` was never called, the start's objective was
  finite, it was accepted as an incumbent, and the solve ended `feasible`.

Each assertion then read as a defect in the solver when the defect was in the
test's own mock.

PR #1070 knew about this mode: it fixed the identical
`test_amp_does_not_accept_start_with_nonfinite_objective` in `test_amp.py:2190`,
patching *both* backends and adding a call counter with the comment "*patching
only the JAX class silently patched a class this path never instantiates*". The
near-duplicate copies in `test_amp_integration.py` were missed.

## Why the PR was green and `main` went red

`test_amp_integration.py:46` sets a module-level
`pytestmark = [slow, integration, amp_benchmark, memory_heavy]`. Every `ci.yml`
selector deselects those markers and `python-amp-coverage` runs only
`test_amp.py`, so this file runs *only* in the AMP integration workflow — which
`amp-integration.yml:23-26` gates off for pull requests unless the
`amp-integration` label is set. Every PR run in the history shows `skipped`.
#1070's PR could not have caught this; it was observable only post-merge.

## The change

Test-side only. Patch the funnel the code actually calls, and count the
injections so a patch that stops intercepting fails loudly rather than asserting
nothing (CLAUDE.md §6):

* `test_constraint_check_rejects_eval_failure` patches
  `tape_eval.make_evaluator` and asserts `BrokenEvaluator` was constructed
  before asserting the return value.
* `test_amp_does_not_accept_start_with_nonfinite_objective` patches
  `evaluate_objective` on both `NLPEvaluator` and `TapeNLPEvaluator` and asserts
  the NaN was actually evaluated — the same shape `test_amp.py` already carries.

No solver code is touched. No certificate or soundness assertion was among the
failures; both are mocked-failure-injection tests.

## Verification

Run with CI's own invocations, in this worktree:

| step | before | after |
|---|---|---|
| bulk (`-n 2 --dist=load`, CI's marker expression) | 2 failed, 178 passed, 2 xpassed | **180 passed, 2 xpassed** (36.9 s) |
| cert-heavy (`-m amp_cert_heavy --timeout=900`) | 3 passed, 1 xfailed | **3 passed, 1 xfailed** (302 s) |

The two failures were reproduced locally first (they need the marker expression;
a bare `pytest <file>::<test>` deselects them), so the before column is measured
rather than quoted from CI.

Closes #1072.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017PQaiDVuY5Rs3tga98tnNo
