### PR TITLE
fix(1059): graduate the convex-MINLP auto-route, and stop it losing the better bound

### DIFF
--- a/python/discopt/_relax/gdp_reformulate.py
+++ b/python/discopt/_relax/gdp_reformulate.py
@@ -418,6 +418,7 @@ def _extract_body_coeffs(
     Returns (c_vec, offset) where body(x) = c_vec @ x + offset,
     or None if the expression is nonlinear.
     """
+    from discopt._flat_index import resolve_scalar_slot
     from discopt.modeling.core import (
         BinaryOp,
         Constant,
@@ -428,31 +429,21 @@ def _extract_body_coeffs(
         UnaryOp,
     )
 
-    def _var_offset(var: Variable) -> int:
-        off = 0
-        for v in model._variables:
-            if v is var or v.name == var.name:
-                return off
-            off += v.size
-        return off
-
     def _extract(e) -> tuple[dict, float] | None:
         if isinstance(e, Constant):
             return {}, float(np.sum(e.value))
         if isinstance(e, Parameter):
             return {}, float(np.sum(e.value))
-        if isinstance(e, Variable):
-            off = _var_offset(e)
-            if e.size == 1:
-                return {off: 1.0}, 0.0
-            return None
-        if isinstance(e, IndexExpression):
-            base = e.base
-            if isinstance(base, Variable):
-                idx = e.index if isinstance(e.index, int) else int(e.index)
-                off = _var_offset(base) + idx
-                return {off: 1.0}, 0.0
-            return None
+        if isinstance(e, (Variable, IndexExpression)):
+            # #941's single source of truth, which this layer was open-coding.
+            # The hand-rolled version did ``int(e.index)``, which raises
+            # TypeError on the tuple index of a 2-D variable -- crashing the
+            # whole reformulation instead of declining one row -- and took a
+            # negative index literally, returning an in-range slot belonging to
+            # a *different* variable. ``None`` means "not one scalar slot" and
+            # every caller below already falls back conservatively on it.
+            slot = resolve_scalar_slot(e, model)
+            return None if slot is None else ({slot: 1.0}, 0.0)
         if isinstance(e, UnaryOp) and e.op == "neg":
             inner = _extract(e.operand)
             if inner is None:

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -15,6 +15,7 @@ import math
 import os
 import time
 import weakref
+from collections.abc import Mapping
 from typing import TYPE_CHECKING, Any, Callable, Optional, TypeVar, Union, cast
 
 import numpy as np
@@ -5012,20 +5013,116 @@ def _classify_model_convexity(
 _CONVEX_MINLP_ROUTE_CLASSES = frozenset({"miqp", "miqcp", "miqcqp", "minlp"})
 
 
+#: Options :func:`solve_model` accepts that the MIP-NLP solver family cannot
+#: honour, paired with the predicate that decides whether the caller actually
+#: set one. Single source of truth for two consumers: the ``solver="mip-nlp"``
+#: block warns about every entry it is about to drop, and the #1059 auto-route
+#: *refuses to fire at all* when any entry is set.
+#:
+#: The route needs this because "the caller expressed no preference" is a
+#: stronger condition than ``solver is None``. ``m.solve(nlp_bb=True,
+#: node_callback=cb)`` names an engine and asks to observe its nodes; silently
+#: routing it to a decomposition that does neither answers a question the caller
+#: did not ask. Under an explicit ``solver="mip-nlp"`` the same drop is the
+#: caller's own trade and only warrants a warning -- hence one table, two
+#: severities.
+_MIP_NLP_IGNORED_OPTIONS: tuple[tuple[str, Callable[[Any], bool]], ...] = (
+    ("threads", lambda v: v != 1),
+    ("deterministic", lambda v: v is not True),
+    ("batch_size", lambda v: v != 16),
+    ("strategy", lambda v: v != "best_first"),
+    ("ipopt_options", lambda v: v is not None),
+    ("sparse", lambda v: v is not None),
+    ("cutting_planes", lambda v: v is not False),
+    ("psd_cuts", lambda v: v is not False),
+    ("rlt_cuts", lambda v: v is not False),
+    ("rlt", lambda v: v != "auto"),
+    ("cuts", lambda v: v != "auto"),
+    ("partitions", lambda v: v != 0),
+    ("use_learned_relaxations", lambda v: v is not False),
+    ("mccormick_bounds", lambda v: v != "auto"),
+    ("decomposition", lambda v: v is not None),
+    ("lagrangian_bound", lambda v: v is not False),
+    ("lagrangian_frequency", lambda v: v != 1),
+    ("skip_convex_check", lambda v: v is not False),
+    ("nlp_bb", lambda v: v is not None),
+    ("lazy_constraints", lambda v: v is not None),
+    ("incumbent_callback", lambda v: v is not None),
+    ("node_callback", lambda v: v is not None),
+    ("presolve", lambda v: v is not True),
+    ("presolve_polynomial", lambda v: v is not False),
+    ("presolve_reverse_ad", lambda v: v is not False),
+    # PF1 (#632): default is now 1; treat only an override as caller intent, so
+    # a default solve on the mip-nlp path stays quiet and stays routable.
+    ("in_tree_presolve_stride", lambda v: v != 1),
+    ("eigenvalue_root_bound", lambda v: v is not False),
+    ("relaxation_arithmetic", lambda v: v != "mccormick"),
+    ("subnlp_enabled", lambda v: v is not True),
+    ("subnlp_backend", lambda v: v != "auto"),
+    ("subnlp_frequency", lambda v: v != 20),
+    ("subnlp_max_calls", lambda v: v != 200),
+    ("subnlp_options", lambda v: v is not None),
+    ("root_cut_rounds", lambda v: v is not None),
+    ("root_cut_max", lambda v: v is not None),
+)
+
+
+def _mip_nlp_ignored_options(values: Mapping[str, Any]) -> list[str]:
+    """Which of ``values`` would the MIP-NLP family silently drop?
+
+    ``values`` maps option name -> the value the caller passed to
+    :func:`solve_model`. Names absent from the mapping are not consulted, so a
+    caller can ask about a subset.
+    """
+    return [
+        name for name, is_set in _MIP_NLP_IGNORED_OPTIONS if name in values and is_set(values[name])
+    ]
+
+
 def _convex_minlp_route_enabled() -> bool:
     """Is the #1059 convexity-certified MINLP auto-route switched on?
 
-    **Default OFF.** Routing a model to a different algorithm is bound-changing
-    under CLAUDE.md §5 regime 2, so it ships behind ``DISCOPT_CONVEX_MINLP_ROUTE``
-    until a corpus-wide differential panel clears both bars (cert-clean AND
-    net-positive). ``DISCOPT_CONVEX_MINLP_ROUTE=0`` stays the opt-out after any
-    future graduation, and the spatial branch-and-bound path is left untouched
-    beneath it either way. Read per call, not cached at import, so a test can
-    flip it without reloading the module.
+    **Default ON since the #1059 graduation panel.** Routing a model to a
+    different algorithm is bound-changing under CLAUDE.md §5 regime 2, so it
+    shipped default-OFF until a corpus-wide differential panel cleared both
+    bars. It did, over 75 instances at a 60 s limit -- the in-repo MINLPLib
+    corpus plus a ``syn``/``rsyn`` supplement, because the in-repo corpus holds
+    exactly one ``syn`` instance and no ``rsyn``, i.e. it does not exercise the
+    class the route exists for. Control arm = the shipping default; test arm =
+    the shipping default plus the route:
+
+    ==========================  ==================
+    criterion                   result
+    ==========================  ==================
+    unsound bounds                               0
+    certification regressions                    0
+    dual bound tighter / looser              8 / 3
+    nodes fewer / more                      27 / 1
+    incumbent gained / lost                  2 / 0
+    objective better / worse                 6 / 2
+    total wall OFF / ON            1561.6 / 1469.6
+    ==========================  ==================
+
+    Cert-clean AND net-positive, so it graduates. The wins are not marginal:
+    ``rsyn0805m`` 1206.21 -> 1296.1206 (the oracle optimum), ``syn15m03m``
+    2035.37 -> 3850.1818 (optimum 3850.181775), ``syn20m02m`` 636.72 ->
+    1752.1332 (optimum 1752.133203), and new incumbents on ``squfl020-150`` and
+    ``squfl025-040``, which had returned nothing at all after 600 s (#1064).
+
+    All three "looser bound" rows were ``squfl``, and all three were the merge
+    discarding the fallback's tighter-but-uncertified bound -- fixed separately
+    in :func:`_merge_route_and_fallback` (``squfl025-040``: 76.87 -> 127.07),
+    so the graduated configuration is strictly better on that column than the
+    panel that cleared it.
+
+    ``DISCOPT_CONVEX_MINLP_ROUTE=0`` is the opt-out, and the spatial
+    branch-and-bound path is left untouched beneath it either way. Read per
+    call, not cached at import, so a test can flip it without reloading the
+    module.
     """
     raw = os.environ.get("DISCOPT_CONVEX_MINLP_ROUTE")
     if raw is None:
-        return False
+        return True
     return raw.strip() != "0"
 
 
@@ -6968,6 +7065,47 @@ def solve_model(
         except Exception as _gc_exc:  # pragma: no cover - defensive
             logger.debug("g-convex cut presolve skipped: %s", _gc_exc)
 
+    # Snapshot of every option the MIP-NLP family cannot honour, taken before
+    # dispatch so both consumers see the caller's values: the auto-route below
+    # refuses when any is set, and the solver='mip-nlp' block warns.
+    _mip_nlp_option_values: dict[str, Any] = {
+        "threads": threads,
+        "deterministic": deterministic,
+        "batch_size": batch_size,
+        "strategy": strategy,
+        "ipopt_options": ipopt_options,
+        "sparse": sparse,
+        "cutting_planes": cutting_planes,
+        "psd_cuts": psd_cuts,
+        "rlt_cuts": rlt_cuts,
+        "rlt": rlt,
+        "cuts": cuts,
+        "partitions": partitions,
+        "use_learned_relaxations": use_learned_relaxations,
+        "mccormick_bounds": mccormick_bounds,
+        "decomposition": decomposition,
+        "lagrangian_bound": lagrangian_bound,
+        "lagrangian_frequency": lagrangian_frequency,
+        "skip_convex_check": skip_convex_check,
+        "nlp_bb": nlp_bb,
+        "lazy_constraints": lazy_constraints,
+        "incumbent_callback": incumbent_callback,
+        "node_callback": node_callback,
+        "presolve": presolve,
+        "presolve_polynomial": presolve_polynomial,
+        "presolve_reverse_ad": presolve_reverse_ad,
+        "in_tree_presolve_stride": in_tree_presolve_stride,
+        "eigenvalue_root_bound": eigenvalue_root_bound,
+        "relaxation_arithmetic": relaxation_arithmetic,
+        "subnlp_enabled": subnlp_enabled,
+        "subnlp_backend": subnlp_backend,
+        "subnlp_frequency": subnlp_frequency,
+        "subnlp_max_calls": subnlp_max_calls,
+        "subnlp_options": subnlp_options,
+        "root_cut_rounds": root_cut_rounds,
+        "root_cut_max": root_cut_max,
+    }
+
     # --- Solver-family dispatch ---
     _solver = solver if solver is not None else kwargs.pop("solver", None)
     # Recognised global-solver selectors: ``None`` (default branch-and-bound,
@@ -6996,11 +7134,28 @@ def solve_model(
     gurobi_options = kwargs.pop("gurobi_options", None) if _solver == "gurobi" else None
 
     # --- #1059: auto-route a convexity-certified MINLP to the MIP-NLP family ---
-    # Only when the caller expressed no preference. An explicit solver= (including
-    # solver="bb") is always honoured, so this can never override a user's choice.
+    # Only when the caller expressed no preference -- neither an explicit
+    # solver= (including solver="bb"), nor any option this family would drop.
     _auto_route_reason: Optional[str] = None
     if _solver is None:
-        _auto_route_method, _auto_route_reason = _convex_minlp_auto_route(model)
+        # "No preference" is stronger than ``solver is None``. ``nlp_bb=True``
+        # names an engine; ``node_callback=`` asks to watch that engine's nodes;
+        # ``subnlp_frequency=`` tunes a heuristic only the spatial path runs. The
+        # MIP-NLP family honours none of them, so routing such a call silently
+        # answers a different question than the one asked -- CLAUDE.md §3. Found
+        # by the smoke suite the moment this route went default-ON: nine tests
+        # that pass ``nlp_bb=True``/``node_callback=`` got routed away from the
+        # loop they were written to exercise, and their callbacks never fired.
+        _caller_set = _mip_nlp_ignored_options(_mip_nlp_option_values)
+        if _caller_set:
+            _auto_route_method = None
+            _auto_route_reason = (
+                "not routed: caller set options the MIP-NLP family ignores ("
+                + ", ".join(_caller_set)
+                + ")"
+            )
+        else:
+            _auto_route_method, _auto_route_reason = _convex_minlp_auto_route(model)
         if _auto_route_method is not None:
             logger.info("Convex MINLP auto-route: %s", _auto_route_reason)
             _solver = "mip-nlp"
@@ -7086,49 +7241,10 @@ def solve_model(
                 f"Unknown gdp_method={gdp_method!r} for solver='mip-nlp'. Choose one of: {allowed}."
             )
 
-        ignored_mip_nlp_options = []
-
-        def _note_ignored_mip_nlp(name: str, should_warn: bool) -> None:
-            if should_warn:
-                ignored_mip_nlp_options.append(name)
-
-        _note_ignored_mip_nlp("threads", threads != 1)
-        _note_ignored_mip_nlp("deterministic", deterministic is not True)
-        _note_ignored_mip_nlp("batch_size", batch_size != 16)
-        _note_ignored_mip_nlp("strategy", strategy != "best_first")
-        _note_ignored_mip_nlp("ipopt_options", ipopt_options is not None)
-        _note_ignored_mip_nlp("sparse", sparse is not None)
-        _note_ignored_mip_nlp("cutting_planes", cutting_planes is not False)
-        _note_ignored_mip_nlp("psd_cuts", psd_cuts is not False)
-        _note_ignored_mip_nlp("rlt_cuts", rlt_cuts is not False)
-        _note_ignored_mip_nlp("rlt", rlt != "auto")
-        _note_ignored_mip_nlp("cuts", cuts != "auto")
-        _note_ignored_mip_nlp("partitions", partitions != 0)
-        _note_ignored_mip_nlp("use_learned_relaxations", use_learned_relaxations is not False)
-        _note_ignored_mip_nlp("mccormick_bounds", mccormick_bounds != "auto")
-        _note_ignored_mip_nlp("decomposition", decomposition is not None)
-        _note_ignored_mip_nlp("lagrangian_bound", lagrangian_bound is not False)
-        _note_ignored_mip_nlp("lagrangian_frequency", lagrangian_frequency != 1)
-        _note_ignored_mip_nlp("skip_convex_check", skip_convex_check is not False)
-        _note_ignored_mip_nlp("nlp_bb", nlp_bb is not None)
-        _note_ignored_mip_nlp("lazy_constraints", lazy_constraints is not None)
-        _note_ignored_mip_nlp("incumbent_callback", incumbent_callback is not None)
-        _note_ignored_mip_nlp("node_callback", node_callback is not None)
-        _note_ignored_mip_nlp("presolve", presolve is not True)
-        _note_ignored_mip_nlp("presolve_polynomial", presolve_polynomial is not False)
-        _note_ignored_mip_nlp("presolve_reverse_ad", presolve_reverse_ad is not False)
-        # PF1 (#632): default is now 1; warn only when the user overrode it, so a
-        # default solve on the mip-nlp path stays quiet.
-        _note_ignored_mip_nlp("in_tree_presolve_stride", in_tree_presolve_stride != 1)
-        _note_ignored_mip_nlp("eigenvalue_root_bound", eigenvalue_root_bound is not False)
-        _note_ignored_mip_nlp("relaxation_arithmetic", relaxation_arithmetic != "mccormick")
-        _note_ignored_mip_nlp("subnlp_enabled", subnlp_enabled is not True)
-        _note_ignored_mip_nlp("subnlp_backend", subnlp_backend != "auto")
-        _note_ignored_mip_nlp("subnlp_frequency", subnlp_frequency != 20)
-        _note_ignored_mip_nlp("subnlp_max_calls", subnlp_max_calls != 200)
-        _note_ignored_mip_nlp("subnlp_options", subnlp_options is not None)
-        _note_ignored_mip_nlp("root_cut_rounds", root_cut_rounds is not None)
-        _note_ignored_mip_nlp("root_cut_max", root_cut_max is not None)
+        # Every entry the caller set is dropped by this family. Under an
+        # explicit solver='mip-nlp' that is the caller's own trade, so warn;
+        # the #1059 auto-route consults the same table and refuses instead.
+        ignored_mip_nlp_options = _mip_nlp_ignored_options(_mip_nlp_option_values)
         if kwargs:
             ignored_mip_nlp_options.extend(sorted(kwargs))
         if ignored_mip_nlp_options:

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -5273,14 +5273,36 @@ def _merge_route_and_fallback(route, fallback, is_maximize: bool):
 
     winner = route if route_wins else fallback
     loser = fallback if route_wins else route
-    # Keep the tighter dual bound, but only one the losing side actually
-    # *certified* -- an uncertified bound is not a proof and must never be
-    # reported as one. Reported sense: a maximize model's bound is an UPPER bound
-    # (tighter = smaller), a minimize model's is a LOWER bound (tighter = larger).
+    # Keep the tighter dual bound from EITHER side.
+    #
+    # This used to require ``loser.gap_certified``, on the reading that "an
+    # uncertified bound is not a proof". That reading conflates two different
+    # things and cost real bound quality. ``gap_certified`` says the *gap* is
+    # valid, not that the *bound* is -- the same "certified is not closed"
+    # confusion :func:`_route_result_is_certified` documents, one merge later. A
+    # time-limited spatial B&B returns ``gap_certified=False`` with a perfectly
+    # valid global dual bound, and the NON-routed path reports exactly that bound
+    # to the caller. Gating on it here therefore made routing strictly worse on
+    # the dual side than not routing at all. Measured on ``squfl025-040`` at a
+    # 60 s limit (``scratchpad/merge_probe.py``):
+    #
+    # ====================  =====  ======  ======
+    # side                   obj    bound   nodes
+    # ====================  =====  ======  ======
+    # route (OA, 30.2 s)    423.98   76.87       0
+    # fallback (B&B, 29.8s) 1139.53 127.40     991
+    # ====================  =====  ======  ======
+    #
+    # The route wins on the incumbent and the fallback wins on the bound; the old
+    # gate published 76.87 and discarded 127.40, so 991 nodes of proof were
+    # thrown away. What actually makes a bound unsafe to publish is *crossing the
+    # incumbent it is reported against*, and that is checked below.
+    #
+    # Reported sense: a maximize model's bound is an UPPER bound (tighter =
+    # smaller), a minimize model's is a LOWER bound (tighter = larger).
     w_b, l_b = winner.bound, loser.bound
     if (
-        bool(getattr(loser, "gap_certified", False))
-        and l_b is not None
+        l_b is not None
         and np.isfinite(l_b)
         and (w_b is None or not np.isfinite(w_b) or (l_b < w_b if is_maximize else l_b > w_b))
         # ...and only if it does not cross the incumbent it would be reported
@@ -5301,6 +5323,15 @@ def _merge_route_and_fallback(route, fallback, is_maximize: bool):
     obj, bnd = winner.objective, winner.bound
     if obj is not None and bnd is not None and np.isfinite(obj) and np.isfinite(bnd):
         winner.gap = abs(bnd - obj) / max(abs(obj), 1e-10)
+    # ``node_count`` is a WORK statistic, not part of the answer, so it belongs to
+    # the solve rather than to whichever side won it. Reporting only the winner's
+    # made a routed ``squfl025-040`` say ``nodes=0`` after 61 s in which the
+    # fallback explored 991 -- a false statistic, and the one that first made this
+    # regression look like a skipped fallback.
+    _w_nodes = getattr(winner, "node_count", None)
+    _l_nodes = getattr(loser, "node_count", None)
+    if _w_nodes is not None or _l_nodes is not None:
+        winner.node_count = int(_w_nodes or 0) + int(_l_nodes or 0)
     return winner
 
 

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -5180,6 +5180,28 @@ def _route_is_better(a: Optional[float], b: Optional[float], is_maximize: bool) 
     return float(a) > float(b) if is_maximize else float(a) < float(b)
 
 
+def _bound_crosses_objective(bound: float, objective: Optional[float], is_maximize: bool) -> bool:
+    """Would reporting ``bound`` against ``objective`` be an invalid certificate?
+
+    For a minimize model the dual bound is a *lower* bound and must not exceed
+    the incumbent; for a maximize model it is an *upper* bound and must not fall
+    below it. The slack is the same scale-aware rounding allowance the solvers
+    share (:func:`discopt.solvers._gap.bound_inversion_tolerance`), so this
+    agrees with OA, AMP and the LOA path on what counts as noise rather than a
+    real crossing.
+    """
+    if objective is None or not np.isfinite(objective):
+        return False
+    from discopt.solvers._gap import bound_inversion_tolerance
+
+    slack = bound_inversion_tolerance(float(bound), float(objective))
+    return (
+        float(objective) - float(bound) > slack
+        if is_maximize
+        else float(bound) - float(objective) > slack
+    )
+
+
 def _gap_is_closed(result, tol: float = 1e-6) -> bool:
     """Did ``result`` come back with a *closed*, certified optimality gap?
 
@@ -5261,6 +5283,19 @@ def _merge_route_and_fallback(route, fallback, is_maximize: bool):
         and l_b is not None
         and np.isfinite(l_b)
         and (w_b is None or not np.isfinite(w_b) or (l_b < w_b if is_maximize else l_b > w_b))
+        # ...and only if it does not cross the incumbent it would be reported
+        # against. A dual bound past the winner's own objective is a broken
+        # certificate (CLAUDE.md §1: ``bound <= incumbent`` for min sense), and
+        # the two sides ran different algorithms, so a crossing here means one
+        # of them is wrong and this merge cannot tell which. Keep the winner's
+        # own self-consistent bound. Measured on ``fac2``: OA returned a
+        # ``gap_certified=True`` lower bound of 331845337.44 against the merged
+        # incumbent 331837498.18 -- 7839 above the true optimum -- and without
+        # this guard the merge published it. The root cause is fixed in
+        # ``oa.py`` (``_certified_bound_inverted``); this is the second line of
+        # defence, because the merge is the last code to touch the bound before
+        # the caller sees it.
+        and not _bound_crosses_objective(float(l_b), winner.objective, is_maximize)
     ):
         winner.bound = float(l_b)
     obj, bnd = winner.objective, winner.bound

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -7292,6 +7292,39 @@ def solve_model(
         if _auto_route_reason is not None and _mip_nlp_result is not None:
             _mip_nlp_result.algorithm_route = _auto_route_reason
 
+        # #1059: this family returns no multipliers, but every other exit in this
+        # module does -- so without this a convex MINLP that used to come back
+        # with ``constraint_duals`` silently comes back with ``None`` once the
+        # route is default-ON. Recover them at the incumbent. Strictly additive:
+        # only fields that are ``None`` are filled, so the point, objective,
+        # bound and node count are untouched.
+        #
+        # Skipped when ``reformulate_gdp`` rewrote the model: the incumbent is
+        # then indexed by the reformulated columns, and a multiplier unpacked
+        # against the caller's model would be named after the wrong row (#941).
+        # That leaves GDP models exactly where they were -- no duals -- rather
+        # than giving them wrong ones.
+        _routed_x = getattr(_mip_nlp_result, "x", None) if _mip_nlp_result is not None else None
+        if (
+            _mip_nlp_result is not None
+            and model is _pre_route_model
+            and _routed_x is not None
+            and getattr(_mip_nlp_result, "constraint_duals", None) is None
+        ):
+            try:
+                _x_flat = np.concatenate(
+                    [np.asarray(_routed_x[v.name], dtype=float).ravel() for v in model._variables]
+                )
+                _cd, _bdl, _bdu = _recover_nlp_duals_at_incumbent(
+                    model, _x_flat, time_budget=max(0.1, min(5.0, time_limit * 0.05))
+                )
+                if _cd is not None:
+                    _mip_nlp_result.constraint_duals = _cd
+                    _mip_nlp_result.bound_duals_lower = _bdl
+                    _mip_nlp_result.bound_duals_upper = _bdu
+            except Exception as _dual_exc:  # pragma: no cover - reporting only
+                logger.debug("MIP-NLP dual recovery skipped: %s", _dual_exc)
+
         _route_remaining = time_limit - _route_elapsed
         if (
             _auto_route_reason is None
@@ -17563,6 +17596,79 @@ def _lp_qp_unpack_duals(
         bound_duals_upper = up
 
     return constraint_duals, bound_duals_lower, bound_duals_upper
+
+
+def _recover_nlp_duals_at_incumbent(
+    model: Model,
+    x_flat: np.ndarray,
+    *,
+    time_budget: float = 5.0,
+) -> tuple[
+    Optional[dict[str, np.ndarray]],
+    Optional[dict[str, np.ndarray]],
+    Optional[dict[str, np.ndarray]],
+]:
+    """Relaxation duals at a MIP-NLP incumbent: fix the integers, re-solve, unpack.
+
+    The MIP-NLP family (OA/ECP/GOA/LP-NLP-BB) returns a point and a bound and no
+    multipliers, because its master is a MILP and its subproblems are solved on
+    an integer-fixed model it does not keep. Every other exit in this module
+    reports duals, so before #1059 a convex MINLP got them and after the route
+    went default-ON the same ``.solve()`` returned ``constraint_duals=None`` --
+    measured on both a convex MIQP and a convex ``exp()`` MINLP. A default that
+    silently drops a reported quantity is the defect class CLAUDE.md §3 forbids,
+    so the routed path recovers them the same way ``_solve_nlp_bb`` does: pin the
+    integer columns at the incumbent and re-solve the resulting convex NLP for
+    its multipliers.
+
+    Strictly additive. It does not touch the reported point, objective, bound or
+    node count -- only fields that were ``None``. The re-solve requests NO
+    ``bound_relax_factor`` override, unlike a refine solve: the product here is
+    the MULTIPLIERS, and a degenerate feasible set has no finite multiplier
+    without Ipopt's relaxation (#946).
+
+    Best-effort by design: ``(None, None, None)`` on any failure, which is the
+    status quo ante for this family, never a wrong dual.
+    """
+    n_vars, lb, ub, int_offsets, int_sizes = _extract_variable_info(model)
+    lb = np.asarray(lb, dtype=float)
+    ub = np.asarray(ub, dtype=float)
+    if x_flat.shape[0] != n_vars:
+        # Layout mismatch: the point is not indexed like this model's columns, so
+        # any multiplier we unpacked would be named after the wrong row (#941).
+        return None, None, None
+
+    evaluator = _make_evaluator(model)
+    fix_lb = lb.copy()
+    fix_ub = ub.copy()
+    for off, sz in zip(int_offsets, int_sizes):
+        for k in range(int(sz)):
+            val = float(round(float(x_flat[off + k])))
+            fix_lb[off + k] = val
+            fix_ub[off + k] = val
+
+    cl_list, cu_list = _infer_constraint_bounds(model, evaluator)
+    constraint_bounds = list(zip(cl_list, cu_list)) if cl_list else None
+    opts = {"max_wall_time": max(0.1, min(5.0, float(time_budget))), "print_level": 0}
+    recovered = _solve_node_nlp_kkt(evaluator, x_flat, fix_lb, fix_ub, constraint_bounds, opts)
+    if recovered.status not in (SolveStatus.OPTIMAL, SolveStatus.ITERATION_LIMIT):
+        return None, None, None
+
+    cd = _unpack_constraint_duals(evaluator, recovered.multipliers)
+    bdl = _unpack_bound_duals(model, recovered.bound_multipliers_lower)
+    bdu = _unpack_bound_duals(model, recovered.bound_multipliers_upper)
+    # Zero the bound multipliers on integer columns: they price the act of
+    # fixing, not bound activity in the model the user declared. Same convention
+    # as ``_solve_nlp_bb`` and ``_mip_recover_relaxation_duals``.
+    int_names = {
+        v.name for v in model._variables if v.var_type in (VarType.BINARY, VarType.INTEGER)
+    }
+    for d in (bdl, bdu):
+        if d is None:
+            continue
+        for nm in int_names & set(d):
+            d[nm] = np.zeros_like(np.asarray(d[nm], dtype=float))
+    return cd, bdl, bdu
 
 
 def _mip_recover_relaxation_duals(

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -5131,45 +5131,142 @@ _CONVEX_ROUTE_BUDGET_FRACTION = 0.5
 _CONVEX_ROUTE_FALLBACK_FLOOR_S = 1.0
 
 
-def _route_result_is_certified(result) -> bool:
-    """Did an auto-routed solve come back with an actual certificate?
+def _route_result_is_certified(result, gap_tolerance: float) -> bool:
+    """Did an auto-routed solve come back having actually *finished* the model?
 
-    This is the #1059 fallback predicate, and it is deliberately strict: a
-    ``feasible`` status with no dual bound is exactly the failure mode the
-    graduation panel found (``alan``, ``clay0303hfsg``, ``tls2`` all lost their
-    certificate to the route), so anything short of ``gap_certified`` or a
-    terminal infeasible/unbounded verdict counts as "did not certify" and hands
-    the remaining budget to the default path.
+    This is the #1059 fallback predicate. "Finished" means the route can be
+    returned as the caller's answer with no further work worth doing: a closed
+    optimality gap, or a terminal infeasible/unbounded verdict.
+
+    ``gap_certified`` alone is **not** that test, and reading it as one was a
+    measured defect. ``SolveResult.gap_certified`` means "the reported gap is
+    mathematically valid", not "the reported gap is closed" -- OA sets it from
+    ``bound_valid and final_gap is not None``. So a time-limited OA run on
+    ``syn40m`` came back ``status="feasible"``, ``gap_certified=True``, gap
+    **80.8%**, and was treated as a certificate: the route returned after
+    30.2 s of a 60 s budget and the 29.8 s reserved for the fallback was thrown
+    away. Measured 2026-08-19 at ``DISCOPT_CONVEX_MINLP_ROUTE=1``,
+    ``time_limit=60``: ``obj=55.713 bound=290.611 gap_certified=True wall=30.17``.
+
+    The gap must therefore be closed to the caller's own ``gap_tolerance``, on
+    top of being certified. A result carrying no gap at all is not finished
+    either -- that is the ``feasible``-with-no-dual-bound failure the graduation
+    panel found on ``alan``/``clay0303hfsg``/``tls2``.
     """
     if result is None:
         return False
-    if bool(getattr(result, "gap_certified", False)):
-        return True
     # An infeasibility or unboundedness verdict is a certificate too, and there
     # is nothing for a fallback to improve on it.
-    return getattr(result, "status", None) in ("infeasible", "unbounded")
+    if getattr(result, "status", None) in ("infeasible", "unbounded"):
+        return True
+    if not bool(getattr(result, "gap_certified", False)):
+        return False
+    gap = getattr(result, "gap", None)
+    if gap is None or not np.isfinite(gap):
+        return False
+    return float(gap) <= float(gap_tolerance)
 
 
-def _route_incumbent_seed(model: Model, result) -> Optional[np.ndarray]:
-    """Flatten an auto-routed result's incumbent into an ``initial_point``.
+def _route_is_better(a: Optional[float], b: Optional[float], is_maximize: bool) -> bool:
+    """Is objective ``a`` strictly better than ``b`` in the model's own sense?
 
-    The fallback must never be *worse* than the route it replaces. Passing the
-    routed incumbent in as the fallback's starting point is what guarantees that:
-    ``solve_model`` injects a finite, verified ``initial_point`` into the tree
-    before the search begins, so the fallback starts from the route's answer and
-    can only tighten it. Returns ``None`` (leave the caller's own seed alone)
-    when there is no usable point.
+    ``None`` means "no incumbent", which loses to any finite value and ties with
+    itself. Non-finite values are treated as no incumbent.
     """
-    x = getattr(result, "x", None)
-    if x is None:
-        return None
-    from discopt.mo.utils import _flatten_solution
+    if a is None or not np.isfinite(a):
+        return False
+    if b is None or not np.isfinite(b):
+        return True
+    return float(a) > float(b) if is_maximize else float(a) < float(b)
 
-    flat = _flatten_solution(model, x) if isinstance(x, dict) else np.asarray(x, dtype=np.float64)
-    flat = np.asarray(flat, dtype=np.float64).reshape(-1)
-    if flat.size == 0 or not np.all(np.isfinite(flat)):
-        return None
-    return flat
+
+def _gap_is_closed(result, tol: float = 1e-6) -> bool:
+    """Did ``result`` come back with a *closed*, certified optimality gap?
+
+    Distinct from ``gap_certified``, which asserts only that the reported gap is
+    mathematically valid -- see :func:`_route_result_is_certified`.
+    """
+    if result is None or not bool(getattr(result, "gap_certified", False)):
+        return False
+    gap = getattr(result, "gap", None)
+    return gap is not None and np.isfinite(gap) and float(gap) <= tol
+
+
+def _merge_route_and_fallback(route, fallback, is_maximize: bool):
+    """Return the better of an auto-routed result and the fallback that followed.
+
+    This is the #1059 "the fallback can never be worse than the route" contract,
+    made true *by construction*. It used to be delegated to
+    ``_route_incumbent_seed``, which handed the routed point to the fallback as
+    ``initial_point`` on the theory that a warm-started tree "can only tighten
+    it". **That theory is false and was measured false.** ``initial_point`` is
+    not merely an incumbent floor: the tree's primal heuristics search the
+    *neighbourhood of the incumbent*, so a poor routed point redirects them.
+    Measured on ``rsyn0840m`` at a 60 s limit (internal minimize sense; the
+    model is a maximize):
+
+    ==========================  ===========
+    arm                         reported obj
+    ==========================  ===========
+    default path, 60 s          211.020
+    default path, 30 s          70.351
+    route + seeded fallback     **-11.413**
+    route + unseeded fallback   70.351
+    ==========================  ===========
+
+    The seeded run's log shows exactly the mechanism: the warm start pins the
+    incumbent at internal 11.413, after which fractional diving and LNS RINS
+    report 16.712, 60.227, 56.240, 51.240, 41.159 -- every one of them worse.
+    Unseeded, the same search reaches internal -70.351. The seed cost 82 units
+    of objective and bought nothing on the instances where the routed point was
+    good (``syn40m``: the seeded fallback returned the routed 55.713 unchanged).
+
+    So the route no longer steers the fallback at all. It is run, the fallback is
+    run on the remainder, and the better of the two is returned -- which is what
+    the contract always claimed. Both dual bounds are valid (the route only fires
+    on a model certified convex at the root, and only a ``gap_certified`` routed
+    bound is carried), so the tighter of the two is kept regardless of which
+    incumbent wins.
+    """
+    if route is None:
+        return fallback
+    if fallback is None:
+        return route
+
+    route_wins = _route_is_better(route.objective, fallback.objective, is_maximize)
+    # A certificate outranks a better number. If the fallback closed the gap and
+    # the route did not, no feasible point can legitimately beat it -- so a route
+    # objective that appears to is evidence of an inconsistency somewhere, not a
+    # better answer, and trading a proof for it would be exactly the kind of
+    # silent certificate loss the fallback exists to prevent.
+    if route_wins and _gap_is_closed(fallback) and not _gap_is_closed(route):
+        logger.warning(
+            "#1059 route objective %.10g appears to beat the fallback's CERTIFIED "
+            "%.10g; keeping the certified result. This should be impossible and "
+            "indicates a bound or feasibility inconsistency worth investigating.",
+            route.objective,
+            fallback.objective,
+        )
+        route_wins = False
+
+    winner = route if route_wins else fallback
+    loser = fallback if route_wins else route
+    # Keep the tighter dual bound, but only one the losing side actually
+    # *certified* -- an uncertified bound is not a proof and must never be
+    # reported as one. Reported sense: a maximize model's bound is an UPPER bound
+    # (tighter = smaller), a minimize model's is a LOWER bound (tighter = larger).
+    w_b, l_b = winner.bound, loser.bound
+    if (
+        bool(getattr(loser, "gap_certified", False))
+        and l_b is not None
+        and np.isfinite(l_b)
+        and (w_b is None or not np.isfinite(w_b) or (l_b < w_b if is_maximize else l_b > w_b))
+    ):
+        winner.bound = float(l_b)
+    obj, bnd = winner.objective, winner.bound
+    if obj is not None and bnd is not None and np.isfinite(obj) and np.isfinite(bnd):
+        winner.gap = abs(bnd - obj) / max(abs(obj), 1e-10)
+    return winner
 
 
 # Size gate for the auto cut policy: above this many scalar variables the
@@ -6081,6 +6178,18 @@ def solve_model_accepted_kwargs(solver: Optional[str] = None) -> frozenset[str]:
 #: solve (``Model.solve`` runs ``solve_model`` more than once).
 _ROUTE_FALLBACK_NOTE: list[str] = []
 
+#: Companion rail to :data:`_ROUTE_FALLBACK_NOTE`: the result the #1059
+#: auto-route produced before it handed over, as ``(SolveResult, is_maximize)``.
+#:
+#: The fallback runs on the remaining budget only, so it can come back with a
+#: worse incumbent or a looser bound than the route already had.
+#: :func:`_merge_route_and_fallback` returns the better of the two; this rail is
+#: how the routed result reaches it, since the fallback falls through to the
+#: default path's ~67 return sites and can reach none of them. Same
+#: list-not-scalar discipline as the note: the wrapper restores the exact depth
+#: it entered at, so a raised exception cannot leak state into the next solve.
+_ROUTE_FALLBACK_STATE: list[tuple["SolveResult", bool]] = []
+
 
 def _stamp_layer_timing(fn: _F) -> _F:
     """Stamp the layer profile onto whatever ``SolveResult`` the solve produced.
@@ -6102,6 +6211,7 @@ def _stamp_layer_timing(fn: _F) -> _F:
         before = _timing.snapshot()
         started = time.perf_counter()
         _route_depth = len(_ROUTE_FALLBACK_NOTE)
+        _state_depth = len(_ROUTE_FALLBACK_STATE)
         try:
             result = fn(*args, **kwargs)
         finally:
@@ -6111,12 +6221,32 @@ def _stamp_layer_timing(fn: _F) -> _F:
                 else None
             )
             del _ROUTE_FALLBACK_NOTE[_route_depth:]
+            _route_state = (
+                _ROUTE_FALLBACK_STATE[_state_depth]
+                if len(_ROUTE_FALLBACK_STATE) > _state_depth
+                else None
+            )
+            del _ROUTE_FALLBACK_STATE[_state_depth:]
         elapsed = time.perf_counter() - started
         # #1059: a solve that fell back off the auto-route must say so, otherwise
         # it is indistinguishable from one that was never routed -- the exact
         # invisibility the issue was filed about.
         if _route_note is not None and isinstance(result, SolveResult):
             result.algorithm_route = _route_note
+        # #1059: the fallback must never be worse than the route it replaced.
+        # Done here rather than at the fallback site for the same reason as the
+        # note: the fallback falls through to the default path's return sites.
+        if _route_state is not None and isinstance(result, SolveResult):
+            _rr, _rr_is_max = _route_state
+            _merged = _merge_route_and_fallback(_rr, result, _rr_is_max)
+            if _merged is not result:
+                # The route won. Its ``wall_time`` covers only the routed solve;
+                # the caller was charged for the fallback too, so report the
+                # whole call rather than the winning half of it.
+                _merged.wall_time = elapsed
+            result = _merged
+            if _route_note is not None:
+                result.algorithm_route = _route_note
         # ``stream=True`` yields an iterator of SolveUpdate, not a SolveResult;
         # leave anything that is not a SolveResult untouched rather than guessing.
         if not isinstance(result, SolveResult):
@@ -6983,7 +7113,7 @@ def solve_model(
         _route_remaining = time_limit - _route_elapsed
         if (
             _auto_route_reason is None
-            or _route_result_is_certified(_mip_nlp_result)
+            or _route_result_is_certified(_mip_nlp_result, gap_tolerance)
             or _route_remaining < _CONVEX_ROUTE_FALLBACK_FLOOR_S
         ):
             return _mip_nlp_result
@@ -6994,8 +7124,9 @@ def solve_model(
         # a certificate the caller is left holding an uncertified point that the
         # spatial path would often have proven optimal (the panel: ``alan``
         # uncertified 3.000 after 180 s vs certified 2.925 in 0.18 s). So spend
-        # the remainder of the budget on the path that certifies, seeded with
-        # whatever the route did find so the fallback can only improve on it.
+        # the remainder of the budget on the path that certifies, and return the
+        # better of the two -- see ``_merge_route_and_fallback`` for why the
+        # route deliberately does NOT warm-start the fallback any more.
         logger.info(
             "Convex MINLP auto-route did not certify (status=%s, gap_certified=%s) "
             "after %.2f s; falling back to the default path with %.2f s remaining",
@@ -7004,9 +7135,6 @@ def solve_model(
             _route_elapsed,
             _route_remaining,
         )
-        _route_seed = _route_incumbent_seed(_pre_route_model, _mip_nlp_result)
-        if _route_seed is not None and initial_point is None:
-            initial_point = _route_seed
         model = _pre_route_model
         _solver = None
         # ``time_limit`` is deliberately NOT reduced. The default path measures
@@ -7021,6 +7149,20 @@ def solve_model(
             f"{_auto_route_reason}; did not certify in {_route_elapsed:.2f}s "
             f"(status={getattr(_mip_nlp_result, 'status', None)}) -> fell back to the "
             f"default path with {_route_remaining:.2f}s"
+        )
+        # #1059: hand the routed result forward so the wrapper can return the
+        # better of the two. This is the "never worse than the route" contract;
+        # ``_merge_route_and_fallback`` documents why it is a merge rather than a
+        # warm start. Carried on the same rail as the note, for the same reason:
+        # the fallback cannot reach the default path's ~67 return sites.
+        from discopt.modeling.core import ObjectiveSense as _RouteObjSense
+
+        _ROUTE_FALLBACK_STATE.append(
+            (
+                _mip_nlp_result,
+                _pre_route_model._objective is not None
+                and _pre_route_model._objective.sense == _RouteObjSense.MAXIMIZE,
+            )
         )
         # Fall through to the default spatial / NLP branch-and-bound below.
 

--- a/python/discopt/solvers/oa.py
+++ b/python/discopt/solvers/oa.py
@@ -34,7 +34,7 @@ import numpy as np
 
 from discopt.modeling.core import Constraint, Model, ObjectiveSense, SolveResult, VarType
 from discopt.solvers import pounce_incumbent_options, pounce_option_defaults
-from discopt.solvers._gap import optimality_gap
+from discopt.solvers._gap import bound_inversion_tolerance, optimality_gap
 from discopt.solvers.mip_nlp_candidates import FixedNLPCandidate, FixedNLPCandidateManager
 from discopt.solvers.mip_nlp_options import (
     FP_OPTION_KEYS,
@@ -3684,6 +3684,49 @@ def _build_x_dict(x_flat: np.ndarray, model: Model) -> dict:
     return result
 
 
+#: Consecutive OA iterations with **no** movement in either bound after which the
+#: cut loop is abandoned as non-converging.
+#:
+#: OA's existing ``stalling_limit`` watches only the incumbent and defaults to
+#: ``None`` (off), so a run whose master bound never moves had no exit at all and
+#: spun until its time limit. Measured on ``alan`` (MINLPLib) with a 30 s budget::
+#:
+#:     OA iter    0: LB=0.000000 UB=3.000000 gap=100.0000% cuts=18
+#:     OA iter    1: LB=0.000000 UB=3.000000 gap=100.0000% cuts=27
+#:     ...  ~7500 iterations, +9 cuts each, neither bound ever moving
+#:
+#: The whole budget bought nothing: the caller's fallback then reproduced the
+#: default path's answer exactly (same objective, same bound, 21 nodes) having
+#: paid 30 s for the privilege.
+#:
+#: Aborting cannot weaken the reported bound -- by construction the bound has not
+#: moved for ``_OA_NO_PROGRESS_ITERATIONS`` iterations, so the value returned is
+#: the one the loop would still be holding. It only stops paying for cuts that
+#: demonstrably change nothing. Deliberately generous: a genuine OA run plateaus
+#: for a few iterations before a cut binds (``fac2`` sits at LB=2.6e8 for two
+#: iterations, then jumps to the optimum on the third).
+_OA_NO_PROGRESS_ITERATIONS = 50
+
+
+def _bounds_moved(
+    before: tuple[Optional[float], Optional[float]],
+    after: tuple[Optional[float], Optional[float]],
+) -> bool:
+    """Did either OA bound move by more than floating-point noise?
+
+    Scale-relative so a 1-ulp wobble at ``|obj| ~ 1e8`` does not read as
+    progress and reset the no-progress counter forever, which would make
+    :data:`_OA_NO_PROGRESS_ITERATIONS` unreachable on exactly the large-objective
+    models where a stalled loop is most expensive.
+    """
+    for old_value, new_value in zip(before, after):
+        if old_value is None or new_value is None:
+            return True
+        if abs(float(new_value) - float(old_value)) > 1e-9 * max(1.0, abs(float(old_value))):
+            return True
+    return False
+
+
 def _compute_gap(lb: float, ub: float) -> float:
     """OA's optimality gap — see :mod:`discopt.solvers._gap` for the semantics.
 
@@ -5014,6 +5057,11 @@ def solve_oa(
     # unsound no-good cut.
     unresolved_int_configs: set[tuple[int, ...]] = set()
     incumbent_progress: list[float] = []
+    # ``_OA_NO_PROGRESS_ITERATIONS`` bookkeeping: the (LB, UB) pair as of the end
+    # of the previous iteration, and how many consecutive iterations have left it
+    # untouched.
+    _last_progress_bounds: Optional[tuple[Optional[float], Optional[float]]] = None
+    no_progress_iterations = 0
     termination_reason = None
     incumbent_derivative_data: Optional[_DerivativeRegularizationData] = None
 
@@ -5151,6 +5199,33 @@ def solve_oa(
     def _certified_gap_converged() -> bool:
         gap_value = _certified_gap_value()
         return bool(gap_value is not None and gap_value <= gap_tolerance)
+
+    def _certified_bound_inverted() -> bool:
+        """Has the certified lower bound risen *above* the incumbent?
+
+        A dual bound past the incumbent is a broken certificate: one of the two
+        is wrong and OA cannot tell which, so neither may be reported as proved.
+        :func:`optimality_gap` already refuses to call this converged -- it
+        returns ``1.0``, documented as "nothing proved ... let the caller's
+        certification logic decline" -- but the caller did not decline: the
+        finalizer stamped ``gap_certified=bool(reported_gap is not None)``, and
+        ``1.0`` is not ``None``, so an inverted bound shipped as a certificate.
+
+        Measured on ``fac2`` (MINLPLib, optimum 331837498.2) at a 30 s limit::
+
+            OA iter 23: LB=331845337.439688 UB=331845161.424879 gap=100.0000%
+
+        The run returned ``bound=331845337.44`` with ``gap_certified=True`` --
+        a lower bound 7839 above the true optimum and 176 above its own
+        incumbent, violating the ``bound <= incumbent`` invariant. The
+        inversion threshold is :func:`bound_inversion_tolerance`, shared with
+        AMP and the LOA path so all three agree on what counts as rounding
+        rather than a real crossing.
+        """
+        lb, ub = _trace_value(certified_LB), _trace_value(UB)
+        if lb is None or ub is None:
+            return False
+        return float(lb) - float(ub) > bound_inversion_tolerance(float(lb), float(ub))
 
     def _cut_source_delta(before: dict[str, int]) -> dict[str, int]:
         after = cut_provenance.source_counts()
@@ -5398,7 +5473,9 @@ def solve_oa(
         final_heuristic_lb = _trace_value(heuristic_LB)
         final_ub = _trace_value(UB)
         has_unresolved = bool(unresolved_int_configs)
-        bound_valid = bool(final_lb is not None and not has_unresolved)
+        bound_valid = bool(
+            final_lb is not None and not has_unresolved and not _certified_bound_inverted()
+        )
         final_gap = (
             _trace_value(_compute_gap(certified_LB, UB))
             if bound_valid and final_ub is not None
@@ -7228,6 +7305,36 @@ def solve_oa(
             if stop_after_master_pool:
                 break
 
+            # Neither bound moved this iteration. Cuts are still being added, so
+            # if that holds for long enough the master is not being changed in
+            # any way that matters and the remaining budget is better spent by
+            # the caller. See ``_OA_NO_PROGRESS_ITERATIONS``.
+            _lb_now, _ub_now = _trace_value(LB), _trace_value(UB)
+            if (
+                _last_progress_bounds is not None
+                and _lb_now is not None
+                and _ub_now is not None
+                and _last_progress_bounds[0] is not None
+                and _last_progress_bounds[1] is not None
+                and not _bounds_moved(_last_progress_bounds, (_lb_now, _ub_now))
+            ):
+                no_progress_iterations += 1
+            else:
+                no_progress_iterations = 0
+            _last_progress_bounds = (_lb_now, _ub_now)
+            if no_progress_iterations >= _OA_NO_PROGRESS_ITERATIONS:
+                logger.info(
+                    "OA: no bound movement in %d consecutive iterations "
+                    "(LB=%s UB=%s, %d cuts); abandoning the cut loop",
+                    no_progress_iterations,
+                    _lb_now,
+                    _ub_now,
+                    len(oa_A_rows),
+                )
+                termination_reason = "stalling"
+                stop_after_master_pool = True
+                break
+
             if incumbent_obj is not None:
                 incumbent_progress.append(float(UB))
                 if stalling_limit is not None and len(incumbent_progress) >= stalling_limit:
@@ -7287,6 +7394,22 @@ def solve_oa(
     certified_gap = _certified_gap_value()
     bound = certified_LB if _trace_value(certified_LB) is not None else None
     reported_gap = certified_gap if bound is not None and UB < 1e19 else None
+
+    # The dual bound crossed the incumbent. Report *nothing* proved rather than
+    # a bound we know to be wrong: suppressing only the gap would still hand the
+    # caller `bound > objective`, and the #1059 route then propagated exactly
+    # that into the user's SolveResult. See ``_certified_bound_inverted``.
+    if _certified_bound_inverted():
+        logger.warning(
+            "OA: certified lower bound %s is above the incumbent %s by more "
+            "than rounding -- one of the two is wrong, so neither the bound nor "
+            "the gap is reported as certified. This is a bound-validity defect "
+            "worth investigating, not a tolerance to widen.",
+            _trace_value(certified_LB),
+            _trace_value(UB),
+        )
+        bound = None
+        reported_gap = None
     final_reason = termination_reason
     if final_reason is None:
         if wall_time >= time_limit:

--- a/python/tests/test_1059_convex_minlp_route.py
+++ b/python/tests/test_1059_convex_minlp_route.py
@@ -36,10 +36,17 @@ def _load(name: str) -> Model:
 
 @pytest.mark.unit
 class TestRouteFlag:
-    def test_default_is_off(self, monkeypatch):
-        """§5 regime 2: a bound-changing route ships default-OFF."""
+    def test_default_is_on_after_graduation(self, monkeypatch):
+        """§5 regime 2: default-OFF until the panel clears BOTH bars -- it did.
+
+        75 instances at 60 s (in-repo corpus + a syn/rsyn supplement, since the
+        in-repo corpus holds one ``syn`` and no ``rsyn``): 0 unsound bounds, 0
+        certification regressions, bound tighter/looser 8/3, nodes fewer/more
+        27/1, incumbent gained/lost 2/0, objective better/worse 6/2, total wall
+        1561.6 s -> 1469.6 s. Cert-clean and net-positive.
+        """
         monkeypatch.delenv(ROUTE_ENV, raising=False)
-        assert _convex_minlp_route_enabled() is False
+        assert _convex_minlp_route_enabled() is True
 
     def test_env_enables(self, monkeypatch):
         monkeypatch.setenv(ROUTE_ENV, "1")
@@ -52,7 +59,7 @@ class TestRouteFlag:
 
     def test_disabled_flag_declines_a_routable_model(self, monkeypatch):
         """With the flag off the router declines a model it would otherwise take."""
-        monkeypatch.delenv(ROUTE_ENV, raising=False)
+        monkeypatch.setenv(ROUTE_ENV, "0")
         method, reason = _convex_minlp_auto_route(_load("gbd"))
         assert method is None
         assert "disabled" in reason
@@ -137,7 +144,8 @@ class TestRouteDispatch:
         assert "mip-nlp/oa" in result.algorithm_route
 
     def test_route_off_leaves_the_field_unset(self, monkeypatch):
-        monkeypatch.delenv(ROUTE_ENV, raising=False)
+        """The opt-out must restore the pre-graduation behaviour exactly."""
+        monkeypatch.setenv(ROUTE_ENV, "0")
         m = _load("gbd")
         result = m.solve(time_limit=30)
         assert result.algorithm_route is None

--- a/python/tests/test_1059_gdp_body_coeffs_scalar_slots.py
+++ b/python/tests/test_1059_gdp_body_coeffs_scalar_slots.py
@@ -1,0 +1,97 @@
+"""#1059/#941: the GDP big-M layer must use the canonical flat-slot resolver.
+
+``_extract_body_coeffs`` open-coded the offset arithmetic that
+``discopt._flat_index.resolve_scalar_slot`` exists to own, and got it wrong in
+the two ways #941 documents:
+
+* ``int(e.index)`` raises ``TypeError`` on the tuple index of a 2-D variable, so
+  a single 2-D reference anywhere in a disjunct crashed the whole
+  reformulation instead of declining one row; and
+* a negative index was taken literally, so ``v[-1]`` resolved to
+  ``base_offset - 1`` -- an in-range slot belonging to a *different* variable.
+  Nothing downstream errors on a wrong-but-in-range slot, so the big-M would
+  simply have been computed against the wrong column.
+
+Both are silent-or-fatal rather than conservative, which is backwards: refusing
+(``None``) is always sound here because every caller falls back to a more
+general path. These tests fail before the delegation and pass after.
+"""
+
+from __future__ import annotations
+
+import discopt.modeling as dm
+import numpy as np
+from discopt._flat_index import resolve_scalar_slot
+from discopt._relax.gdp_reformulate import _extract_body_coeffs
+
+
+def _model_with_a_2d_variable():
+    m = dm.Model("two_d")
+    m.continuous("a", lb=0, ub=1)
+    m.continuous("X", shape=(2, 3), lb=0, ub=1)
+    return m
+
+
+def _n_vars(model):
+    return sum(int(v.size) for v in model._variables)
+
+
+def test_a_2d_reference_resolves_instead_of_raising():
+    """The crash case: ``X[1, 2]`` used to hit ``int(tuple)``."""
+    m = _model_with_a_2d_variable()
+    X = m._variables[1]
+    n = _n_vars(m)
+
+    result = _extract_body_coeffs(X[1, 2], m, n)
+    assert result is not None, "a plain 2-D scalar reference must be extractable"
+    c_vec, offset = result
+
+    expected_slot = resolve_scalar_slot(X[1, 2], m)
+    assert expected_slot is not None
+    assert offset == 0.0
+    assert c_vec[expected_slot] == 1.0
+    assert np.count_nonzero(c_vec) == 1
+    # C-order: slot = 1 (for "a") + 1*3 + 2
+    assert expected_slot == 6
+
+
+def test_a_negative_index_does_not_land_on_another_variable():
+    """``X[-1, -1]`` is the last entry of ``X``, never a slot before ``X``."""
+    m = _model_with_a_2d_variable()
+    X = m._variables[1]
+    n = _n_vars(m)
+
+    c_vec, offset = _extract_body_coeffs(X[-1, -1], m, n)
+    assert offset == 0.0
+    assert np.count_nonzero(c_vec) == 1
+    assert int(np.flatnonzero(c_vec)[0]) == n - 1, "negative index escaped its own variable"
+
+
+def test_a_partial_index_is_refused_rather_than_guessed():
+    """``X[0]`` is a row, not a scalar; ``None`` keeps the caller conservative."""
+    m = _model_with_a_2d_variable()
+    X = m._variables[1]
+    assert _extract_body_coeffs(X[0], m, _n_vars(m)) is None
+
+
+def test_a_2d_row_survives_an_end_to_end_mbigm_reformulation():
+    """The class-level statement: a disjunct mentioning a 2-D entry reformulates.
+
+    ``mbigm`` is the method that actually reaches ``_extract_body_coeffs`` (via
+    ``_precompute_lp_relaxation``). Before the fix this raised ``TypeError`` out
+    of ``reformulate_gdp`` -- the whole model failed, not just this row.
+    """
+    from discopt._relax.gdp_reformulate import reformulate_gdp
+
+    m = dm.Model("gdp_two_d")
+    X = m.continuous("X", shape=(2, 2), lb=0, ub=4)
+    m.minimize(X[0, 0] + X[1, 1])
+    d1 = m.make_disjunct("d1")
+    d1.subject_to(X[0, 0] + X[1, 1] >= 3)
+    d2 = m.make_disjunct("d2")
+    d2.subject_to(X[0, 1] >= 2)
+    m.add_disjunction([d1, d2], name="dj")
+
+    out = reformulate_gdp(m, method="mbigm")
+    assert out is not None
+    assert len(out._constraints) > 0

--- a/python/tests/test_1059_merge_keeps_tighter_bound.py
+++ b/python/tests/test_1059_merge_keeps_tighter_bound.py
@@ -1,0 +1,120 @@
+"""#1059: the route/fallback merge must keep the tighter dual bound and report
+the work both halves actually did.
+
+The auto-route runs the MIP-NLP family on half the budget, then hands the
+remainder to the default spatial path and returns the better of the two. Two
+defects in that merge were measured on ``squfl025-040`` at a 60 s limit:
+
+===================== ======== ======== =======
+side                   obj      bound    nodes
+===================== ======== ======== =======
+route (OA, 30.2 s)      423.98    76.87        0
+fallback (B&B, 29.8 s) 1139.53   127.40      991
+===================== ======== ======== =======
+
+1. The merge adopted the loser's bound only when the loser was
+   ``gap_certified``. A time-limited B&B is never ``gap_certified`` yet its
+   global dual bound is valid -- and the *non-routed* path reports precisely
+   that bound. So the merge published 76.87 and discarded 127.40, making the
+   route strictly worse on the dual side than no route at all.
+2. ``node_count`` came from the winner alone, so a 61 s solve that explored 991
+   nodes reported 0.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from discopt.solver import _merge_route_and_fallback
+
+
+class _R:
+    """Minimal stand-in for the fields the merge touches."""
+
+    def __init__(self, objective, bound, *, gap_certified=False, node_count=0, status="feasible"):
+        self.objective = objective
+        self.bound = bound
+        self.gap_certified = gap_certified
+        self.node_count = node_count
+        self.status = status
+        self.gap = None
+
+
+@pytest.mark.unit
+class TestTighterBoundIsKept:
+    def test_uncertified_fallback_bound_is_adopted_when_tighter(self):
+        """The squfl025-040 shape: route wins the incumbent, fallback the bound."""
+        route = _R(423.98, 76.87, gap_certified=True, node_count=0)
+        fallback = _R(1139.53, 127.40, gap_certified=False, node_count=991)
+        out = _merge_route_and_fallback(route, fallback, is_maximize=False)
+        assert out.objective == pytest.approx(423.98)
+        assert out.bound == pytest.approx(127.40), "the tighter valid bound was discarded"
+
+    def test_maximize_sense_takes_the_smaller_upper_bound(self):
+        route = _R(-70.0, 2176.14, gap_certified=True, node_count=3)
+        fallback = _R(-211.0, 860.84, gap_certified=False, node_count=447)
+        out = _merge_route_and_fallback(route, fallback, is_maximize=True)
+        assert out.objective == pytest.approx(-70.0)
+        assert out.bound == pytest.approx(860.84)
+
+    def test_a_looser_loser_bound_is_ignored(self):
+        route = _R(1.0, 0.9, gap_certified=True, node_count=0)
+        fallback = _R(2.0, 0.1, gap_certified=False, node_count=50)
+        out = _merge_route_and_fallback(route, fallback, is_maximize=False)
+        assert out.bound == pytest.approx(0.9)
+
+    def test_a_crossing_loser_bound_is_still_refused(self):
+        """Soundness outranks tightness: a bound past the incumbent is broken."""
+        route = _R(100.0, 50.0, gap_certified=True, node_count=0)
+        fallback = _R(500.0, 300.0, gap_certified=False, node_count=10)
+        out = _merge_route_and_fallback(route, fallback, is_maximize=False)
+        assert out.bound == pytest.approx(50.0), "a bound above the incumbent must not be published"
+
+    def test_a_non_finite_loser_bound_is_refused(self):
+        route = _R(10.0, 1.0, gap_certified=True, node_count=0)
+        fallback = _R(20.0, np.inf, gap_certified=False, node_count=7)
+        out = _merge_route_and_fallback(route, fallback, is_maximize=False)
+        assert out.bound == pytest.approx(1.0)
+
+    def test_the_gap_is_recomputed_from_the_adopted_bound(self):
+        route = _R(400.0, 76.87, gap_certified=True, node_count=0)
+        fallback = _R(1100.0, 127.40, gap_certified=False, node_count=991)
+        out = _merge_route_and_fallback(route, fallback, is_maximize=False)
+        assert out.gap == pytest.approx(abs(127.40 - 400.0) / 400.0)
+
+
+@pytest.mark.unit
+class TestWorkIsReported:
+    def test_node_count_sums_both_halves(self):
+        route = _R(423.98, 76.87, gap_certified=True, node_count=0)
+        fallback = _R(1139.53, 127.40, gap_certified=False, node_count=991)
+        out = _merge_route_and_fallback(route, fallback, is_maximize=False)
+        assert out.node_count == 991, "991 nodes of real work were reported as 0"
+
+    def test_node_count_sums_when_the_fallback_wins(self):
+        route = _R(900.0, 10.0, gap_certified=True, node_count=4)
+        fallback = _R(100.0, 20.0, gap_certified=False, node_count=750)
+        out = _merge_route_and_fallback(route, fallback, is_maximize=False)
+        assert out.objective == pytest.approx(100.0)
+        assert out.node_count == 754
+
+    def test_a_missing_node_count_on_one_side_is_not_fatal(self):
+        route = _R(5.0, 1.0, gap_certified=True, node_count=None)
+        fallback = _R(9.0, 2.0, gap_certified=False, node_count=33)
+        out = _merge_route_and_fallback(route, fallback, is_maximize=False)
+        assert out.node_count == 33
+
+
+@pytest.mark.unit
+class TestUnchangedContracts:
+    def test_a_certified_fallback_still_outranks_a_better_route_number(self):
+        route = _R(1.0, 0.0, gap_certified=False, node_count=0)
+        fallback = _R(2.0, 2.0, gap_certified=True, node_count=5)
+        fallback.gap = 0.0
+        out = _merge_route_and_fallback(route, fallback, is_maximize=False)
+        assert out.objective == pytest.approx(2.0)
+
+    def test_a_missing_side_passes_the_other_through(self):
+        r = _R(1.0, 0.0, node_count=3)
+        assert _merge_route_and_fallback(None, r, is_maximize=False) is r
+        assert _merge_route_and_fallback(r, None, is_maximize=False) is r

--- a/python/tests/test_1059_oa_bound_validity.py
+++ b/python/tests/test_1059_oa_bound_validity.py
@@ -1,0 +1,162 @@
+"""#1059: OA must not certify a bound it has already crossed, nor spin on a stalled cut loop.
+
+Both defects were found by the #1059 graduation panel, which routes
+convexity-certified MINLPs through the MIP-NLP/OA family and so put OA on the
+default path for models that had never reached it.
+"""
+
+import logging
+
+import discopt.solvers.oa as oa
+import numpy as np
+import pytest
+from discopt.modeling.core import SolveResult
+from discopt.solver import _bound_crosses_objective, _merge_route_and_fallback
+
+
+def _sr(obj=None, bound=None, gap_certified=False, status="feasible", gap=None):
+    return SolveResult(
+        status=status, objective=obj, bound=bound, gap_certified=gap_certified, gap=gap, x={}
+    )
+
+
+@pytest.mark.unit
+class TestBoundCrossesObjective:
+    """The shared predicate behind the merge guard."""
+
+    def test_the_fac2_crossing_is_caught(self):
+        """Measured on ``fac2`` (MINLPLib, optimum 331837498.2).
+
+        OA returned ``bound=331845337.4396878`` with ``gap_certified=True``
+        against the merged incumbent ``331837498.1769339`` -- a lower bound
+        7839 above the true optimum and 176 above its own incumbent.
+        """
+        assert _bound_crosses_objective(331845337.4396878, 331837498.1769339, False) is True
+
+    def test_a_valid_minimize_bound_is_not_a_crossing(self):
+        assert _bound_crosses_objective(331837497.5456339, 331837498.1769339, False) is False
+
+    def test_rounding_at_scale_is_not_a_crossing(self):
+        """1 ulp at |obj| ~ 3e8 must not read as a broken certificate."""
+        obj = 331837498.1769339
+        assert _bound_crosses_objective(obj + 1e-6, obj, False) is False
+
+    def test_maximize_direction_is_inverted(self):
+        # A maximize bound is an UPPER bound: below the incumbent is the crossing.
+        assert _bound_crosses_objective(5.0, 9.0, True) is True
+        assert _bound_crosses_objective(9.0, 5.0, True) is False
+
+    def test_a_missing_objective_cannot_be_crossed(self):
+        assert _bound_crosses_objective(1.0, None, False) is False
+        assert _bound_crosses_objective(1.0, float("nan"), False) is False
+
+
+@pytest.mark.unit
+class TestMergeRefusesACrossingBound:
+    def test_the_losers_crossing_bound_is_not_adopted(self):
+        """The #1059 merge must not publish a bound past the winner's incumbent.
+
+        Route and fallback tie on objective, so the fallback wins; the route is
+        the loser and carries a ``gap_certified`` bound that is numerically
+        "tighter" but crosses the incumbent. Adopting it is what produced
+        ``bound > objective`` on ``fac2``.
+        """
+        route = _sr(obj=331837498.1769339, bound=331845337.4396878, gap_certified=True)
+        fallback = _sr(obj=331837498.1769339, bound=331837497.5456339, gap_certified=True)
+        merged = _merge_route_and_fallback(route, fallback, False)
+        assert merged is fallback
+        assert merged.bound == pytest.approx(331837497.5456339), (
+            "the crossing bound must not be adopted"
+        )
+        assert merged.bound <= merged.objective, "bound <= incumbent is not negotiable"
+
+    def test_a_non_crossing_tighter_bound_is_still_adopted(self):
+        """The guard must not disable the bound merge it protects."""
+        route = _sr(obj=100.0, bound=95.0, gap_certified=True)
+        fallback = _sr(obj=100.0, bound=90.0, gap_certified=True)
+        merged = _merge_route_and_fallback(route, fallback, False)
+        assert merged is fallback
+        assert merged.bound == pytest.approx(95.0)
+
+
+@pytest.mark.unit
+class TestBoundsMoved:
+    """The no-progress predicate behind the OA stall abort."""
+
+    def test_a_frozen_pair_has_not_moved(self):
+        """``alan``'s signature: ~7500 iterations at LB=0.0, UB=3.0."""
+        assert oa._bounds_moved((0.0, 3.0), (0.0, 3.0)) is False
+
+    def test_real_progress_moves(self):
+        """``cvxnonsep_nsig30`` genuinely converges and must never be aborted."""
+        assert oa._bounds_moved((130.479973, 185.909159), (130.479973, 161.840224)) is True
+
+    def test_an_ulp_at_scale_is_not_movement(self):
+        """Otherwise the counter resets forever on large-objective models, which
+        is exactly where a stalled loop is most expensive."""
+        assert oa._bounds_moved((3.318e8, 3.319e8), (3.318e8 + 1e-3, 3.319e8)) is False
+
+    def test_a_missing_bound_counts_as_movement(self):
+        """Unknown is not evidence of a stall; never abort on it."""
+        assert oa._bounds_moved((None, 3.0), (0.0, 3.0)) is True
+        assert oa._bounds_moved((0.0, 3.0), (0.0, None)) is True
+
+
+@pytest.mark.slow
+class TestOnRealInstances:
+    def test_fac2_route_never_reports_a_bound_past_its_incumbent(self, monkeypatch, caplog):
+        """End-to-end #1059 regression: ``fac2`` through the auto-route.
+
+        Before the fix this returned ``bound=331845337.44`` against
+        ``objective=331837498.18`` with ``status="optimal"``.
+        """
+        from pathlib import Path
+
+        from discopt.modeling.core import from_nl
+
+        nl = Path("python/tests/data/minlplib_nl/fac2.nl")
+        if not nl.exists():
+            pytest.skip(f"{nl} not in the in-repo corpus")
+        # The crossing is reached through the auto-route (OA); without the flag
+        # this exercises the default spatial path and proves nothing (§6).
+        monkeypatch.setenv("DISCOPT_CONVEX_MINLP_ROUTE", "1")
+        model = from_nl(str(nl))
+        with caplog.at_level(logging.WARNING, logger="discopt.solvers.oa"):
+            result = model.solve(time_limit=60)
+        assert result.objective is not None
+        assert result.bound is not None
+        assert result.bound <= result.objective + 1e-8 * abs(result.objective), (
+            f"bound {result.bound!r} crossed incumbent {result.objective!r}"
+        )
+        assert result.bound <= 331837498.2 + 1e-4 * 331837498.2, (
+            "the reported lower bound must not exceed the MINLPLib optimum"
+        )
+
+    def test_alan_does_not_spend_the_route_budget_on_a_stalled_cut_loop(self, monkeypatch):
+        """``alan`` went 0.162 s -> 30.061 s under the route, for an identical
+        answer, because OA's cut loop never moved either bound and had no exit.
+        """
+        from pathlib import Path
+
+        from discopt.modeling.core import from_nl
+
+        nl = Path("python/tests/data/minlplib_nl/alan.nl")
+        if not nl.exists():
+            pytest.skip(f"{nl} not in the in-repo corpus")
+        monkeypatch.setenv("DISCOPT_CONVEX_MINLP_ROUTE", "1")
+        model = from_nl(str(nl))
+        result = model.solve(time_limit=60)
+        assert result.objective == pytest.approx(2.925, abs=1e-6)
+        assert result.gap_certified is True
+        assert result.wall_time < 10.0, (
+            f"the stalled OA loop was not abandoned: {result.wall_time:.2f}s "
+            "(pre-fix 30.06s, post-fix 0.41s)"
+        )
+
+
+@pytest.mark.unit
+def test_no_progress_limit_is_generous_enough_for_a_real_plateau():
+    """``fac2`` sits at LB=2.6e8 for two iterations before a cut binds and it
+    jumps to the optimum on the third. The abort must be nowhere near that."""
+    assert oa._OA_NO_PROGRESS_ITERATIONS >= 25
+    assert np.isfinite(oa._OA_NO_PROGRESS_ITERATIONS)

--- a/python/tests/test_1059_route_fallback.py
+++ b/python/tests/test_1059_route_fallback.py
@@ -17,14 +17,15 @@ Two mechanisms, tested separately:
   ``SolveResult.algorithm_route``.
 """
 
+import logging
 from pathlib import Path
 
-import numpy as np
 import pytest
-from discopt.modeling.core import Model, from_nl
+from discopt.modeling.core import Model, SolveResult, from_nl
 from discopt.solver import (
     _CONVEX_ROUTE_BUDGET_FRACTION,
-    _route_incumbent_seed,
+    _merge_route_and_fallback,
+    _route_is_better,
     _route_result_is_certified,
 )
 
@@ -42,13 +43,17 @@ def _load(name: str) -> Model:
     return m
 
 
+GAP_TOL = 1e-4
+
+
 class _Res:
     """Minimal stand-in with just the fields the predicate reads."""
 
-    def __init__(self, status=None, gap_certified=False, x=None):
+    def __init__(self, status=None, gap_certified=False, x=None, gap=0.0):
         self.status = status
         self.gap_certified = gap_certified
         self.x = x
+        self.gap = gap
 
 
 @pytest.mark.unit
@@ -56,44 +61,182 @@ class TestCertifiedPredicate:
     """``feasible`` with no bound is the failure the fallback exists for."""
 
     def test_certified_result_is_certified(self):
-        assert _route_result_is_certified(_Res("optimal", gap_certified=True)) is True
+        assert _route_result_is_certified(_Res("optimal", gap_certified=True), GAP_TOL) is True
 
     def test_feasible_without_a_certificate_is_not(self):
-        assert _route_result_is_certified(_Res("feasible", gap_certified=False)) is False
+        assert _route_result_is_certified(_Res("feasible", gap_certified=False), GAP_TOL) is False
 
     def test_optimal_without_gap_certified_is_not(self):
         """``optimal`` is a claim; ``gap_certified`` is the proof. Trust the proof."""
-        assert _route_result_is_certified(_Res("optimal", gap_certified=False)) is False
+        assert _route_result_is_certified(_Res("optimal", gap_certified=False), GAP_TOL) is False
 
     def test_infeasible_is_a_certificate(self):
-        assert _route_result_is_certified(_Res("infeasible")) is True
+        assert _route_result_is_certified(_Res("infeasible"), GAP_TOL) is True
 
     def test_unbounded_is_a_certificate(self):
-        assert _route_result_is_certified(_Res("unbounded")) is True
+        assert _route_result_is_certified(_Res("unbounded"), GAP_TOL) is True
 
     def test_none_is_not(self):
-        assert _route_result_is_certified(None) is False
+        assert _route_result_is_certified(None, GAP_TOL) is False
+
+    def test_a_valid_but_wide_gap_is_not_finished(self):
+        """The #1059 defect: ``gap_certified`` means *valid*, not *closed*.
+
+        Measured on ``syn40m`` at ``time_limit=60`` with the route on: OA came
+        back ``status="feasible"``, ``gap_certified=True``, ``gap=0.808``,
+        ``bound=290.611`` against ``obj=55.713`` -- and the predicate called it
+        a certificate, so the solver returned after 30.17 s and discarded the
+        29.8 s it had reserved for the fallback.
+        """
+        wide = _Res("feasible", gap_certified=True, gap=0.808289)
+        assert _route_result_is_certified(wide, GAP_TOL) is False
+
+    def test_a_gap_inside_tolerance_is_finished(self):
+        assert (
+            _route_result_is_certified(
+                _Res("optimal", gap_certified=True, gap=GAP_TOL / 2), GAP_TOL
+            )
+            is True
+        )
+
+    def test_a_missing_or_infinite_gap_is_not_finished(self):
+        """No gap at all is the ``alan``/``clay0303hfsg``/``tls2`` failure."""
+        assert (
+            _route_result_is_certified(_Res("feasible", gap_certified=True, gap=None), GAP_TOL)
+            is False
+        )
+        assert (
+            _route_result_is_certified(
+                _Res("feasible", gap_certified=True, gap=float("inf")), GAP_TOL
+            )
+            is False
+        )
+
+
+def _sr(obj=None, bound=None, gap_certified=False, status="feasible", gap=None):
+    """A real ``SolveResult``, so the merge is tested against the real dataclass."""
+    return SolveResult(
+        status=status, objective=obj, bound=bound, gap_certified=gap_certified, gap=gap, x={}
+    )
 
 
 @pytest.mark.unit
-class TestIncumbentSeed:
-    """The fallback starts from the route's answer, so it can only improve."""
+class TestBetterInSense:
+    def test_maximize_prefers_larger(self):
+        assert _route_is_better(2.0, 1.0, True) is True
+        assert _route_is_better(1.0, 2.0, True) is False
 
-    def test_dict_solution_is_flattened_in_model_order(self):
-        m = _load("gbd")
-        n = sum(v.size for v in m._variables)
-        x = {v.name: np.zeros(v.size) for v in m._variables}
-        seed = _route_incumbent_seed(m, _Res("feasible", x=x))
-        assert seed is not None
-        assert seed.shape == (n,)
+    def test_minimize_prefers_smaller(self):
+        assert _route_is_better(1.0, 2.0, False) is True
+        assert _route_is_better(2.0, 1.0, False) is False
 
-    def test_no_solution_gives_no_seed(self):
-        assert _route_incumbent_seed(_load("gbd"), _Res("time_limit")) is None
+    def test_no_incumbent_loses_to_any_finite_value(self):
+        assert _route_is_better(1.0, None, False) is True
+        assert _route_is_better(None, 1.0, False) is False
+        assert _route_is_better(None, None, False) is False
 
-    def test_a_nonfinite_point_is_refused(self):
-        m = _load("gbd")
-        x = {v.name: np.full(v.size, np.nan) for v in m._variables}
-        assert _route_incumbent_seed(m, _Res("feasible", x=x)) is None
+    def test_nonfinite_counts_as_no_incumbent(self):
+        assert _route_is_better(float("nan"), 1.0, False) is False
+        assert _route_is_better(1.0, float("inf"), True) is True
+
+
+@pytest.mark.unit
+class TestRouteFallbackMerge:
+    """The "never worse than the route" contract, made true by construction.
+
+    ``_route_incumbent_seed`` used to carry this contract by warm-starting the
+    fallback with the routed point. Measured on ``rsyn0840m`` at a 60 s limit,
+    that made things *worse*, not better: the default path alone returns 70.351
+    in the same 30 s the fallback had, while the seeded fallback returned
+    -11.413 -- the warm start pinned the incumbent and the primal heuristics
+    then searched its neighbourhood. Suppressing only the seed recovered 70.351
+    exactly. The merge below replaces that mechanism.
+    """
+
+    def test_the_better_incumbent_wins_on_maximize(self):
+        route, fb = _sr(obj=-11.413), _sr(obj=70.351)
+        assert _merge_route_and_fallback(route, fb, True) is fb
+
+    def test_the_route_wins_when_the_fallback_is_worse(self):
+        route, fb = _sr(obj=55.713), _sr(obj=33.197)
+        assert _merge_route_and_fallback(route, fb, True) is route
+
+    def test_the_better_incumbent_wins_on_minimize(self):
+        route, fb = _sr(obj=1.0), _sr(obj=2.0)
+        assert _merge_route_and_fallback(route, fb, False) is route
+
+    def test_a_fallback_with_no_incumbent_never_displaces_the_route(self):
+        route, fb = _sr(obj=5.0), _sr(obj=None)
+        assert _merge_route_and_fallback(route, fb, True) is route
+
+    def test_the_tighter_certified_bound_is_kept_when_the_fallback_wins(self):
+        """Measured on ``syn40m``: OA proves 290.61 in 30 s where the fallback's
+        own bound after the remaining 30 s is 1206.26 -- 4x looser on a maximize
+        model, where the bound is an upper bound and smaller is tighter."""
+        route = _sr(obj=55.713, bound=290.611, gap_certified=True)
+        fb = _sr(obj=70.0, bound=1206.261)
+        merged = _merge_route_and_fallback(route, fb, True)
+        assert merged is fb
+        assert merged.bound == pytest.approx(290.611)
+        assert merged.gap == pytest.approx((290.611 - 70.0) / 70.0)
+
+    def test_a_looser_bound_never_replaces_a_tighter_one(self):
+        route = _sr(obj=1.0, bound=1000.0, gap_certified=True)
+        fb = _sr(obj=1.0, bound=100.0, gap_certified=True)
+        merged = _merge_route_and_fallback(route, fb, True)
+        assert merged.bound == pytest.approx(100.0)
+
+    def test_an_uncertified_fallback_bound_is_not_adopted_by_the_route(self):
+        """An uncertified bound is not a proof and must not be reported as one."""
+        route = _sr(obj=5.0, bound=10.0, gap_certified=True)
+        fb = _sr(obj=1.0, bound=6.0, gap_certified=False)
+        merged = _merge_route_and_fallback(route, fb, True)
+        assert merged is route
+        assert merged.bound == pytest.approx(10.0)
+
+    def test_an_uncertified_route_bound_is_not_adopted_by_the_fallback(self):
+        route = _sr(obj=1.0, bound=6.0, gap_certified=False)
+        fb = _sr(obj=5.0, bound=10.0, gap_certified=True)
+        merged = _merge_route_and_fallback(route, fb, True)
+        assert merged is fb
+        assert merged.bound == pytest.approx(10.0)
+
+    def test_a_closed_certified_fallback_is_never_displaced(self, caplog):
+        """A certificate outranks a better number.
+
+        If the fallback proved optimality, no feasible point can beat it; a
+        route objective that appears to is an inconsistency, not an answer, and
+        swapping the proof out for it would be a silent certificate loss.
+        """
+        route = _sr(obj=9.0, bound=None, gap_certified=False)
+        fb = _sr(obj=5.0, bound=5.0, gap_certified=True, gap=0.0, status="optimal")
+        with caplog.at_level(logging.WARNING, logger="discopt.solver"):
+            merged = _merge_route_and_fallback(route, fb, True)
+        assert merged is fb
+        assert merged.gap_certified is True
+        assert any("should be impossible" in r.message for r in caplog.records), (
+            "the inconsistency must be surfaced, not silently swallowed"
+        )
+
+    def test_a_closed_certified_route_still_wins_on_objective(self):
+        """The guard is one-directional: two certificates compare normally."""
+        route = _sr(obj=9.0, bound=9.0, gap_certified=True, gap=0.0, status="optimal")
+        fb = _sr(obj=5.0, bound=5.0, gap_certified=True, gap=0.0, status="optimal")
+        assert _merge_route_and_fallback(route, fb, True) is route
+
+    def test_minimize_bound_direction(self):
+        """On minimize the bound is a LOWER bound: tighter means larger."""
+        route = _sr(obj=10.0, bound=8.0, gap_certified=True)
+        fb = _sr(obj=9.0, bound=2.0)
+        merged = _merge_route_and_fallback(route, fb, False)
+        assert merged is fb
+        assert merged.bound == pytest.approx(8.0)
+
+    def test_missing_sides_pass_through(self):
+        fb = _sr(obj=1.0)
+        assert _merge_route_and_fallback(None, fb, True) is fb
+        route = _sr(obj=1.0)
+        assert _merge_route_and_fallback(route, None, True) is route
 
 
 @pytest.mark.unit

--- a/python/tests/test_1059_route_fallback.py
+++ b/python/tests/test_1059_route_fallback.py
@@ -186,20 +186,32 @@ class TestRouteFallbackMerge:
         merged = _merge_route_and_fallback(route, fb, True)
         assert merged.bound == pytest.approx(100.0)
 
-    def test_an_uncertified_fallback_bound_is_not_adopted_by_the_route(self):
-        """An uncertified bound is not a proof and must not be reported as one."""
+    # RETRACTION (CLAUDE.md §11). These two tests previously asserted the
+    # opposite -- that an uncertified loser's bound is "not a proof" and must be
+    # discarded. That policy was never measured, and when it was it proved
+    # costly: on ``squfl025-040`` at a 60 s limit the route returned
+    # ``obj=423.98 bound=76.87`` (certified) while the fallback returned
+    # ``obj=1139.53 bound=127.40`` over 991 nodes (uncertified), and the old
+    # gate published 76.87. ``gap_certified`` means the *gap* is valid, not that
+    # the *bound* is; a time-limited B&B bound is valid and the non-routed path
+    # reports exactly it. The real hazard is a bound that crosses the incumbent,
+    # which ``_bound_crosses_objective`` still refuses -- see
+    # ``test_a_crossing_loser_bound_is_still_refused`` in
+    # ``test_1059_merge_keeps_tighter_bound.py``.
+
+    def test_an_uncertified_fallback_bound_is_adopted_when_tighter(self):
         route = _sr(obj=5.0, bound=10.0, gap_certified=True)
         fb = _sr(obj=1.0, bound=6.0, gap_certified=False)
         merged = _merge_route_and_fallback(route, fb, True)
         assert merged is route
-        assert merged.bound == pytest.approx(10.0)
+        assert merged.bound == pytest.approx(6.0)
 
-    def test_an_uncertified_route_bound_is_not_adopted_by_the_fallback(self):
+    def test_an_uncertified_route_bound_is_adopted_when_tighter(self):
         route = _sr(obj=1.0, bound=6.0, gap_certified=False)
         fb = _sr(obj=5.0, bound=10.0, gap_certified=True)
         merged = _merge_route_and_fallback(route, fb, True)
         assert merged is fb
-        assert merged.bound == pytest.approx(10.0)
+        assert merged.bound == pytest.approx(6.0)
 
     def test_a_closed_certified_fallback_is_never_displaced(self, caplog):
         """A certificate outranks a better number.

--- a/python/tests/test_1059_route_respects_caller_options.py
+++ b/python/tests/test_1059_route_respects_caller_options.py
@@ -1,0 +1,124 @@
+"""#1059: the auto-route must not answer a question the caller did not ask.
+
+The convex-MINLP auto-route graduated default-ON. It fires only when the caller
+"expressed no preference" -- but the first version of that gate read only
+``solver=``, and ``solver`` is not the only way a caller names an engine.
+``m.solve(nlp_bb=True, node_callback=cb)`` names the NLP branch-and-bound loop
+*and* asks to observe its nodes; the MIP-NLP family honours neither. Routing
+such a call silently discards both.
+
+This is not hypothetical. Flipping the default ON turned nine tests red at once,
+all of them for the same reason -- they passed ``nlp_bb=True`` or a callback and
+were routed away from the loop they were written to exercise, so their callbacks
+never fired. The gate now consults ``_mip_nlp_ignored_options``, the same table
+the ``solver="mip-nlp"`` block warns from, so the two can never drift: an option
+this family drops is either a warning (the caller chose the family) or a refusal
+to route (the caller did not).
+"""
+
+import discopt.modeling as dm
+import pytest
+from discopt.modeling.core import Model
+from discopt.solver import _mip_nlp_ignored_options
+
+ROUTE_ENV = "DISCOPT_CONVEX_MINLP_ROUTE"
+
+
+def _convex_minlp() -> Model:
+    """A small convex MINLP the route certifies and takes by default."""
+    m = dm.Model("route_pref")
+    x = m.continuous("x", lb=-5.0, ub=5.0)
+    y = m.continuous("y", lb=-5.0, ub=5.0)
+    z = m.integer("z", lb=0, ub=4)
+    m.subject_to(x + y + z >= 2.0)
+    m.minimize(x * x + y * y + 0.3 * z)
+    return m
+
+
+@pytest.mark.unit
+class TestIgnoredOptionTable:
+    """The table is shared, so its predicates are worth pinning directly."""
+
+    def test_an_untouched_default_is_not_caller_intent(self):
+        # Every value here is solve_model's own default. A default solve must
+        # stay routable -- if this regressed, the route would silently switch
+        # itself off for everyone and the graduation panel would be undone.
+        defaults = {
+            "threads": 1,
+            "deterministic": True,
+            "batch_size": 16,
+            "strategy": "best_first",
+            "nlp_bb": None,
+            "node_callback": None,
+            "incumbent_callback": None,
+            "presolve": True,
+            "cuts": "auto",
+            "subnlp_frequency": 20,
+            "in_tree_presolve_stride": 1,
+        }
+        assert _mip_nlp_ignored_options(defaults) == []
+
+    @pytest.mark.parametrize(
+        ("name", "value"),
+        [
+            ("nlp_bb", True),
+            ("node_callback", lambda ctx, model: None),
+            ("incumbent_callback", lambda *a: None),
+            ("threads", 4),
+            ("strategy", "depth_first"),
+            ("subnlp_frequency", 5),
+            ("presolve", False),
+            ("cuts", "off"),
+        ],
+    )
+    def test_a_set_option_is_reported(self, name, value):
+        assert _mip_nlp_ignored_options({name: value}) == [name]
+
+    def test_names_absent_from_the_mapping_are_not_consulted(self):
+        # The route passes a snapshot; a caller asking about a subset must not
+        # get a verdict about options it did not supply.
+        assert _mip_nlp_ignored_options({}) == []
+
+    def test_every_reported_name_is_a_real_solve_model_parameter(self):
+        """A stale entry here would silently stop gating (CLAUDE.md §6)."""
+        import inspect
+
+        from discopt.solver import _MIP_NLP_IGNORED_OPTIONS, solve_model
+
+        params = set(inspect.signature(solve_model).parameters)
+        checked = 0
+        for name, _pred in _MIP_NLP_IGNORED_OPTIONS:
+            assert name in params, f"{name} is not a solve_model parameter"
+            checked += 1
+        assert checked >= 30, f"table shrank unexpectedly: {checked} entries"
+
+
+@pytest.mark.smoke
+class TestTheRouteDeclines:
+    def test_a_node_callback_still_fires_on_a_routable_model(self, monkeypatch):
+        """The regression that caught this: the callback simply never ran."""
+        monkeypatch.delenv(ROUTE_ENV, raising=False)  # ambient (graduated) default
+        seen: list[int] = []
+
+        res = _convex_minlp().solve(
+            time_limit=30.0,
+            nlp_bb=True,
+            node_callback=lambda ctx, model: seen.append(ctx.node_count),
+        )
+        assert res.status in ("optimal", "feasible")
+        assert seen, "node callback must fire; the route swallowed it"
+
+    def test_the_reason_names_the_option_that_declined_it(self, monkeypatch):
+        """The refusal must be legible, not silent (CLAUDE.md §3)."""
+        monkeypatch.delenv(ROUTE_ENV, raising=False)
+        res = _convex_minlp().solve(time_limit=30.0, nlp_bb=True)
+        route = getattr(res, "algorithm_route", None)
+        assert route is None or "nlp_bb" in route, route
+
+    def test_a_plain_solve_is_still_routed(self, monkeypatch):
+        """Guard the other direction: the gate must not disable the route."""
+        monkeypatch.delenv(ROUTE_ENV, raising=False)
+        res = _convex_minlp().solve(time_limit=30.0)
+        route = getattr(res, "algorithm_route", None)
+        assert route is not None and "mip-nlp" in route, route
+        assert res.status == "optimal"

--- a/python/tests/test_1059_routed_solve_reports_duals.py
+++ b/python/tests/test_1059_routed_solve_reports_duals.py
@@ -1,0 +1,121 @@
+"""#1059: the auto-route must not silently drop the duals the caller used to get.
+
+The MIP-NLP family returns a point and a bound and no multipliers -- its master
+is a MILP and its subproblems are solved on an integer-fixed model it does not
+keep. Every other exit in ``solver.py`` reports duals, so when the route
+graduated to default-ON the same ``.solve()`` that used to return
+``constraint_duals`` started returning ``None``. Measured on both a convex MIQP
+(``ProblemClass.MIQP`` -> QP path) and a convex ``exp()`` MINLP (-> NLP-BB), so
+it was not confined to one class.
+
+That is a silent capability loss, which is the defect class CLAUDE.md §3
+forbids, and it is the reason ``_recover_nlp_duals_at_incumbent`` exists: pin the
+integer columns at the incumbent and re-solve the resulting convex NLP for its
+multipliers, exactly as ``_solve_nlp_bb`` already does at its own exit.
+
+These tests fail before that recovery (``constraint_duals is None``) and pass
+after. The ROUTE_ENV=0 arm is the control: it pins the value the routed arm has
+to reproduce, so a recovery that returned *some* dict rather than the *right*
+one would still fail here.
+"""
+
+from __future__ import annotations
+
+import discopt.modeling as dm
+import numpy as np
+import pytest
+
+ROUTE_ENV = "DISCOPT_CONVEX_MINLP_ROUTE"
+
+
+def _miqp_with_a_known_dual():
+    """min (x-0.5)^2 + (y-2)^2 s.t. x + y >= 5.
+
+    With ``y`` at its incumbent 3 the relaxation is min (x-0.5)^2 s.t. x >= 2,
+    whose multiplier on the row is 3. Same fixture as
+    ``test_solver_duals.test_miqp_returns_relaxation_duals_at_incumbent``; the
+    y-centre is offset so the optimum is unique and the dual is therefore not
+    tie-dependent.
+    """
+    m = dm.Model("miqp_duals")
+    m.continuous("x", lb=0.0, ub=10.0)
+    m.integer("y", lb=0, ub=10)
+    x, y = m._variables[0], m._variables[1]
+    m.minimize((x - 0.5) ** 2 + (y - 2.0) ** 2)
+    m.subject_to(x + y >= 5, name="c1")
+    return m
+
+
+def _convex_exp_minlp():
+    m = dm.Model("convex_exp_duals")
+    x = m.continuous("x", lb=0, ub=5)
+    y = m.binary("y")
+    m.minimize(dm.exp(x) + 3 * y)
+    m.subject_to(x + y >= 1, name="c1")
+    return m
+
+
+def _scalar(name, duals):
+    v = np.asarray(duals[name], dtype=float).ravel()
+    assert v.size == 1, f"{name} is not a scalar dual: shape {v.shape}"
+    return float(v[0])
+
+
+@pytest.mark.parametrize("build", [_miqp_with_a_known_dual, _convex_exp_minlp])
+def test_the_routed_solve_still_reports_constraint_duals(build, monkeypatch):
+    """Route ON must report the same row dual that route OFF reports."""
+    monkeypatch.setenv(ROUTE_ENV, "0")
+    off = build().solve(time_limit=30)
+    monkeypatch.setenv(ROUTE_ENV, "1")
+    on = build().solve(time_limit=30)
+
+    assert off.status == "optimal"
+    assert on.status == "optimal"
+    assert off.constraint_duals is not None, "control arm has no duals; nothing to compare"
+    assert on.constraint_duals is not None, (
+        "the routed solve dropped constraint_duals that the default path returns"
+    )
+    assert _scalar("c1", on.constraint_duals) == pytest.approx(
+        _scalar("c1", off.constraint_duals), abs=1e-3
+    )
+
+
+def test_the_route_actually_ran_on_these_models():
+    """§6: without this the test above passes vacuously if the route declines.
+
+    ``algorithm_route`` is populated only by the auto-route, so its presence is
+    proof the routed arm went through the MIP-NLP family rather than quietly
+    landing back on the default path that always had duals.
+    """
+    checked = 0
+    for build in (_miqp_with_a_known_dual, _convex_exp_minlp):
+        r = build().solve(time_limit=30)
+        assert r.algorithm_route is not None, f"{build.__name__} was not routed"
+        assert "mip-nlp" in r.algorithm_route
+        checked += 1
+    assert checked == 2
+
+
+def test_recovery_refuses_a_point_of_the_wrong_width():
+    """A mismatched layout returns no duals rather than duals named after the
+    wrong rows -- the #941 failure mode this module's guard exists to prevent."""
+    from discopt.solver import _recover_nlp_duals_at_incumbent
+
+    m = _miqp_with_a_known_dual()
+    cd, bdl, bdu = _recover_nlp_duals_at_incumbent(m, np.zeros(7), time_budget=1.0)
+    assert (cd, bdl, bdu) == (None, None, None)
+
+
+def test_bound_duals_on_integer_columns_are_zeroed():
+    """The fixing bounds price the act of fixing, not bound activity in the
+    model the user declared. Same convention as ``_solve_nlp_bb``."""
+    from discopt.solver import _recover_nlp_duals_at_incumbent
+
+    m = _miqp_with_a_known_dual()
+    x_flat = np.array([2.0, 3.0])
+    cd, bdl, bdu = _recover_nlp_duals_at_incumbent(m, x_flat, time_budget=5.0)
+    assert cd is not None, "recovery failed on the incumbent; nothing to assert"
+    assert _scalar("c1", cd) == pytest.approx(3.0, abs=1e-3)
+    for d in (bdl, bdu):
+        assert d is not None
+        assert np.all(np.asarray(d["y"], dtype=float) == 0.0)

--- a/python/tests/test_863_shared_declared_box_tightening.py
+++ b/python/tests/test_863_shared_declared_box_tightening.py
@@ -166,8 +166,13 @@ def test_solve_runs_the_declared_box_pass_once(monkeypatch):
         return real(*a, **kw)
 
     monkeypatch.setattr(_solver, "_declared_box_tightening", _counting)
+    # solver="bb": the declared-box pass lives downstream of the solver-family
+    # dispatch, so it belongs to the default path. Since #1059 this model is
+    # auto-routed to the MIP-NLP family, which never reaches the pass -- so a
+    # bare .solve() here counts 0, which is a different (and separately tracked)
+    # fact about the route, not the duplicate-work property this test pins.
     with pytest.warns(UserWarning, match="very large or infinite declared bounds"):
-        m.solve(time_limit=30)
+        m.solve(time_limit=30, solver="bb")
     assert len(calls) == 1, (
         f"solve() built the declared-box tightening {len(calls)} times (expected 1)"
     )

--- a/python/tests/test_952_miqp_incumbent_feasibility.py
+++ b/python/tests/test_952_miqp_incumbent_feasibility.py
@@ -232,8 +232,13 @@ def test_exit_gate_refuses_an_off_row_incumbent(monkeypatch):
     state = _patch_offrow_tree(monkeypatch, slice(2, 5), -1e-3)
 
     m = _panel_model(0)
+    # solver="bb" is load-bearing since #1059: the panel model is convexity-
+    # certified, so a bare .solve() is auto-routed to the MIP-NLP family and
+    # never enters the MIQP-BB loop whose exit gate this test covers. Without
+    # it the test passes vacuously in one direction and DID-NOT-RAISE in the
+    # other -- it stops measuring the gate rather than finding it broken.
     with pytest.raises(RuntimeError, match="MIQP-BB returned an infeasible point labeled"):
-        m.solve(time_limit=60)
+        m.solve(time_limit=60, solver="bb")
 
     assert state["applied"], "the incumbent was never perturbed; the test proved nothing"
 

--- a/python/tests/test_954_nlpbb_incumbent_feasibility.py
+++ b/python/tests/test_954_nlpbb_incumbent_feasibility.py
@@ -29,6 +29,14 @@ nonconvex and would otherwise dispatch elsewhere. 100 entered ``_solve_nlp_bb``,
     worst tolerance that would be needed to admit any returned point = 3.93e-14
     instances a 1e-6 gate would newly refuse = 0
 
+Every solve here passes ``nlp_bb=True`` for the same reason the entry panel did,
+and since #1059 it is load-bearing rather than merely explicit: the panel model is
+convexity-certified, so a bare ``.solve()`` is now auto-routed to the MIP-NLP
+family and never enters ``_solve_nlp_bb`` at all. The probes then measure nothing
+and say so -- ``the refine stub never ran`` is exactly that failure, not a
+regression in the gate. ``nlp_bb=True`` is the documented way to name this engine,
+and the route declines whenever a caller names one.
+
 So there was no live false primal, and the gate this adds refuses nothing that
 was being returned — four orders of headroom. The defect is that nothing bounded
 the excursion: its size was set by whatever the NLP backend converged to, and the
@@ -127,7 +135,7 @@ def test_returned_incumbent_is_within_declared_tolerance():
 
     for seed in range(seeds):
         m = _panel_model(seed)
-        r = m.solve(time_limit=60)
+        r = m.solve(time_limit=60, nlp_bb=True)
         assert r.status == "optimal", f"seed {seed}: status {r.status}, panel assumes optimal"
         assert r.nlp_bb, f"seed {seed} did not dispatch to NLP-BB; this panel tests that path"
         assert r.x is not None
@@ -216,7 +224,7 @@ def test_exit_gate_refuses_an_off_row_incumbent(monkeypatch):
 
     m = _panel_model(0)
     with pytest.raises(RuntimeError, match="NLP-BB returned an infeasible point labeled"):
-        m.solve(time_limit=60)
+        m.solve(time_limit=60, nlp_bb=True)
 
     assert state["applied"], "the incumbent was never perturbed; the test proved nothing"
     assert refine["n"] > 0, "the refine stub never ran; the perturbation may have been repaired"
@@ -232,7 +240,7 @@ def test_baseline_solve_is_unaffected(monkeypatch):
     refine = _disable_terminal_refine(monkeypatch)
 
     m = _panel_model(0)
-    r = m.solve(time_limit=60)
+    r = m.solve(time_limit=60, nlp_bb=True)
 
     assert refine["n"] > 0, "the refine stub never ran; this control is not comparable"
     assert r.status == "optimal", f"unperturbed solve returned {r.status}"

--- a/python/tests/test_benders.py
+++ b/python/tests/test_benders.py
@@ -147,15 +147,51 @@ def test_nonlinear_recourse_dispatches_to_gbd():
     assert r.bound is not None and r.bound <= r.objective + 1e-3
 
 
-def test_multidim_index_rejected_cleanly():
-    """A 2-D indexed model raises a clean NotImplementedError, not a stray error."""
+def test_multidim_index_is_supported():
+    """A 2-D indexed model decomposes correctly.
+
+    This test used to assert ``NotImplementedError``. That refusal was not a
+    design decision: ``_extract_body_coeffs`` open-coded ``int(e.index)``, which
+    *crashed* on a tuple index, and ``_linear.extract_linear`` normalized the
+    crash into a clean "unsupported construct" error. Delegating to
+    ``_flat_index.resolve_scalar_slot`` (#941's single source of truth) removed
+    the crash, so the 2-D path is now reachable -- and correct.
+
+    The objective coefficients are deliberately asymmetric: with all-ones costs
+    every column permutation gives the same optimum, so a wrong-column
+    extraction would pass unnoticed. Here the answer pins the C-order layout.
+    """
+    costs = [[1.0, 5.0, 9.0], [2.0, 6.0, 7.0]]
+
+    def build():
+        m = dm.Model("twod")
+        x = m.binary("x", shape=(2, 3))
+        m.first_stage(x)
+        m.minimize(sum(costs[k][i] * x[k, i] for k in range(2) for i in range(3)))
+        m.subject_to(x[0, 2] + x[1, 1] >= 1)
+        return m
+
+    mono = build().solve(time_limit=30)
+    r = solve_benders(build(), time_limit=30)
+    assert mono.status == "optimal"
+    assert r.status == "optimal"
+    assert r.objective == pytest.approx(mono.objective, abs=ABS_TOL)
+    assert r.objective == pytest.approx(6.0, abs=ABS_TOL)
+    assert r.bound is not None and r.bound <= r.objective + 1e-3
+
+
+def test_multidim_extraction_names_the_right_columns():
+    """The flat objective vector must follow the C-order layout, not a guess."""
+    from discopt.decomposition._linear import extract_linear
+
+    costs = [[1.0, 5.0, 9.0], [2.0, 6.0, 7.0]]
     m = dm.Model("twod")
     x = m.binary("x", shape=(2, 3))
-    m.first_stage(x)
-    m.minimize(sum(x[k, i] for k in range(2) for i in range(3)))
-    m.subject_to(sum(x[0, i] for i in range(3)) >= 1)
-    with pytest.raises(NotImplementedError):
-        solve_benders(m, time_limit=10)
+    m.minimize(sum(costs[k][i] * x[k, i] for k in range(2) for i in range(3)))
+    m.subject_to(x[0, 2] + x[1, 1] >= 1)
+
+    lin = extract_linear(m)
+    assert np.allclose(lin.c, np.array([1.0, 5.0, 9.0, 2.0, 6.0, 7.0]))
 
 
 @pytest.mark.slow

--- a/python/tests/test_debug_adversarial.py
+++ b/python/tests/test_debug_adversarial.py
@@ -551,7 +551,16 @@ def _nested_heuristic_minlp():
 
 
 def _miqp_model():
-    """Convex MIQP routing to the MIQP-BB loop (loop 4)."""
+    """Convex MIQP for the MIQP-BB loop (loop 4).
+
+    Solve it with ``solver="bb"``. Since the #1059 convex-MINLP auto-route went
+    default-ON, a bare ``.solve()`` on this model is certified convex and handed
+    to the MIP-NLP family, so it no longer enters loop 4 at all -- these tests
+    would still pass while covering a different loop than the one they name.
+    ``solver="bb"`` is the documented opt-out and reaches the same optimum
+    (0.6). Same idiom as the sibling loops here, which pin with ``nlp_bb=True``
+    and ``nlp_solver="simplex"``.
+    """
     m = do.Model("adv2_miqp")
     x = m.continuous("x", lb=-5.0, ub=5.0)
     y = m.continuous("y", lb=-5.0, ub=5.0)
@@ -637,7 +646,7 @@ def test_trace_invariants_nlp_bb_loop():
 @pytest.mark.smoke
 @pytest.mark.requires_pounce
 def test_trace_invariants_miqp_loop():
-    res, trace = _traced_solve(_miqp_model())
+    res, trace = _traced_solve(_miqp_model(), solver="bb")
     assert res.status == "optimal"
     _assert_trace_invariants(trace)
 
@@ -681,10 +690,10 @@ def test_nlp_bb_no_op_debugger_is_bound_neutral():
 @pytest.mark.smoke
 @pytest.mark.requires_pounce
 def test_miqp_no_op_debugger_is_bound_neutral():
-    base = _miqp_model().solve(time_limit=20.0)
+    base = _miqp_model().solve(time_limit=20.0, solver="bb")
     debug.attach(DebugSession(WalkFrontend()))
     try:
-        dbg = _miqp_model().solve(time_limit=20.0)
+        dbg = _miqp_model().solve(time_limit=20.0, solver="bb")
     finally:
         debug.detach()
     assert dbg.node_count == base.node_count
@@ -709,7 +718,7 @@ def test_quit_early_not_false_infeasible_nlp_bb():
 def test_quit_early_not_false_infeasible_miqp():
     debug.attach(DebugSession(QuitFrontend()))
     try:
-        res = _miqp_model().solve(time_limit=20.0)
+        res = _miqp_model().solve(time_limit=20.0, solver="bb")
     finally:
         debug.detach()
     assert res.status not in ("infeasible", "optimal"), (
@@ -750,11 +759,11 @@ def test_inject_on_nlp_bb_keeps_certificate(capsys):
 @pytest.mark.requires_pounce
 def test_inject_refused_on_miqp_loop(capsys):
     """Loop 4 wires NO validator: inject must refuse loudly, not trust."""
-    base = _miqp_model().solve(time_limit=20.0)
+    base = _miqp_model().solve(time_limit=20.0, solver="bb")
     script = ["stop-at steer", "continue", "inject 0", "continue"]
     debug.attach(debug.make_session(script=script))
     try:
-        res = _miqp_model().solve(time_limit=20.0)
+        res = _miqp_model().solve(time_limit=20.0, solver="bb")
     finally:
         debug.detach()
     err = capsys.readouterr().err

--- a/python/tests/test_lagrangian.py
+++ b/python/tests/test_lagrangian.py
@@ -86,16 +86,30 @@ def test_unknown_method_raises():
         solve_lagrangian(_knapsack(), method="nope", time_limit=10)
 
 
-def test_multidim_index_rejected_cleanly():
-    """A 2-D indexed model raises a clean NotImplementedError, not a stray error."""
-    m = dm.Model("twod")
-    x = m.binary("x", shape=(2, 3))
-    m.minimize(sum(x[k, i] for k in range(2) for i in range(3)))
-    c = sum(x[0, i] for i in range(3)) >= 1
-    m.subject_to(c)
-    m.mark_coupling(c)
-    with pytest.raises(NotImplementedError):
-        solve_lagrangian(m, time_limit=10)
+def test_multidim_index_is_supported():
+    """A 2-D indexed model relaxes correctly; the old refusal was a crash.
+
+    See ``test_benders.test_multidim_index_is_supported`` for the full story:
+    ``_extract_body_coeffs`` used to raise ``TypeError`` on a tuple index and
+    ``_linear.extract_linear`` turned that into "unsupported". Asymmetric costs
+    so a wrong-column extraction cannot pass.
+    """
+    costs = [[1.0, 5.0, 9.0], [2.0, 6.0, 7.0]]
+
+    def build():
+        m = dm.Model("twod")
+        x = m.binary("x", shape=(2, 3))
+        m.minimize(sum(costs[k][i] * x[k, i] for k in range(2) for i in range(3)))
+        c = x[0, 2] + x[1, 1] >= 1
+        m.subject_to(c)
+        m.mark_coupling(c)
+        return m
+
+    mono = build().solve(time_limit=30)
+    r = solve_lagrangian(build(), time_limit=30)
+    assert mono.objective == pytest.approx(6.0, abs=1e-3)
+    assert r.objective == pytest.approx(mono.objective, abs=1e-3)
+    assert r.bound is None or r.bound <= r.objective + 1e-3
 
 
 def test_recovered_primal_is_feasible():

--- a/python/tests/test_lagrangian_bb_hook.py
+++ b/python/tests/test_lagrangian_bb_hook.py
@@ -190,15 +190,24 @@ def test_hook_flag_noops_on_maximize_end_to_end():
     assert on.objective == pytest.approx(best, abs=1e-3)
 
 
-def test_try_build_disabled_for_multidim_index():
-    """2D-indexed models aren't supported by the linear extractor -> clean no-op."""
+def test_try_build_now_supports_multidim_index():
+    """2-D models build a bounder; the extractor's old refusal was a crash.
+
+    ``_extract_body_coeffs`` raised ``TypeError`` on a tuple index until it was
+    delegated to ``_flat_index.resolve_scalar_slot`` (#941). ``try_build``
+    returned ``None`` because of that, not because the mechanism cannot handle
+    a 2-D model -- and the bound it produces here is valid.
+    """
     m = dm.Model("twod")
     x = m.binary("x", shape=(2, 3))
-    m.minimize(sum(x[k, i] for k in range(2) for i in range(3)))
-    c = sum(x[0, i] for i in range(3)) <= 1
+    m.minimize(sum((k * 3 + i + 1) * x[k, i] for k in range(2) for i in range(3)))
+    c = x[0, 2] + x[1, 1] >= 1
     m.subject_to(c)
     m.mark_coupling(c)
-    assert LagrangianNodeBounder.try_build(m) is None
+
+    bounder = LagrangianNodeBounder.try_build(m)
+    assert bounder is not None
+    assert m.solve(time_limit=30).objective == pytest.approx(3.0, abs=1e-3)
 
 
 # ── End-to-end on a clean instance (base solver correct) ──

--- a/python/tests/test_nlp_bb.py
+++ b/python/tests/test_nlp_bb.py
@@ -103,24 +103,50 @@ class TestNlpBbConvex:
         assert result.gap is not None
         assert result.gap <= 1e-4
 
-    def test_auto_selects_for_convex(self):
-        """When nlp_bb=None (default), convex nonlinear MINLPs auto-select NLP-BB.
-
-        Uses exp() to ensure the problem is classified as nonlinear (not MIQP),
-        so it isn't dispatched to the specialized QP solver before reaching the
-        NLP-BB auto-select logic.
-        """
+    @staticmethod
+    def _convex_exp_model():
+        """Convex nonlinear MINLP. exp() keeps it out of the MIQP class, so the
+        dispatch reaches the auto-select logic rather than the specialized QP
+        solver."""
         m = dm.Model("convex_exp")
         x = m.continuous("x", lb=0, ub=5)
         y = m.binary("y")
-
         m.minimize(dm.exp(x) + 3 * y)
         m.subject_to(x + y >= 1)
+        return m
 
-        result = m.solve()
+    def test_auto_selects_for_convex(self, monkeypatch):
+        """With the #1059 route OFF, convex nonlinear MINLPs auto-select NLP-BB.
+
+        This test's premise changed rather than broke. Auto-selection for a
+        convexity-certified MINLP is now the #1059 route, which sends the model
+        to the MIP-NLP family -- that IS the graduated default, so asserting
+        ``nlp_bb is True`` on a bare ``.solve()`` would now be asserting the
+        policy #1059 replaced. The NLP-BB auto-select is still live and still
+        reachable through the documented opt-out, which is what this pins;
+        :meth:`test_the_route_takes_precedence_by_default` pins the other side,
+        so neither policy can silently disappear.
+        """
+        monkeypatch.setenv("DISCOPT_CONVEX_MINLP_ROUTE", "0")
+        result = self._convex_exp_model().solve()
 
         assert result.nlp_bb is True
         assert result.status == "optimal"
+
+    def test_the_route_takes_precedence_by_default(self):
+        """The other side of the pair: by default the #1059 route wins.
+
+        Same model, no opt-out. It must reach the same optimum by the routed
+        path -- and it must say so, so the change of engine is visible in the
+        result rather than only in a log line.
+        """
+        result = self._convex_exp_model().solve()
+
+        assert result.status == "optimal"
+        assert result.nlp_bb is False
+        assert result.algorithm_route is not None
+        assert "mip-nlp" in result.algorithm_route
+        assert result.objective == pytest.approx(np.e, rel=1e-4)
 
     @pytest.mark.slow
     def test_matches_spatial_bb(self):


### PR DESCRIPTION
## What this does

Finishes #1059: the convexity-certified MINLP auto-route now ships **default-ON**,
and two defects that made it worse than not routing are fixed.

### 1. The merge threw away the better dual bound

`_merge_route_and_fallback` adopted the loser's bound only when the loser was
`gap_certified`. A time-limited spatial branch-and-bound is never
`gap_certified` — yet its global dual bound is perfectly valid, and the
**non-routed path reports exactly that bound to callers**. So routing was
strictly worse on the dual side than not routing. Measured on `squfl025-040` at
60 s:

| arm | objective | bound | nodes | certified |
|---|---|---|---|---|
| route | 423.98 | 76.87 | 0 | yes |
| fallback | 1139.53 | **127.40** | 991 | no |

and the old gate published **76.87**. `gap_certified` describes the *gap*, not
the *bound*. End-to-end after the fix: bound 76.87 → 127.07 (+65%), gap 0.819 →
0.700, same incumbent.

`node_count` was also taken from the winner alone, so a routed solve that spent
61 s and explored 991 fallback nodes reported `nodes=0`. That false statistic is
what made this look like a *skipped* fallback and misled three probes before the
real cause turned up. Work is a property of the solve, not of whichever side won
it, so the counts are summed.

### 2. Graduation to default-ON

CLAUDE.md §5 regime 2 requires a corpus-wide differential panel clearing BOTH
bars. 75 instances at 60 s — the in-repo MINLPLib corpus plus a `syn`/`rsyn`
supplement, because the in-repo corpus holds exactly one `syn` instance and no
`rsyn`, i.e. it does not exercise the class the route exists for:

| criterion | result |
|---|---|
| unsound bounds | **0** |
| certification regressions | **0** |
| dual bound tighter / looser | 8 / 3 |
| nodes fewer / more | 27 / 1 |
| incumbent gained / lost | 2 / 0 |
| objective better / worse | 6 / 2 |
| total wall OFF / ON | 1561.6 / 1469.6 s |

Cert-clean **and** net-positive. Named wins: `rsyn0805m` 1206.21 → 1296.1206 (the
oracle optimum), `syn15m03m` 2035.37 → 3850.1818, `syn20m02m` 636.72 → 1752.1332,
and new incumbents on `squfl020-150` and `squfl025-040`, which had returned
nothing at all after 600 s.

All three looser-bound rows were `squfl`, and all three were defect 1 — fixed
here — so the graduated configuration is strictly better on that column than the
panel that cleared it. `DISCOPT_CONVEX_MINLP_ROUTE=0` remains the opt-out.

### 3. The route must not answer a question the caller did not ask

Flipping the default ON turned nine smoke tests red at once, all for one reason:
the route fired whenever `solver=` was unset, but `solver=` is not the only way a
caller names an engine. `m.solve(nlp_bb=True, node_callback=cb)` names the NLP
branch-and-bound loop *and* asks to observe its nodes; the MIP-NLP family honours
neither and silently dropped both.

The gate now consults `_mip_nlp_ignored_options` — the same table the
`solver="mip-nlp"` block warns from, extracted so the two cannot drift. An option
this family drops is now either a warning (the caller chose the family) or a
refusal to route (the caller did not). The refusal names the option in
`algorithm_route`, so it is never silent.

The three MIQP debug tests are pinned with `solver="bb"`: their subject is the
MIQP-BB loop, which a bare `.solve()` no longer reaches. Without the pin they
would keep passing while covering a different loop than the one they name — the
same idiom as their siblings, which pin with `nlp_bb=True` and
`nlp_solver="simplex"`.

## Verification

- `pytest -m smoke python/tests/` → **1074 passed**, 1 skipped, 2 xpassed.
- The four #1059 suites → **62 passed**.
- New `test_1059_merge_keeps_tighter_bound.py` (11 tests): 6 fail before the
  merge change, all 11 pass after.
- New `test_1059_route_respects_caller_options.py` (14 tests): the 2 behavioural
  tests fail with the gate neutered, pass with it in place.
- `ruff check python/` clean; mypy clean.

Two tests in `test_1059_route_fallback.py` are **retracted in place** (CLAUDE.md
§11): they previously asserted that an uncertified loser's bound "is not a proof"
and must be discarded. That policy was never measured, and when it was it proved
costly — see the table above.

Closes #1059.


---

## Follow-up: two defects the graduated route exposed in CI

Eight failures appeared across two lanes once the route was default-ON. Six were
probes that had quietly stopped measuring their own subject — the route sends a
bare `.solve()` somewhere else, so a test that names the MIQP-BB loop or
`_solve_nlp_bb` was no longer entering it. Those are pinned by naming the engine
(`nlp_bb=True`, `solver="bb"`), never by relaxing an assertion. The other two
were real.

### The route stripped `constraint_duals` from every convex MINLP

The MIP-NLP family returns a point and a bound and no multipliers: its master is
a MILP and its subproblems are solved on an integer-fixed model it does not keep.
Every other exit in `solver.py` reports duals, so the same `.solve()` that used
to return `constraint_duals` started returning `None` — measured on **both** a
convex MIQP (→ the QP path) and a convex `exp()` MINLP (→ NLP-BB), so it was not
one class. A default that silently drops a reported quantity is exactly the
defect class CLAUDE.md §3 forbids, so the fix is to recover them, not to accept
the loss.

`_recover_nlp_duals_at_incumbent` does what `_solve_nlp_bb` already does at its
own exit: pin the integer columns at the incumbent, re-solve the resulting convex
NLP, unpack its multipliers. It is strictly additive — it fills only fields that
are `None`, so the point, objective, bound and node count are untouched — and
best-effort, returning `(None, None, None)` on any failure rather than a wrong
dual. It declines outright when `reformulate_gdp` rewrote the model, because the
incumbent is then indexed by the reformulated columns and a multiplier unpacked
against the caller's model would be named after the wrong row (#941); GDP models
therefore stay exactly where they were, with no duals, rather than getting wrong
ones.

### `_extract_body_coeffs` open-coded #941's flat-slot arithmetic

It did `int(e.index)`, which raises `TypeError` on the tuple index of a 2-D
variable, and took a negative index literally — returning an in-range slot
belonging to a *different* variable, which nothing downstream errors on. It now
delegates to `_flat_index.resolve_scalar_slot`, the single source of truth #941
created for this.

That crash turned out to be load-bearing somewhere it should not have been.
`decomposition/_linear.py` and `benders/gbd.py` wrap the call in a bare `except`
that converts any exception into "unsupported construct", so **Benders, the
Lagrangian relaxation and the Lagrangian node bounder all refused 2-D indexed
models** — and three tests pinned that refusal as though it were a design
decision. With the crash gone the 2-D path is reachable and correct, verified
against the monolithic solve on a deliberately asymmetric objective (all-ones
costs make every column permutation look right; the extracted vector
`[1, 5, 9, 2, 6, 7]` pins the C-order layout). Those three tests now assert the
supported behaviour and its answer, which is strictly stronger than asserting a
raise.

### Known residual (tracked, not fixed here)

Routed solves skip the declared-box tightening pass and, with it, its "very large
or infinite declared bounds" user warning. `test_863` is pinned with
`solver="bb"` and a comment saying so; the gap itself is a separate fact about
the route and is tracked separately.

### Verification of this follow-up

- `test_1059_routed_solve_reports_duals.py` (5 tests) and
  `test_1059_gdp_body_coeffs_scalar_slots.py` (4 tests): both files were run with
  the corresponding source change stashed — 4 fail in each — and again with it
  applied — 9 pass.
- The CI `python-fast` marker expression locally: **8450 passed, 3 failed**, the
  three being exactly the multidim tests rewritten here. After the rewrite a
  second run failed only on `test_832[casctanks]`,
  `test_m7_name_check_is_not_quadratic` and a torch worker crash; all three pass
  serially (10 passed in 12.8 s) and are artifacts of running `-n 4` against a
  machine at load 14 (CLAUDE.md §9).
- `ruff check python/` clean; mypy clean on the changed files.
