### PR TITLE
feat(1082): graduate the convex stalled-node abstention to default ON

### DIFF
--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -414,8 +414,9 @@ _PER_NODE_OBBT_TOPK = 20
 
 def _convex_stall_abstain_enabled() -> bool:
     """Whether a stalled convex node ABSTAINS from its bound instead of
-    decertifying the whole solve (env flag, **default OFF** pending the §5
-    differential panel).
+    decertifying the whole solve (``DISCOPT_CONVEX_STALL_ABSTAIN``, **default
+    ON** since the §5 panel recorded below; ``=0`` restores the decertifying
+    behaviour and the legacy path is retained intact).
 
     A convex node NLP that returns ``ITERATION_LIMIT`` is not KKT, so its
     objective is not a valid lower bound (roadmap P0.3). ``_solve_nlp_bb``
@@ -441,8 +442,15 @@ def _convex_stall_abstain_enabled() -> bool:
     ``feasible``/uncertified/159 nodes. A boosted re-solve does NOT rescue the
     node (4x ``max_iter`` returns ``ITERATION_LIMIT`` again, objective moving in
     the 7th digit), so a polish-retry is not the fix — abstention is.
+
+    Graduation evidence (2026-08-19, §5 regime 2, 69 instances x 60 s): unsound=0,
+    cert_regressions=0, bound tighter on 3 and looser on 2, nodes fewer on 2 and
+    more on 3, total wall 1195.1 s vs 1210.6 s OFF — cert-clean AND net-positive.
     """
-    return os.environ.get("DISCOPT_CONVEX_STALL_ABSTAIN", "").strip().lower() in (
+    raw = os.environ.get("DISCOPT_CONVEX_STALL_ABSTAIN", "").strip().lower()
+    if raw == "":
+        return True
+    return raw in (
         "1",
         "true",
         "yes",

--- a/python/tests/test_1082_convex_stall_abstain.py
+++ b/python/tests/test_1082_convex_stall_abstain.py
@@ -39,15 +39,27 @@ TLS2_OPT = 5.3
 
 @pytest.mark.unit
 class TestFlagDefault:
-    """The flag is off unless asked for, and reads the documented spellings."""
+    """The flag is ON since the §5 panel, and reads the documented spellings.
 
-    def test_default_off(self, monkeypatch):
+    The opt-out arms are the load-bearing half now: §5 graduates a flag by
+    flipping the default while keeping the legacy path intact, so a regression
+    that made ``=0`` a no-op would remove the escape hatch the policy requires
+    -- invisibly, since the ON arm would keep passing.
+    """
+
+    def test_default_on(self, monkeypatch):
         monkeypatch.delenv(ABSTAIN_ENV, raising=False)
-        assert _convex_stall_abstain_enabled() is False
+        assert _convex_stall_abstain_enabled() is True
 
-    def test_empty_value_is_off(self, monkeypatch):
+    def test_empty_value_does_not_switch_off_the_graduated_default(self, monkeypatch):
+        """#993's rule: an empty env value must not switch off a graduated default.
+
+        ``os.environ.get(name, "")`` cannot distinguish unset from set-empty, so
+        a graduated flag that treats ``""`` as false silently reverts for anyone
+        whose shell exports the variable empty -- which is how #993 shipped.
+        """
         monkeypatch.setenv(ABSTAIN_ENV, "")
-        assert _convex_stall_abstain_enabled() is False
+        assert _convex_stall_abstain_enabled() is True
 
     def test_zero_is_off(self, monkeypatch):
         monkeypatch.setenv(ABSTAIN_ENV, "0")

--- a/python/tests/test_p03_trust_gate.py
+++ b/python/tests/test_p03_trust_gate.py
@@ -172,20 +172,60 @@ class TestCallerDecertifies:
         assert r.gap_certified is True
         assert abs(r.objective - _OPT) < 1e-3
 
-    def test_batch_untrusted_node_decertifies(self, monkeypatch):
-        """An untrusted batch node decertifies the gap but keeps the answer."""
+    @staticmethod
+    def _untrust_first_batch_node(monkeypatch):
+        """Simulate an unpolishable non-KKT convex node in every batch."""
         orig = S._solve_batch_pounce
 
         def wrap(*a, **k):
             ids, lbs, sols, feas, trusted = orig(*a, **k)
             trusted = np.asarray(trusted).copy()
-            trusted[0] = False  # simulate an unpolishable non-KKT convex node
+            trusted[0] = False
             return ids, lbs, sols, feas, trusted
 
         # POUNCE is the NLP-node batch engine; force batching on this small model.
         monkeypatch.setattr(S, "_POUNCE_BATCH_MIN_VARS", 1)
         monkeypatch.setattr(S, "_solve_batch_pounce", wrap)
+
+    def test_batch_untrusted_node_abstains_and_keeps_a_true_certificate(self, monkeypatch):
+        """An untrusted batch node abstains; the gap stays certified and is TRUE.
+
+        Before #1082 a single untrusted node decertified the whole solve (the
+        behaviour the opt-out test below still pins). Under the graduated
+        ``DISCOPT_CONVEX_STALL_ABSTAIN`` default the node instead imports
+        ``-inf`` floored at its parent's bound. A child's feasible region is a
+        subset of its parent's, so the inherited value is a valid lower bound
+        for that subtree and the global bound stays sound — which is why the
+        solve may legitimately certify.
+
+        This test therefore does not merely flip the old assertion. It checks
+        the certificate is *true*: the reported bound must not cross either the
+        incumbent or the independently known optimum. If abstention ever
+        certified a bound above the optimum, that is a false certificate and
+        these assertions fail rather than being relaxed.
+        """
+        monkeypatch.delenv("DISCOPT_CONVEX_STALL_ABSTAIN", raising=False)
+        self._untrust_first_batch_node(monkeypatch)
         r = _convex_minlp().solve(nlp_solver="pounce", time_limit=60, batch_size=8)
+
+        assert r.gap_certified is True
+        assert abs(r.objective - _OPT) < 1e-2
+        # The certificate invariant, both halves. These are the soundness
+        # assertions; the `gap_certified` check above is only the contract.
+        assert r.bound <= r.objective + 1e-6
+        assert r.bound <= _OPT + 1e-6
+
+    def test_the_opt_out_restores_the_decertifying_behaviour(self, monkeypatch):
+        """`=0` still gives the pre-#1082 contract, exactly as graduated.
+
+        §5 requires a graduated flag to keep its opt-out and its legacy path
+        intact, so the old behaviour stays under test rather than being
+        deleted along with the old default.
+        """
+        monkeypatch.setenv("DISCOPT_CONVEX_STALL_ABSTAIN", "0")
+        self._untrust_first_batch_node(monkeypatch)
+        r = _convex_minlp().solve(nlp_solver="pounce", time_limit=60, batch_size=8)
+
         assert r.gap_certified is False
         assert r.status == "feasible"
         # Bounds were untouched, so the incumbent is still correct.


### PR DESCRIPTION
## What this changes

`DISCOPT_CONVEX_STALL_ABSTAIN` flips from default OFF to default **ON**. The
`=0` opt-out and the legacy decertifying path are retained intact, as CLAUDE.md
§5 requires.

## Why

A convex node NLP that returns `ITERATION_LIMIT` is not KKT, so its objective is
not a valid lower bound. `_solve_nlp_bb` handled that by importing the invalid
objective anyway and setting `_gap_certified = False` for the **entire** solve.
Sound, but far more conservative than it needs to be: one stalled node out of
hundreds destroys a certificate the rest of the search earned. `solve_model`'s
spatial path already does the precise thing; this brings `_solve_nlp_bb` in line.

Abstention imports `-inf`, which `TreeManager::import_results` floors at the
node's inherited parent bound (valid — a child box is contained in its parent's)
and records as `bound_trusted=False`. An untrusted node is branched, never
fathomed and never promoted to the incumbent, so no unproven subtree is closed
and `global_lower_bound` stays valid. Certification is dropped only in the case
that genuinely lacks a proof.

## Graduation panel (CLAUDE.md §5 regime 2)

69 instances × 60 s, ON vs a common OFF baseline re-measured on the same tree:

```
DISCOPT_CONVEX_STALL_ABSTAIN
  compared=69  soundness_screened=66/69
  unsound=0  cert_regressions=0
  bound tighter=3 looser=2
  nodes fewer=2 more=3
  incumbent gained=0 lost=0
  total wall OFF=1210.6s  ON=1195.1s
  cert-clean: YES
  net-positive: YES
  GRADUATE: YES
```

## The empty-environment-value rule (#993)

An empty value now reads as **ON**, not OFF. `os.environ.get(name, "")` cannot
distinguish unset from set-empty, so a graduated flag that treats `""` as false
silently reverts for anyone whose shell exports the variable empty — which is
exactly how #993 shipped. The test that pinned the old `test_empty_value_is_off`
behaviour is rewritten to assert the #993 rule and name it, rather than deleted.

## Verification

```
pytest python/tests/test_1082_convex_stall_abstain.py          -> 9 passed
pytest python/tests/test_1082_convex_stall_abstain.py -m slow  -> 3 passed
```

The pre-existing `test_legacy_arm_still_decertifies` guard still passes on the
`=0` arm, so the legacy behaviour is genuinely still reachable. This change does
**not** fix the underlying node stall on the default path — it stops one stall
from costing the whole certificate.

## Knock-on result for #1059

The graduation panel scored `DISCOPT_CONVEX_MINLP_ROUTE` (#1059) as
`GRADUATE: NO` on a single certification regression, `tls2`. That regression is
this issue's scenario: the route moves the search onto a node whose NLP stalls.
Measured on a quiet machine, four arms, certificate invariant asserted on each
against the `minlplib.solu` oracle (`=opt= tls2 5.3`):

| arm | status | bound | cert | nodes |
|---|---|---|---|---|
| baseline (all OFF) | optimal | 5.3 | True | 255 |
| route only | feasible | 1.034 | **False** | 159 |
| abstain only | optimal | 5.3 | True | 255 |
| **route + abstain** | optimal | 5.3 | **True** | **159** |

So the panel's one blocking regression was an artifact of measuring the route
against an abstain-OFF baseline. With abstain graduated, the shipping
configuration removes it, and the route keeps its node win (255 → 159). #1059
still needs its own re-panel against the new default before its flag can
graduate — this PR does not flip it.

Closes #1082.
