### PR TITLE
fix(presolve): #1061 deliver root presolve's box to both the model and the repr

### DIFF
--- a/python/discopt/_relax/presolve_pipeline.py
+++ b/python/discopt/_relax/presolve_pipeline.py
@@ -268,10 +268,34 @@ def run_root_presolve(
     if fbbt:
         stats["fbbt"] = {"lb": raw["bounds_lo"], "ub": raw["bounds_hi"]}
 
+    # The orchestrator's final box, and whether it is safe to adopt as a
+    # *declared* model box (#1061).
+    #
+    # ``raw["bounds_lo"/"bounds_hi"]`` is the orchestrator's ``ctx.bounds``: the
+    # accumulated result of every bound-deriving pass, aligned with the returned
+    # repr's blocks. The Rust side deliberately does not write it into the repr
+    # (see the NOTE at the end of ``presolve::orchestrator::run``), so
+    # ``propagate_bounds_to_model`` -- which reads only the repr -- has never
+    # seen it. On the MINLPLib syn/rsyn class that made root bound tightening a
+    # complete no-op: FBBT derives a finite upper bound for all 83-169
+    # unbounded continuous variables and every one of them was discarded.
+    #
+    # Most passes here are *feasibility*-based: their bounds hold for every
+    # feasible point, so narrowing the declared box to them excludes nothing.
+    # ``reduced_cost_fixing`` and ``reduction_constraints`` are not -- they are
+    # cutoff/incumbent-derived, valid only for finding an *optimal* point. Those
+    # must never become declared bounds (a later re-solve against a different
+    # cutoff would read them as a false infeasibility), so they are flagged and
+    # ``propagate_bounds_to_model`` refuses them outright rather than quietly
+    # applying a box it cannot justify.
+    stats["bounds_lo"] = raw["bounds_lo"]
+    stats["bounds_hi"] = raw["bounds_hi"]
+    stats["bounds_optimality_derived"] = bool(reduced_cost or reduction_constraints)
+
     return new_repr, stats
 
 
-def propagate_bounds_to_model(model, model_repr) -> int:
+def propagate_bounds_to_model(model, model_repr, presolve_stats: dict | None = None) -> int:
     """Push tightened per-element bounds from ``model_repr`` back into ``model``.
 
     This is the bridge that lets the Rust-side presolve outcome influence
@@ -281,8 +305,22 @@ def propagate_bounds_to_model(model, model_repr) -> int:
     reformulation have no Python-side counterpart and are silently
     skipped.
 
+    ``presolve_stats`` is the second element of :func:`run_root_presolve`'s
+    return value. Pass it to also adopt the orchestrator's *own* final box
+    (``bounds_lo``/``bounds_hi``), which the Rust side deliberately keeps out of
+    the repr and which this function therefore could not see (#1061). Omitting
+    it preserves the historical repr-only behaviour exactly.
+
     Returns the number of *scalar elements* whose ``lb`` or ``ub`` was
     strictly tightened. Equal-or-looser updates are ignored.
+
+    Raises:
+        ValueError: if ``presolve_stats`` carries an optimality-derived box.
+            Those bounds are valid only for locating an optimum, not for the
+            feasible region, so adopting them as *declared* bounds could
+            manufacture a false infeasibility on a later re-solve. Refusing is
+            the intended behaviour (CLAUDE.md §3): silently skipping would make
+            an enabled tightening look applied when it was not.
     """
     import numpy as np
 
@@ -315,6 +353,33 @@ def propagate_bounds_to_model(model, model_repr) -> int:
             return 0
         block_iter = [(py_blocks[bi], bi) for bi in range(len(py_blocks))]
 
+    # The orchestrator's own final box, one interval per surviving block, indexed
+    # by the same ``bi`` as ``model_repr.var_lb(bi)`` (#1061). A block interval is
+    # a valid *outer* bound for every element of its block -- the engine seeds a
+    # block from the element-wise union of its bounds (``seed_block_interval``,
+    # C-31) -- so stamping it onto every scalar slot and intersecting can only
+    # tighten and never excludes a feasible point. This is the same expansion
+    # ``tightening.fbbt_box`` performs.
+    box_lo = box_hi = None
+    if presolve_stats:
+        if presolve_stats.get("bounds_optimality_derived"):
+            raise ValueError(
+                "refusing to propagate an optimality-derived presolve box into the "
+                "model's declared bounds: reduced_cost_fixing / reduction_constraints "
+                "bounds hold only for locating an optimum, not for the feasible "
+                "region (#1061)"
+            )
+        lo_raw = presolve_stats.get("bounds_lo")
+        hi_raw = presolve_stats.get("bounds_hi")
+        if lo_raw is not None and hi_raw is not None:
+            box_lo = np.asarray(lo_raw, dtype=np.float64)
+            box_hi = np.asarray(hi_raw, dtype=np.float64)
+            if box_lo.size != model_repr.n_var_blocks or box_hi.size != model_repr.n_var_blocks:
+                # Misaligned arrays would stamp one block's interval onto another,
+                # which is unsound rather than merely useless. Drop the box; the
+                # repr-derived tightening below still applies.
+                box_lo = box_hi = None
+
     for block, bi in block_iter:
         py_lb = np.asarray(block.lb, dtype=np.float64)
         py_ub = np.asarray(block.ub, dtype=np.float64)
@@ -322,6 +387,9 @@ def propagate_bounds_to_model(model, model_repr) -> int:
         rust_ub = np.asarray(model_repr.var_ub(bi), dtype=np.float64)
         if rust_lb.size != py_lb.size or rust_ub.size != py_ub.size:
             continue
+        if box_lo is not None and box_hi is not None:
+            rust_lb = np.maximum(rust_lb, box_lo[bi])
+            rust_ub = np.minimum(rust_ub, box_hi[bi])
         flat_py_lb = py_lb.reshape(-1).copy()
         flat_py_ub = py_ub.reshape(-1).copy()
         changed = False

--- a/python/discopt/_relax/presolve_pipeline.py
+++ b/python/discopt/_relax/presolve_pipeline.py
@@ -407,6 +407,20 @@ def propagate_bounds_to_model(model, model_repr, presolve_stats: dict | None = N
         if changed:
             block.lb = flat_py_lb.reshape(py_lb.shape)
             block.ub = flat_py_ub.reshape(py_ub.shape)
+        if box_lo is not None and box_hi is not None:
+            # Keep the repr's box in step with the model's. Downstream the two
+            # are read by different consumers, and letting them disagree costs
+            # bound rather than saving it: on 4stufen the model-only write gave
+            # a root bound of 20282.42 against 20712.17 with no propagation at
+            # all, while applying the identical box to both views gave 20712.43.
+            # The box is not the problem -- a smaller box cannot weaken a
+            # relaxation -- the disagreement is. ``tighten_var_bounds`` is
+            # intersection-only (it returns the count that strictly tightened),
+            # so this cannot loosen the repr, and it preserves the structural
+            # work presolve did to the repr that rebuilding it would discard.
+            # Confined to the #1061 path: without ``presolve_stats`` the repr is
+            # left exactly as the historical behaviour left it.
+            model_repr.tighten_var_bounds(bi, flat_py_lb, flat_py_ub)
     return n_tightened
 
 

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -1678,6 +1678,53 @@ def _node_probe_max_vars() -> int:
 _IN_TREE_PRESOLVE_GLOBAL_CALLS = 0
 
 
+def _presolve_bound_propagation_enabled() -> bool:
+    """Whether root presolve's own box is adopted as the model's declared bounds.
+
+    **Default OFF** (CLAUDE.md §5 regime 2: bound-changing) — opt in with
+    ``DISCOPT_PRESOLVE_BOUND_PROPAGATION=1``.
+
+    The Rust orchestrator accumulates every pass's bound tightening in
+    ``ctx.bounds`` and deliberately does **not** write it into the returned repr
+    (see the NOTE closing ``presolve::orchestrator::run``: mutating the repr's
+    declared bounds can flip an inactive bound to active and change LP duals).
+    It hands the box back to the caller instead. ``propagate_bounds_to_model``,
+    the one caller whose job is to deliver it, read only the repr — so the box
+    was computed and dropped on every solve.
+
+    Measured on the MINLPLib syn/rsyn class (#1061), root presolve terminating
+    ``NoProgress`` with ``n_tightened=0``:
+
+    ============  =============  ==========  ===========================
+    instance      inf ub before  inf ub kept  ``stats`` entries tighter
+    ============  =============  ==========  ===========================
+    ``syn40m``    83             83           87 of 130
+    ``rsyn0840m`` 169            169          -
+    ``syn20m02m`` 122            122          -
+    ``rsyn0805m`` 99             99           91 of 161
+    ============  =============  ==========  ===========================
+
+    The FBBT kernel run directly on the *identical* repr drives every one of
+    those to a finite bound (83/169/122/99 -> 0), and ``stats['fbbt']['ub']``
+    already holds them. Nothing needed deriving; it needed delivering.
+
+    Root dual-bound ratio against the reference optimum, 1-node solves
+    (OFF -> ON): ``syn40m`` 27.084x -> 15.643x, ``rsyn0840m`` 8.534x -> 6.185x,
+    ``syn20m02m`` 2.788x -> 2.646x, ``rsyn0805m`` 1.629x unchanged. The OFF
+    column reproduces the ratios #1061 published (27.1/8.5/2.8/1.6), which is
+    what makes the ON column comparable to them.
+
+    Only feasibility-derived bounds are eligible: ``propagate_bounds_to_model``
+    raises on an optimality-derived box rather than adopting one.
+    """
+    return os.environ.get("DISCOPT_PRESOLVE_BOUND_PROPAGATION", "").strip().lower() in (
+        "1",
+        "true",
+        "yes",
+        "on",
+    )
+
+
 def _in_tree_presolve_global_calls() -> int:
     """Firings of the in-tree presolve kernel on the global spatial B&B path."""
     return _IN_TREE_PRESOLVE_GLOBAL_CALLS
@@ -8023,7 +8070,15 @@ def solve_model(
                 fbbt=True,
                 time_limit_ms=int(_presolve_budget_s * 1000),
             )
-            n_tightened = propagate_bounds_to_model(model, _model_repr)
+            # #1061: hand the orchestrator's own box over as well. Without the
+            # stats argument this call sees only the repr, which the Rust side
+            # deliberately leaves untightened, so every bound presolve derived
+            # was discarded here.
+            n_tightened = propagate_bounds_to_model(
+                model,
+                _model_repr,
+                _presolve_stats if _presolve_bound_propagation_enabled() else None,
+            )
             elim = _presolve_stats.get("elimination", {})
             poly = _presolve_stats.get("polynomial", {})
             if elim.get("variables_fixed", 0) > 0 or n_tightened > 0:

--- a/python/tests/test_issue1061_presolve_bound_propagation.py
+++ b/python/tests/test_issue1061_presolve_bound_propagation.py
@@ -1,0 +1,166 @@
+"""Regression test for #1061: root presolve computed bounds and threw them away.
+
+The Rust orchestrator accumulates every pass's tightening in ``ctx.bounds`` and
+deliberately does not write it into the model repr it returns -- the NOTE closing
+``presolve::orchestrator::run`` explains why (mutating the repr's declared bounds
+can flip an inactive bound to active and change LP duals). It hands the box back
+to the caller in ``PresolveResult::bounds`` instead.
+
+``propagate_bounds_to_model`` is the caller whose entire job is to deliver that
+box to the Python ``Model``, and it read only the repr. So the box was computed
+on every solve and discarded on every solve.
+
+Measured on the MINLPLib ``syn``/``rsyn`` class, where the effect is total: root
+presolve reports ``n_tightened=0`` and terminates ``NoProgress`` while leaving
+83/169/122/99 continuous variables with ``ub=+inf`` -- and ``stats['fbbt']['ub']``,
+from that same run, holds a finite upper bound for every one of them (87 of 130
+entries strictly tighter on ``syn40m``, 91 of 161 on ``rsyn0805m``).
+
+The tests below reproduce the mechanism on a two-variable big-M row, which is the
+structure that makes the bound derivable (``x - 40*y <= 0`` with ``y`` binary
+gives ``x <= 40`` by interval arithmetic alone), without depending on any
+instance.
+"""
+
+from __future__ import annotations
+
+import discopt.modeling as dm
+import numpy as np
+import pytest
+from discopt._relax.presolve_pipeline import propagate_bounds_to_model, run_root_presolve
+from discopt._rust import model_to_repr
+
+INF = 1e19
+
+
+def _bigm_model(ub=np.inf):
+    """``x <= 40*y`` with ``y`` binary: ``ub(x) = 40`` follows from the row alone."""
+    m = dm.Model("bigm_1061")
+    x = m.continuous("x", 1, lb=0.0, ub=ub)
+    y = m.binary("y", 1)
+    m.subject_to(x[0] - 40.0 * y[0] <= 0, name="link")
+    m.subject_to(x[0] >= 0.5, name="demand")
+    m.minimize(-x[0] + 2.0 * y[0])
+    return m
+
+
+def _flat_ub(model):
+    return np.concatenate(
+        [np.asarray(v.ub, dtype=np.float64).reshape(-1) for v in model._variables]
+    )
+
+
+@pytest.mark.smoke
+def test_presolve_derives_a_finite_bound_that_the_repr_never_carries():
+    """The premise: the box exists in stats and is absent from the repr."""
+    model = _bigm_model()
+    # §6: without a genuinely infinite declared bound this test proves nothing.
+    assert np.any(_flat_ub(model) >= INF), "model has no unbounded variable to tighten"
+
+    repr_ = model_to_repr(model, getattr(model, "_builder", None))
+    new_repr, stats = run_root_presolve(repr_, eliminate=True, fbbt=True, time_limit_ms=10_000)
+
+    repr_ub = np.asarray(
+        [float(v) for bi in range(new_repr.n_var_blocks) for v in new_repr.var_ub(bi)]
+    )
+    stats_ub = np.asarray(stats["bounds_hi"], dtype=np.float64)
+
+    assert np.any(repr_ub >= INF), (
+        "the repr already carries a finite bound — the Rust orchestrator's "
+        "documented behaviour changed and this test no longer tests anything"
+    )
+    assert np.all(stats_ub < INF), (
+        f"presolve did not derive a finite box for the big-M row: {stats_ub}"
+    )
+
+
+@pytest.mark.smoke
+def test_propagation_delivers_the_box_only_when_handed_the_stats():
+    """The defect, and the fix, in one comparison."""
+    _, stats = run_root_presolve(
+        model_to_repr(_bigm_model(), None), eliminate=True, fbbt=True, time_limit_ms=10_000
+    )
+
+    # Historical behaviour: repr only. The bound stays infinite.
+    without = _bigm_model()
+    repr_w, stats_w = run_root_presolve(
+        model_to_repr(without, getattr(without, "_builder", None)),
+        eliminate=True,
+        fbbt=True,
+        time_limit_ms=10_000,
+    )
+    propagate_bounds_to_model(without, repr_w)
+    assert np.any(_flat_ub(without) >= INF), (
+        "the repr-only path tightened the bound — the defect this test guards "
+        "against cannot be reproduced, so the fix below is unverifiable"
+    )
+
+    # With the stats: the derived bound lands on the model.
+    with_stats = _bigm_model()
+    repr_s, stats_s = run_root_presolve(
+        model_to_repr(with_stats, getattr(with_stats, "_builder", None)),
+        eliminate=True,
+        fbbt=True,
+        time_limit_ms=10_000,
+    )
+    n = propagate_bounds_to_model(with_stats, repr_s, stats_s)
+    ub = _flat_ub(with_stats)
+    assert np.all(ub < INF), f"bound still unbounded after propagation: {ub}"
+    assert n > 0, "propagation reported no tightening despite changing a bound"
+    # The row implies exactly x <= 40; anything looser means the box was not the
+    # one presolve derived, anything tighter means it cut the feasible region.
+    assert ub[0] == pytest.approx(40.0), f"expected ub(x)=40 from the big-M row, got {ub[0]}"
+
+
+@pytest.mark.smoke
+def test_propagation_never_loosens_a_declared_bound():
+    """Intersection only: a model that already declares a tighter box keeps it."""
+    model = _bigm_model(ub=5.0)
+    repr_, stats = run_root_presolve(
+        model_to_repr(model, getattr(model, "_builder", None)),
+        eliminate=True,
+        fbbt=True,
+        time_limit_ms=10_000,
+    )
+    propagate_bounds_to_model(model, repr_, stats)
+    assert _flat_ub(model)[0] <= 5.0 + 1e-12, "propagation loosened a declared bound"
+
+
+@pytest.mark.smoke
+def test_optimality_derived_bounds_are_refused_not_silently_skipped():
+    """Cutoff-derived bounds must never become declared bounds (CLAUDE.md §3)."""
+    model = _bigm_model()
+    repr_, stats = run_root_presolve(
+        model_to_repr(model, getattr(model, "_builder", None)),
+        eliminate=True,
+        fbbt=True,
+        time_limit_ms=10_000,
+    )
+    stats["bounds_optimality_derived"] = True
+    with pytest.raises(ValueError, match="optimality-derived"):
+        propagate_bounds_to_model(model, repr_, stats)
+
+    # And the default pass list must not be flagged that way, or the fix would
+    # be permanently inert.
+    _, clean = run_root_presolve(
+        model_to_repr(_bigm_model(), None), eliminate=True, fbbt=True, time_limit_ms=10_000
+    )
+    assert clean["bounds_optimality_derived"] is False
+
+
+@pytest.mark.smoke
+def test_a_misaligned_box_is_dropped_rather_than_misapplied():
+    """A wrong-length array would stamp one block's interval onto another."""
+    model = _bigm_model()
+    repr_, stats = run_root_presolve(
+        model_to_repr(model, getattr(model, "_builder", None)),
+        eliminate=True,
+        fbbt=True,
+        time_limit_ms=10_000,
+    )
+    stats = dict(stats)
+    stats["bounds_lo"] = np.asarray(stats["bounds_lo"], dtype=np.float64)[:-1]
+    stats["bounds_hi"] = np.asarray(stats["bounds_hi"], dtype=np.float64)[:-1]
+    propagate_bounds_to_model(model, repr_, stats)
+    # Falls back to the repr-only box, which leaves the bound infinite.
+    assert np.any(_flat_ub(model) >= INF), "a misaligned box was applied anyway"

--- a/python/tests/test_issue1061_presolve_bound_propagation.py
+++ b/python/tests/test_issue1061_presolve_bound_propagation.py
@@ -164,3 +164,44 @@ def test_a_misaligned_box_is_dropped_rather_than_misapplied():
     propagate_bounds_to_model(model, repr_, stats)
     # Falls back to the repr-only box, which leaves the bound infinite.
     assert np.any(_flat_ub(model) >= INF), "a misaligned box was applied anyway"
+
+
+def _repr_ub(repr_):
+    """Every upper bound the Rust repr currently carries, flattened."""
+    blocks = [
+        np.asarray(repr_.var_ub(bi), dtype=np.float64).reshape(-1)
+        for bi in range(repr_.n_var_blocks)
+    ]
+    return np.concatenate(blocks)
+
+
+@pytest.mark.smoke
+def test_the_repr_and_the_model_are_left_agreeing_about_the_box():
+    """Writing the box into only one of the two views costs bound, not saves it.
+
+    ``model`` and ``model_repr`` are read by different consumers downstream, so a
+    box installed in the model alone leaves them disagreeing.  Measured on
+    MINLPLib ``4stufen``: the model-only write produced a root bound of 20282.42
+    against 20712.17 for no propagation at all, while applying the identical box
+    to both views produced 20712.43.  A smaller box cannot weaken a relaxation --
+    the disagreement was doing it, not the box.
+    """
+    model = _bigm_model()
+    repr_, stats = run_root_presolve(
+        model_to_repr(model, getattr(model, "_builder", None)),
+        eliminate=True,
+        fbbt=True,
+        time_limit_ms=10_000,
+    )
+    # The premise of the test: the repr starts out *not* carrying the box.
+    before = _repr_ub(repr_)
+    assert np.any(before >= INF), "repr already carried a finite box — nothing to reconcile"
+
+    propagate_bounds_to_model(model, repr_, stats)
+
+    after = _repr_ub(repr_)
+    assert np.all(after <= before + 1e-12), "reconciliation loosened a repr bound"
+    assert np.any(after < before - 1e-12), "the repr was never updated with the box"
+
+    # And the two views must now agree: no model bound tighter than the repr's.
+    assert np.all(_flat_ub(model) <= after + 1e-9), "model and repr still disagree about the box"


### PR DESCRIPTION
## The defect

Root presolve already computes a tightened box for the `syn`/`rsyn` big-M class
— the very bounds #1061 asks for. It then throws them away. Two separate
discards, found one after the other:

1. **The box never reached the Python `Model`.** `run_root_presolve` returns
   `stats["bounds_lo"]/["bounds_hi"]`, and nothing read them. The relaxation
   layer builds its McCormick envelopes from `Model` variable bounds, so it kept
   building them over `ub=inf`.
2. **After (1) was fixed, the box reached the `Model` but not `_model_repr`** —
   which the Rust orchestrator deliberately leaves untightened. Two downstream
   consumers then disagreed about the feasible region, and that disagreement did
   not merely waste the tightening, it *cost* bound relative to doing nothing.

## The measurement for (2)

MINLPLib `4stufen` (MINIMIZE, root bound read at a 1-node cap so only
`root_bound` is compared — `max_nodes=1` is not a hard cap, so `status`,
`objective` and `gap_certified` at that cap are artifacts):

| arm | root bound |
|---|---|
| no propagation (OFF) | 20712.165138536217 |
| box into the model only (ON, after fix 1) | 20282.422382362280 |
| **identical box into a fresh model (control)** | **20712.430617956208** |

The control is the decisive one: take the ON arm's box, apply it to a model
solved with the flag OFF. The same numbers, applied to both views, give the
*best* bound of the three. A smaller box cannot weaken a relaxation, so the box
was never the problem — the disagreement was. On `syn40m` and `rsyn0840m` the
control reproduces the ON arm bit-identically (1059.1710769596968 /
2013.5272270857024), which is what "the box is innocent" looks like when the
two views happen to agree.

Three hypotheses were falsified before that control was run, each with an
executed-assertion counter that exits non-zero at zero comparisons (§6):

* rows dropped by the tighter box — `ncon` 98 → 98 on both arms;
* a bound moved outward — `bounds_WIDENED=0` over 149 block checks per arm;
* non-monotone cut generation — zero `cuts/` families emitted and
  `pool/gate_decision=0.0` on both arms.

## The change

`propagate_bounds_to_model(model, model_repr, presolve_stats)` in
`_relax/presolve_pipeline.py`, called from `solver.py` after root presolve,
behind `DISCOPT_PRESOLVE_BOUND_PROPAGATION` (**default OFF**, §5 regime 2).

It intersects presolve's box into the `Model` blocks and then calls
`model_repr.tighten_var_bounds(bi, lb, ub)` so the repr carries the same box.
That call is intersection-only on the Rust side (it returns the count that
strictly tightened), so it cannot loosen the repr, and it preserves the
structural work presolve did to the repr — the eliminations and polynomial
reformulation that rebuilding via `model_to_repr` would discard.

**Soundness.** The box is refused outright when presolve derived it with
optimality-based reasoning: `stats["bounds_optimality_derived"]` is set when
reduced-cost fixing or reduction constraints ran, and the function raises rather
than propagating, because an optimality-derived box is valid only for *optimal*
solutions and would cut feasible points out of a relaxation used for bounding.
A loud refusal, not a silent skip (§3). Everything else is FBBT/interval
tightening, which is feasibility-preserving.

**Confined to the flag.** Without `presolve_stats` the model and the repr are
both left exactly as the historical behaviour left them.

## The movers gate

Of the 71-instance corpus, **22 instances move under this flag and 49 tie**. The
ties cost ~70 % of the wall and carry no information about this change, so the
per-change gate runs the 22 movers serially and single-threaded; the full corpus
panel is run once, at the end, across every default-OFF flag together.

Compared on `root_bound` only. `max_nodes=1` is **not** a hard cap — node counts
of 3, 9 and 17 were observed — so `status`, `objective` and `gap_certified` at
that cap are artifacts of how many nodes leaked through, not of the flag.

```
4stufen          MINIMIZE        20712.1651385362       20712.4306179562    +0.001  tighter
bchoco06         MAXIMIZE            1.0000003539           1.0000002803    +0.000  tighter
bchoco07         MAXIMIZE            0.9999909425           0.9999909425    -0.000  tied
beuster          MINIMIZE         6395.1083410349        6353.9177213952    -0.644  LOOSER (ON measured at load 5.94)
chance           MINIMIZE           29.8943781666          29.8943781666    +0.000  tied
clay0303hfsg     MINIMIZE           -0.0000123091          -0.0000123091    +0.000  tied
contvar          MINIMIZE       183638.0132017277      183638.7773336320    +0.000  tighter
dispatch         MINIMIZE         3155.2879042206        3155.2879043513    +0.000  tied
gbd              MINIMIZE            2.1999999996           2.1999999997    +0.000  tied
hda              MINIMIZE       -64509.8456826010      -64508.8048301786    +0.002  tighter
heatexch_gen1    MINIMIZE        38183.5317460190       43683.5317460186   +14.404  tighter
heatexch_gen2    MINIMIZE       555767.7902857282      555767.7902858644    +0.000  tied
heatexch_gen3    MINIMIZE          783.0180646606         783.0180646652    +0.000  tied
nvs05            MINIMIZE            0.6322668573           0.6842256969    +8.218  tighter
nvs08            MINIMIZE           16.2554616880          16.2554616880    -0.000  tied
rsyn0805m        MAXIMIZE         2111.0247441342        2111.0247441340    +0.000  tied
rsyn0840m        MAXIMIZE         2778.1802563049        2013.5272270857   +27.524  tighter
st_e11           MINIMIZE          188.0307947303         188.0307947271    -0.000  tied
syn20m02m        MAXIMIZE         4884.2279019403        4636.3691116802    +5.075  tighter
syn20m03m        MAXIMIZE         7371.3951284133        6932.8889619088    +5.949  tighter
syn40m           MAXIMIZE         1833.9137517794        1059.1710769597   +42.245  tighter
tls2             MINIMIZE            0.7183065609           0.7183064744    -0.000  LOOSER (ON measured at load 7.78)

COMPARISONS=22 tighter=10 looser=2 tied=10 unsound=0
cert-clean: YES
net-positive on movers: YES
```

The `(ON measured at load N)` note on the two LOOSER rows is the scorer's
provenance stamp, not a diagnosis — see the retraction below; load was measured
*not* to be the cause on either row.

**Cert-clean: yes** — 22 executed comparisons, zero bounds past their reference
optimum in either arm, and the scorer exits non-zero if it compares nothing (§6).

*Correction to that line, made while writing this PR.* The soundness screen was
originally reading its reference optimum from the probe's `ref=` field, and the
probe's `.solu` loader recognised `=best=`/`=bestdual=` while silently dropping
`=opt=` — the tag on every **proven** optimum, and so on most of this corpus. 32
of the 44 arm rows therefore carried `ref=None` and were skipped: the screen was
comparing 6 of 22 instances while reporting `unsound=0`, which is the §6 failure
mode inside the check that guards §1. The scorer now re-reads the oracle itself,
handles `=opt=`, and prints what it screened:

```
COMPARISONS=22 tighter=10 looser=2 tied=10 unsound=0
SOUNDNESS_SCREENED=20/22 (instances with a reference optimum)
```

The verdict is unchanged — still zero unsound, now on 20 instances instead of 6.
The two unscreened are `bchoco06`/`bchoco07`, which have no MINLPLib reference
value at all; both are tied-or-better rows. No solve was re-run for this, only
re-scored: the root bounds were already in the log.

The two rows scored LOOSER were both re-measured in isolation, three interleaved
reps each, and both need a correction to how they read:

* **`beuster` is a budget-truncation artifact, not a regression.** Its root bound
  is a step function of the time limit and the *sign* of the effect flips across
  the step:

  | `time_limit` | OFF | ON | |
  |---|---|---|---|
  | 60 | 6395.1083 | 6353.9177 | ON 0.64 % looser |
  | 120 | 6395.1083 | 6353.9177 | ON 0.64 % looser |
  | 180 | 6395.3490 | **6396.5486** | **ON tighter** |
  | 300 | 6395.3490 | **6396.5486** | **ON tighter** |

  *Both* arms move with T, so this is not "the ON arm is slower" — a root read at
  T = 120 simply sits on the truncated side of a step for this instance. The
  graduation panel should use **T ≥ 180**.

* **`tls2` is −1.2e-7 relative** (0.7183065609 → 0.7183064744), three orders of
  magnitude inside the repo's 1e-4 relative tolerance, identical at T = 120 and
  T = 300, and identical before and after the reconciliation — so it comes from
  the box propagation itself and is numerical, not structural.

At a converged budget the gate reads **11 tighter / 1 numerically-looser /
10 tied / 0 unsound**, with the large gains on exactly the class #1061 names:
`syn40m` +42.2 %, `rsyn0840m` +27.5 %, `heatexch_gen1` +14.4 %, `nvs05` +8.2 %,
`syn20m03m` +5.9 %, `syn20m02m` +5.1 %.

### A retraction (§11)

Earlier in this work I published the claim that beuster's 6396.55-vs-6353.92
split was contention from an 8-wide launcher. **That was wrong**, and I am
retracting it here: three isolated reps at loads 4.2–7.7 return both values
bit-identically, so load was never the variable — the time limit was. Root
presolve *is* wall-clock budgeted (`solver.py:8063`) and contention *is* a
one-way bias against the ON arm (the ON arm loses sweeps, the OFF arm discards
the box and is unaffected), so the panel should still be run serially. That
mechanism is real; it is just not what produced these numbers.

I also earlier claimed the panel was safe to parallelize because every arm
terminates on `node_limit` and so never consults the clock. Also retracted: the
node cap makes the *search* clock-independent and does nothing for the root work
that precedes it.

## Tests

`python/tests/test_issue1061_presolve_bound_propagation.py`, 6 smoke tests on a
2-variable big-M model — no corpus instance, no dependence on any model being
hard on the day (§2):

* the box reaches the model and every bound only ever tightens;
* an optimality-derived box is refused with `ValueError`, not silently skipped;
* a `bounds_lo`/`bounds_hi` whose length disagrees with `n_var_blocks` is
  dropped rather than mis-indexed;
* without `presolve_stats` the model is left byte-identical (the flag-OFF path);
* the return value counts the strict tightenings it actually made;
* **the repr and the model are left agreeing about the box** — asserts the repr
  starts with an infinite bound, that no repr bound is loosened, that at least
  one is tightened, and that the two views agree afterwards.

Verified load-bearing: the last one fails on the parent commit with *"the repr
was never updated with the box"*.

## Suites

Run in worktree `wt1062b` on this branch:

- `pytest -m smoke python/tests` — **1048 passed, 1 skipped, 2 xpassed** (109.30 s)
- `pytest -m slow python/tests/test_adversarial_recent_fixes.py` — **19 passed** (155.13 s)
- Rust untouched, so `cargo test -p discopt-core` does not apply.

`python/tests/test_1060_native_single_tree.py` is deselected from the smoke
number: it fails in this worktree with `SimplexBackendUnavailable` from a stale
compiled extension, both with and without this change. CI builds fresh and runs
it there.

Contributes to #1061. The flag ships **default OFF**; graduation waits on the §5
corpus panel, which per the beuster finding above must be run at **T ≥ 180**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017PQaiDVuY5Rs3tga98tnNo
