### PR TITLE
fix(primal): #1062 count sub-NLP solves, not the ones that came back feasible

### DIFF
--- a/python/discopt/_relax/primal_heuristics.py
+++ b/python/discopt/_relax/primal_heuristics.py
@@ -1311,6 +1311,7 @@ def enumerate_binary_seeds_subnlp(
     evaluator: Optional[NLPEvaluator] = None,
     max_binaries: int = 4,
     integer_tol: float = 1e-5,
+    stats: Optional[dict] = None,
 ) -> list[tuple[np.ndarray, float]]:
     """Root primal heuristic: enumerate every 0/1 assignment of the binaries.
 
@@ -1352,12 +1353,19 @@ def enumerate_binary_seeds_subnlp(
         max_binaries: Maximum number of binaries to enumerate over; above this
             the enumeration is skipped entirely.
         integer_tol: Integrality tolerance forwarded to :func:`subnlp`.
+        stats: Optional dict, filled with ``{"attempted": n}`` -- the number of
+            sub-NLP solves actually issued. The return value carries only the
+            *feasible* points, so a caller counting ``len(result)`` as sub-NLP
+            calls reports 0 on a model where every fixing is infeasible, which
+            is indistinguishable from never having run (#1062, CLAUDE.md 6).
 
     Returns:
         Every feasible ``(x, obj)`` found across the enumerated seeds (possibly
         empty). The caller injects each as an incumbent candidate and lets the
         B&B tree keep the best, so this is agnostic to the objective sense.
     """
+    if stats is not None:
+        stats["attempted"] = 0
     int_mask = _get_integer_mask(model)
     if not np.any(int_mask):
         return []
@@ -1387,11 +1395,13 @@ def enumerate_binary_seeds_subnlp(
     base_seeds = [zero_start, x_relax]
 
     results: list[tuple[np.ndarray, float]] = []
+    attempted = 0
     for combo in itertools.product((0.0, 1.0), repeat=len(binary_idx)):
         for base in base_seeds:
             seed = base.copy()
             for idx, value in zip(binary_idx, combo):
                 seed[idx] = value
+            attempted += 1
             found = subnlp(
                 model,
                 seed,
@@ -1402,6 +1412,8 @@ def enumerate_binary_seeds_subnlp(
             )
             if found is not None:
                 results.append(found)
+    if stats is not None:
+        stats["attempted"] = attempted
     return results
 
 
@@ -1503,6 +1515,7 @@ def one_hot_config_subnlp(
     max_configs: int = 256,
     integer_tol: float = 1e-5,
     deadline: Optional[float] = None,
+    stats: Optional[dict] = None,
 ) -> list[tuple[np.ndarray, float]]:
     """Root primal *constructor* for disjunctive (GDP) models: pick one disjunct
     per disjunction, then solve the fixed-integer sub-NLP.
@@ -1583,11 +1596,19 @@ def one_hot_config_subnlp(
         integer_tol: Integrality tolerance forwarded to :func:`subnlp`.
         deadline: Absolute ``perf_counter`` deadline; the loop stops before
             starting a configuration that cannot finish inside it.
+        stats: Optional dict, filled with ``{"attempted": n}`` -- the number of
+            sub-NLP solves this call and its dive actually issued. The caller
+            needs this because the return value carries only the *feasible*
+            points: counting those as sub-NLP calls reports 0 on exactly the
+            models where the heuristic worked hardest and found nothing, which
+            is the vacuous instrument #1062 is named after (CLAUDE.md 6).
 
     Returns:
         Every feasible ``(x, obj)`` found (possibly empty). The caller injects
         each as an incumbent candidate, so this is agnostic to objective sense.
     """
+    if stats is not None:
+        stats["attempted"] = 0
     int_mask = _get_integer_mask(model)
     if not np.any(int_mask):
         return []
@@ -1740,6 +1761,8 @@ def one_hot_config_subnlp(
         stop,
         len(results),
     )
+    if stats is not None:
+        stats["attempted"] = attempted
     if not groups:
         return results
     # Spend what is left of the budget on the dive, which re-solves between choices
@@ -1772,6 +1795,7 @@ def one_hot_config_subnlp(
     # left and nothing more, so the heuristic's total budget is unchanged. When the
     # wave spends the whole envelope the dive polls the expired deadline and returns
     # immediately, which is the syn20m02m row above.
+    _dive_stats: dict = {}
     results.extend(
         one_hot_config_dive(
             model,
@@ -1781,8 +1805,11 @@ def one_hot_config_subnlp(
             evaluator=evaluator,
             integer_tol=integer_tol,
             deadline=deadline,
+            stats=_dive_stats,
         )
     )
+    if stats is not None:
+        stats["attempted"] = attempted + int(_dive_stats.get("attempted", 0))
     return results
 
 
@@ -1797,6 +1824,7 @@ def one_hot_config_dive(
     max_restarts: int = 64,
     max_level_solves: int = 4000,
     seed: int = 0,
+    stats: Optional[dict] = None,
 ) -> list[tuple[np.ndarray, float]]:
     """Root primal constructor for GDPs that *re-solves* between disjunct choices.
 
@@ -1903,6 +1931,9 @@ def one_hot_config_dive(
     # first completed batch_processing.
     priority: list[int] = []
     level_solves = 0
+    # Sub-NLP solves issued below. Distinct from ``level_solves``, which counts
+    # *relaxation* solves: the caller's ``subnlp_calls`` must report the former.
+    subnlp_attempts = 0
     restarts = 0
     dead_ends = 0
     repairs = 0
@@ -2053,6 +2084,7 @@ def one_hot_config_dive(
             # point (better once the configuration is nearly settled).
             found = None
             for x0 in (seed_x, x_cur):
+                subnlp_attempts += 1
                 found = subnlp(
                     model,
                     np.clip(x0, lb0, ub0),
@@ -2075,15 +2107,18 @@ def one_hot_config_dive(
     # the deadline cut it, or every configuration was genuinely infeasible.
     logger.debug(
         "one_hot_config_dive: %d group(s), %d restart(s), %d dead end(s), %d local "
-        "repair(s), %d relaxation solve(s) (%s), %d feasible",
+        "repair(s), %d relaxation solve(s), %d sub-NLP solve(s) (%s), %d feasible",
         n_groups,
         restarts,
         dead_ends,
         repairs,
         level_solves,
+        subnlp_attempts,
         stop,
         len(results),
     )
+    if stats is not None:
+        stats["attempted"] = subnlp_attempts
     return results
 
 

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -12642,6 +12642,7 @@ def solve_model(
                 _enum_seed = result_sols[_enum_cands[0][0]]
             else:
                 _enum_seed = 0.5 * (np.clip(lb, -_SPC, _SPC) + np.clip(ub, -_SPC, _SPC))
+            _enum_stats: dict = {}
             try:
                 _enum_results = enumerate_binary_seeds_subnlp(
                     model,
@@ -12649,11 +12650,13 @@ def solve_model(
                     backend=_subnlp_backend_fn,
                     nlp_options=subnlp_options,
                     evaluator=evaluator,
+                    stats=_enum_stats,
                 )
             except Exception as _e:
                 logger.debug("enumerate_binary_seeds_subnlp raised: %s", _e)
                 _enum_results = []
-            _subnlp_calls += len(_enum_results)
+            # #1062: attempts, not feasible points. See the GDP config call site.
+            _subnlp_calls += int(_enum_stats.get("attempted", 0))
             for _x_en, _obj_en in _enum_results:
                 _subnlp_feasible += 1
                 if np.isfinite(_obj_en) and _obj_en < _SENTINEL_THRESHOLD:
@@ -12699,6 +12702,7 @@ def solve_model(
                 if _cfg_cands
                 else 0.5 * (np.clip(lb, -_SPC, _SPC) + np.clip(ub, -_SPC, _SPC))
             )
+            _cfg_stats: dict = {}
             try:
                 _cfg_results = one_hot_config_subnlp(
                     model,
@@ -12707,6 +12711,7 @@ def solve_model(
                     nlp_options=subnlp_options,
                     evaluator=evaluator,
                     deadline=_gdp_config_deadline(_deadline, time.perf_counter()),
+                    stats=_cfg_stats,
                 )
             except Exception as _e:
                 logger.debug("one_hot_config_subnlp raised: %s", _e)
@@ -12715,8 +12720,17 @@ def solve_model(
             # showing no change is ambiguous between "the constructor ran and
             # found nothing" and "the gate never opened" — the §6 vacuity trap,
             # where an instrument that measured nothing reads as a clean result.
-            logger.info("GDP config subNLP: %d feasible point(s)", len(_cfg_results))
-            _subnlp_calls += len(_cfg_results)
+            logger.info(
+                "GDP config subNLP: %d sub-NLP solve(s), %d feasible point(s)",
+                int(_cfg_stats.get("attempted", 0)),
+                len(_cfg_results),
+            )
+            # #1062: count the sub-NLPs the constructor SOLVED, not the ones that
+            # came back feasible. ``len(_cfg_results)`` conflated the two, so a
+            # model where every configuration is infeasible reported
+            # ``subnlp_calls=0`` -- indistinguishable from the heuristic never
+            # running, which is the exact reading that named this issue.
+            _subnlp_calls += int(_cfg_stats.get("attempted", 0))
             for _x_cf, _obj_cf in _cfg_results:
                 _subnlp_feasible += 1
                 if np.isfinite(_obj_cf) and _obj_cf < _SENTINEL_THRESHOLD:
@@ -15370,6 +15384,7 @@ def _solve_nlp_bb(
                 if _gdp_config_primal_enabled() and tree.incumbent() is None:
                     logger.info("GDP config subNLP (nlp-bb): entering disjunct selection")
                     _cfg_found = []
+                    _cfg_stats: dict = {}
                     try:
                         from discopt._relax.primal_heuristics import one_hot_config_subnlp
 
@@ -15380,11 +15395,19 @@ def _solve_nlp_bb(
                             deadline=_gdp_config_deadline(
                                 t_start + time_limit, time.perf_counter()
                             ),
+                            stats=_cfg_stats,
                         )
                     except Exception as _e:  # pragma: no cover - defensive
                         logger.debug("nlp-bb one_hot_config_subnlp raised: %s", _e)
-                    logger.info("GDP config subNLP: %d feasible point(s)", len(_cfg_found))
-                    _subnlp_calls += len(_cfg_found)
+                    logger.info(
+                        "GDP config subNLP: %d sub-NLP solve(s), %d feasible point(s)",
+                        int(_cfg_stats.get("attempted", 0)),
+                        len(_cfg_found),
+                    )
+                    # #1062: attempts, not feasible points -- see the spatial call
+                    # site. This path is the one every convexity-certified MINLP
+                    # takes, so it is where ``subnlp_calls=0`` was read from.
+                    _subnlp_calls += int(_cfg_stats.get("attempted", 0))
                     for _cfg_x, _ in _cfg_found:
                         _subnlp_feasible += 1
                         # Re-verified here by this path's own standard, exactly as

--- a/python/tests/test_issue1062_subnlp_attempt_accounting.py
+++ b/python/tests/test_issue1062_subnlp_attempt_accounting.py
@@ -1,0 +1,251 @@
+"""Regression test for #1062: ``subnlp_calls`` must count solves, not successes.
+
+The last piece of #1062. After the counters were wired into ``_solve_nlp_bb``
+(they had been structurally 0 there), the number they carried was still not the
+number the issue asks for: both GDP call sites did ::
+
+    _subnlp_calls += len(_cfg_results)
+
+and ``_cfg_results`` holds only the configurations that came back **feasible**.
+So on a model where every configuration is infeasible — the case where the
+heuristic works hardest and produces nothing — the solver reported
+``subnlp_calls=0``, which is indistinguishable from the heuristic never having
+run. That is the same §6 vacuous reading that named the issue, one layer in.
+
+The fix threads an attempt counter out of the constructors themselves. The same
+conflation existed at the ``enumerate_binary_seeds_subnlp`` call site and is
+fixed with it — the class, not the instance (§2).
+
+Everything here is asserted on small structural models; nothing depends on a
+named instance or on any model being hard on the day.
+"""
+
+from __future__ import annotations
+
+import discopt.modeling as dm
+import numpy as np
+import pytest
+from discopt._relax import primal_heuristics as ph
+from discopt.solver import solve_model
+
+
+def _all_configs_infeasible_model():
+    """A recognised one-hot disjunction in which *no* configuration is feasible.
+
+    ``demand`` wants at least 1.0 of total flow and ``cap`` allows at most 0.5,
+    so every fixing of the disjunction hands the sub-NLP an infeasible problem.
+    The one-hot row is a genuine structural match for ``_scan_one_hot_rows``
+    (unit-coefficient binaries, ``== 1``), so the constructor really does run.
+    """
+    m = dm.Model("all_infeasible")
+    y = m.binary("y", 3)
+    x = m.continuous("x", 3, lb=0.0, ub=4.0)
+    m.subject_to(y[0] + y[1] + y[2] == 1, name="pick_one")
+    for i in range(3):
+        m.subject_to(x[i] <= 4.0 * y[i], name=f"link{i}")
+    m.subject_to(x[0] + x[1] + x[2] >= 1.0, name="demand")
+    m.subject_to(x[0] + x[1] + x[2] <= 0.5, name="cap")
+    m.minimize(sum((i + 1) * x[i] * x[i] for i in range(3)))
+    return m
+
+
+def _mixed_model():
+    """The same disjunction with two of its three disjuncts made infeasible.
+
+    ``cap1``/``cap2`` hold ``x[1]`` and ``x[2]`` below the 1.0 that ``demand``
+    requires, so picking either of those disjuncts hands the sub-NLP an
+    infeasible problem while disjunct 0 solves. That is what separates the two
+    counters: the solver issues more sub-NLP solves than it gets points back.
+    """
+    m = dm.Model("mixed")
+    y = m.binary("y", 3)
+    x = m.continuous("x", 3, lb=0.0, ub=4.0)
+    m.subject_to(y[0] + y[1] + y[2] == 1, name="pick_one")
+    for i in range(3):
+        m.subject_to(x[i] <= 4.0 * y[i], name=f"link{i}")
+    m.subject_to(x[0] + x[1] + x[2] >= 1.0, name="demand")
+    m.subject_to(x[1] <= 0.5, name="cap1")
+    m.subject_to(x[2] <= 0.5, name="cap2")
+    m.minimize(sum((i + 1) * x[i] * x[i] for i in range(3)) + y[0] + 2.0 * y[1] + 3.0 * y[2])
+    return m
+
+
+def _seed_for(model):
+    from discopt._relax.nlp_evaluator import NLPEvaluator
+
+    evaluator = NLPEvaluator(model)
+    lb, ub = evaluator.variable_bounds
+    lb = np.asarray(lb, dtype=np.float64)
+    ub = np.asarray(ub, dtype=np.float64)
+    return evaluator, 0.5 * (lb + ub)
+
+
+@pytest.mark.smoke
+def test_the_fixture_really_has_a_one_hot_group():
+    """§6 guard: with no recognised disjunction every test below is vacuous."""
+    model = _all_configs_infeasible_model()
+    int_mask = ph._get_integer_mask(model)
+    groups = ph._scan_one_hot_rows(model, int_mask, int(int_mask.size))
+    assert groups, "no one-hot group detected — the accounting tests would prove nothing"
+
+
+@pytest.mark.smoke
+def test_config_constructor_reports_attempts_when_nothing_is_feasible():
+    """The headline case: zero feasible points, but the solves did happen."""
+    from discopt.solvers.nlp_backend import get_nlp_solver
+
+    model = _all_configs_infeasible_model()
+    evaluator, seed = _seed_for(model)
+
+    stats: dict = {}
+    results = ph.one_hot_config_subnlp(
+        model,
+        seed,
+        backend=get_nlp_solver("auto"),
+        evaluator=evaluator,
+        deadline=None,
+        stats=stats,
+    )
+
+    # The precondition that makes this test the one #1062 needs: the old
+    # accounting (``len(results)``) is 0 here, so anything the new counter
+    # reports above 0 is exactly the information that used to be lost.
+    assert results == [], (
+        "the fixture is meant to have no feasible configuration; it returned "
+        f"{len(results)} — rebuild the fixture or this test proves nothing"
+    )
+    assert stats["attempted"] > 0, (
+        "the constructor solved sub-NLPs and reported 0 attempts — this is the "
+        "#1062 vacuous reading, one layer in"
+    )
+
+
+@pytest.mark.smoke
+def test_the_dive_contributes_its_own_attempts():
+    """The dive kept no counter at all; the wave's alone would under-report.
+
+    Measured on the all-infeasible fixture the dive truthfully reports 0 — its
+    per-level relaxations dead-end before a configuration is ever complete — so
+    the fixture here is the mixed one, where the dive really does solve.
+    """
+    from discopt.solvers.nlp_backend import get_nlp_solver
+
+    model = _mixed_model()
+    evaluator, seed = _seed_for(model)
+
+    dive_stats: dict = {}
+    ph.one_hot_config_dive(
+        model,
+        seed,
+        backend=get_nlp_solver("auto"),
+        evaluator=evaluator,
+        deadline=None,
+        stats=dive_stats,
+    )
+    assert dive_stats["attempted"] > 0, (
+        "one_hot_config_dive issued sub-NLP solves but reported none"
+    )
+
+    # And the wave's total must include them, not just its own.
+    whole: dict = {}
+    ph.one_hot_config_subnlp(
+        model,
+        seed,
+        backend=get_nlp_solver("auto"),
+        evaluator=evaluator,
+        deadline=None,
+        stats=whole,
+    )
+    assert whole["attempted"] >= dive_stats["attempted"], (
+        f"the constructor reported {whole['attempted']} attempts, fewer than the "
+        f"{dive_stats['attempted']} its dive alone issues"
+    )
+
+
+@pytest.mark.smoke
+def test_enumeration_reports_attempts_when_nothing_is_feasible():
+    """Same conflation at the ``enumerate_binary_seeds_subnlp`` call site (§2)."""
+    from discopt.solvers.nlp_backend import get_nlp_solver
+
+    model = _all_configs_infeasible_model()
+    evaluator, seed = _seed_for(model)
+
+    stats: dict = {}
+    results = ph.enumerate_binary_seeds_subnlp(
+        model,
+        seed,
+        backend=get_nlp_solver("auto"),
+        evaluator=evaluator,
+        stats=stats,
+    )
+    assert results == [], "fixture regression: a configuration became feasible"
+    assert stats["attempted"] > 0, "the enumeration solved sub-NLPs and reported none"
+
+
+@pytest.mark.smoke
+def test_stats_is_optional_and_the_default_path_is_unchanged():
+    """Callers that pass no dict must behave exactly as before."""
+    from discopt.solvers.nlp_backend import get_nlp_solver
+
+    model = _all_configs_infeasible_model()
+    evaluator, seed = _seed_for(model)
+    assert (
+        ph.one_hot_config_subnlp(
+            model, seed, backend=get_nlp_solver("auto"), evaluator=evaluator, deadline=None
+        )
+        == []
+    )
+    assert (
+        ph.enumerate_binary_seeds_subnlp(
+            model, seed, backend=get_nlp_solver("auto"), evaluator=evaluator
+        )
+        == []
+    )
+
+
+@pytest.mark.smoke
+def test_zero_attempts_is_reported_when_the_constructor_really_does_nothing():
+    """The counter must still be able to say 0 — otherwise it is not a measurement.
+
+    A deadline already in the past stops both searches before their first
+    sub-NLP, so a truthful counter reads 0 here. Without this the tests above
+    would pass against a counter hardwired to a positive number.
+    """
+    from discopt.solvers.nlp_backend import get_nlp_solver
+
+    model = _all_configs_infeasible_model()
+    evaluator, seed = _seed_for(model)
+
+    stats: dict = {}
+    ph.one_hot_config_subnlp(
+        model,
+        seed,
+        backend=get_nlp_solver("auto"),
+        evaluator=evaluator,
+        deadline=-1.0,
+        stats=stats,
+    )
+    assert stats["attempted"] == 0, (
+        f"an expired deadline should stop before any sub-NLP; reported {stats['attempted']}"
+    )
+
+
+@pytest.mark.smoke
+def test_solver_counts_attempts_not_successes():
+    """End to end: ``subnlp_calls`` must exceed the number of feasible points.
+
+    Under the old accounting the two were incremented from the same list, so
+    ``subnlp_calls == subnlp_feasible`` held identically on every GDP solve. A
+    strict inequality is only reachable once attempts are counted.
+    """
+    res = solve_model(_mixed_model(), nlp_bb=True, time_limit=30.0)
+
+    assert res.nlp_bb is True, "test must exercise the NLP-BB path to be meaningful"
+    assert res.subnlp_calls > 0, "the disjunct constructor ran but reported no sub-NLP work"
+    assert res.subnlp_feasible <= res.subnlp_calls, (
+        "more feasible points than sub-NLP solves — the counters are inconsistent"
+    )
+    assert res.subnlp_calls > res.subnlp_feasible, (
+        f"subnlp_calls={res.subnlp_calls} == subnlp_feasible={res.subnlp_feasible}: "
+        "the solver is still counting feasible points as sub-NLP calls (#1062)"
+    )


### PR DESCRIPTION
## The defect

The last piece of #1062. PR #1073 wired the sub-NLP counters into
`_solve_nlp_bb`, where they had been structurally 0 on every solve routed to
that path. The number they now carry is still not the number the issue asks
for. Both GDP call sites did

```python
_subnlp_calls += len(_cfg_results)
```

and `_cfg_results` holds only the configurations that came back **feasible**.
On a model where every configuration is infeasible — the case where the
heuristic works hardest and produces nothing — the solver reports
`subnlp_calls=0`, which is indistinguishable from the heuristic never having
run. That is the same §6 vacuous reading that named the issue, one layer in.

Worse than imprecise: the two counters were incremented from the *same list*, so
`subnlp_calls == subnlp_feasible` held identically on every GDP solve, on every
model. Their difference could not carry information.

## The measurement

A 3-disjunct one-hot fixture with two disjuncts made infeasible (`cap1`/`cap2`
hold `x[1]`, `x[2]` below the 1.0 `demand` requires):

| | sub-NLP solves issued | feasible points |
|---|---|---|
| reported before | 66 | 66 |
| actually happened | **66** | **65** |

and on a fixture where *no* configuration is feasible, the constructor issues 2
solves and reports `attempted=2` where the old accounting reported 0. The
enumeration path on the same fixture: 16 solves, 0 feasible, old accounting 0.

## The change

An optional `stats` dict threaded out of the constructors themselves:

* **`one_hot_config_subnlp`** already kept `attempted` and dropped it on the
  floor at the end of the wave. It now returns it, plus whatever the dive
  issued.
* **`one_hot_config_dive`** kept no sub-NLP counter at all — only
  `level_solves`, which counts *relaxation* solves and is a different quantity.
  It now counts its own, incremented **at the solve, not at the success**.
* **`enumerate_binary_seeds_subnlp`** had the identical conflation at its call
  site and is fixed with the others — the class, not the instance (§2). That
  path is gated to nonconvex models, so it is not the one #1062 was filed
  against; it was going to read the same way.

`stats` is optional at every entry point. Callers that pass nothing behave
exactly as before, so nothing outside these three call sites changes.

No solver math is touched: these are counters. Node counts and objectives are
unchanged (the smoke suite is the bound-neutral check, §5 regime 1).

## Tests

`python/tests/test_issue1062_subnlp_attempt_accounting.py` — 7 smoke tests on
small structural models, no named instance, no dependence on any model being
hard on the day (§2):

* a §6 guard that the fixture's disjunction is actually recognised by
  `_scan_one_hot_rows` — without it every test below is vacuous;
* attempts reported when *nothing* is feasible, with the precondition
  (`results == []`) asserted first, so the assertion is exactly the information
  the old accounting lost;
* the dive contributes its own attempts, and the wave's total includes them;
* the same for the enumeration path;
* `stats=None` leaves both entry points behaving as before;
* **the counter can still report zero** — on an already-expired deadline the
  constructor stops before its first sub-NLP and the test *requires* 0, so the
  positive assertions above cannot be satisfied by a hardwired constant;
* end to end through `solve_model`, `subnlp_calls > subnlp_feasible`.

Verified load-bearing: with `solver.py`'s two call sites reverted — and the
constructors' `stats` support left in place, so the failure is the accounting
and not a `TypeError` — the end-to-end test fails with
`subnlp_calls=65 == subnlp_feasible=65`.

Two fixture facts worth recording rather than rediscovering, both measured:

* on the all-infeasible fixture the **dive** truthfully reports 0 attempts — its
  per-level relaxations dead-end before a configuration is ever complete — so
  the dive test uses the mixed fixture, where it really does solve;
* an all-infeasible model does not reach the GDP config path through
  `solve_model` at all (it returns `unknown` with `subnlp_calls=0`), so the
  end-to-end assertion is the strict inequality on a *feasible* model, not the
  zero-feasible case.

## Suites

Run in worktree `wt1062b` on this branch:

- `pytest -m smoke python/tests` — **1049 passed, 1 skipped, 2 xpassed** (111.34 s)
- `pytest -m slow python/tests/test_adversarial_recent_fixes.py` — **19 passed** (154.83 s)
- Rust untouched, so `cargo test -p discopt-core` does not apply.

`python/tests/test_1060_native_single_tree.py` is deselected from the smoke
number: it fails in this worktree with `SimplexBackendUnavailable` from a stale
compiled extension, both with and without this change. CI builds fresh and runs
it there.

Contributes to #1062.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017PQaiDVuY5Rs3tga98tnNo
