### PR TITLE
fix(correctness): #1061 the false-primal screen must be scale-aware

### DIFF
--- a/python/discopt/_relax/primal_heuristics.py
+++ b/python/discopt/_relax/primal_heuristics.py
@@ -538,6 +538,58 @@ def _check_constraint_feasibility(
     return bool(np.all(viol <= tol + rtol * scale))
 
 
+# --- The false-primal screen (#772 / #815 / #1061) ---------------------------
+#
+# Two call sites ask the same question with the same intended meaning: is this
+# point GROSSLY infeasible in the original problem -- wrong in a way no converged
+# solve could ever produce? They are the final incumbent guard in
+# ``modeling/core.py`` and the single-NLP source screen in ``solver.py``. Both
+# used to spell the answer inline as ``tol=1e-3``, and both therefore inherited
+# ``rtol``'s ACCEPTANCE default of 1e-9.
+#
+# That combination is not "loose". It loosens only the ABSOLUTE leg (1000x, from
+# 1e-6 to 1e-3) while leaving the RELATIVE leg at the value calibrated for
+# accepting an incumbent, so on a row whose terms are large the screen collapses
+# to an absolute-only test -- exactly the scale blindness the docstring above
+# describes for prob07. Measured on nvs05 (#1061): row 2 has scale
+# ``sum_j |J_2j|*|x_j| = 73674``, and a point whose RELATIVE residual on that row
+# is 2.8e-8 -- converged by IPOPT's own default tolerance, and 1e-7 per component
+# away from the point the very same solver certifies as optimal -- carries an
+# absolute residual of 2.06e-3 and read as a false primal. The default path sits
+# at 1.34e-4 on that row, a factor of 7.5 from tripping: a landmine, not a margin.
+#
+# So the screen loosens BOTH legs by the same 1000x, which is what "the same test,
+# a thousand times looser" actually means. On a well-scaled row (scale ~1) the
+# behaviour is unchanged at ``1e-3``; on nvs05's row 2 the threshold becomes
+# ``1e-3 + 1e-6*73674 = 0.075``, still an order of magnitude below the smallest
+# genuine false primal on record (the #770 violations were 0.4-17.6) and four
+# orders of magnitude tighter than a mutation-scale error, whose residual is
+# comparable to the row's OWN magnitude rather than 1e-8 of it.
+#
+# Defined once, here, because the two sites must never drift apart: solver.py's
+# comment already says it uses "the SAME loose check" as core.py's, and the only
+# thing keeping that true was that both had the same literal typed into them.
+FALSE_PRIMAL_ATOL = 1e-3
+FALSE_PRIMAL_RTOL = 1e-6
+
+
+def passes_false_primal_screen(evaluator: NLPEvaluator, x: np.ndarray) -> bool:
+    """Is ``x`` free of any GROSS infeasibility in ``evaluator``'s problem?
+
+    The deliberately-loose screen used to refuse a false primal (#772/#815). It is
+    not a feasibility test -- :func:`_check_constraint_feasibility` at its default
+    tolerances is -- and must never be used as one: it is calibrated to flag only
+    a violation no converged solve could produce, so that it can never withhold a
+    point that is feasible within the solver's own tolerance.
+
+    Scale-aware in both legs (see the note above); returns ``True`` when the point
+    passes, i.e. when there is no reason to suspect a false primal.
+    """
+    return _check_constraint_feasibility(
+        evaluator, x, tol=FALSE_PRIMAL_ATOL, rtol=FALSE_PRIMAL_RTOL
+    )
+
+
 def subnlp(
     model: Model,
     x_relax: np.ndarray,

--- a/python/discopt/modeling/core.py
+++ b/python/discopt/modeling/core.py
@@ -4846,14 +4846,18 @@ class Model:
         # primal — the worst error class (CLAUDE.md §1). It cannot happen on correct
         # solver code, but if an unsound presolve mutation or a heuristic bug ever
         # produces one, this guard refuses to return it: withhold the incumbent and
-        # decertify, loudly. The check is deliberately LOOSE (abs tol 1e-3) so it can
-        # never flag an incumbent that is feasible within the solver's own tolerance
-        # — only a gross violation (the #770 violations were 0.4–17.6) trips it.
+        # decertify, loudly. The check is deliberately LOOSE so it can never flag an
+        # incumbent that is feasible within the solver's own tolerance — only a gross
+        # violation (the #770 violations were 0.4–17.6) trips it. That looseness lives
+        # in ``passes_false_primal_screen``, shared with the single-NLP source screen
+        # in ``solver.py`` so the two cannot drift; spelling it inline as ``tol=1e-3``
+        # loosened only the absolute leg and made the screen scale-blind on
+        # large-magnitude rows (#1061).
         if _verify_snap is not None and result.x is not None:
             try:
                 import numpy as _np
 
-                from discopt._relax.primal_heuristics import _check_constraint_feasibility
+                from discopt._relax.primal_heuristics import passes_false_primal_screen
 
                 _snap_ev, _snap_names = _verify_snap
                 _flat = _np.concatenate(
@@ -4862,7 +4866,7 @@ class Model:
                         for _n in _snap_names
                     ]
                 )
-                if not _check_constraint_feasibility(_snap_ev, _flat, tol=1e-3):
+                if not passes_false_primal_screen(_snap_ev, _flat):
                     _logging.getLogger("discopt.solver").error(
                         "FALSE PRIMAL DETECTED: the reported incumbent (objective=%s) is "
                         "INFEASIBLE in the original problem. This indicates an unsound presolve "

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -14716,18 +14716,17 @@ def _solve_continuous(
     # at an all-10 point violating the distance-defining equalities by ~9.5, and
     # this path would otherwise report it as objective=594). Reporting that point
     # as an incumbent is a false primal. Verify feasibility HERE, at the source,
-    # with the SAME loose check the final incumbent-verification guard (#772) uses
-    # (abs tol 1e-3 — it can only flag a gross violation, never a point feasible
-    # within the solver's own tolerance), and withhold an infeasible point so a
+    # with the SAME loose check the final incumbent-verification guard (#772) uses —
+    # literally the same function now (#1061), so the two can only ever agree; it can
+    # only flag a gross violation, never a point feasible within the solver's own
+    # tolerance — and withhold an infeasible point so a
     # bogus incumbent never propagates. This only ever removes a bad incumbent;
     # the path carries no valid dual bound when it is not "optimal", so refusing
     # here can never loosen a bound below truth (soundness is untouched).
     if x_dict is not None and nlp_result.x is not None:
-        from discopt._relax.primal_heuristics import (
-            _check_constraint_feasibility as _cc_feas_verify,
-        )
+        from discopt._relax.primal_heuristics import passes_false_primal_screen
 
-        if not _cc_feas_verify(evaluator, np.asarray(nlp_result.x, dtype=np.float64), tol=1e-3):
+        if not passes_false_primal_screen(evaluator, np.asarray(nlp_result.x, dtype=np.float64)):
             logger.warning(
                 "continuous NLP returned an infeasible point (status=%s, obj=%s); "
                 "withholding the incumbent — no feasible solution was found.",

--- a/python/tests/test_false_primal_screen_scale_1061.py
+++ b/python/tests/test_false_primal_screen_scale_1061.py
@@ -1,0 +1,207 @@
+"""#1061 — the false-primal screen must be scale-aware, not absolute-only.
+
+The screen's whole contract (stated in its own comment since #772) is that it
+"can never flag an incumbent that is feasible within the solver's own tolerance —
+only a gross violation trips it". Both call sites spelled that as ``tol=1e-3`` and
+inherited ``rtol``'s *acceptance* default of 1e-9, which loosens only the absolute
+leg. On a row whose terms are large the screen therefore collapses to an
+absolute-only test and withholds converged points.
+
+Measured on ``nvs05`` before this fix: row 2 has scale ``sum_j |J_2j|*|x_j|`` =
+73,674; a point whose RELATIVE residual there is 2.8e-8 (converged by IPOPT's own
+default tolerance, and within 1e-7 per component of the point the same solver
+certifies optimal) carries a 2.06e-3 absolute residual and was reported as
+``status="error"``, objective withheld. The default path sits at 1.34e-4 on that
+same row — a factor of 7.5 from tripping.
+
+These tests fix the boundary in both directions: a converged point on a
+large-magnitude row is kept, and a violation that is large *relative to the row's
+own scale* is still refused, so the relative leg is not a blank cheque.
+"""
+
+from __future__ import annotations
+
+import pathlib
+
+import discopt.modeling as dm
+import discopt.solver as solver_mod
+import numpy as np
+import pytest
+from discopt._relax import primal_heuristics as ph
+from discopt.modeling.core import SolveResult
+
+# x**3 - y == 0, cubic so the model is genuinely nonlinear (a quadratic row routes
+# to the fast LP/MILP/QP family, which skips the verification snapshot entirely and
+# would make every assertion below vacuous).
+_X = 30.0
+_Y = _X**3  # 27000
+# scale = |d/dx|*|x| + |d/dy|*|y| = 3*30^2*30 + 1*27000 = 108000
+_ROW_SCALE = 3 * _X**2 * _X + _Y
+
+
+def _cubic_model():
+    m = dm.Model()
+    x = m.continuous("x", lb=0.0, ub=100.0)
+    y = m.continuous("y", lb=0.0, ub=1.0e6)
+    m.subject_to(x * x * x - y == 0.0)
+    m.minimize(y)
+    return m
+
+
+def _solve_with_injected_point(monkeypatch, x_val: float, y_val: float):
+    """Return ``(result, screen_calls)`` for an injected incumbent.
+
+    ``screen_calls`` is the CLAUDE.md §6 counter: without it, "the guard accepted
+    the point" and "the guard never ran" are indistinguishable, since both leave
+    ``incumbent_verification_failed`` False.
+    """
+    calls = {"n": 0}
+    real = ph.passes_false_primal_screen
+
+    def _counting(evaluator, x):
+        calls["n"] += 1
+        return real(evaluator, x)
+
+    monkeypatch.setattr(ph, "passes_false_primal_screen", _counting)
+
+    def _fake_solve_model(model, **kwargs):
+        return SolveResult(
+            status="optimal",
+            objective=y_val,
+            bound=y_val,
+            gap=0.0,
+            x={"x": np.array(x_val), "y": np.array(y_val)},
+            gap_certified=True,
+        )
+
+    monkeypatch.setattr(solver_mod, "solve_model", _fake_solve_model)
+    m = _cubic_model()
+    return m.solve(time_limit=5), calls
+
+
+def test_converged_point_on_a_large_row_is_not_a_false_primal(monkeypatch):
+    """The nvs05 signature: absolute residual over 1e-3, relative residual ~1e-8.
+
+    Fails before the fix (the screen was effectively absolute-only and withheld
+    this point); passes after.
+    """
+    resid = 2.0e-3
+    r, calls = _solve_with_injected_point(monkeypatch, _X, _Y + resid)
+
+    assert calls["n"] > 0, "the screen never ran — this test asserted nothing"
+    rel = resid / _ROW_SCALE
+    assert rel < 1e-7, f"fixture is not the intended regime (rel={rel:.2e})"
+    assert resid > ph.FALSE_PRIMAL_ATOL, "fixture must exceed the absolute leg"
+
+    assert r.incumbent_verification_failed is False, (
+        f"a point with relative residual {rel:.2e} on a row of scale {_ROW_SCALE:g} "
+        f"was reported as a false primal — the screen is scale-blind"
+    )
+    assert r.x is not None and r.objective is not None
+    assert r.status == "optimal"
+
+
+def test_a_violation_large_relative_to_the_row_is_still_refused(monkeypatch):
+    """The relative leg is not a blank cheque: a residual that is large *in the
+    row's own units* still trips the screen, on the very same large-scale row."""
+    resid = 10.0  # rel = 9.3e-5, ~93x the relative leg
+    r, calls = _solve_with_injected_point(monkeypatch, _X, _Y + resid)
+
+    assert calls["n"] > 0, "the screen never ran — this test asserted nothing"
+    assert resid / _ROW_SCALE > ph.FALSE_PRIMAL_RTOL, "fixture below the relative leg"
+
+    assert r.incumbent_verification_failed is True
+    assert r.x is None and r.objective is None
+    assert r.gap_certified is False
+    assert r.status == "error"
+
+
+def test_a_gross_violation_is_still_refused(monkeypatch):
+    """The #770 failure mode (violations 0.4–17.6) is untouched."""
+    r, calls = _solve_with_injected_point(monkeypatch, _X, 0.0)  # residual 27000
+
+    assert calls["n"] > 0, "the screen never ran — this test asserted nothing"
+    assert r.incumbent_verification_failed is True
+    assert r.x is None and r.objective is None
+
+
+def test_a_well_scaled_row_keeps_the_1e_3_behaviour():
+    """On a row whose terms are O(1) the relative leg contributes ~1e-6, so the
+    screen still behaves as the plain absolute 1e-3 test it has always been.
+
+    This is what makes the change safe: it only ever differs where the absolute
+    test was meaningless.
+    """
+    from discopt._relax.nlp_evaluator import cached_evaluator
+
+    m = dm.Model()
+    x = m.continuous("x", lb=-10.0, ub=10.0)
+    y = m.continuous("y", lb=-10.0, ub=10.0)
+    m.subject_to(x * x * x + y * y * y <= 1.0)
+    m.minimize(x + y)
+    ev = cached_evaluator(m)
+
+    checks = 0
+    # (point, expected) — the boundary sits at 1e-3 + 1e-6*scale, and with terms of
+    # size O(1) that second term cannot move the verdict at these magnitudes.
+    for pt, expected in (
+        (np.array([0.5, 0.5]), True),  # 0.25 <= 1, comfortably feasible
+        (np.array([1.0, 1.0]), False),  # 2.0 vs 1.0 — a gross violation
+    ):
+        assert ph.passes_false_primal_screen(ev, pt) is expected, f"{pt} -> {expected}"
+        checks += 1
+    assert checks == 2
+
+
+@pytest.mark.parametrize(
+    "rel_path",
+    ["python/discopt/modeling/core.py", "python/discopt/solver.py"],
+)
+def test_neither_call_site_hardcodes_its_own_screen_tolerance(rel_path):
+    """The two screens must not drift apart.
+
+    ``solver.py`` already claimed to use "the SAME loose check" as ``core.py``, and
+    the only thing making that true was the same literal typed into both. Keeping
+    the tolerance in one place is the fix; this test keeps it there.
+    """
+    root = pathlib.Path(__file__).resolve().parents[2]
+    src = (root / rel_path).read_text()
+    assert "passes_false_primal_screen" in src, f"{rel_path} no longer uses the shared screen"
+
+    # Comments are allowed to name the old literal (they explain why it is gone);
+    # executable code is not.
+    code = "\n".join(line for line in src.splitlines() if not line.lstrip().startswith("#"))
+    assert "tol=1e-3" not in code, (
+        f"{rel_path} hardcodes a false-primal tolerance again; use "
+        f"passes_false_primal_screen so the two sites cannot diverge"
+    )
+
+
+def test_the_old_absolute_only_tolerance_is_what_rejected_the_point():
+    """Pin the mechanism directly, in one run, without reverting anything.
+
+    The other tests here fail on the pre-fix tree because the shared screen does
+    not exist there, which proves they are new but not *why* they are needed. This
+    one compares the two tolerance models side by side on the same evaluator and
+    the same point: the old ``tol=1e-3, rtol=1e-9`` pair rejects a point whose
+    relative residual is ~1e-8, and the new pair accepts it. That difference is the
+    entire bug.
+    """
+    from discopt._relax.nlp_evaluator import cached_evaluator
+
+    m = _cubic_model()
+    ev = cached_evaluator(m)
+    resid = 2.0e-3
+    pt = np.array([_X, _Y + resid])
+
+    old_verdict = ph._check_constraint_feasibility(ev, pt, tol=1e-3, rtol=1e-9)
+    new_verdict = ph.passes_false_primal_screen(ev, pt)
+
+    assert old_verdict is False, (
+        "fixture no longer reproduces the bug: the old absolute-only screen "
+        "accepts this point, so there is nothing to fix"
+    )
+    assert new_verdict is True, (
+        f"the scale-aware screen still rejects a point whose relative residual is "
+        f"{resid / _ROW_SCALE:.2e} on a row of scale {_ROW_SCALE:g}"
+    )

--- a/python/tests/test_false_primal_status_1061.py
+++ b/python/tests/test_false_primal_status_1061.py
@@ -49,29 +49,30 @@ def _nonlinear_model(name="false_primal_guard"):
 def _force_guard_verdict(monkeypatch, feasible: bool):
     """Force the GUARD's feasibility verdict, leaving every other caller real.
 
-    ``_check_constraint_feasibility`` has ~35 call sites; patching it wholesale
-    also rewires the solver's own primal screens, which withhold the incumbent
-    earlier and leave the guard nothing to act on (the first draft of this test
-    did exactly that and never reached the code under test). The guard is the
-    only caller in ``modeling/core.py``, so dispatch on the calling frame and
-    let everyone else through untouched.
+    Patching ``_check_constraint_feasibility`` (~35 call sites) wholesale also
+    rewires the solver's own primal screens, which withhold the incumbent earlier
+    and leave the guard nothing to act on -- the first draft of this test did
+    exactly that and never reached the code under test. ``passes_false_primal_screen``
+    is the narrow entry point instead: only the final guard and the single-NLP
+    source screen call it, and dispatching on the calling frame keeps the latter
+    real, so the solver still screens its own points normally.
 
     Returns a dict whose ``n`` counts guard calls actually intercepted (§6).
     """
     import discopt._relax.primal_heuristics as ph
 
-    real = ph._check_constraint_feasibility
+    real = ph.passes_false_primal_screen
     calls = {"n": 0}
     here = "modeling/core.py"
 
-    def _dispatch(evaluator, *args, **kwargs):
+    def _dispatch(evaluator, x):
         caller = inspect.currentframe().f_back
         if caller is not None and caller.f_code.co_filename.replace("\\", "/").endswith(here):
             calls["n"] += 1
             return feasible
-        return real(evaluator, *args, **kwargs)
+        return real(evaluator, x)
 
-    monkeypatch.setattr(ph, "_check_constraint_feasibility", _dispatch)
+    monkeypatch.setattr(ph, "passes_false_primal_screen", _dispatch)
     return calls
 
 
@@ -127,19 +128,19 @@ def test_a_broken_guard_is_loud_rather_than_silent(monkeypatch):
     """
     import discopt._relax.primal_heuristics as ph
 
-    real = ph._check_constraint_feasibility
+    real = ph.passes_false_primal_screen
     seen = {"n": 0}
 
-    def _explode(evaluator, *args, **kwargs):
+    def _explode(evaluator, x):
         caller = inspect.currentframe().f_back
         if caller is not None and caller.f_code.co_filename.replace("\\", "/").endswith(
             "modeling/core.py"
         ):
             seen["n"] += 1
             raise RuntimeError("guard is broken")
-        return real(evaluator, *args, **kwargs)
+        return real(evaluator, x)
 
-    monkeypatch.setattr(ph, "_check_constraint_feasibility", _explode)
+    monkeypatch.setattr(ph, "passes_false_primal_screen", _explode)
     with warnings.catch_warnings(record=True) as caught:
         warnings.simplefilter("always")
         res = _nonlinear_model().solve(time_limit=30)


### PR DESCRIPTION
## The bug

The final incumbent guard (#772) and the single-NLP source screen (#815) ask the
same question — is this point *grossly* infeasible in the original problem? — and
both state the same contract in their own comments:

> The check is deliberately LOOSE (abs tol 1e-3) so it can never flag an incumbent
> that is feasible within the solver's own tolerance — only a gross violation (the
> #770 violations were 0.4–17.6) trips it.

Neither honours it. Both spelled the check inline as `tol=1e-3` and inherited
`rtol`'s **acceptance** default of `1e-9`, so only the *absolute* leg was loosened.
On a row built from large terms the relative leg contributes nothing and the screen
collapses to an absolute-only test — precisely the scale blindness
`_check_constraint_feasibility`'s own docstring documents from a prior incident
(prob07: a 2.4e-6 residual on a row of magnitude 1.5e5 discarded the true global
basin, while BARON, which scales feasibility by constraint magnitude, accepted it).

## The measurement

On `nvs05`, row 2's own scale — `sum_j |J_2j|*|x_j|`, the magnitude of the terms
that must cancel for the equality to hold — is **73,674**:

```
           abs viol      scale       RELATIVE residual
OFF        1.339e-04     73674.6     1.817e-09
ON         2.060e-03     73674.6     2.796e-08     <- reported as a FALSE PRIMAL
SCALE_CHECKS_EXECUTED=8
```

A relative residual of 2.8e-8 is a converged NLP solution — it meets IPOPT's own
default tolerance, and the point is within 1e-7 per component of the point the very
same solver certifies as optimal. It was reported as `status="error"` with the
objective withheld.

The default path sits at **1.339e-04** on that same row: a factor of 7.5 from
tripping, on a model nobody had flagged. That is a landmine, not a margin.

Three probes established there is nothing else wrong (details and the full
retraction of my earlier "unsound presolve mutation" claim are in
[#1061](https://github.com/jkitchin/discopt/issues/1061#issuecomment-5333640255),
per CLAUDE.md §11):

- the presolve box does not cut off the optimum (`BOUND_CHECKS_EXECUTED=8`,
  `X_STAR_CUT_OFF=0`);
- both arms build the same problem — all four (evaluator × point) combinations
  agree to every printed digit (`RESIDUAL_EVALUATIONS_EXECUTED=4`);
- the rejected point is converged, not infeasible.

## The change

Both legs now loosen by the same 1000×, which is what "the same test, a thousand
times looser" was always meant to say:

| | absolute | relative |
|---|---|---|
| acceptance (`_check_constraint_feasibility` defaults) | 1e-6 | 1e-9 |
| false-primal screen — before | 1e-3 | **1e-9** |
| false-primal screen — after | 1e-3 | **1e-6** |

The pair lives in one shared `passes_false_primal_screen` so the two call sites
cannot drift. `solver.py` already claimed to use "the SAME loose check" as
`core.py`, and the only thing making that true was the same literal typed into both.

## Calibration (the entry experiment, CLAUDE.md §4)

The relative leg was chosen from data, not by symmetry. Full in-repo corpus (66
instances), default path, 25 s each, intercepting the exact `(evaluator, x)` the
screen tests and attributing the worst row:

```
instances with the guard armed and an incumbent: 43
scale range: 2.7e-12 .. 3.89e+06
max RELATIVE residual on an accepted incumbent: 9.117e-11  (tls2)
max ABSOLUTE residual:                          3.058e-09
GUARD_MARGIN_ROWS_MEASURED=43
```

`rtol = 1e-6` therefore sits **~11,000× above** the worst relative residual any
accepted incumbent in the corpus produces, and 36× above the `nvs05` point that was
wrongly rejected. On a well-scaled row it changes nothing: the threshold stays
`1e-3` to within one part in a thousand.

Kill criterion, stated before the run: if any *good* incumbent showed a relative
residual above 1e-6, the relative framing would be wrong and the fix would have to
be elsewhere. None came within four orders of magnitude.

## Why this is not weakening a guard (CLAUDE.md §1)

- A false primal from an unsound mutation lands in a **different basin**: its
  residual is a fraction of the row's own magnitude, not 1e-6 of it. The screen
  still catches anything violating a row by more than one part per million of that
  row's own scale.
- The solver's own acceptance screen is untouched and remains 1000× tighter on
  both legs. This is a backstop, not the feasibility test.
- An absolute-only threshold cannot be simultaneously correct for a row of scale
  1 and a row of scale 3.9e6 — both of which the corpus contains. The relative leg
  is the only principled way to mean the same thing on both.
- The same principle is already accepted in this codebase on the dual side: POUNCE
  certifies against "the scale-relative floor set by the terms the Lagrangian
  gradient is built from" (`dual_inf_scale_kappa`).

## Tests

`python/tests/test_false_primal_screen_scale_1061.py` — 7 tests, **all failing
before this change and passing after**, pinning the boundary in both directions:

- a converged point on a large-magnitude row is kept (the `nvs05` signature);
- a residual that is large *in the row's own units* is still refused, on the very
  same row — the relative leg is not a blank cheque;
- a gross violation is still refused (the #770 mode);
- a well-scaled row keeps the `1e-3` behaviour exactly;
- the mechanism itself is pinned in one run: the old `(1e-3, 1e-9)` pair rejects
  the fixture point and the new pair accepts it;
- neither call site re-hardcodes its own tolerance.

`test_false_primal_status_1061.py`'s frame-targeted patches were retargeted at the
new, narrower entry point (2 call sites instead of ~35, so the dispatch is simpler
and no longer depends on which module happens to call the feasibility helper).

## Verification run

- `pytest -m smoke python/tests/` → **1061 passed, 7 failed**. All 7 are in
  `test_1060_native_single_tree.py` and fail identically with this change reverted
  (verified by checking out `HEAD~1` for `python/`): this worktree has no compiled
  `_rust.abi3.so`, so `discopt._rust` resolves through the shared editable install
  to `wt1061`'s, which predates `solve_milp_lazy_csc_py`. CI builds its own.
- `pytest -m slow python/tests/test_adversarial_recent_fixes.py` → **19 passed**.
- Guard-specific suites — `test_incumbent_verification_guard_772.py`,
  `test_incumbent_soundness_772.py`, `test_815_continuous_false_primal.py`,
  `test_coef_tighten_774.py`, `test_false_primal_status_1061.py`,
  `test_false_primal_screen_scale_1061.py` → all pass.
- No Rust touched, so `cargo test` was not required.

Contributes to #1061 (the flag's graduation verdict is unchanged and it stays
default-OFF; this fixes the screen that mis-reported it).
