### PR TITLE
chore(ci): raise the Python floor to 3.12 and pin the typecheck stubs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,17 @@ repos:
         # errors are cross-file, so run on the whole package, not per changed file.
         files: ^python/discopt/
         pass_filenames: false
-        additional_dependencies: [numpy, scipy, jax, jaxlib]
+        # Pinned, not floating. Unpinned stub packages made CI a function of
+        # the upstream release calendar: numpy 2.5 (which needs Python 3.12)
+        # shipped a `type` statement in its stubs, and every PR went red at
+        # `numpy/__init__.pyi:737: Type statement is only supported in Python
+        # 3.12 and greater` without a line of repo code changing. Bump these
+        # deliberately, with the typecheck re-run, rather than by surprise.
+        additional_dependencies:
+          - numpy==2.5.2
+          - scipy==1.18.0
+          - jax==0.11.1
+          - jaxlib==0.11.1
         args: [python/discopt/, --ignore-missing-imports]
   - repo: local
     hooks:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,9 +9,9 @@ license = "EPL-2.0"
 repository = "https://github.com/discopt-org/discopt"
 
 [workspace.dependencies]
-# abi3-py310 builds against CPython's stable ABI, so ONE wheel per platform
+# abi3-py312 builds against CPython's stable ABI, so ONE wheel per platform
 # covers every supported interpreter. The floor must track `requires-python` in
-# pyproject.toml -- if that moves to >=3.11, this becomes abi3-py311.
+# pyproject.toml -- if that moves to >=3.13, this becomes abi3-py313.
 # `.github/scripts/check_wheel_coverage.py` fails the release if the two drift.
-pyo3 = { version = "0.23", features = ["extension-module", "abi3-py310"] }
+pyo3 = { version = "0.23", features = ["extension-module", "abi3-py312"] }
 numpy = "0.23"

--- a/discopt_benchmarks/pyproject.toml
+++ b/discopt_benchmarks/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "discopt-benchmarks"
 version = "0.2.0"
 description = "Testing and benchmarking framework for discopt"
-requires-python = ">=3.10"
+requires-python = ">=3.12"
 dependencies = [
     "numpy>=1.24",
     "pytest>=7.4",
@@ -70,7 +70,7 @@ disallow_untyped_defs = true
 
 [tool.ruff]
 line-length = 100
-target-version = "py310"
+target-version = "py312"
 
 [tool.ruff.lint]
 select = ["E", "F", "W", "I", "N", "UP", "B", "A", "C4", "SIM", "TCH"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "maturin"
 name = "discopt"
 version = "0.8.1.dev0"
 description = "MINLP solver with a Rust core: spatial branch and bound over convex relaxations"
-requires-python = ">=3.10"
+requires-python = ">=3.12"
 authors = [{name = "John Kitchin"}]
 license = {text = "EPL-2.0"}
 readme = "README.md"
@@ -23,8 +23,6 @@ classifiers = [
     "Development Status :: 3 - Alpha",
     "Intended Audience :: Science/Research",
     "License :: OSI Approved :: Eclipse Public License 2.0 (EPL-2.0)",
-    "Programming Language :: Python :: 3.10",
-    "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Rust",
     "Topic :: Scientific/Engineering",
@@ -89,12 +87,6 @@ dev = [
     # (Also in the `gams` extra, for gamsconfig.yaml merging.)
     "pyyaml>=6",
     "pytest-xdist",
-    # `python/tests/_optima.py` -- the reference-optima oracle for every
-    # correctness suite -- needs a TOML parser, and stdlib `tomllib` is 3.11+.
-    # Without this the correctness tier is a *collection error* on the 3.10 floor
-    # that `requires-python` promises, which is how #1055 stayed invisible: no
-    # CI job runs 3.10, so nothing ever tried.
-    "tomli>=2; python_version < '3.11'",
     # Pin the lint/typecheck toolchain to the exact versions in
     # .pre-commit-config.yaml (the single source of truth CI also runs), so a
     # local `pip install -e .[dev]` cannot drift from CI.
@@ -138,14 +130,14 @@ include = [
 
 [tool.ruff]
 line-length = 100
-target-version = "py310"
+target-version = "py312"
 extend-exclude = ["adversary/"]
 
 [tool.ruff.lint]
 select = ["E", "F", "I", "W"]
 
 [tool.mypy]
-python_version = "3.10"
+python_version = "3.12"
 warn_return_any = true
 warn_unused_configs = true
 ignore_missing_imports = true

--- a/python/discopt/estimate.py
+++ b/python/discopt/estimate.py
@@ -363,8 +363,8 @@ def estimate_parameters(
     # Extract estimated parameters
     params = {}
     for name, var in em.unknown_parameters.items():
-        val = result.value(var)
-        params[name] = float(np.asarray(val).flat[0])
+        raw = np.asarray(result.value(var))
+        params[name] = float(raw.flat[0])
 
     # Compute FIM at the solution for covariance estimation. Per-response
     # replication counts come from the observed data so that repeated

--- a/python/discopt/export/nl.py
+++ b/python/discopt/export/nl.py
@@ -26,7 +26,7 @@ from __future__ import annotations
 import io
 import math
 from pathlib import Path
-from typing import Union, cast
+from typing import Any, Union, cast
 
 import numpy as np
 
@@ -130,6 +130,17 @@ _FUNC_OPCODES: dict[str, int] = {
     "tanh": _OP_TANH,
     "abs": _OP_ABS,
 }
+
+
+def _elem(arr: np.ndarray, idx: Any) -> Expression:
+    """Read one element out of an ``object``-dtype array of expressions.
+
+    ``ndarray`` is not generic over its ``object`` payload, so numpy's stubs
+    type every element access as another array. These arrays only ever hold
+    :class:`Expression` nodes; the cast records that once instead of silencing
+    the checker at each of the five call sites.
+    """
+    return cast(Expression, arr[idx])
 
 
 class _NLWriter:
@@ -639,7 +650,7 @@ class _NLWriter:
     def _sum_axis(self, arr: np.ndarray, axis: int | None) -> np.ndarray:
         """Symbolic reduction (``+``) of an object array along ``axis``."""
         if axis is None:
-            return self._obj0(self._sum_terms([arr[idx] for idx in np.ndindex(arr.shape)]))
+            return self._obj0(self._sum_terms([_elem(arr, idx) for idx in np.ndindex(arr.shape)]))
         moved = np.moveaxis(arr, axis, 0)
         out_shape = moved.shape[1:]
         out = np.empty(out_shape, dtype=object)
@@ -685,7 +696,7 @@ class _NLWriter:
             operand = self._scalarize(expr.operand)
             out = np.empty(operand.shape, dtype=object)
             for idx in np.ndindex(operand.shape):
-                out[idx] = UnaryOp(expr.op, operand[idx])
+                out[idx] = UnaryOp(expr.op, _elem(operand, idx))
             return out
 
         if isinstance(expr, BinaryOp):
@@ -694,7 +705,7 @@ class _NLWriter:
             )
             out = np.empty(left.shape, dtype=object)
             for idx in np.ndindex(left.shape):
-                out[idx] = BinaryOp(expr.op, left[idx], right[idx])
+                out[idx] = BinaryOp(expr.op, _elem(left, idx), _elem(right, idx))
             return out
 
         if isinstance(expr, FunctionCall):
@@ -703,7 +714,7 @@ class _NLWriter:
             shape = bargs[0].shape
             out = np.empty(shape, dtype=object)
             for idx in np.ndindex(shape):
-                out[idx] = FunctionCall(expr.func_name, *[b[idx] for b in bargs])
+                out[idx] = FunctionCall(expr.func_name, *[_elem(b, idx) for b in bargs])
             return out
 
         if isinstance(expr, MatMulExpression):
@@ -718,7 +729,7 @@ class _NLWriter:
             shape = bterms[0].shape
             out = np.empty(shape, dtype=object)
             for idx in np.ndindex(shape):
-                out[idx] = self._sum_terms([b[idx] for b in bterms])
+                out[idx] = self._sum_terms([_elem(b, idx) for b in bterms])
             return out
 
         # Opaque scalar leaf (e.g. Parameter): leave intact.

--- a/python/discopt/nn/tree.py
+++ b/python/discopt/nn/tree.py
@@ -55,7 +55,8 @@ class DecisionTree:
     @property
     def leaves(self) -> np.ndarray:
         """Indices of leaf nodes."""
-        return np.where(self.feature == _LEAF_MARKER)[0]
+        idx: np.ndarray = np.where(self.feature == _LEAF_MARKER)[0]
+        return idx
 
     @property
     def n_leaves(self) -> int:

--- a/python/discopt/solvers/direct.py
+++ b/python/discopt/solvers/direct.py
@@ -372,7 +372,7 @@ class _DirectSearch:
         coordinate" without disturbing the unit-cube geometry that makes the
         centre-vertex distance scale-free.
         """
-        x = self.lb + u * self.width
+        x: np.ndarray = self.lb + u * self.width
         if self.integer_mask.any():
             x = x.copy()
             x[self.integer_mask] = np.clip(

--- a/python/discopt/solvers/surrogate.py
+++ b/python/discopt/solvers/surrogate.py
@@ -846,6 +846,8 @@ def _mirror_box(source: Model, target: Model) -> list:
     for v in source._variables:
         lb = np.asarray(v.lb, dtype=np.float64)
         ub = np.asarray(v.ub, dtype=np.float64)
+        lb_arg: float | np.ndarray
+        ub_arg: float | np.ndarray
         if v.shape == ():
             lb_arg, ub_arg = float(lb.reshape(-1)[0]), float(ub.reshape(-1)[0])
         else:


### PR DESCRIPTION
## What broke

CI went red on every PR without a line of repo code changing.

The mypy hook installed its stub dependencies unpinned
(`additional_dependencies: [numpy, scipy, jax, jaxlib]`), so it picked up
numpy 2.5.2 the day it shipped. numpy 2.5 requires Python >= 3.12 and its stubs
use a `type` statement, which mypy rejects when asked to check against an older
target — and `pyproject.toml` set `python_version = "3.10"`:

```
numpy/__init__.pyi:737: error: Type statement is only supported in Python 3.12 and greater  [syntax]
Found 1 error in 1 file (errors prevented further checking)
```

Reproduced in a clean 3.12 venv with numpy 2.5.2 + mypy 2.1.0 — `--python-version 3.10`
exits 2 with exactly that, `--python-version 3.12` does not. Not caused by any
branch; it is repo-wide and blocks every PR.

## Why raise the floor rather than pin numpy back

The 3.10 floor was never real. All 15 `python-version:` entries across
`.github/workflows/` are `"3.12"` — no job has ever executed a test, an import,
or a typecheck on 3.10, which is how #1055 stayed invisible. The alternative
(pinning to genuinely 3.10-compatible stubs: numpy 2.2.6 / scipy 1.15.3 /
jax 0.6.2) was measured and produces **33 errors in 20 files**, so it is not a
drop-in either.

Raising `requires-python` to `>=3.12` makes the declaration match what is
actually tested. `abi3-py310` → `abi3-py312` in `Cargo.toml` moves with it, as
that file's comment and `.github/scripts/check_wheel_coverage.py` both require.
`test_requires_python_floor.py` reads `requires-python` at runtime, so it now
enforces the 3.12 line automatically with no edit.

## Pinning the stubs

The dev extra already pins ruff and mypy to the exact pre-commit versions so a
local install cannot drift from CI; the stub packages were the hole that made CI
a function of the upstream release calendar. Now pinned to `numpy==2.5.2`,
`scipy==1.18.0`, `jax==0.11.1`, `jaxlib==0.11.1`. The next release lands as a
deliberate bump with the typecheck re-run, not as a surprise red.

## The 11 errors the newer target surfaced

Pre-existing, in 5 files; the older stubs were not precise enough to catch them.
Fixed, not silenced:

| file | n | cause |
|---|---|---|
| `export/nl.py` | 5 | numpy 2.5 types element access on an `object`-dtype array as another array, so `operand[idx]` no longer satisfies an `Expression` parameter. One `_elem()` helper records the cast once instead of five `# type: ignore`s. |
| `solvers/surrogate.py` | 2 | `lb_arg`/`ub_arg` inferred `float` from the scalar branch, reassigned an array in the other; annotated the union before the branch. |
| `nn/tree.py`, `solvers/direct.py` | 2 | `no-any-return` on values numpy now types as `Any`; annotated the local. |
| `estimate.py` | 1 | `val` was already bound to a `float64` by the residual loop earlier in the same function; renamed to `raw`. |

## Verification

- `pre-commit clean` then `SKIP=cargo-fmt pre-commit run --all-files` — fresh
  hook env, so the new pins are what actually got installed: ruff / ruff format /
  mypy all **Passed**, rc=0.
- mypy in a clean 3.12 venv: `Success: no issues found in 333 source files`
  (before: 11 errors in 5 files at 3.12; hard stop at 3.10).
- `cargo check -p discopt-python` with `abi3-py312`: clean.
- `test_requires_python_floor.py` + `test_dev_extra_declares_test_deps.py`: 3 passed.
- `pytest -m smoke`: result posted as a comment below.

No solver behavior is touched — only the CI/type surface.
