### PR TITLE
fix(miqp): #1064 bound round-fix-resolve by time, not by attempt count

### DIFF
--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -18930,6 +18930,19 @@ def _pounce_snap_incumbent(
 # coordinate flipped. Anything deeper is a dive, which is a separate mechanism.
 _ROUND_MAX_TRIES = 2
 
+# #1064: fraction of the solve's time limit that round-fix-resolve may spend in
+# total. Each attempt is a POUNCE re-solve whose cost varies by orders of
+# magnitude across instances, so the attempt *count* cap below bounds nothing on
+# its own -- measured on slay05h at T=60 s: 31 attempts, 0 hits, 66.5 s = 98.3%
+# of the wall, turning a certified optimum (1335 nodes, 15.5 s) into a
+# time_limit with no incumbent at all (63 nodes). A first-incumbent heuristic
+# that can consume the whole budget is not a heuristic.
+_ROUND_TIME_FRAC = 0.1
+
+# Backstop on the attempt count, for a family where each rounding is cheap
+# enough that the time budget above would allow an unbounded number of them.
+_ROUND_ATTEMPT_CAP = 64
+
 
 def _round_into_box(vals: np.ndarray, lo: np.ndarray, hi: np.ndarray):
     """Round to the nearest integer that actually lies inside ``[lo, hi]``.
@@ -21107,13 +21120,17 @@ def _solve_miqp_bb(
     # only while the tree has none, and it is capped so a family where every
     # rounding is infeasible cannot eat the search. Both are counted, not
     # assumed: ``_round_attempts`` is what the regression test asserts on.
-    _ROUND_ATTEMPT_CAP = 64
     _round_attempts = 0
+    # The real bound is time, not calls (see _ROUND_TIME_FRAC). Both are
+    # counted, not assumed: the regression test asserts on _round_attempts and
+    # on the seconds actually spent here.
+    _round_budget = _ROUND_TIME_FRAC * float(time_limit)
+    _round_secs = 0.0
 
     def _maybe_inject_snapped(x_row, node_lb_i, node_ub_i):
         # Purification (increment 3): near-integral interior points become
         # exact incumbents via snap-fix-resolve.
-        nonlocal _round_attempts
+        nonlocal _round_attempts, _round_secs
         inc = _pounce_snap_incumbent(
             x_row,
             int_offsets,
@@ -21136,12 +21153,22 @@ def _solve_miqp_bb(
             and _tuning().round_fix_resolve
             and tree.incumbent() is None
             and _round_attempts < _ROUND_ATTEMPT_CAP
+            and _round_secs < _round_budget
         ):
             # The snap path declined, i.e. this point is genuinely fractional.
             # With no incumbent in hand there is no primal bound at all, so a
             # rounded completion is strictly better than nothing — and it can
             # only ever supply an upper bound (see _pounce_round_incumbent).
             _round_attempts += 1
+            # Bound this single attempt by whatever is left of the heuristic's
+            # budget as well as by the solve deadline: _pounce_recover_node_bound
+            # derives its own limit as ``time_limit - (now - t_start)``, so
+            # handing it the global limit lets one attempt run to the deadline.
+            _t_round = time.perf_counter()
+            _round_tl = min(
+                float(time_limit),
+                (_t_round - t_start) + max(0.0, _round_budget - _round_secs),
+            )
             inc = _pounce_round_incumbent(
                 x_row,
                 int_offsets,
@@ -21155,9 +21182,10 @@ def _solve_miqp_bb(
                 _A_eq_m,
                 _b_eq_m,
                 t_start,
-                time_limit,
+                _round_tl,
                 Q=_Q_m,
             )
+            _round_secs += time.perf_counter() - _t_round
             how = "rounded"
         if inc is not None:
             x_inc = np.asarray(inc[1][:n_vars], dtype=np.float64).copy()

--- a/python/tests/test_1064_round_fix_resolve.py
+++ b/python/tests/test_1064_round_fix_resolve.py
@@ -138,3 +138,118 @@ def test_flag_defaults_off_and_is_env_settable(monkeypatch):
     assert SolverTuning().round_fix_resolve is True
     monkeypatch.setenv("DISCOPT_ROUND_FIX_RESOLVE", "0")
     assert SolverTuning().round_fix_resolve is False
+
+
+def _ufl_model(n_i=6, n_j=12):
+    """Uncapacitated-facility-location shape -- the #1064 class.
+
+    Binary ``y_i``, continuous ``x_ij``, VUB links ``x_ij <= y_i``, covering
+    equalities ``sum_i x_ij == 1``, convex quadratic objective. This routes to
+    ``_solve_miqp_bb`` and reaches the round gate, which is what makes the
+    assertions below about the gate meaningful.
+    """
+    from discopt import Model
+
+    m = Model("ufl")
+    y = m.binary("y", shape=(n_i,))
+    x = m.continuous("x", shape=(n_i, n_j), lb=0.0, ub=1.0)
+    rng = np.random.default_rng(0)
+    serve = rng.uniform(1.0, 9.0, size=(n_i, n_j))
+    opens = rng.uniform(5.0, 15.0, size=n_i)
+    for i in range(n_i):
+        for j in range(n_j):
+            m.subject_to(x[i, j] <= y[i])
+    for j in range(n_j):
+        m.subject_to(sum(x[i, j] for i in range(n_i)) == 1)
+    m.minimize(
+        sum(opens[i] * y[i] for i in range(n_i))
+        + sum(serve[i, j] * x[i, j] * x[i, j] for i in range(n_i) for j in range(n_j))
+    )
+    return m
+
+
+_STUB_SLEEP = 0.3
+_STUB_TIME_LIMIT = 10.0
+
+
+def _run_with_declining_stub(monkeypatch, frac):
+    """Solve the UFL fixture with a stub that always declines and costs time.
+
+    Standing in for the expensive ``_pounce_recover_node_bound`` re-solve keeps
+    the bound under test the *budget* rather than POUNCE's convergence.
+    """
+    import time as _time
+
+    seen = {"calls": 0, "limits": []}
+
+    def _stub(*args, **kwargs):
+        seen["calls"] += 1
+        # Signature: (..., t_start, time_limit, Q=None) -- time_limit is arg 13.
+        seen["limits"].append(float(args[12]))
+        _time.sleep(_STUB_SLEEP)
+        return None
+
+    monkeypatch.setattr(S, "_pounce_round_incumbent", _stub)
+    monkeypatch.setattr(S, "_ROUND_TIME_FRAC", frac)
+    monkeypatch.setenv("DISCOPT_ROUND_FIX_RESOLVE", "1")
+
+    t0 = _time.perf_counter()
+    S.solve_model(_ufl_model(), time_limit=_STUB_TIME_LIMIT)
+    seen["wall"] = _time.perf_counter() - t0
+    # The probe must have fired, or every assertion downstream is vacuous.
+    assert seen["calls"] > 0, (
+        "round-fix-resolve never ran: this model no longer reaches the MIQP "
+        "round gate, so the budget is untested -- fix the fixture, not the bound"
+    )
+    return seen
+
+
+def test_round_fix_resolve_is_bounded_by_a_time_budget(monkeypatch):
+    """The heuristic may not spend the solve.
+
+    ``_ROUND_ATTEMPT_CAP`` caps the *number* of attempts, but each attempt is up
+    to two ``_pounce_recover_node_bound`` calls -- a full POUNCE re-solve whose
+    cost varies by orders of magnitude across instances -- so a count cap bounds
+    nothing. Measured on slay05h at T=60 s before this budget existed: 31
+    attempts, 0 hits, 66.5 s = 98.3% of the wall, turning a certified optimum
+    (1335 nodes, 15.5 s) into a time_limit with no incumbent (63 nodes).
+    """
+    budget = S._ROUND_TIME_FRAC * _STUB_TIME_LIMIT
+    seen = _run_with_declining_stub(monkeypatch, S._ROUND_TIME_FRAC)
+
+    assert seen["calls"] < _ROUND_ATTEMPT_CAP_REF
+    spent = seen["calls"] * _STUB_SLEEP
+    assert spent <= budget + _STUB_SLEEP + 0.5, (
+        f"spent {spent:.2f}s of a {budget:.2f}s budget over {seen['calls']} attempts"
+    )
+    # Each attempt is handed the budget's deadline, not the solve's: passing the
+    # global limit lets a single attempt run all the way to the deadline.
+    assert max(seen["limits"]) < _STUB_TIME_LIMIT
+    assert seen["wall"] < _STUB_TIME_LIMIT + 5.0
+
+
+def test_the_time_budget_is_what_bounds_the_spend(monkeypatch):
+    """Neutralising only the budget restores the unbounded behaviour.
+
+    Without this arm the test above would pass on any solve that happens to make
+    few attempts, and would not show that the *budget* is the binding constraint
+    rather than the attempt cap or the search finishing early.
+    """
+    default_frac = S._ROUND_TIME_FRAC
+    budgeted = _run_with_declining_stub(monkeypatch, default_frac)
+    unbudgeted = _run_with_declining_stub(monkeypatch, 1e6)
+
+    assert unbudgeted["calls"] > 2 * budgeted["calls"], (
+        f"budget frac made no difference: {budgeted['calls']} attempts budgeted "
+        f"vs {unbudgeted['calls']} unbudgeted"
+    )
+    # Unbudgeted, the stub alone outruns the solve's own time limit.
+    assert unbudgeted["calls"] * _STUB_SLEEP > _STUB_TIME_LIMIT * default_frac
+
+
+_ROUND_ATTEMPT_CAP_REF = 64
+
+
+def test_attempt_cap_is_still_a_backstop():
+    assert S._ROUND_ATTEMPT_CAP == _ROUND_ATTEMPT_CAP_REF
+    assert 0.0 < S._ROUND_TIME_FRAC < 1.0


### PR DESCRIPTION
## Problem

`_ROUND_ATTEMPT_CAP = 64` caps the *number* of round-fix-resolve attempts, but each
attempt is up to two `_pounce_recover_node_bound` calls -- a full POUNCE re-solve whose
cost varies by orders of magnitude across instances. A count cap on a variable-cost
operation bounds nothing.

Measured on `slay05h` at T=60 s, thread-pinned, interleaved, `DISCOPT_ROUND_FIX_RESOLVE`
ON vs OFF:

| | status | obj | nodes | cert | wall | round calls | round time |
|---|---|---|---|---|---|---|---|
| ON | time_limit | none | 63 | False | 67.6 s | 31 | **66.5 s = 98.3% of wall**, 0 hits |
| OFF | optimal | 22664.678607624723 | 1335 | True | 15.5 s | 0 | — |

The heuristic consumed the entire budget, found nothing (every rounding infeasible), and
overran its own deadline. `slay06h` collapsed the same way, 2407 -> 31 nodes. Those are
exactly the two certification regressions that failed this flag's graduation panel
(259 instances: unsound 0, **cert regressions 2**, incumbents gained 0 / **lost 2**,
bound tighter 5 / looser 17, wall OFF 7556.4 s vs ON 7658.4 s).

## Change

- Bound the heuristic by a fraction of the solve's time limit, `_ROUND_TIME_FRAC = 0.1`,
  accumulated across attempts.
- Hand each attempt the *budget's* deadline rather than the global one.
  `_pounce_recover_node_bound` derives its own limit as `time_limit - (now - t_start)`,
  so passing the global limit let a single attempt run to the deadline.
- Keep `_ROUND_ATTEMPT_CAP` as a backstop for families where each rounding is cheap
  enough that the time budget alone would allow unboundedly many; promote it to module
  scope so it is testable.

After the fix, same instance and conditions:

| | status | obj | nodes | cert | wall | round |
|---|---|---|---|---|---|---|
| ON | optimal | 22664.678607624723 | **1335** | True | 21.8 s | 3 calls, 6.4 s |
| OFF | optimal | 22664.678607624723 | 1335 | True | 15.4 s | — |

ON now returns the OFF arm's exact objective at its exact node count, paying only its
bounded budget.

## Scope

Behaviour changes **only** when `DISCOPT_ROUND_FIX_RESOLVE=1`, which stays default OFF.
This does **not** graduate the flag -- the panel above must be re-run against this fix,
and the mechanism has still never gained an incumbent anywhere in the corpus. Per §5 a
cert-clean but neutral flag stays OFF.

## Verification

- `python/tests/test_1064_round_fix_resolve.py`: **10 passed**. New arms:
  - the budget bounds the spend, and each attempt gets a deadline strictly inside the
    solve's limit;
  - **neutralising only `_ROUND_TIME_FRAC` restores the unbounded behaviour** -- 4
    attempts budgeted vs 47 unbudgeted -- so the budget is demonstrably what binds,
    not the attempt cap or an early finish;
  - the fixture asserts the round gate was actually reached, so the bound cannot be
    tested vacuously.
  The budget test fails on the pre-change tree.
- `pytest -m slow python/tests/test_adversarial_recent_fixes.py`: **19 passed**.
- `pytest -m smoke`: see comment below.
- `ruff` and `mypy` clean. No Rust touched.

Contributes to #1064.
