### PR TITLE
fix(solver): #1059 the convex-MINLP auto-route must certify or fall back

### DIFF
--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -5067,6 +5067,65 @@ def _convex_minlp_auto_route(model: Model) -> tuple[Optional[str], str]:
     )
 
 
+#: Fraction of the caller's time limit the #1059 auto-route may spend before the
+#: fallback takes over. The §5 graduation panel measured the failure this bounds:
+#: on ``alan`` (a 9-variable convex MIQP) the routed OA path burned the ENTIRE
+#: 180 s budget and returned an uncertified 3.000, where the default spatial path
+#: certifies 2.925 in 0.18 s -- reproducibly, 3/3 reps. Handing OA the whole
+#: budget leaves nothing to recover with, so the route is budgeted and the
+#: remainder is reserved for the path that is known to certify. Half is the split
+#: because the same panel's Arm B -- the ``syn``/``rsyn`` class the route exists
+#: for -- certifies through OA well inside it (``syn40m`` 59.2 s, ``syn20m02m``
+#: 23.5 s, ``rsyn0805m`` 9.8 s, all measured at a 60 s limit).
+_CONVEX_ROUTE_BUDGET_FRACTION = 0.5
+
+#: Below this many seconds a fallback solve cannot do anything useful, so the
+#: routed (uncertified) result is returned as-is rather than being replaced by a
+#: fallback that is itself out of time.
+_CONVEX_ROUTE_FALLBACK_FLOOR_S = 1.0
+
+
+def _route_result_is_certified(result) -> bool:
+    """Did an auto-routed solve come back with an actual certificate?
+
+    This is the #1059 fallback predicate, and it is deliberately strict: a
+    ``feasible`` status with no dual bound is exactly the failure mode the
+    graduation panel found (``alan``, ``clay0303hfsg``, ``tls2`` all lost their
+    certificate to the route), so anything short of ``gap_certified`` or a
+    terminal infeasible/unbounded verdict counts as "did not certify" and hands
+    the remaining budget to the default path.
+    """
+    if result is None:
+        return False
+    if bool(getattr(result, "gap_certified", False)):
+        return True
+    # An infeasibility or unboundedness verdict is a certificate too, and there
+    # is nothing for a fallback to improve on it.
+    return getattr(result, "status", None) in ("infeasible", "unbounded")
+
+
+def _route_incumbent_seed(model: Model, result) -> Optional[np.ndarray]:
+    """Flatten an auto-routed result's incumbent into an ``initial_point``.
+
+    The fallback must never be *worse* than the route it replaces. Passing the
+    routed incumbent in as the fallback's starting point is what guarantees that:
+    ``solve_model`` injects a finite, verified ``initial_point`` into the tree
+    before the search begins, so the fallback starts from the route's answer and
+    can only tighten it. Returns ``None`` (leave the caller's own seed alone)
+    when there is no usable point.
+    """
+    x = getattr(result, "x", None)
+    if x is None:
+        return None
+    from discopt.mo.utils import _flatten_solution
+
+    flat = _flatten_solution(model, x) if isinstance(x, dict) else np.asarray(x, dtype=np.float64)
+    flat = np.asarray(flat, dtype=np.float64).reshape(-1)
+    if flat.size == 0 or not np.all(np.isfinite(flat)):
+        return None
+    return flat
+
+
 # Size gate for the auto cut policy: above this many scalar variables the
 # per-node cut-separation overhead (eigh / extra LP re-solves) outweighs the
 # typical bound gain, so the policy declines to enable cuts (sound: a no-op).
@@ -5963,6 +6022,20 @@ def solve_model_accepted_kwargs(solver: Optional[str] = None) -> frozenset[str]:
     return frozenset(allowed)
 
 
+#: Note left by the #1059 route fallback for the decorator below to stamp onto
+#: ``SolveResult.algorithm_route``.
+#:
+#: The fallback decides mid-function that the auto-route failed and then falls
+#: through to the default path, whose ~67 return sites it has no way to reach.
+#: Threading a field through all of them is precisely the accounting bug
+#: ``_stamp_layer_timing`` was written to remove (see its docstring), so the note
+#: rides the same rail: set once, stamped once, in the one place every return
+#: passes through. A list, not a scalar, so the wrapper can restore the exact
+#: depth it entered at and a raised exception cannot leak a note into the next
+#: solve (``Model.solve`` runs ``solve_model`` more than once).
+_ROUTE_FALLBACK_NOTE: list[str] = []
+
+
 def _stamp_layer_timing(fn: _F) -> _F:
     """Stamp the layer profile onto whatever ``SolveResult`` the solve produced.
 
@@ -5982,8 +6055,22 @@ def _stamp_layer_timing(fn: _F) -> _F:
     def wrapper(*args, **kwargs):
         before = _timing.snapshot()
         started = time.perf_counter()
-        result = fn(*args, **kwargs)
+        _route_depth = len(_ROUTE_FALLBACK_NOTE)
+        try:
+            result = fn(*args, **kwargs)
+        finally:
+            _route_note = (
+                _ROUTE_FALLBACK_NOTE[_route_depth]
+                if len(_ROUTE_FALLBACK_NOTE) > _route_depth
+                else None
+            )
+            del _ROUTE_FALLBACK_NOTE[_route_depth:]
         elapsed = time.perf_counter() - started
+        # #1059: a solve that fell back off the auto-route must say so, otherwise
+        # it is indistinguishable from one that was never routed -- the exact
+        # invisibility the issue was filed about.
+        if _route_note is not None and isinstance(result, SolveResult):
+            result.algorithm_route = _route_note
         # ``stream=True`` yields an iterator of SolveUpdate, not a SolveResult;
         # leave anything that is not a SolveResult untouched rather than guessing.
         if not isinstance(result, SolveResult):
@@ -6811,26 +6898,85 @@ def solve_model(
 
         from discopt._relax.gdp_reformulate import reformulate_gdp
 
+        # #1059 fallback: keep the caller's model. ``reformulate_gdp`` is what the
+        # MIP-NLP family needs, but if the route does not certify we hand the
+        # remaining budget back to the default path, and that path must see the
+        # model it was called with rather than a big-M reformulation of it.
+        _pre_route_model = model
         model = reformulate_gdp(model, method=resolved_gdp_method)
 
+        # An EXPLICIT solver="mip-nlp" gets the whole budget: the caller chose the
+        # algorithm and there is no fallback to reserve for. Only the auto-route
+        # is budgeted.
+        _route_budget = time_limit
+        if _auto_route_reason is not None:
+            _route_budget = max(
+                time_limit * _CONVEX_ROUTE_BUDGET_FRACTION,
+                min(time_limit, _CONVEX_ROUTE_FALLBACK_FLOOR_S),
+            )
+        _route_t0 = time.perf_counter()
         _mip_nlp_result = solve_mip_nlp(
             model,
             method=mip_nlp_method,
             mip_nlp_options=mip_nlp_options,
-            time_limit=time_limit,
+            time_limit=_route_budget,
             gap_tolerance=gap_tolerance,
             max_iterations=max_nodes,
             nlp_solver=nlp_solver,
             initial_point=initial_point,
             **mip_nlp_kwargs,
         )
+        _route_elapsed = time.perf_counter() - _route_t0
         # #1059: record WHY this algorithm ran. Only set on the auto-route, so an
         # explicit solver="mip-nlp" leaves the field None (the caller already
         # knows what they asked for) and the field reads as "the router chose
         # this" wherever it is populated.
         if _auto_route_reason is not None and _mip_nlp_result is not None:
             _mip_nlp_result.algorithm_route = _auto_route_reason
-        return _mip_nlp_result
+
+        _route_remaining = time_limit - _route_elapsed
+        if (
+            _auto_route_reason is None
+            or _route_result_is_certified(_mip_nlp_result)
+            or _route_remaining < _CONVEX_ROUTE_FALLBACK_FLOOR_S
+        ):
+            return _mip_nlp_result
+
+        # --- #1059: the auto-route did not certify -- fall back to the default path ---
+        #
+        # The route is a *decision*, not a commitment. When it comes back without
+        # a certificate the caller is left holding an uncertified point that the
+        # spatial path would often have proven optimal (the panel: ``alan``
+        # uncertified 3.000 after 180 s vs certified 2.925 in 0.18 s). So spend
+        # the remainder of the budget on the path that certifies, seeded with
+        # whatever the route did find so the fallback can only improve on it.
+        logger.info(
+            "Convex MINLP auto-route did not certify (status=%s, gap_certified=%s) "
+            "after %.2f s; falling back to the default path with %.2f s remaining",
+            getattr(_mip_nlp_result, "status", None),
+            getattr(_mip_nlp_result, "gap_certified", None),
+            _route_elapsed,
+            _route_remaining,
+        )
+        _route_seed = _route_incumbent_seed(_pre_route_model, _mip_nlp_result)
+        if _route_seed is not None and initial_point is None:
+            initial_point = _route_seed
+        model = _pre_route_model
+        _solver = None
+        # ``time_limit`` is deliberately NOT reduced. The default path measures
+        # its own elapsed from ``_solve_t0`` (``t_start = _solve_t0``), which was
+        # taken before the route ran, and ``model._solve_deadline`` is anchored
+        # there too -- so the route's wall is already charged against the
+        # caller's budget. Subtracting it a second time double-charges: measured
+        # on ``alan`` at a 60 s limit, the fallback saw 30 s elapsed against a
+        # 29.9 s limit and returned ``time_limit`` after 1 node with no
+        # incumbent, which is the failure this whole change exists to remove.
+        _ROUTE_FALLBACK_NOTE.append(
+            f"{_auto_route_reason}; did not certify in {_route_elapsed:.2f}s "
+            f"(status={getattr(_mip_nlp_result, 'status', None)}) -> fell back to the "
+            f"default path with {_route_remaining:.2f}s"
+        )
+        # Fall through to the default spatial / NLP branch-and-bound below.
 
     # --- Surrogate (model-based) derivative-free search (no certificate) ---
     #

--- a/python/tests/test_1059_route_fallback.py
+++ b/python/tests/test_1059_route_fallback.py
@@ -1,0 +1,161 @@
+"""#1059: the convex-MINLP auto-route must certify or fall back, never strand.
+
+The §5 graduation panel refused ``DISCOPT_CONVEX_MINLP_ROUTE`` for a specific,
+reproducible reason: on three in-repo instances the routed OA path terminated
+*without a dual bound*, and on ``alan`` — a 9-variable convex MIQP — it burned
+the entire 180 s budget and returned an uncertified 3.000 where the default
+spatial path certifies 2.925 in 0.18 s (3/3 reps). A route is a decision, not a
+commitment; these tests pin the decision being revisited.
+
+Two mechanisms, tested separately:
+
+* the auto-route is **budgeted** to a fraction of the caller's limit, so there
+  is a remainder left to recover with (an explicit ``solver="mip-nlp"`` is a
+  caller's choice and keeps the whole budget);
+* an auto-routed result that did not certify **falls back** to the default path
+  with the remainder, seeded by whatever the route did find, and says so on
+  ``SolveResult.algorithm_route``.
+"""
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+from discopt.modeling.core import Model, from_nl
+from discopt.solver import (
+    _CONVEX_ROUTE_BUDGET_FRACTION,
+    _route_incumbent_seed,
+    _route_result_is_certified,
+)
+
+NL_DIR = Path(__file__).parent / "data" / "minlplib_nl"
+ROUTE_ENV = "DISCOPT_CONVEX_MINLP_ROUTE"
+
+pytest.importorskip("highspy", reason="the OA master needs a MILP backend")
+
+
+def _load(name: str) -> Model:
+    path = NL_DIR / f"{name}.nl"
+    assert path.exists(), f"missing corpus instance {path}"
+    m = from_nl(str(path))
+    m._convexity_time_budget = 10.0
+    return m
+
+
+class _Res:
+    """Minimal stand-in with just the fields the predicate reads."""
+
+    def __init__(self, status=None, gap_certified=False, x=None):
+        self.status = status
+        self.gap_certified = gap_certified
+        self.x = x
+
+
+@pytest.mark.unit
+class TestCertifiedPredicate:
+    """``feasible`` with no bound is the failure the fallback exists for."""
+
+    def test_certified_result_is_certified(self):
+        assert _route_result_is_certified(_Res("optimal", gap_certified=True)) is True
+
+    def test_feasible_without_a_certificate_is_not(self):
+        assert _route_result_is_certified(_Res("feasible", gap_certified=False)) is False
+
+    def test_optimal_without_gap_certified_is_not(self):
+        """``optimal`` is a claim; ``gap_certified`` is the proof. Trust the proof."""
+        assert _route_result_is_certified(_Res("optimal", gap_certified=False)) is False
+
+    def test_infeasible_is_a_certificate(self):
+        assert _route_result_is_certified(_Res("infeasible")) is True
+
+    def test_unbounded_is_a_certificate(self):
+        assert _route_result_is_certified(_Res("unbounded")) is True
+
+    def test_none_is_not(self):
+        assert _route_result_is_certified(None) is False
+
+
+@pytest.mark.unit
+class TestIncumbentSeed:
+    """The fallback starts from the route's answer, so it can only improve."""
+
+    def test_dict_solution_is_flattened_in_model_order(self):
+        m = _load("gbd")
+        n = sum(v.size for v in m._variables)
+        x = {v.name: np.zeros(v.size) for v in m._variables}
+        seed = _route_incumbent_seed(m, _Res("feasible", x=x))
+        assert seed is not None
+        assert seed.shape == (n,)
+
+    def test_no_solution_gives_no_seed(self):
+        assert _route_incumbent_seed(_load("gbd"), _Res("time_limit")) is None
+
+    def test_a_nonfinite_point_is_refused(self):
+        m = _load("gbd")
+        x = {v.name: np.full(v.size, np.nan) for v in m._variables}
+        assert _route_incumbent_seed(m, _Res("feasible", x=x)) is None
+
+
+@pytest.mark.unit
+class TestRouteBudget:
+    """An auto-route is budgeted; an explicit choice is not."""
+
+    @staticmethod
+    def _capture(monkeypatch):
+        seen = {}
+        import discopt.solvers.mip_nlp as mn
+
+        real = mn.solve_mip_nlp
+
+        def spy(model, **kw):
+            seen["time_limit"] = kw.get("time_limit")
+            return real(model, **kw)
+
+        monkeypatch.setattr(mn, "solve_mip_nlp", spy)
+        return seen
+
+    def test_auto_route_gets_a_fraction_of_the_limit(self, monkeypatch):
+        monkeypatch.setenv(ROUTE_ENV, "1")
+        seen = self._capture(monkeypatch)
+        _load("gbd").solve(time_limit=20.0)
+        assert seen, "solve_mip_nlp was never called -- the router did not fire"
+        assert seen["time_limit"] == pytest.approx(20.0 * _CONVEX_ROUTE_BUDGET_FRACTION)
+
+    def test_explicit_mip_nlp_keeps_the_whole_limit(self, monkeypatch):
+        """The caller chose the algorithm; there is no fallback to reserve for."""
+        monkeypatch.delenv(ROUTE_ENV, raising=False)
+        seen = self._capture(monkeypatch)
+        _load("gbd").solve(solver="mip-nlp", mip_nlp_method="oa", time_limit=20.0)
+        assert seen, "solve_mip_nlp was never called"
+        assert seen["time_limit"] == pytest.approx(20.0)
+
+
+@pytest.mark.slow
+class TestFallbackEndToEnd:
+    """``alan``: the panel's sharpest regression, and the reason for this change.
+
+    Reference optimum 2.925 (``minlplib.solu``). Before the fallback the routed
+    arm returned an uncertified 3.000 after spending the whole budget.
+    """
+
+    def test_alan_recovers_its_certificate_through_the_fallback(self, monkeypatch):
+        monkeypatch.setenv(ROUTE_ENV, "1")
+        result = _load("alan").solve(time_limit=60.0)
+        assert result.gap_certified is True
+        assert result.objective == pytest.approx(2.925, abs=1e-3)
+
+    def test_the_fallback_is_visible_on_the_result(self, monkeypatch):
+        """A fallback solve must not read as one that was never routed."""
+        monkeypatch.setenv(ROUTE_ENV, "1")
+        result = _load("alan").solve(time_limit=60.0)
+        assert result.algorithm_route is not None
+        assert "mip-nlp/oa" in result.algorithm_route
+        assert "fell back" in result.algorithm_route
+
+    def test_route_off_is_untouched(self, monkeypatch):
+        """The default path keeps its own answer and its empty route field."""
+        monkeypatch.delenv(ROUTE_ENV, raising=False)
+        result = _load("alan").solve(time_limit=60.0)
+        assert result.algorithm_route is None
+        assert result.gap_certified is True
+        assert result.objective == pytest.approx(2.925, abs=1e-3)


### PR DESCRIPTION
## The problem this fixes

The §5 graduation panel refused `DISCOPT_CONVEX_MINLP_ROUTE`, and the reason was
not "routing is a bad idea". Three in-repo instances lost their certificate to
the routed path, reproducibly in 3/3 reps:

| instance | route OFF | route ON |
|---|---|---|
| `alan` | `optimal`, obj 2.92500, certified, 21 nodes, 0.18±0.02 s | `feasible`, obj **3.00000**, *uncertified*, 180.07±0.02 s |
| `clay0303hfsg` | `optimal`, certified, 299 nodes, 30.63±0.81 s | `feasible`, uncertified, 136.77±2.47 s |
| `tls2` | `optimal`, certified, 255 nodes, 10.46±0.95 s | `feasible`, uncertified, 1.93±0.12 s |

`alan` is a 9-variable convex MIQP. The route handed it to OA, OA spent the whole
180 s budget, and the caller got an uncertified point that is *worse* than the one
the default path proves optimal in 0.18 s. That is not a tradeoff, and the issue
says so outright: the route "must either certify or fall back to spatial B&B
rather than returning an uncertified worse point."

## What changed

A route is a decision, not a commitment.

**1. The auto-route is budgeted.** It gets `_CONVEX_ROUTE_BUDGET_FRACTION` (0.5)
of the caller's limit, so a failed route leaves a remainder to recover with. An
explicit `solver="mip-nlp"` is the caller's own choice and keeps the whole budget
— there is no fallback to reserve for. Half is the split because the panel's Arm B,
the `syn`/`rsyn` class the route exists for, certifies through OA well inside it:
`syn40m` 59.2 s, `syn20m02m` 23.5 s, `rsyn0805m` 9.8 s, all measured at a 60 s limit.

**2. An uncertified auto-routed result falls back.** `_route_result_is_certified`
is deliberately strict — `gap_certified`, or a terminal infeasible/unbounded
verdict, and nothing else. `optimal` without `gap_certified` is a claim, not a
proof, and does not qualify. On a failure the default path runs with the remaining
budget, against the caller's **original** model rather than its big-M
reformulation, seeded by whatever incumbent the route did find so the fallback can
only improve on it.

**3. The fallback is visible.** It stamps `SolveResult.algorithm_route`, because a
fallback solve that leaves the field empty is indistinguishable from one that was
never routed — the exact invisibility #1059 was filed about.

### Two details worth reviewing

`time_limit` is deliberately **not** reduced for the fallback leg. The default path
measures its elapsed from `_solve_t0`, taken before the route ran, and
`model._solve_deadline` is anchored there too, so the route's wall is already
charged against the caller's budget. Subtracting it a second time double-charges.
This was not reasoned out in advance — the first version did subtract, and on
`alan` at a 60 s limit the fallback saw 30 s elapsed against a 29.9 s limit and
returned `time_limit` after 1 node with no incumbent, reproducing the very failure
being fixed. The comment in the code records that.

The `algorithm_route` note is stamped in the `_stamp_layer_timing` wrapper rather
than threaded through `solve_model`'s ~67 return sites, for the reason that
decorator's own docstring already gives about the timing buckets. The note rides a
list whose depth the wrapper restores in a `finally`, so a raised exception cannot
leak it into the next solve (`Model.solve` runs `solve_model` more than once).

## Verification

**`python/tests/test_1059_route_fallback.py` — 14 tests, all pass.** Three are
end-to-end on `alan`, the panel's sharpest regression: the certificate is
recovered (2.925, `gap_certified=True`), the fallback is visible on
`algorithm_route`, and the flag-off arm is unchanged. The rest are unit-level —
the certified predicate, the incumbent seed, and the budget split (an auto-route
receives `0.5 * T`, an explicit `solver="mip-nlp"` receives `T`, both captured by
spying on the real `solve_mip_nlp` rather than asserted).

All 14 fail on the pre-fix tree, where `_route_result_is_certified` does not
exist. That absence is *asserted* against the baseline tree, not assumed
(CLAUDE.md §8).

**`python/tests/test_1059_convex_minlp_route.py` — 12 pass, unchanged.**

**`pytest -m smoke` — 1061 passed, 7 failed.** The 7 failures are all in
`test_1060_native_single_tree.py` and are **pre-existing and unrelated**: the
compiled `discopt._rust` extension in these worktrees predates #1060's Rust API
and raises `SimplexBackendUnavailable: discopt._rust.solve_milp_lazy_csc_py is
unavailable; build the Rust extension`. Verified by running the same file against
unmodified `main`, which fails identically 7/13. CI builds the extension.

**`pytest -m slow python/tests/test_adversarial_recent_fixes.py` — 19 passed.**

Rust was not touched, so `cargo test` was not run.

## Scope

The route stays **default-OFF** behind `DISCOPT_CONVEX_MINLP_ROUTE`. Nothing on
the default solve path changes. This PR removes the specific defect that blocked
graduation; the corpus Arm A re-run that would actually graduate the flag is not
in it.

Contributes to #1059. Leaves #1059 open.
