### PR TITLE
fix(correctness): #1061 a withheld false primal must not report status=optimal

### DIFF
--- a/python/discopt/gp/__init__.py
+++ b/python/discopt/gp/__init__.py
@@ -726,6 +726,11 @@ def solve_gp(model: Model, **solve_kwargs) -> Optional[SolveResult]:
         wall_time=log_result.wall_time,
         convex_fast_path=certified,
         gap_certified=certified,
+        # If the log-space solve's false-primal guard withheld its incumbent, the
+        # caller of ``solve_gp`` must be told. Dropping this flag here hid a
+        # detected false primal behind an ordinary-looking x-space result: the
+        # status propagated but the reason did not (#1061).
+        incumbent_verification_failed=log_result.incumbent_verification_failed,
         _model=model,
     )
     return result

--- a/python/discopt/modeling/core.py
+++ b/python/discopt/modeling/core.py
@@ -2149,8 +2149,11 @@ class SolveResult:
     # on) found the returned incumbent INFEASIBLE in the ORIGINAL problem — a
     # false primal, which can only arise from an unsound presolve mutation or a
     # heuristic bug. When True, the incumbent (``x``/``objective``) has been
-    # withheld and ``gap_certified`` forced False (a false primal is never
-    # reported as a valid or certified solution). This should never be True on
+    # withheld, ``gap_certified`` forced False, and ``status`` set to ``"error"``
+    # (a false primal is never reported as a valid, certified, or *optimal*
+    # solution -- leaving the status at ``"optimal"`` with no incumbent claims a
+    # proven optimum that does not exist). ``bound`` is retained: only the primal
+    # was invalidated. This should never be True on
     # correct solver code; it exists so such a bug cannot silently escape as a
     # false result (regression guard for the #770/#772 class).
     incumbent_verification_failed: bool = False
@@ -4540,9 +4543,23 @@ class Model:
                     build_evaluator(self, _jax_evaluator),
                     [v.name for v in self._variables],
                 )
-            except Exception as _snap_exc:  # pragma: no cover - defensive
-                _logging.getLogger("discopt.solver").debug(
-                    "incumbent-verification snapshot skipped: %s", _snap_exc
+            except Exception as _snap_exc:
+                # Same §7 point as the verification handler below: without the
+                # snapshot the false-primal guard cannot run at all, so this is a
+                # disabled soundness check, not a skipped nicety. Non-fatal, but
+                # never silent.
+                _logging.getLogger("discopt.solver").error(
+                    "INCUMBENT-VERIFICATION SNAPSHOT FAILED: %s: %s. The false-primal "
+                    "guard cannot run on this solve.",
+                    type(_snap_exc).__name__,
+                    _snap_exc,
+                )
+                _warnings.warn(
+                    f"incumbent-verification snapshot failed "
+                    f"({type(_snap_exc).__name__}: {_snap_exc}); the false-primal "
+                    f"guard is disabled for this solve",
+                    RuntimeWarning,
+                    stacklevel=2,
                 )
 
         # Install a process-global wall-clock deadline that JAX-compiled
@@ -4858,9 +4875,36 @@ class Model:
                     result.x = None
                     result.objective = None
                     result.gap = None
-            except Exception as _ver_exc:  # pragma: no cover - defensive
-                _logging.getLogger("discopt.solver").debug(
-                    "incumbent verification skipped: %s", _ver_exc
+                    # The status must stop asserting what the guard just withdrew.
+                    # Clearing ``x``/``objective`` while leaving ``status="optimal"``
+                    # reports a PROVEN OPTIMUM WITH NO SOLUTION -- a caller that keys
+                    # on the status (every gate and panel in this repo does) reads a
+                    # certificate that the guard has already refused to stand behind.
+                    # Observed under ``DISCOPT_PRESOLVE_BOUND_PROPAGATION=1`` on
+                    # nvs05: ``status='optimal'``, ``objective=None``, 3/3 reps.
+                    # This is not a limit termination -- an unsound mutation was
+                    # detected -- so it reports as an error and refuses loudly
+                    # (CLAUDE.md §1/§3). ``bound`` is untouched: only the PRIMAL was
+                    # shown to be invalid, and the dual bound remains rigorous.
+                    result.status = "error"
+            except Exception as _ver_exc:
+                # A swallowed exception here does not "skip verification" -- it
+                # DELETES the soundness guard while leaving every caller believing
+                # it ran, which is exactly the failure CLAUDE.md §7 is written from.
+                # The solve is still returned (a broken checker must not break a
+                # correct solve), but silently is not an option.
+                _logging.getLogger("discopt.solver").error(
+                    "INCUMBENT VERIFICATION DID NOT RUN: %s: %s. The false-primal "
+                    "guard was skipped, so this incumbent is UNSCREENED.",
+                    type(_ver_exc).__name__,
+                    _ver_exc,
+                )
+                _warnings.warn(
+                    f"incumbent verification did not run "
+                    f"({type(_ver_exc).__name__}: {_ver_exc}); the returned incumbent "
+                    f"is unscreened by the false-primal guard",
+                    RuntimeWarning,
+                    stacklevel=2,
                 )
 
         if llm:

--- a/python/tests/test_amp.py
+++ b/python/tests/test_amp.py
@@ -3541,10 +3541,19 @@ def test_amp_restores_model_bounds_after_objective_cutoff_tightening(monkeypatch
             1,
         ),
     )
+    # The stub incumbent must be FEASIBLE in this model. The original stub,
+    # (-0.6, 0.3, 0.5) with objective -0.33, violates ``x**2 <= y**2 + z**2`` by
+    # 0.02 -- 20x the false-primal guard's 1e-3 tolerance -- and its declared
+    # objective did not match the point either (the true value there is -0.385).
+    # The guard therefore withheld the incumbent on every run of this test; the
+    # status assertion below only passed because a withheld false primal used to
+    # keep reporting ``status="optimal"`` (#1061). (-0.5, 0.3, 0.5) is feasible
+    # with margin (slacks 1.99 / 0.09 / 0.05) and -0.285 is its true objective,
+    # so the test now exercises bound restoration rather than the guard.
     monkeypatch.setattr(
         amp_mod,
         "_solve_best_nlp_candidate",
-        lambda *args, **kwargs: (np.array([-0.6, 0.3, 0.5], dtype=np.float64), -0.33),
+        lambda *args, **kwargs: (np.array([-0.5, 0.3, 0.5], dtype=np.float64), -0.285),
     )
 
     m = Model("issue_63_bound_restore")

--- a/python/tests/test_false_primal_status_1061.py
+++ b/python/tests/test_false_primal_status_1061.py
@@ -1,0 +1,190 @@
+"""The false-primal guard must not leave the status claiming optimality (#1061).
+
+Found by the §5 graduation panel for ``DISCOPT_PRESOLVE_BOUND_PROPAGATION``.
+On ``nvs05`` with that flag on, the guard fired correctly -- the incumbent was
+infeasible in the original problem, so it was withheld and decertified -- but
+``status`` stayed ``"optimal"``. The returned object therefore read
+
+    status='optimal'  objective=None  x=None  gap_certified=False
+
+which is a *proven optimum with no solution*: every gate, panel and script in
+this repo keys on ``status``, so the withdrawal was invisible to all of them.
+Reproduced 3/3 interleaved reps, so it is a code path, not a timing artifact.
+
+These tests drive the guard directly rather than through that flag, because the
+invariant belongs to the guard and must hold whatever made the incumbent bad
+(CLAUDE.md §2: fix the class, not the instance).
+"""
+
+import inspect
+import warnings
+
+import numpy as np
+import pytest
+from discopt import Model
+
+
+def _nonlinear_model(name="false_primal_guard"):
+    """A model that takes the constrained nonlinear path, so the guard is armed.
+
+    The guard only builds its verification snapshot for a model with constraints
+    that is not in the fast linear/quadratic family; on a linear model the code
+    under test is never reached and every assertion below would pass vacuously
+    (CLAUDE.md §6).
+    """
+    m = Model(name)
+    x = m.continuous("x", lb=0.1, ub=4.0)
+    y = m.continuous("y", lb=0.1, ub=4.0)
+    z = m.integer("z", lb=0, ub=3)
+    # The ``- z`` matters: the posynomial version of this model classifies as a
+    # geometric program and is solved by ``solve_gp`` through a *nested*
+    # ``Model.solve`` on the log-space model, so the guard fires on the inner
+    # result and these assertions would inspect the wrong object.
+    m.subject_to(x * y * y - z >= 1.0)
+    m.subject_to(x + y + z <= 6.0)
+    m.minimize(x + y + 0.5 * z)
+    return m
+
+
+def _force_guard_verdict(monkeypatch, feasible: bool):
+    """Force the GUARD's feasibility verdict, leaving every other caller real.
+
+    ``_check_constraint_feasibility`` has ~35 call sites; patching it wholesale
+    also rewires the solver's own primal screens, which withhold the incumbent
+    earlier and leave the guard nothing to act on (the first draft of this test
+    did exactly that and never reached the code under test). The guard is the
+    only caller in ``modeling/core.py``, so dispatch on the calling frame and
+    let everyone else through untouched.
+
+    Returns a dict whose ``n`` counts guard calls actually intercepted (§6).
+    """
+    import discopt._relax.primal_heuristics as ph
+
+    real = ph._check_constraint_feasibility
+    calls = {"n": 0}
+    here = "modeling/core.py"
+
+    def _dispatch(evaluator, *args, **kwargs):
+        caller = inspect.currentframe().f_back
+        if caller is not None and caller.f_code.co_filename.replace("\\", "/").endswith(here):
+            calls["n"] += 1
+            return feasible
+        return real(evaluator, *args, **kwargs)
+
+    monkeypatch.setattr(ph, "_check_constraint_feasibility", _dispatch)
+    return calls
+
+
+def _solve_with_guard_verdict(monkeypatch, feasible: bool):
+    calls = _force_guard_verdict(monkeypatch, feasible)
+    res = _nonlinear_model().solve(time_limit=30)
+    # §6: without this, "status is not optimal" could pass because the solve
+    # failed for an unrelated reason and the guard never ran at all.
+    assert calls["n"] > 0, "the false-primal guard never ran; this test proves nothing"
+    return res
+
+
+def test_guard_runs_and_passes_a_genuine_incumbent(monkeypatch):
+    """Control arm: verdict 'feasible' withholds nothing."""
+    res = _solve_with_guard_verdict(monkeypatch, feasible=True)
+    assert res.incumbent_verification_failed is False
+    assert res.x is not None
+    assert res.objective is not None
+    assert res.status != "error"
+
+
+def test_withheld_false_primal_does_not_report_optimal(monkeypatch):
+    """The regression. Before the fix this returned status='optimal'."""
+    res = _solve_with_guard_verdict(monkeypatch, feasible=False)
+
+    assert res.incumbent_verification_failed is True
+    assert res.x is None
+    assert res.objective is None
+    assert res.gap is None
+    assert res.gap_certified is False
+    assert res.status != "optimal", (
+        "a withheld false primal was still reported as status='optimal' with no "
+        "incumbent -- a proven optimum that does not exist"
+    )
+    assert res.status == "error"
+
+
+def test_the_dual_bound_survives_the_withhold(monkeypatch):
+    """Only the PRIMAL was shown invalid; the dual bound stays rigorous."""
+    ok = _solve_with_guard_verdict(monkeypatch, feasible=True)
+    monkeypatch.undo()
+    bad = _solve_with_guard_verdict(monkeypatch, feasible=False)
+    assert ok.bound is not None, "control arm produced no dual bound; nothing to compare"
+    assert bad.bound is not None, "the withhold must not discard the valid dual bound"
+    assert bad.bound == pytest.approx(ok.bound, rel=1e-6, abs=1e-9)
+
+
+def test_a_broken_guard_is_loud_rather_than_silent(monkeypatch):
+    """CLAUDE.md §7: a swallowed exception here DELETES the soundness guard.
+
+    It was logged at DEBUG, so a solve whose incumbent was never screened looked
+    exactly like one that passed screening.
+    """
+    import discopt._relax.primal_heuristics as ph
+
+    real = ph._check_constraint_feasibility
+    seen = {"n": 0}
+
+    def _explode(evaluator, *args, **kwargs):
+        caller = inspect.currentframe().f_back
+        if caller is not None and caller.f_code.co_filename.replace("\\", "/").endswith(
+            "modeling/core.py"
+        ):
+            seen["n"] += 1
+            raise RuntimeError("guard is broken")
+        return real(evaluator, *args, **kwargs)
+
+    monkeypatch.setattr(ph, "_check_constraint_feasibility", _explode)
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        res = _nonlinear_model().solve(time_limit=30)
+
+    assert seen["n"] > 0, "the guard never ran; this test proves nothing"
+    # The solve is still returned -- a broken checker must not break a good solve.
+    assert res is not None
+    msgs = [str(w.message) for w in caught if issubclass(w.category, RuntimeWarning)]
+    assert any("unscreened" in m for m in msgs), (
+        f"a guard that raised produced no RuntimeWarning; warnings seen: {msgs}"
+    )
+
+
+def test_status_error_is_reachable_only_through_the_guard():
+    """Guard against a hardwired pass: an unpatched solve of this model is fine."""
+    res = _nonlinear_model("false_primal_control").solve(time_limit=30)
+    assert res.status != "error"
+    assert res.incumbent_verification_failed is False
+    assert isinstance(res.objective, float) and np.isfinite(res.objective)
+
+
+def test_a_gp_does_not_hide_the_guards_verdict(monkeypatch):
+    """``solve_gp`` must propagate the withhold flag, not just the status.
+
+    A posynomial model is routed to ``solve_gp``, which runs a *nested*
+    ``Model.solve`` on the log-space model. The guard therefore fires on the
+    inner result, and the x-space result handed back to the caller is rebuilt
+    field by field -- so the flag has to be carried across explicitly or a
+    detected false primal reads as an ordinary empty result.
+    """
+    m = Model("false_primal_gp")
+    x = m.continuous("x", lb=0.1, ub=4.0)
+    y = m.continuous("y", lb=0.1, ub=4.0)
+    m.subject_to(x * y * y >= 1.0)
+    m.subject_to(x + y <= 5.0)
+    m.minimize(x + y)
+
+    calls = _force_guard_verdict(monkeypatch, feasible=False)
+    res = m.solve(time_limit=30)
+    assert calls["n"] > 0, "the guard never ran; this test proves nothing"
+
+    assert res.x is None
+    assert res.objective is None
+    assert res.status != "optimal"
+    assert res.incumbent_verification_failed is True, (
+        "solve_gp dropped the false-primal flag, so the caller cannot tell a "
+        "withheld unsound incumbent from an ordinary no-solution result"
+    )


### PR DESCRIPTION
## What

The false-primal guard in `Model.solve` withholds an incumbent that is infeasible in the
*original* problem — it clears `x`/`objective`/`gap` and forces `gap_certified=False`. It
left `status` alone, so a caught false primal came back as:

```
status='optimal'  objective=None  x=None  gap_certified=False
```

A **proven optimum with no solution**. Every gate, panel and script in this repo keys on
`status`, so the guard's withdrawal was invisible to all of them.

## How it was found

The §5 graduation panel for `DISCOPT_PRESOLVE_BOUND_PROPAGATION` (#1061). With that flag
on, `nvs05` trips the guard and returns exactly the above — in **3/3 interleaved reps**,
identical values, both arms finishing well inside the time limit, so it is a code path and
not a timing artifact.

**The guard is not touched.** It is working: the flag produces an unsound presolve mutation,
the guard catches it and refuses the point. Only the *report* was wrong.

## Changes

- **`status` becomes `"error"` on a withhold.** Not a limit termination — an unsound
  mutation was detected — so it refuses loudly (§1/§3). `bound` is deliberately retained:
  only the primal was invalidated; the dual bound remains rigorous.
- **`solve_gp` propagates `incumbent_verification_failed`.** It rebuilds the x-space result
  field by field from a *nested* log-space `Model.solve`, so the guard fired on the inner
  result and the flag was dropped — a detected false primal read as an ordinary empty
  result.
- **Both `except Exception` handlers around the guard are no longer silent.** They logged at
  DEBUG. A swallowed exception there does not skip a nicety, it **deletes the soundness
  check** while every caller believes it ran (§7). Now ERROR + `RuntimeWarning`; the solve is
  still returned, because a broken checker must not break a correct solve.
- **`test_amp.py` stub fixed.** Its bound-restore stub returned `(-0.6, 0.3, 0.5)`, which
  violates `x**2 <= y**2 + z**2` by 0.02 — 20x the guard's 1e-3 tolerance — with a declared
  objective (`-0.33`) that did not match the point (`-0.385`). The guard withheld it on
  *every* run of that test, and its `status in ("optimal","feasible")` assertion passed only
  because of the bug fixed here. Replaced with a feasible point (slacks 1.99 / 0.09 / 0.05)
  and its true objective, so the test exercises bound restoration rather than the guard.

## Tests

`python/tests/test_false_primal_status_1061.py`, 6 tests. Each drives the guard by
dispatching on the *calling frame* rather than patching `_check_constraint_feasibility`
wholesale — it has ~35 call sites, and patching it globally rewires the solver's own primal
screens so the incumbent is withheld earlier and the guard never runs (the first draft did
exactly that and proved nothing). Every test carries a §6 counter asserting the guard was
actually intercepted.

Fails before / passes after: `test_withheld_false_primal_does_not_report_optimal` and
`test_a_broken_guard_is_loud_rather_than_silent` fail on the pre-change tree;
`test_a_gp_does_not_hide_the_guards_verdict` fails with only the `gp` change reverted.

## Verification

| suite | result |
|---|---|
| `pytest -m smoke` | 8 failed → **7 pre-existing**, identical with and without this change |
| `pytest -m slow test_adversarial_recent_fixes.py` | 19 passed |
| `pytest -k "gp or solve_result or false_primal or verification"` | 135 passed, 1 skipped |
| `ruff check` / `ruff format --check` / `mypy` | clean |

The 7 remaining smoke failures are all `test_1060_native_single_tree.py` and are an
environment artifact of my worktree, not a code regression: this worktree has no compiled
`_rust.abi3.so`, so `discopt._rust` resolves through the shared editable install to another
worktree's stale extension, which predates `solve_milp_lazy_csc_py`. They fail identically
on `origin/main` in this environment. CI builds the extension, so it is the authority here.

No Rust touched.

Contributes to #1061; leaves it open — the unsound presolve mutation that produces the
false primal on `nvs05` is the remaining work there, and the flag stays default-OFF.
