### PR TITLE
fix(convex-bb): #1082 a stalled convex node abstains instead of being excluded

### DIFF
--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -412,6 +412,44 @@ _PER_NODE_OBBT_ROUNDS = 3
 _PER_NODE_OBBT_TOPK = 20
 
 
+def _convex_stall_abstain_enabled() -> bool:
+    """Whether a stalled convex node ABSTAINS from its bound instead of
+    decertifying the whole solve (env flag, **default OFF** pending the §5
+    differential panel).
+
+    A convex node NLP that returns ``ITERATION_LIMIT`` is not KKT, so its
+    objective is not a valid lower bound (roadmap P0.3). ``_solve_nlp_bb``
+    handles that by importing the invalid objective anyway and setting
+    ``_gap_certified = False`` for the entire solve. That is sound but far more
+    conservative than it needs to be: ONE stalled node out of hundreds destroys a
+    certificate the rest of the search earned.
+
+    ``solve_model``'s spatial path already does the precise thing, and this
+    brings ``_solve_nlp_bb`` in line with it. The node abstains — it imports
+    ``-inf``, which ``TreeManager::import_results`` floors at the node's
+    *inherited parent bound* (valid: a child box is contained in its parent's)
+    and records as ``bound_trusted=False``. An untrusted node is branched, never
+    fathomed and never promoted to the incumbent, so no unproven subtree is
+    closed and the tree's ``global_lower_bound`` stays valid. Certification is
+    then dropped only in the case that genuinely lacks a proof: an untrusted node
+    fathomed with no branch direction left, which the tree reports as
+    ``bound_unresolved`` (#598/#467).
+
+    Measured entry experiment (tls2, in-repo corpus): seeding the solver with its
+    own proven optimum moved the search onto a node whose NLP stalls, and that
+    single node took the run from ``optimal``/certified/255 nodes to
+    ``feasible``/uncertified/159 nodes. A boosted re-solve does NOT rescue the
+    node (4x ``max_iter`` returns ``ITERATION_LIMIT`` again, objective moving in
+    the 7th digit), so a polish-retry is not the fix — abstention is.
+    """
+    return os.environ.get("DISCOPT_CONVEX_STALL_ABSTAIN", "").strip().lower() in (
+        "1",
+        "true",
+        "yes",
+        "on",
+    )
+
+
 def _obbt_topk_enabled() -> bool:
     """Whether the T2.5 scored top-k OBBT de-gate is on (env flag, default OFF)."""
     return os.environ.get("DISCOPT_OBBT_TOPK", "").strip().lower() in ("1", "true", "yes", "on")
@@ -15163,6 +15201,13 @@ def _solve_nlp_bb(
     # fathomed on non-convergence; otherwise feasibility is genuinely UNKNOWN.
     _unconverged_fathom = False
 
+    # #1059 follow-on: whether a stalled (non-KKT) convex node abstains from its
+    # bound instead of decertifying the whole solve. ``_stall_abstained`` counts
+    # the nodes that actually abstained, so a panel can tell "this arm changed
+    # nothing" from "this arm never fired" (CLAUDE.md §6).
+    _stall_abstain = _convex_stall_abstain_enabled()
+    _stall_abstained = 0
+
     # --- NLP-BB loop ---
     # POUNCE batches node NLPs via solve_nlp_batch (Phase A, discopt#97); it is
     # a true KKT solver, so its converged objective is a reliable lower bound
@@ -15426,7 +15471,17 @@ def _solve_nlp_bb(
             # not a valid lower bound, so decertify the gap rather than trust
             # it — leaving bound/incumbent untouched (roadmap P0.3).
             if _model_is_convex and not bool(np.all(_batch_trusted)):
-                _gap_certified = False
+                if _stall_abstain:
+                    # Abstain instead: import ``-inf`` for the untrusted nodes so
+                    # each one keeps its inherited parent bound (valid) and is
+                    # branched rather than fathomed. Certification is decided at
+                    # result build from the tree's ``bound_unresolved``.
+                    _untrusted = ~np.asarray(_batch_trusted, dtype=bool)
+                    result_lbs = np.asarray(result_lbs, dtype=np.float64)
+                    result_lbs[_untrusted] = -np.inf
+                    _stall_abstained += int(np.count_nonzero(_untrusted))
+                else:
+                    _gap_certified = False
             # Constraint feasibility post-check
             if cl_list:
                 for i in range(n_batch):
@@ -15508,18 +15563,34 @@ def _solve_nlp_bb(
                     # (the serial IPM path polishes; POUNCE does not), so the
                     # objective is not a valid lower bound — decertify the gap
                     # (roadmap P0.3) while still using it as a branching point.
+                    _serial_abstain = False
                     if _model_is_convex and nlp_result.status == SolveStatus.ITERATION_LIMIT:
-                        _gap_certified = False
+                        if _stall_abstain:
+                            _serial_abstain = True
+                        else:
+                            _gap_certified = False
                     # Constraint feasibility check
                     if cl_list and not _check_constraint_feasibility(
                         evaluator, nlp_result.x, cl_list, cu_list
                     ):
-                        nlp_lb = _INFEASIBILITY_SENTINEL
-                        # The solver returned OPTIMAL/ITERATION_LIMIT yet the
-                        # iterate violates constraints — this is non-convergence
-                        # (a stall), not a SolveStatus.INFEASIBLE proof. Fathoming
-                        # it cannot certify global infeasibility.
-                        _unconverged_fathom = True
+                        if _serial_abstain:
+                            # A stalled convex node whose iterate also violates
+                            # constraints proves nothing either way. The legacy
+                            # arm below EXCLUDES it (sentinel), and the tree
+                            # prunes an excluded node without a proof — which is
+                            # precisely why that arm must decertify. Abstaining
+                            # keeps the node instead: it imports at its inherited
+                            # parent bound, stays untrusted, and is branched, so
+                            # the subtree is still searched and nothing unproven
+                            # is closed.
+                            pass
+                        else:
+                            nlp_lb = _INFEASIBILITY_SENTINEL
+                            # The solver returned OPTIMAL/ITERATION_LIMIT yet the
+                            # iterate violates constraints — this is non-convergence
+                            # (a stall), not a SolveStatus.INFEASIBLE proof. Fathoming
+                            # it cannot certify global infeasibility.
+                            _unconverged_fathom = True
                     # For nonconvex: reset non-integer-feasible to -inf
                     elif not _model_is_convex:
                         sol_is_int_feas = True
@@ -15536,6 +15607,12 @@ def _solve_nlp_bb(
                     # Guard: NaN lower bounds corrupt the Rust B&B tree.
                     if not np.isfinite(nlp_lb):
                         nlp_lb = _INFEASIBILITY_SENTINEL
+                    if _serial_abstain:
+                        # Applied AFTER the NaN guard, which would otherwise
+                        # rewrite the abstention's ``-inf`` into the exclusion
+                        # sentinel and undo it.
+                        nlp_lb = -np.inf
+                        _stall_abstained += 1
                     result_lbs[i] = nlp_lb
                     result_sols[i] = nlp_result.x
                     result_feas[i] = False
@@ -16033,6 +16110,24 @@ def _solve_nlp_bb(
 
     stats = tree.stats()
     incumbent = tree.incumbent()
+
+    # #1059 follow-on: an abstaining node kept only its inherited parent bound
+    # and was branched, so the search stayed complete and the tree bound stayed
+    # valid — certification survives. The one case that genuinely proves nothing
+    # is an untrusted node the tree had to fathom with no branch direction left;
+    # it reports that as ``bound_unresolved`` (#598/#467), which is exactly the
+    # gate ``solve_model``'s spatial path already applies. Decertify on that and
+    # on nothing else. The counter makes a no-op arm distinguishable from an arm
+    # that never fired (CLAUDE.md §6).
+    if _stall_abstain and _stall_abstained:
+        logger.info(
+            "Convex stall abstention: %d node(s) fell back to their inherited "
+            "parent bound (DISCOPT_CONVEX_STALL_ABSTAIN); tree bound_unresolved=%s",
+            _stall_abstained,
+            stats.get("bound_unresolved"),
+        )
+    if _stall_abstain and bool(stats.get("bound_unresolved", False)):
+        _gap_certified = False
     # #933: capture the tree-bound taint state NOW, before the exit-status logic
     # below overwrites ``_gap_certified`` on limit exits. "The exit is not
     # certified" (no incumbent at a time/node limit) says nothing about whether

--- a/python/tests/test_1082_convex_stall_abstain.py
+++ b/python/tests/test_1082_convex_stall_abstain.py
@@ -1,0 +1,140 @@
+"""#1082: a stalled convex node must abstain from its bound, not be excluded.
+
+On the convex B&B path a node whose NLP returns ``ITERATION_LIMIT`` with a
+constraint-violating iterate was imported at the ``1e30`` infeasibility
+sentinel -- i.e. **excluded**. The Rust tree prunes an excluded node by
+``node_lb >= incumbent_value`` without any proof, which is exactly why that arm
+also had to decertify the whole solve.
+
+The observable cost is worse than a lost certificate: handing the solver a
+*proven optimal* point makes it stop early. On ``tls2`` (reference optimum 5.3)
+the unseeded solve proves ``optimal`` at 255 nodes, while the same solve seeded
+with its own optimum returns ``feasible`` with a dual bound of 1.03.
+
+``solve_model``'s spatial path already does the precise thing: abstain
+(``nlp_lb = -inf``). ``import_results`` floors an imported bound at the node's
+inherited parent bound -- valid, since a child box is a subset of its parent --
+and marks the node ``bound_trusted=False``, so it is *branched*, never fathomed
+and never promoted to the incumbent. The one case that proves nothing is an
+untrusted node the tree had to fathom with no branch direction left, reported as
+``bound_unresolved`` (#598/#467). ``DISCOPT_CONVEX_STALL_ABSTAIN=1`` adopts that
+rule on the convex path; it is bound-changing, so it is default-OFF pending the
+CLAUDE.md §5 differential panel.
+"""
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+from discopt.mo.utils import _flatten_solution
+from discopt.modeling.core import from_nl
+from discopt.solver import _convex_stall_abstain_enabled, solve_model
+
+NL_DIR = Path(__file__).parent / "data" / "minlplib_nl"
+ABSTAIN_ENV = "DISCOPT_CONVEX_STALL_ABSTAIN"
+
+# minlplib.solu: ``=opt=  tls2  5.3000000000``
+TLS2_OPT = 5.3
+
+
+@pytest.mark.unit
+class TestFlagDefault:
+    """The flag is off unless asked for, and reads the documented spellings."""
+
+    def test_default_off(self, monkeypatch):
+        monkeypatch.delenv(ABSTAIN_ENV, raising=False)
+        assert _convex_stall_abstain_enabled() is False
+
+    def test_empty_value_is_off(self, monkeypatch):
+        monkeypatch.setenv(ABSTAIN_ENV, "")
+        assert _convex_stall_abstain_enabled() is False
+
+    def test_zero_is_off(self, monkeypatch):
+        monkeypatch.setenv(ABSTAIN_ENV, "0")
+        assert _convex_stall_abstain_enabled() is False
+
+    @pytest.mark.parametrize("value", ["1", "true", "TRUE", "yes", "on", " On "])
+    def test_truthy_spellings_are_on(self, monkeypatch, value):
+        monkeypatch.setenv(ABSTAIN_ENV, value)
+        assert _convex_stall_abstain_enabled() is True
+
+
+def _solve_tls2(seed=None, time_limit=180.0):
+    path = NL_DIR / "tls2.nl"
+    assert path.exists(), f"missing corpus instance {path}"
+    model = from_nl(str(path))
+    kwargs = {"time_limit": time_limit}
+    if seed is not None:
+        kwargs["initial_point"] = seed
+    return model, solve_model(model, **kwargs)
+
+
+def _optimal_seed():
+    """A genuinely optimal point for tls2, obtained by solving it."""
+    model, result = _solve_tls2()
+    assert result.status == "optimal", f"unseeded tls2 did not prove optimal: {result.status}"
+    seed = np.asarray(_flatten_solution(model, result.x), dtype=np.float64).reshape(-1)
+    assert seed.size and np.all(np.isfinite(seed)), "seed is not a usable point"
+    return seed
+
+
+@pytest.mark.slow
+@pytest.mark.correctness
+class TestSeededSolveKeepsCertificate:
+    """Seeding an optimal point must not cost the certificate."""
+
+    def test_seeded_solve_certifies_with_abstention(self, monkeypatch):
+        monkeypatch.setenv(ABSTAIN_ENV, "1")
+        seed = _optimal_seed()
+        _, result = _solve_tls2(seed=seed)
+
+        # The point of the fix: the seeded solve still proves optimality.
+        assert result.gap_certified is True, (
+            f"seeded solve lost the certificate: bound={result.bound} "
+            f"obj={result.objective} status={result.status}"
+        )
+        assert result.status == "optimal"
+
+        # Soundness (CLAUDE.md §1): the dual bound never crosses the oracle,
+        # and never exceeds the incumbent it is certifying.
+        assert result.bound <= TLS2_OPT + 1e-6, (
+            f"dual bound {result.bound} exceeds the reference optimum {TLS2_OPT}"
+        )
+        assert result.bound <= result.objective + 1e-6
+        assert abs(result.objective - TLS2_OPT) <= 1e-4 * max(1.0, abs(TLS2_OPT))
+
+    def test_legacy_arm_still_loses_it(self, monkeypatch):
+        """Pins the defect: with the flag off, the same seed strands the bound.
+
+        This is the "fails before, passes after" half. It asserts the *old*
+        behaviour, so if a later change fixes the default path this test fails
+        loudly and the flag can be retired rather than silently kept.
+        """
+        monkeypatch.setenv(ABSTAIN_ENV, "0")
+        seed = _optimal_seed()
+        _, result = _solve_tls2(seed=seed)
+
+        assert result.gap_certified is False, (
+            "the legacy arm now certifies -- #1082 may be fixed on the default "
+            "path; retire DISCOPT_CONVEX_STALL_ABSTAIN instead of keeping it"
+        )
+        # Even uncertified, the reported bound must remain a valid dual bound.
+        assert result.bound <= TLS2_OPT + 1e-6
+
+
+@pytest.mark.slow
+@pytest.mark.correctness
+def test_unseeded_solve_is_unchanged_by_the_flag(monkeypatch):
+    """No node stalls without the seed, so the flag must be inert there."""
+    monkeypatch.setenv(ABSTAIN_ENV, "0")
+    _, off = _solve_tls2()
+    monkeypatch.setenv(ABSTAIN_ENV, "1")
+    _, on = _solve_tls2()
+
+    assert off.status == on.status == "optimal"
+    assert off.gap_certified is on.gap_certified is True
+    # Bound-neutral where the flag does not fire: node count exactly unchanged.
+    assert off.node_count == on.node_count, (
+        f"flag perturbed a solve with no stalled node: {off.node_count} -> {on.node_count}"
+    )
+    assert on.bound == pytest.approx(off.bound, abs=1e-9)


### PR DESCRIPTION
## What this fixes

On the convex B&B path (`_solve_nlp_bb`), a node whose NLP returns
`ITERATION_LIMIT` **and** whose stalled iterate violates constraints was
imported at the `1e30` `_INFEASIBILITY_SENTINEL` — i.e. **excluded**. The Rust
tree prunes an excluded node by `node_lb >= incumbent_value` *without a proof*,
which is exactly why that arm also had to decertify the whole solve.

The observable cost is worse than a lost certificate: **handing the solver a
proven-optimal point makes it stop early**. On `tls2` (`=opt= tls2
5.3000000000`), `solve_model(..., time_limit=180)`:

| arm | status | objective | dual bound | `gap_certified` | nodes | wall |
|---|---|---|---|---|---|---|
| unseeded | `optimal` | 5.2999999999875085 | 5.3 | True | 255 | 10.76 s |
| seeded with its own optimum | `feasible` | 5.299999999987505 | **1.0337579607277** | **False** | 159 | 3.02 s |

That is how it surfaced: the #1059 convex-route fallback (#1081) seeds exactly
such a point, and `tls2` was the one panel regression the fallback did not
recover.

## The fix

`solve_model`'s spatial path already does the precise thing — **abstain**
(`nlp_lb = -np.inf`). The Rust tree is built for it: `import_results` floors an
imported bound at the node's inherited parent bound (valid, since a child box ⊆
its parent) and records `bound_trusted = lower_bound.is_finite() && lower_bound
< SENTINEL_THRESHOLD`. An untrusted node is **branched, never fathomed and
never promoted to the incumbent**, so the subtree stays searched and nothing
unproven is closed. The one case that genuinely proves nothing is an untrusted
node the tree had to fathom with no branch direction left — reported as
`bound_unresolved` (#598/#467), which is the gate the spatial path already
applies.

`DISCOPT_CONVEX_STALL_ABSTAIN=1` adopts that rule on the convex path (both the
batch and serial sites) and moves the decertification onto `bound_unresolved`.
Three details worth review:

* the abstention is applied **after** the NaN guard, which would otherwise
  rewrite the `-inf` back into the exclusion sentinel and silently undo it;
* the constraint-violating case is covered too — that is the case the legacy
  arm *excluded*, and leaving it out made the first version of this change a
  measured no-op;
* `_stall_abstained` counts nodes that actually abstained and is logged, so a
  panel can tell "this arm changed nothing" from "this arm never fired"
  (CLAUDE.md §6 — this counter is what caught the no-op above).

Bound-changing, so per §5 it ships **default-OFF**; the legacy path is intact
and is what runs unless the flag is set.

## Measurement

Thread-pinned (`OMP/RAYON/OPENBLAS/MKL/VECLIB/NUMEXPR=1`), same binary, arms
interleaved:

```
##### ABSTAIN=0
ARM1 nosed  status=optimal  obj=5.2999999999875085 bound=5.3                cert=True  nodes=255 wall=10.76
ARM2 seeded status=feasible obj=5.299999999987505  bound=1.0337579607276999 cert=False nodes=159 wall=3.02
##### ABSTAIN=1
ARM1 nosed  status=optimal  obj=5.2999999999875085 bound=5.3                cert=True  nodes=255 wall=10.75
ARM2 seeded status=optimal  obj=5.299999999987505  bound=5.299999979932781  cert=True  nodes=159 wall=3.04
```

The seeded arm recovers the certificate at the **same** node count, so the seed
becomes the speedup it should always have been (3.0 s certified vs 10.8 s).
`ARM1` is identical across arms — the flag is inert when no node stalls. The
certified bound 5.299999979932781 sits below both the incumbent and the oracle
5.3, so the certificate invariant holds.

**Falsified alternative, recorded per §4:** retrying the stalled NLP with 4×
`max_iter` does *not* converge it (`ITERATION_LIMIT` again, 3.545151251 →
3.545151117), and the batch path already carries a 3× polish retry. The stall is
not a budget problem; abstention is the right answer. This is written into the
`_convex_stall_abstain_enabled` docstring so the next reader does not re-run it.

## Tests

`python/tests/test_1082_convex_stall_abstain.py`:

* unit — the flag defaults OFF, and `""`/`"0"` are OFF while `1/true/yes/on` are ON;
* slow/correctness — seeded `tls2` certifies with the flag ON, with the bound
  asserted against both the incumbent and the `.solu` oracle;
* slow/correctness — the **legacy arm still loses it** with the flag OFF. This
  is the "fails before, passes after" half, and it is written to fail loudly if
  a later change fixes the default path, so the flag gets retired rather than
  silently kept;
* slow/correctness — unseeded `tls2` has *exactly* the same node count and bound
  with the flag ON and OFF (bound-neutral where it does not fire).

## Verification run

* `pytest python/tests/test_1082_convex_stall_abstain.py` — **12 passed** (9 unit, 3 slow).
* `pytest -m smoke python/tests/` — **1061 passed, 7 failed, 1 skipped, 2 xpassed**.
  All 7 failures are in `test_1060_native_single_tree.py` and are a **local
  environment artifact, not this change**: this worktree has no built
  `_rust.abi3.so`, so the editable install supplies one from another worktree
  that predates #1060's `solve_milp_lazy_csc_py`
  (`ImportError: cannot import name 'solve_milp_lazy_csc_py'`). Confirmed
  pre-existing by `git stash` + re-run: the identical 7 fail without this
  change. CI builds its own extension, which is why #1081 was green.
* `pytest -m slow python/tests/test_adversarial_recent_fixes.py` — **19 passed**.
* `ruff check` / `ruff format --check` / `mypy python/discopt/solver.py` — clean.
* No Rust was touched, so `cargo test` was not required.

## Scope

Contributes to #1082. Leaves #1082 open: the flag cannot graduate default-ON
until the corpus-wide §5 differential panel passes both bars (cert-clean **and**
net-positive). That panel is queued with the other batched panel work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017PQaiDVuY5Rs3tga98tnNo
