### PR TITLE
feat(1064): perspective cuts for semicontinuous squares (default-OFF)

### DIFF
--- a/python/discopt/_relax/mccormick_lp.py
+++ b/python/discopt/_relax/mccormick_lp.py
@@ -2146,6 +2146,22 @@ class MccormickLPRelaxer:
                 return res
             n_total = len(milp._c)
 
+            # Perspective strengthening (#1064). Resolved ONCE per node, before
+            # the round loop appends anything: a semicontinuity read off the
+            # original rows stays true no matter what cuts are added later, and
+            # re-scanning a growing matrix eight times would cost more than the
+            # separation it feeds.
+            indicators: dict[int, int] = {}
+            if _tuning().perspective_cuts:
+                from discopt._relax.perspective import (
+                    perspective_reference,
+                    semicontinuous_indicators,
+                )
+
+                indicators = semicontinuous_indicators(
+                    milp._A_ub, milp._b_ub, milp._bounds, self._orig_integrality
+                )
+
             def _append(rows: list[np.ndarray], rhs: list[float]) -> None:
                 R = np.asarray(rows, dtype=np.float64)
                 b = np.asarray(rhs, dtype=np.float64)
@@ -2188,6 +2204,38 @@ class MccormickLPRelaxer:
                     # sound, just looser at this point (dropping a cut only loosens).
                     if abs(x0) > _LIFT_MAX_CROSS_TERM_ARG_MAGNITUDE:
                         continue
+                    # Perspective form when ``x`` is switched off by a binary
+                    # (#1064): ``s >= 2 z x - z^2 y`` with ``z = x0/y0``. Valid at
+                    # both integral ``y`` -- at ``y=1`` it is the tangent at ``z``,
+                    # at ``y=0`` semicontinuity gives ``x=0`` so it reads ``s>=0``
+                    # -- and its violation at the LP point is ``x0^2/y0 - s``
+                    # against the plain tangent's ``x0^2 - s``. See
+                    # :mod:`discopt._relax.perspective`.
+                    y_col = indicators.get(base)
+                    z = None
+                    if y_col is not None and y_col < x.size:
+                        z = perspective_reference(x0, float(x[y_col]))
+                        if z is not None and abs(z) > _LIFT_MAX_CROSS_TERM_ARG_MAGNITUDE:
+                            z = None  # same conditioning guard as the tangent
+                    if z is not None:
+                        y0 = float(x[y_col])
+                        cut_at_point = 2.0 * z * x0 - z * z * min(y0, 1.0)
+                        if cut_at_point - s > tol * max(1.0, abs(cut_at_point)):
+                            row = np.zeros(n_total)
+                            # Row form is ``A_ub @ v <= b``, and the cut is
+                            # ``s >= 2 z x - z^2 y``, i.e. ``2 z x - z^2 y - s <= 0``
+                            # -- so the indicator coefficient is NEGATIVE. With the
+                            # sign flipped the row asserts ``s >= 2 z x + z^2 y``,
+                            # which is not valid: on the textbook instance in
+                            # ``test_1064_perspective_cuts`` it cut the optimum
+                            # ``(x, y, s) = (2, 1, 4)`` off and lifted the root
+                            # bound from -2.89 to 0, above the true optimum -1.
+                            row[base] += 2.0 * z
+                            row[aux] += -1.0
+                            row[y_col] += -(z * z)
+                            rows.append(row)
+                            rhs.append(0.0)
+                            continue
                     # Separate only where the convex underestimator is slack:
                     # the LP put ``s`` below the true parabola at ``x0``.
                     if x0 * x0 - s > tol * max(1.0, abs(x0 * x0)):

--- a/python/discopt/_relax/perspective.py
+++ b/python/discopt/_relax/perspective.py
@@ -1,0 +1,139 @@
+"""Perspective strengthening of lifted univariate squares (#1064).
+
+A convex MIQP whose continuous variables are *switched off* by binaries carries
+structure the plain convex relaxation throws away. On the MINLPLib ``squfl``
+family (separable quadratic uncapacitated facility location) every continuous
+``x`` is tied to a binary ``y`` by a variable-upper-bound row ``x - u*y <= 0``,
+so ``y = 0`` forces ``x = 0``. Such an ``x`` is *semicontinuous*.
+
+For a semicontinuous ``x`` the epigraph ``s >= x**2`` can be replaced by the
+**perspective** ``s >= x**2 / y``, which is the convex hull of
+``{(x, s, y) : y in {0,1}, x = 0 if y = 0, s >= x**2}``. Its linearizations are
+the Frangioni-Gentile perspective cuts: for any ``z``,
+
+    s >= 2*z*x - z**2 * y                                                  (P)
+
+Validity is immediate on the two integral values of ``y``:
+
+* ``y = 1``: (P) is ``s >= 2*z*x - z**2``, the ordinary tangent to ``x**2`` at
+  ``z`` -- a global underestimator of a convex function.
+* ``y = 0``: semicontinuity gives ``x = 0`` and hence ``s = x**2 = 0``, and (P)
+  reduces to ``s >= 0``. True.
+
+and (P) dominates the plain tangent ``s >= 2*z*x - z**2`` everywhere in
+``y <= 1``, strictly wherever ``y < 1`` and ``z != 0``. Taking ``z = x_bar /
+y_bar`` at the LP point makes (P) the supporting hyperplane of ``x**2/y`` there,
+whose violation is ``x_bar**2 / y_bar - s_bar`` against the plain tangent's
+``x_bar**2 - s_bar``.
+
+This is what SCIP does automatically (Bestuzheva, Gleixner and Vigerske, "A
+computational study of perspective cuts") and what MINLPLib's hand-written
+``squfl*persp`` variants encode by hand; see ``docs/references.bib``.
+
+Nothing here is keyed to a problem name or shape (CLAUDE.md §2): the detector
+reads the relaxation's own rows.
+"""
+
+from __future__ import annotations
+
+from typing import Optional, Union
+
+import numpy as np
+import scipy.sparse as sp
+
+__all__ = ["semicontinuous_indicators", "perspective_reference"]
+
+#: A binary's LP value below which ``z = x_bar / y_bar`` is not formed. The row
+#: ``x <= u*y`` bounds ``z`` by ``u``, so ``z`` cannot actually blow up -- but a
+#: ratio of two values both at the edge of LP tolerance carries no information,
+#: and the plain tangent is used instead.
+_MIN_INDICATOR_VALUE = 1e-6
+
+
+def _binary_columns(
+    bounds: list[tuple[float, float]], integrality: Optional[np.ndarray]
+) -> set[int]:
+    """Columns that are integer with a node box inside ``[0, 1]``.
+
+    ``integrality`` covers the ORIGINAL columns only; lifted aux columns sit past
+    its end and are therefore never taken for binaries, which is correct -- an
+    aux column is a function of the originals, not a switch.
+    """
+    if integrality is None:
+        return set()
+    flags = np.asarray(integrality).ravel()
+    out: set[int] = set()
+    for j, (lo, hi) in enumerate(bounds):
+        if j >= flags.size or not int(flags[j]):
+            continue
+        if lo > -1e-9 and hi < 1.0 + 1e-9:
+            out.add(j)
+    return out
+
+
+def semicontinuous_indicators(
+    A_ub: Optional[Union[np.ndarray, "sp.spmatrix"]],
+    b_ub: Optional[np.ndarray],
+    bounds: list[tuple[float, float]],
+    integrality: Optional[np.ndarray],
+) -> dict[int, int]:
+    """Map each semicontinuous column to a binary that switches it off.
+
+    A two-term row ``a*x + b*y <= c`` with ``a > 0``, ``b < 0`` and ``c <= 0``
+    gives ``x <= (c - b*y)/a``, so at ``y = 0`` it forces ``x <= c/a <= 0``;
+    combined with a node lower bound ``x >= 0`` that is ``x = 0``. Every row of a
+    valid relaxation holds at every feasible point of the original model, so the
+    implication holds there too -- which is what a cut derived from it needs.
+
+    Reading it off the relaxation's rows rather than the model's constraint
+    objects means separated rows are eligible sources as well. That is sound for
+    the same reason, and it costs one pass over the nonzeros.
+
+    Returns ``{x_col: y_col}``. When several binaries switch the same ``x``, the
+    first one found is kept -- each yields a valid cut, and one is enough to
+    dominate the plain tangent.
+    """
+    if A_ub is None or b_ub is None:
+        return {}
+    binaries = _binary_columns(bounds, integrality)
+    if not binaries:
+        return {}
+    A = sp.csr_matrix(A_ub)
+    b = np.asarray(b_ub, dtype=np.float64).ravel()
+    found: dict[int, int] = {}
+    for r in range(A.shape[0]):
+        lo, hi = int(A.indptr[r]), int(A.indptr[r + 1])
+        if hi - lo != 2:
+            continue
+        if not np.isfinite(b[r]) or float(b[r]) > 1e-9:
+            continue
+        cols = A.indices[lo:hi]
+        vals = A.data[lo:hi]
+        for k in (0, 1):
+            y_col, x_col = int(cols[k]), int(cols[1 - k])
+            y_coef, x_coef = float(vals[k]), float(vals[1 - k])
+            if y_col not in binaries or x_col in binaries:
+                continue
+            if x_coef <= 1e-12 or y_coef >= -1e-12:
+                continue
+            if x_col >= len(bounds) or bounds[x_col][0] < -1e-9:
+                continue
+            found.setdefault(x_col, y_col)
+    return found
+
+
+def perspective_reference(x0: float, y0: float) -> Optional[float]:
+    """The ``z`` whose perspective cut supports ``x**2/y`` at ``(x0, y0)``.
+
+    ``None`` when the indicator is too close to zero for the ratio to mean
+    anything; the caller then falls back to the plain tangent, which is still
+    sound (dropping a cut only loosens).
+    """
+    if not (np.isfinite(x0) and np.isfinite(y0)):
+        return None
+    if y0 < _MIN_INDICATOR_VALUE:
+        return None
+    # ``y`` never exceeds 1 in the original model, and a value above it in the LP
+    # would make the cut weaker than the plain tangent rather than unsound; clamp
+    # so the reference is the strongest valid one.
+    return float(x0) / min(float(y0), 1.0)

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -5180,6 +5180,28 @@ def _route_is_better(a: Optional[float], b: Optional[float], is_maximize: bool) 
     return float(a) > float(b) if is_maximize else float(a) < float(b)
 
 
+def _bound_crosses_objective(bound: float, objective: Optional[float], is_maximize: bool) -> bool:
+    """Would reporting ``bound`` against ``objective`` be an invalid certificate?
+
+    For a minimize model the dual bound is a *lower* bound and must not exceed
+    the incumbent; for a maximize model it is an *upper* bound and must not fall
+    below it. The slack is the same scale-aware rounding allowance the solvers
+    share (:func:`discopt.solvers._gap.bound_inversion_tolerance`), so this
+    agrees with OA, AMP and the LOA path on what counts as noise rather than a
+    real crossing.
+    """
+    if objective is None or not np.isfinite(objective):
+        return False
+    from discopt.solvers._gap import bound_inversion_tolerance
+
+    slack = bound_inversion_tolerance(float(bound), float(objective))
+    return (
+        float(objective) - float(bound) > slack
+        if is_maximize
+        else float(bound) - float(objective) > slack
+    )
+
+
 def _gap_is_closed(result, tol: float = 1e-6) -> bool:
     """Did ``result`` come back with a *closed*, certified optimality gap?
 
@@ -5261,6 +5283,19 @@ def _merge_route_and_fallback(route, fallback, is_maximize: bool):
         and l_b is not None
         and np.isfinite(l_b)
         and (w_b is None or not np.isfinite(w_b) or (l_b < w_b if is_maximize else l_b > w_b))
+        # ...and only if it does not cross the incumbent it would be reported
+        # against. A dual bound past the winner's own objective is a broken
+        # certificate (CLAUDE.md §1: ``bound <= incumbent`` for min sense), and
+        # the two sides ran different algorithms, so a crossing here means one
+        # of them is wrong and this merge cannot tell which. Keep the winner's
+        # own self-consistent bound. Measured on ``fac2``: OA returned a
+        # ``gap_certified=True`` lower bound of 331845337.44 against the merged
+        # incumbent 331837498.18 -- 7839 above the true optimum -- and without
+        # this guard the merge published it. The root cause is fixed in
+        # ``oa.py`` (``_certified_bound_inverted``); this is the second line of
+        # defence, because the merge is the last code to touch the bound before
+        # the caller sees it.
+        and not _bound_crosses_objective(float(l_b), winner.objective, is_maximize)
     ):
         winner.bound = float(l_b)
     obj, bnd = winner.objective, winner.bound

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -5131,45 +5131,142 @@ _CONVEX_ROUTE_BUDGET_FRACTION = 0.5
 _CONVEX_ROUTE_FALLBACK_FLOOR_S = 1.0
 
 
-def _route_result_is_certified(result) -> bool:
-    """Did an auto-routed solve come back with an actual certificate?
+def _route_result_is_certified(result, gap_tolerance: float) -> bool:
+    """Did an auto-routed solve come back having actually *finished* the model?
 
-    This is the #1059 fallback predicate, and it is deliberately strict: a
-    ``feasible`` status with no dual bound is exactly the failure mode the
-    graduation panel found (``alan``, ``clay0303hfsg``, ``tls2`` all lost their
-    certificate to the route), so anything short of ``gap_certified`` or a
-    terminal infeasible/unbounded verdict counts as "did not certify" and hands
-    the remaining budget to the default path.
+    This is the #1059 fallback predicate. "Finished" means the route can be
+    returned as the caller's answer with no further work worth doing: a closed
+    optimality gap, or a terminal infeasible/unbounded verdict.
+
+    ``gap_certified`` alone is **not** that test, and reading it as one was a
+    measured defect. ``SolveResult.gap_certified`` means "the reported gap is
+    mathematically valid", not "the reported gap is closed" -- OA sets it from
+    ``bound_valid and final_gap is not None``. So a time-limited OA run on
+    ``syn40m`` came back ``status="feasible"``, ``gap_certified=True``, gap
+    **80.8%**, and was treated as a certificate: the route returned after
+    30.2 s of a 60 s budget and the 29.8 s reserved for the fallback was thrown
+    away. Measured 2026-08-19 at ``DISCOPT_CONVEX_MINLP_ROUTE=1``,
+    ``time_limit=60``: ``obj=55.713 bound=290.611 gap_certified=True wall=30.17``.
+
+    The gap must therefore be closed to the caller's own ``gap_tolerance``, on
+    top of being certified. A result carrying no gap at all is not finished
+    either -- that is the ``feasible``-with-no-dual-bound failure the graduation
+    panel found on ``alan``/``clay0303hfsg``/``tls2``.
     """
     if result is None:
         return False
-    if bool(getattr(result, "gap_certified", False)):
-        return True
     # An infeasibility or unboundedness verdict is a certificate too, and there
     # is nothing for a fallback to improve on it.
-    return getattr(result, "status", None) in ("infeasible", "unbounded")
+    if getattr(result, "status", None) in ("infeasible", "unbounded"):
+        return True
+    if not bool(getattr(result, "gap_certified", False)):
+        return False
+    gap = getattr(result, "gap", None)
+    if gap is None or not np.isfinite(gap):
+        return False
+    return float(gap) <= float(gap_tolerance)
 
 
-def _route_incumbent_seed(model: Model, result) -> Optional[np.ndarray]:
-    """Flatten an auto-routed result's incumbent into an ``initial_point``.
+def _route_is_better(a: Optional[float], b: Optional[float], is_maximize: bool) -> bool:
+    """Is objective ``a`` strictly better than ``b`` in the model's own sense?
 
-    The fallback must never be *worse* than the route it replaces. Passing the
-    routed incumbent in as the fallback's starting point is what guarantees that:
-    ``solve_model`` injects a finite, verified ``initial_point`` into the tree
-    before the search begins, so the fallback starts from the route's answer and
-    can only tighten it. Returns ``None`` (leave the caller's own seed alone)
-    when there is no usable point.
+    ``None`` means "no incumbent", which loses to any finite value and ties with
+    itself. Non-finite values are treated as no incumbent.
     """
-    x = getattr(result, "x", None)
-    if x is None:
-        return None
-    from discopt.mo.utils import _flatten_solution
+    if a is None or not np.isfinite(a):
+        return False
+    if b is None or not np.isfinite(b):
+        return True
+    return float(a) > float(b) if is_maximize else float(a) < float(b)
 
-    flat = _flatten_solution(model, x) if isinstance(x, dict) else np.asarray(x, dtype=np.float64)
-    flat = np.asarray(flat, dtype=np.float64).reshape(-1)
-    if flat.size == 0 or not np.all(np.isfinite(flat)):
-        return None
-    return flat
+
+def _gap_is_closed(result, tol: float = 1e-6) -> bool:
+    """Did ``result`` come back with a *closed*, certified optimality gap?
+
+    Distinct from ``gap_certified``, which asserts only that the reported gap is
+    mathematically valid -- see :func:`_route_result_is_certified`.
+    """
+    if result is None or not bool(getattr(result, "gap_certified", False)):
+        return False
+    gap = getattr(result, "gap", None)
+    return gap is not None and np.isfinite(gap) and float(gap) <= tol
+
+
+def _merge_route_and_fallback(route, fallback, is_maximize: bool):
+    """Return the better of an auto-routed result and the fallback that followed.
+
+    This is the #1059 "the fallback can never be worse than the route" contract,
+    made true *by construction*. It used to be delegated to
+    ``_route_incumbent_seed``, which handed the routed point to the fallback as
+    ``initial_point`` on the theory that a warm-started tree "can only tighten
+    it". **That theory is false and was measured false.** ``initial_point`` is
+    not merely an incumbent floor: the tree's primal heuristics search the
+    *neighbourhood of the incumbent*, so a poor routed point redirects them.
+    Measured on ``rsyn0840m`` at a 60 s limit (internal minimize sense; the
+    model is a maximize):
+
+    ==========================  ===========
+    arm                         reported obj
+    ==========================  ===========
+    default path, 60 s          211.020
+    default path, 30 s          70.351
+    route + seeded fallback     **-11.413**
+    route + unseeded fallback   70.351
+    ==========================  ===========
+
+    The seeded run's log shows exactly the mechanism: the warm start pins the
+    incumbent at internal 11.413, after which fractional diving and LNS RINS
+    report 16.712, 60.227, 56.240, 51.240, 41.159 -- every one of them worse.
+    Unseeded, the same search reaches internal -70.351. The seed cost 82 units
+    of objective and bought nothing on the instances where the routed point was
+    good (``syn40m``: the seeded fallback returned the routed 55.713 unchanged).
+
+    So the route no longer steers the fallback at all. It is run, the fallback is
+    run on the remainder, and the better of the two is returned -- which is what
+    the contract always claimed. Both dual bounds are valid (the route only fires
+    on a model certified convex at the root, and only a ``gap_certified`` routed
+    bound is carried), so the tighter of the two is kept regardless of which
+    incumbent wins.
+    """
+    if route is None:
+        return fallback
+    if fallback is None:
+        return route
+
+    route_wins = _route_is_better(route.objective, fallback.objective, is_maximize)
+    # A certificate outranks a better number. If the fallback closed the gap and
+    # the route did not, no feasible point can legitimately beat it -- so a route
+    # objective that appears to is evidence of an inconsistency somewhere, not a
+    # better answer, and trading a proof for it would be exactly the kind of
+    # silent certificate loss the fallback exists to prevent.
+    if route_wins and _gap_is_closed(fallback) and not _gap_is_closed(route):
+        logger.warning(
+            "#1059 route objective %.10g appears to beat the fallback's CERTIFIED "
+            "%.10g; keeping the certified result. This should be impossible and "
+            "indicates a bound or feasibility inconsistency worth investigating.",
+            route.objective,
+            fallback.objective,
+        )
+        route_wins = False
+
+    winner = route if route_wins else fallback
+    loser = fallback if route_wins else route
+    # Keep the tighter dual bound, but only one the losing side actually
+    # *certified* -- an uncertified bound is not a proof and must never be
+    # reported as one. Reported sense: a maximize model's bound is an UPPER bound
+    # (tighter = smaller), a minimize model's is a LOWER bound (tighter = larger).
+    w_b, l_b = winner.bound, loser.bound
+    if (
+        bool(getattr(loser, "gap_certified", False))
+        and l_b is not None
+        and np.isfinite(l_b)
+        and (w_b is None or not np.isfinite(w_b) or (l_b < w_b if is_maximize else l_b > w_b))
+    ):
+        winner.bound = float(l_b)
+    obj, bnd = winner.objective, winner.bound
+    if obj is not None and bnd is not None and np.isfinite(obj) and np.isfinite(bnd):
+        winner.gap = abs(bnd - obj) / max(abs(obj), 1e-10)
+    return winner
 
 
 # Size gate for the auto cut policy: above this many scalar variables the
@@ -6081,6 +6178,18 @@ def solve_model_accepted_kwargs(solver: Optional[str] = None) -> frozenset[str]:
 #: solve (``Model.solve`` runs ``solve_model`` more than once).
 _ROUTE_FALLBACK_NOTE: list[str] = []
 
+#: Companion rail to :data:`_ROUTE_FALLBACK_NOTE`: the result the #1059
+#: auto-route produced before it handed over, as ``(SolveResult, is_maximize)``.
+#:
+#: The fallback runs on the remaining budget only, so it can come back with a
+#: worse incumbent or a looser bound than the route already had.
+#: :func:`_merge_route_and_fallback` returns the better of the two; this rail is
+#: how the routed result reaches it, since the fallback falls through to the
+#: default path's ~67 return sites and can reach none of them. Same
+#: list-not-scalar discipline as the note: the wrapper restores the exact depth
+#: it entered at, so a raised exception cannot leak state into the next solve.
+_ROUTE_FALLBACK_STATE: list[tuple["SolveResult", bool]] = []
+
 
 def _stamp_layer_timing(fn: _F) -> _F:
     """Stamp the layer profile onto whatever ``SolveResult`` the solve produced.
@@ -6102,6 +6211,7 @@ def _stamp_layer_timing(fn: _F) -> _F:
         before = _timing.snapshot()
         started = time.perf_counter()
         _route_depth = len(_ROUTE_FALLBACK_NOTE)
+        _state_depth = len(_ROUTE_FALLBACK_STATE)
         try:
             result = fn(*args, **kwargs)
         finally:
@@ -6111,12 +6221,32 @@ def _stamp_layer_timing(fn: _F) -> _F:
                 else None
             )
             del _ROUTE_FALLBACK_NOTE[_route_depth:]
+            _route_state = (
+                _ROUTE_FALLBACK_STATE[_state_depth]
+                if len(_ROUTE_FALLBACK_STATE) > _state_depth
+                else None
+            )
+            del _ROUTE_FALLBACK_STATE[_state_depth:]
         elapsed = time.perf_counter() - started
         # #1059: a solve that fell back off the auto-route must say so, otherwise
         # it is indistinguishable from one that was never routed -- the exact
         # invisibility the issue was filed about.
         if _route_note is not None and isinstance(result, SolveResult):
             result.algorithm_route = _route_note
+        # #1059: the fallback must never be worse than the route it replaced.
+        # Done here rather than at the fallback site for the same reason as the
+        # note: the fallback falls through to the default path's return sites.
+        if _route_state is not None and isinstance(result, SolveResult):
+            _rr, _rr_is_max = _route_state
+            _merged = _merge_route_and_fallback(_rr, result, _rr_is_max)
+            if _merged is not result:
+                # The route won. Its ``wall_time`` covers only the routed solve;
+                # the caller was charged for the fallback too, so report the
+                # whole call rather than the winning half of it.
+                _merged.wall_time = elapsed
+            result = _merged
+            if _route_note is not None:
+                result.algorithm_route = _route_note
         # ``stream=True`` yields an iterator of SolveUpdate, not a SolveResult;
         # leave anything that is not a SolveResult untouched rather than guessing.
         if not isinstance(result, SolveResult):
@@ -6983,7 +7113,7 @@ def solve_model(
         _route_remaining = time_limit - _route_elapsed
         if (
             _auto_route_reason is None
-            or _route_result_is_certified(_mip_nlp_result)
+            or _route_result_is_certified(_mip_nlp_result, gap_tolerance)
             or _route_remaining < _CONVEX_ROUTE_FALLBACK_FLOOR_S
         ):
             return _mip_nlp_result
@@ -6994,8 +7124,9 @@ def solve_model(
         # a certificate the caller is left holding an uncertified point that the
         # spatial path would often have proven optimal (the panel: ``alan``
         # uncertified 3.000 after 180 s vs certified 2.925 in 0.18 s). So spend
-        # the remainder of the budget on the path that certifies, seeded with
-        # whatever the route did find so the fallback can only improve on it.
+        # the remainder of the budget on the path that certifies, and return the
+        # better of the two -- see ``_merge_route_and_fallback`` for why the
+        # route deliberately does NOT warm-start the fallback any more.
         logger.info(
             "Convex MINLP auto-route did not certify (status=%s, gap_certified=%s) "
             "after %.2f s; falling back to the default path with %.2f s remaining",
@@ -7004,9 +7135,6 @@ def solve_model(
             _route_elapsed,
             _route_remaining,
         )
-        _route_seed = _route_incumbent_seed(_pre_route_model, _mip_nlp_result)
-        if _route_seed is not None and initial_point is None:
-            initial_point = _route_seed
         model = _pre_route_model
         _solver = None
         # ``time_limit`` is deliberately NOT reduced. The default path measures
@@ -7021,6 +7149,20 @@ def solve_model(
             f"{_auto_route_reason}; did not certify in {_route_elapsed:.2f}s "
             f"(status={getattr(_mip_nlp_result, 'status', None)}) -> fell back to the "
             f"default path with {_route_remaining:.2f}s"
+        )
+        # #1059: hand the routed result forward so the wrapper can return the
+        # better of the two. This is the "never worse than the route" contract;
+        # ``_merge_route_and_fallback`` documents why it is a merge rather than a
+        # warm start. Carried on the same rail as the note, for the same reason:
+        # the fallback cannot reach the default path's ~67 return sites.
+        from discopt.modeling.core import ObjectiveSense as _RouteObjSense
+
+        _ROUTE_FALLBACK_STATE.append(
+            (
+                _mip_nlp_result,
+                _pre_route_model._objective is not None
+                and _pre_route_model._objective.sense == _RouteObjSense.MAXIMIZE,
+            )
         )
         # Fall through to the default spatial / NLP branch-and-bound below.
 

--- a/python/discopt/solver_tuning.py
+++ b/python/discopt/solver_tuning.py
@@ -488,6 +488,21 @@ class SolverTuning:
     )
     """Edge-concave aggregation cuts (``DISCOPT_EDGE_CONCAVE``, default on)."""
 
+    perspective_cuts: bool = field(
+        default_factory=lambda: _env_flag("DISCOPT_PERSPECTIVE_CUTS", default=False)
+    )
+    """Perspective-strengthen the univariate-square tangents (``DISCOPT_PERSPECTIVE_CUTS``).
+
+    For a semicontinuous ``x`` (some binary ``y`` with ``y = 0 => x = 0``, read
+    off a variable-upper-bound row), the tangent ``s >= 2*z*x - z**2`` is replaced
+    by the Frangioni-Gentile perspective cut ``s >= 2*z*x - z**2 * y``, which is
+    valid at both integral values of ``y`` and dominates the tangent wherever
+    ``y < 1``. See :mod:`discopt._relax.perspective` for the derivation.
+
+    Bound-changing (CLAUDE.md §5): default-off behind this flag until a
+    corpus-wide differential panel graduates it.
+    """
+
     # --- cost-aware PSD moment-cut gate (THRU-2a; G1.3 graduated default-ON) ----
     psd_cost_gate: bool = field(
         default_factory=lambda: _env_flag("DISCOPT_PSD_COST_GATE", default=True)

--- a/python/discopt/solvers/oa.py
+++ b/python/discopt/solvers/oa.py
@@ -34,7 +34,7 @@ import numpy as np
 
 from discopt.modeling.core import Constraint, Model, ObjectiveSense, SolveResult, VarType
 from discopt.solvers import pounce_incumbent_options, pounce_option_defaults
-from discopt.solvers._gap import optimality_gap
+from discopt.solvers._gap import bound_inversion_tolerance, optimality_gap
 from discopt.solvers.mip_nlp_candidates import FixedNLPCandidate, FixedNLPCandidateManager
 from discopt.solvers.mip_nlp_options import (
     FP_OPTION_KEYS,
@@ -3684,6 +3684,49 @@ def _build_x_dict(x_flat: np.ndarray, model: Model) -> dict:
     return result
 
 
+#: Consecutive OA iterations with **no** movement in either bound after which the
+#: cut loop is abandoned as non-converging.
+#:
+#: OA's existing ``stalling_limit`` watches only the incumbent and defaults to
+#: ``None`` (off), so a run whose master bound never moves had no exit at all and
+#: spun until its time limit. Measured on ``alan`` (MINLPLib) with a 30 s budget::
+#:
+#:     OA iter    0: LB=0.000000 UB=3.000000 gap=100.0000% cuts=18
+#:     OA iter    1: LB=0.000000 UB=3.000000 gap=100.0000% cuts=27
+#:     ...  ~7500 iterations, +9 cuts each, neither bound ever moving
+#:
+#: The whole budget bought nothing: the caller's fallback then reproduced the
+#: default path's answer exactly (same objective, same bound, 21 nodes) having
+#: paid 30 s for the privilege.
+#:
+#: Aborting cannot weaken the reported bound -- by construction the bound has not
+#: moved for ``_OA_NO_PROGRESS_ITERATIONS`` iterations, so the value returned is
+#: the one the loop would still be holding. It only stops paying for cuts that
+#: demonstrably change nothing. Deliberately generous: a genuine OA run plateaus
+#: for a few iterations before a cut binds (``fac2`` sits at LB=2.6e8 for two
+#: iterations, then jumps to the optimum on the third).
+_OA_NO_PROGRESS_ITERATIONS = 50
+
+
+def _bounds_moved(
+    before: tuple[Optional[float], Optional[float]],
+    after: tuple[Optional[float], Optional[float]],
+) -> bool:
+    """Did either OA bound move by more than floating-point noise?
+
+    Scale-relative so a 1-ulp wobble at ``|obj| ~ 1e8`` does not read as
+    progress and reset the no-progress counter forever, which would make
+    :data:`_OA_NO_PROGRESS_ITERATIONS` unreachable on exactly the large-objective
+    models where a stalled loop is most expensive.
+    """
+    for old_value, new_value in zip(before, after):
+        if old_value is None or new_value is None:
+            return True
+        if abs(float(new_value) - float(old_value)) > 1e-9 * max(1.0, abs(float(old_value))):
+            return True
+    return False
+
+
 def _compute_gap(lb: float, ub: float) -> float:
     """OA's optimality gap — see :mod:`discopt.solvers._gap` for the semantics.
 
@@ -5014,6 +5057,11 @@ def solve_oa(
     # unsound no-good cut.
     unresolved_int_configs: set[tuple[int, ...]] = set()
     incumbent_progress: list[float] = []
+    # ``_OA_NO_PROGRESS_ITERATIONS`` bookkeeping: the (LB, UB) pair as of the end
+    # of the previous iteration, and how many consecutive iterations have left it
+    # untouched.
+    _last_progress_bounds: Optional[tuple[Optional[float], Optional[float]]] = None
+    no_progress_iterations = 0
     termination_reason = None
     incumbent_derivative_data: Optional[_DerivativeRegularizationData] = None
 
@@ -5151,6 +5199,33 @@ def solve_oa(
     def _certified_gap_converged() -> bool:
         gap_value = _certified_gap_value()
         return bool(gap_value is not None and gap_value <= gap_tolerance)
+
+    def _certified_bound_inverted() -> bool:
+        """Has the certified lower bound risen *above* the incumbent?
+
+        A dual bound past the incumbent is a broken certificate: one of the two
+        is wrong and OA cannot tell which, so neither may be reported as proved.
+        :func:`optimality_gap` already refuses to call this converged -- it
+        returns ``1.0``, documented as "nothing proved ... let the caller's
+        certification logic decline" -- but the caller did not decline: the
+        finalizer stamped ``gap_certified=bool(reported_gap is not None)``, and
+        ``1.0`` is not ``None``, so an inverted bound shipped as a certificate.
+
+        Measured on ``fac2`` (MINLPLib, optimum 331837498.2) at a 30 s limit::
+
+            OA iter 23: LB=331845337.439688 UB=331845161.424879 gap=100.0000%
+
+        The run returned ``bound=331845337.44`` with ``gap_certified=True`` --
+        a lower bound 7839 above the true optimum and 176 above its own
+        incumbent, violating the ``bound <= incumbent`` invariant. The
+        inversion threshold is :func:`bound_inversion_tolerance`, shared with
+        AMP and the LOA path so all three agree on what counts as rounding
+        rather than a real crossing.
+        """
+        lb, ub = _trace_value(certified_LB), _trace_value(UB)
+        if lb is None or ub is None:
+            return False
+        return float(lb) - float(ub) > bound_inversion_tolerance(float(lb), float(ub))
 
     def _cut_source_delta(before: dict[str, int]) -> dict[str, int]:
         after = cut_provenance.source_counts()
@@ -5398,7 +5473,9 @@ def solve_oa(
         final_heuristic_lb = _trace_value(heuristic_LB)
         final_ub = _trace_value(UB)
         has_unresolved = bool(unresolved_int_configs)
-        bound_valid = bool(final_lb is not None and not has_unresolved)
+        bound_valid = bool(
+            final_lb is not None and not has_unresolved and not _certified_bound_inverted()
+        )
         final_gap = (
             _trace_value(_compute_gap(certified_LB, UB))
             if bound_valid and final_ub is not None
@@ -7228,6 +7305,36 @@ def solve_oa(
             if stop_after_master_pool:
                 break
 
+            # Neither bound moved this iteration. Cuts are still being added, so
+            # if that holds for long enough the master is not being changed in
+            # any way that matters and the remaining budget is better spent by
+            # the caller. See ``_OA_NO_PROGRESS_ITERATIONS``.
+            _lb_now, _ub_now = _trace_value(LB), _trace_value(UB)
+            if (
+                _last_progress_bounds is not None
+                and _lb_now is not None
+                and _ub_now is not None
+                and _last_progress_bounds[0] is not None
+                and _last_progress_bounds[1] is not None
+                and not _bounds_moved(_last_progress_bounds, (_lb_now, _ub_now))
+            ):
+                no_progress_iterations += 1
+            else:
+                no_progress_iterations = 0
+            _last_progress_bounds = (_lb_now, _ub_now)
+            if no_progress_iterations >= _OA_NO_PROGRESS_ITERATIONS:
+                logger.info(
+                    "OA: no bound movement in %d consecutive iterations "
+                    "(LB=%s UB=%s, %d cuts); abandoning the cut loop",
+                    no_progress_iterations,
+                    _lb_now,
+                    _ub_now,
+                    len(oa_A_rows),
+                )
+                termination_reason = "stalling"
+                stop_after_master_pool = True
+                break
+
             if incumbent_obj is not None:
                 incumbent_progress.append(float(UB))
                 if stalling_limit is not None and len(incumbent_progress) >= stalling_limit:
@@ -7287,6 +7394,22 @@ def solve_oa(
     certified_gap = _certified_gap_value()
     bound = certified_LB if _trace_value(certified_LB) is not None else None
     reported_gap = certified_gap if bound is not None and UB < 1e19 else None
+
+    # The dual bound crossed the incumbent. Report *nothing* proved rather than
+    # a bound we know to be wrong: suppressing only the gap would still hand the
+    # caller `bound > objective`, and the #1059 route then propagated exactly
+    # that into the user's SolveResult. See ``_certified_bound_inverted``.
+    if _certified_bound_inverted():
+        logger.warning(
+            "OA: certified lower bound %s is above the incumbent %s by more "
+            "than rounding -- one of the two is wrong, so neither the bound nor "
+            "the gap is reported as certified. This is a bound-validity defect "
+            "worth investigating, not a tolerance to widen.",
+            _trace_value(certified_LB),
+            _trace_value(UB),
+        )
+        bound = None
+        reported_gap = None
     final_reason = termination_reason
     if final_reason is None:
         if wall_time >= time_limit:

--- a/python/tests/test_1059_oa_bound_validity.py
+++ b/python/tests/test_1059_oa_bound_validity.py
@@ -1,0 +1,162 @@
+"""#1059: OA must not certify a bound it has already crossed, nor spin on a stalled cut loop.
+
+Both defects were found by the #1059 graduation panel, which routes
+convexity-certified MINLPs through the MIP-NLP/OA family and so put OA on the
+default path for models that had never reached it.
+"""
+
+import logging
+
+import discopt.solvers.oa as oa
+import numpy as np
+import pytest
+from discopt.modeling.core import SolveResult
+from discopt.solver import _bound_crosses_objective, _merge_route_and_fallback
+
+
+def _sr(obj=None, bound=None, gap_certified=False, status="feasible", gap=None):
+    return SolveResult(
+        status=status, objective=obj, bound=bound, gap_certified=gap_certified, gap=gap, x={}
+    )
+
+
+@pytest.mark.unit
+class TestBoundCrossesObjective:
+    """The shared predicate behind the merge guard."""
+
+    def test_the_fac2_crossing_is_caught(self):
+        """Measured on ``fac2`` (MINLPLib, optimum 331837498.2).
+
+        OA returned ``bound=331845337.4396878`` with ``gap_certified=True``
+        against the merged incumbent ``331837498.1769339`` -- a lower bound
+        7839 above the true optimum and 176 above its own incumbent.
+        """
+        assert _bound_crosses_objective(331845337.4396878, 331837498.1769339, False) is True
+
+    def test_a_valid_minimize_bound_is_not_a_crossing(self):
+        assert _bound_crosses_objective(331837497.5456339, 331837498.1769339, False) is False
+
+    def test_rounding_at_scale_is_not_a_crossing(self):
+        """1 ulp at |obj| ~ 3e8 must not read as a broken certificate."""
+        obj = 331837498.1769339
+        assert _bound_crosses_objective(obj + 1e-6, obj, False) is False
+
+    def test_maximize_direction_is_inverted(self):
+        # A maximize bound is an UPPER bound: below the incumbent is the crossing.
+        assert _bound_crosses_objective(5.0, 9.0, True) is True
+        assert _bound_crosses_objective(9.0, 5.0, True) is False
+
+    def test_a_missing_objective_cannot_be_crossed(self):
+        assert _bound_crosses_objective(1.0, None, False) is False
+        assert _bound_crosses_objective(1.0, float("nan"), False) is False
+
+
+@pytest.mark.unit
+class TestMergeRefusesACrossingBound:
+    def test_the_losers_crossing_bound_is_not_adopted(self):
+        """The #1059 merge must not publish a bound past the winner's incumbent.
+
+        Route and fallback tie on objective, so the fallback wins; the route is
+        the loser and carries a ``gap_certified`` bound that is numerically
+        "tighter" but crosses the incumbent. Adopting it is what produced
+        ``bound > objective`` on ``fac2``.
+        """
+        route = _sr(obj=331837498.1769339, bound=331845337.4396878, gap_certified=True)
+        fallback = _sr(obj=331837498.1769339, bound=331837497.5456339, gap_certified=True)
+        merged = _merge_route_and_fallback(route, fallback, False)
+        assert merged is fallback
+        assert merged.bound == pytest.approx(331837497.5456339), (
+            "the crossing bound must not be adopted"
+        )
+        assert merged.bound <= merged.objective, "bound <= incumbent is not negotiable"
+
+    def test_a_non_crossing_tighter_bound_is_still_adopted(self):
+        """The guard must not disable the bound merge it protects."""
+        route = _sr(obj=100.0, bound=95.0, gap_certified=True)
+        fallback = _sr(obj=100.0, bound=90.0, gap_certified=True)
+        merged = _merge_route_and_fallback(route, fallback, False)
+        assert merged is fallback
+        assert merged.bound == pytest.approx(95.0)
+
+
+@pytest.mark.unit
+class TestBoundsMoved:
+    """The no-progress predicate behind the OA stall abort."""
+
+    def test_a_frozen_pair_has_not_moved(self):
+        """``alan``'s signature: ~7500 iterations at LB=0.0, UB=3.0."""
+        assert oa._bounds_moved((0.0, 3.0), (0.0, 3.0)) is False
+
+    def test_real_progress_moves(self):
+        """``cvxnonsep_nsig30`` genuinely converges and must never be aborted."""
+        assert oa._bounds_moved((130.479973, 185.909159), (130.479973, 161.840224)) is True
+
+    def test_an_ulp_at_scale_is_not_movement(self):
+        """Otherwise the counter resets forever on large-objective models, which
+        is exactly where a stalled loop is most expensive."""
+        assert oa._bounds_moved((3.318e8, 3.319e8), (3.318e8 + 1e-3, 3.319e8)) is False
+
+    def test_a_missing_bound_counts_as_movement(self):
+        """Unknown is not evidence of a stall; never abort on it."""
+        assert oa._bounds_moved((None, 3.0), (0.0, 3.0)) is True
+        assert oa._bounds_moved((0.0, 3.0), (0.0, None)) is True
+
+
+@pytest.mark.slow
+class TestOnRealInstances:
+    def test_fac2_route_never_reports_a_bound_past_its_incumbent(self, monkeypatch, caplog):
+        """End-to-end #1059 regression: ``fac2`` through the auto-route.
+
+        Before the fix this returned ``bound=331845337.44`` against
+        ``objective=331837498.18`` with ``status="optimal"``.
+        """
+        from pathlib import Path
+
+        from discopt.modeling.core import from_nl
+
+        nl = Path("python/tests/data/minlplib_nl/fac2.nl")
+        if not nl.exists():
+            pytest.skip(f"{nl} not in the in-repo corpus")
+        # The crossing is reached through the auto-route (OA); without the flag
+        # this exercises the default spatial path and proves nothing (§6).
+        monkeypatch.setenv("DISCOPT_CONVEX_MINLP_ROUTE", "1")
+        model = from_nl(str(nl))
+        with caplog.at_level(logging.WARNING, logger="discopt.solvers.oa"):
+            result = model.solve(time_limit=60)
+        assert result.objective is not None
+        assert result.bound is not None
+        assert result.bound <= result.objective + 1e-8 * abs(result.objective), (
+            f"bound {result.bound!r} crossed incumbent {result.objective!r}"
+        )
+        assert result.bound <= 331837498.2 + 1e-4 * 331837498.2, (
+            "the reported lower bound must not exceed the MINLPLib optimum"
+        )
+
+    def test_alan_does_not_spend_the_route_budget_on_a_stalled_cut_loop(self, monkeypatch):
+        """``alan`` went 0.162 s -> 30.061 s under the route, for an identical
+        answer, because OA's cut loop never moved either bound and had no exit.
+        """
+        from pathlib import Path
+
+        from discopt.modeling.core import from_nl
+
+        nl = Path("python/tests/data/minlplib_nl/alan.nl")
+        if not nl.exists():
+            pytest.skip(f"{nl} not in the in-repo corpus")
+        monkeypatch.setenv("DISCOPT_CONVEX_MINLP_ROUTE", "1")
+        model = from_nl(str(nl))
+        result = model.solve(time_limit=60)
+        assert result.objective == pytest.approx(2.925, abs=1e-6)
+        assert result.gap_certified is True
+        assert result.wall_time < 10.0, (
+            f"the stalled OA loop was not abandoned: {result.wall_time:.2f}s "
+            "(pre-fix 30.06s, post-fix 0.41s)"
+        )
+
+
+@pytest.mark.unit
+def test_no_progress_limit_is_generous_enough_for_a_real_plateau():
+    """``fac2`` sits at LB=2.6e8 for two iterations before a cut binds and it
+    jumps to the optimum on the third. The abort must be nowhere near that."""
+    assert oa._OA_NO_PROGRESS_ITERATIONS >= 25
+    assert np.isfinite(oa._OA_NO_PROGRESS_ITERATIONS)

--- a/python/tests/test_1059_route_fallback.py
+++ b/python/tests/test_1059_route_fallback.py
@@ -17,14 +17,15 @@ Two mechanisms, tested separately:
   ``SolveResult.algorithm_route``.
 """
 
+import logging
 from pathlib import Path
 
-import numpy as np
 import pytest
-from discopt.modeling.core import Model, from_nl
+from discopt.modeling.core import Model, SolveResult, from_nl
 from discopt.solver import (
     _CONVEX_ROUTE_BUDGET_FRACTION,
-    _route_incumbent_seed,
+    _merge_route_and_fallback,
+    _route_is_better,
     _route_result_is_certified,
 )
 
@@ -42,13 +43,17 @@ def _load(name: str) -> Model:
     return m
 
 
+GAP_TOL = 1e-4
+
+
 class _Res:
     """Minimal stand-in with just the fields the predicate reads."""
 
-    def __init__(self, status=None, gap_certified=False, x=None):
+    def __init__(self, status=None, gap_certified=False, x=None, gap=0.0):
         self.status = status
         self.gap_certified = gap_certified
         self.x = x
+        self.gap = gap
 
 
 @pytest.mark.unit
@@ -56,44 +61,182 @@ class TestCertifiedPredicate:
     """``feasible`` with no bound is the failure the fallback exists for."""
 
     def test_certified_result_is_certified(self):
-        assert _route_result_is_certified(_Res("optimal", gap_certified=True)) is True
+        assert _route_result_is_certified(_Res("optimal", gap_certified=True), GAP_TOL) is True
 
     def test_feasible_without_a_certificate_is_not(self):
-        assert _route_result_is_certified(_Res("feasible", gap_certified=False)) is False
+        assert _route_result_is_certified(_Res("feasible", gap_certified=False), GAP_TOL) is False
 
     def test_optimal_without_gap_certified_is_not(self):
         """``optimal`` is a claim; ``gap_certified`` is the proof. Trust the proof."""
-        assert _route_result_is_certified(_Res("optimal", gap_certified=False)) is False
+        assert _route_result_is_certified(_Res("optimal", gap_certified=False), GAP_TOL) is False
 
     def test_infeasible_is_a_certificate(self):
-        assert _route_result_is_certified(_Res("infeasible")) is True
+        assert _route_result_is_certified(_Res("infeasible"), GAP_TOL) is True
 
     def test_unbounded_is_a_certificate(self):
-        assert _route_result_is_certified(_Res("unbounded")) is True
+        assert _route_result_is_certified(_Res("unbounded"), GAP_TOL) is True
 
     def test_none_is_not(self):
-        assert _route_result_is_certified(None) is False
+        assert _route_result_is_certified(None, GAP_TOL) is False
+
+    def test_a_valid_but_wide_gap_is_not_finished(self):
+        """The #1059 defect: ``gap_certified`` means *valid*, not *closed*.
+
+        Measured on ``syn40m`` at ``time_limit=60`` with the route on: OA came
+        back ``status="feasible"``, ``gap_certified=True``, ``gap=0.808``,
+        ``bound=290.611`` against ``obj=55.713`` -- and the predicate called it
+        a certificate, so the solver returned after 30.17 s and discarded the
+        29.8 s it had reserved for the fallback.
+        """
+        wide = _Res("feasible", gap_certified=True, gap=0.808289)
+        assert _route_result_is_certified(wide, GAP_TOL) is False
+
+    def test_a_gap_inside_tolerance_is_finished(self):
+        assert (
+            _route_result_is_certified(
+                _Res("optimal", gap_certified=True, gap=GAP_TOL / 2), GAP_TOL
+            )
+            is True
+        )
+
+    def test_a_missing_or_infinite_gap_is_not_finished(self):
+        """No gap at all is the ``alan``/``clay0303hfsg``/``tls2`` failure."""
+        assert (
+            _route_result_is_certified(_Res("feasible", gap_certified=True, gap=None), GAP_TOL)
+            is False
+        )
+        assert (
+            _route_result_is_certified(
+                _Res("feasible", gap_certified=True, gap=float("inf")), GAP_TOL
+            )
+            is False
+        )
+
+
+def _sr(obj=None, bound=None, gap_certified=False, status="feasible", gap=None):
+    """A real ``SolveResult``, so the merge is tested against the real dataclass."""
+    return SolveResult(
+        status=status, objective=obj, bound=bound, gap_certified=gap_certified, gap=gap, x={}
+    )
 
 
 @pytest.mark.unit
-class TestIncumbentSeed:
-    """The fallback starts from the route's answer, so it can only improve."""
+class TestBetterInSense:
+    def test_maximize_prefers_larger(self):
+        assert _route_is_better(2.0, 1.0, True) is True
+        assert _route_is_better(1.0, 2.0, True) is False
 
-    def test_dict_solution_is_flattened_in_model_order(self):
-        m = _load("gbd")
-        n = sum(v.size for v in m._variables)
-        x = {v.name: np.zeros(v.size) for v in m._variables}
-        seed = _route_incumbent_seed(m, _Res("feasible", x=x))
-        assert seed is not None
-        assert seed.shape == (n,)
+    def test_minimize_prefers_smaller(self):
+        assert _route_is_better(1.0, 2.0, False) is True
+        assert _route_is_better(2.0, 1.0, False) is False
 
-    def test_no_solution_gives_no_seed(self):
-        assert _route_incumbent_seed(_load("gbd"), _Res("time_limit")) is None
+    def test_no_incumbent_loses_to_any_finite_value(self):
+        assert _route_is_better(1.0, None, False) is True
+        assert _route_is_better(None, 1.0, False) is False
+        assert _route_is_better(None, None, False) is False
 
-    def test_a_nonfinite_point_is_refused(self):
-        m = _load("gbd")
-        x = {v.name: np.full(v.size, np.nan) for v in m._variables}
-        assert _route_incumbent_seed(m, _Res("feasible", x=x)) is None
+    def test_nonfinite_counts_as_no_incumbent(self):
+        assert _route_is_better(float("nan"), 1.0, False) is False
+        assert _route_is_better(1.0, float("inf"), True) is True
+
+
+@pytest.mark.unit
+class TestRouteFallbackMerge:
+    """The "never worse than the route" contract, made true by construction.
+
+    ``_route_incumbent_seed`` used to carry this contract by warm-starting the
+    fallback with the routed point. Measured on ``rsyn0840m`` at a 60 s limit,
+    that made things *worse*, not better: the default path alone returns 70.351
+    in the same 30 s the fallback had, while the seeded fallback returned
+    -11.413 -- the warm start pinned the incumbent and the primal heuristics
+    then searched its neighbourhood. Suppressing only the seed recovered 70.351
+    exactly. The merge below replaces that mechanism.
+    """
+
+    def test_the_better_incumbent_wins_on_maximize(self):
+        route, fb = _sr(obj=-11.413), _sr(obj=70.351)
+        assert _merge_route_and_fallback(route, fb, True) is fb
+
+    def test_the_route_wins_when_the_fallback_is_worse(self):
+        route, fb = _sr(obj=55.713), _sr(obj=33.197)
+        assert _merge_route_and_fallback(route, fb, True) is route
+
+    def test_the_better_incumbent_wins_on_minimize(self):
+        route, fb = _sr(obj=1.0), _sr(obj=2.0)
+        assert _merge_route_and_fallback(route, fb, False) is route
+
+    def test_a_fallback_with_no_incumbent_never_displaces_the_route(self):
+        route, fb = _sr(obj=5.0), _sr(obj=None)
+        assert _merge_route_and_fallback(route, fb, True) is route
+
+    def test_the_tighter_certified_bound_is_kept_when_the_fallback_wins(self):
+        """Measured on ``syn40m``: OA proves 290.61 in 30 s where the fallback's
+        own bound after the remaining 30 s is 1206.26 -- 4x looser on a maximize
+        model, where the bound is an upper bound and smaller is tighter."""
+        route = _sr(obj=55.713, bound=290.611, gap_certified=True)
+        fb = _sr(obj=70.0, bound=1206.261)
+        merged = _merge_route_and_fallback(route, fb, True)
+        assert merged is fb
+        assert merged.bound == pytest.approx(290.611)
+        assert merged.gap == pytest.approx((290.611 - 70.0) / 70.0)
+
+    def test_a_looser_bound_never_replaces_a_tighter_one(self):
+        route = _sr(obj=1.0, bound=1000.0, gap_certified=True)
+        fb = _sr(obj=1.0, bound=100.0, gap_certified=True)
+        merged = _merge_route_and_fallback(route, fb, True)
+        assert merged.bound == pytest.approx(100.0)
+
+    def test_an_uncertified_fallback_bound_is_not_adopted_by_the_route(self):
+        """An uncertified bound is not a proof and must not be reported as one."""
+        route = _sr(obj=5.0, bound=10.0, gap_certified=True)
+        fb = _sr(obj=1.0, bound=6.0, gap_certified=False)
+        merged = _merge_route_and_fallback(route, fb, True)
+        assert merged is route
+        assert merged.bound == pytest.approx(10.0)
+
+    def test_an_uncertified_route_bound_is_not_adopted_by_the_fallback(self):
+        route = _sr(obj=1.0, bound=6.0, gap_certified=False)
+        fb = _sr(obj=5.0, bound=10.0, gap_certified=True)
+        merged = _merge_route_and_fallback(route, fb, True)
+        assert merged is fb
+        assert merged.bound == pytest.approx(10.0)
+
+    def test_a_closed_certified_fallback_is_never_displaced(self, caplog):
+        """A certificate outranks a better number.
+
+        If the fallback proved optimality, no feasible point can beat it; a
+        route objective that appears to is an inconsistency, not an answer, and
+        swapping the proof out for it would be a silent certificate loss.
+        """
+        route = _sr(obj=9.0, bound=None, gap_certified=False)
+        fb = _sr(obj=5.0, bound=5.0, gap_certified=True, gap=0.0, status="optimal")
+        with caplog.at_level(logging.WARNING, logger="discopt.solver"):
+            merged = _merge_route_and_fallback(route, fb, True)
+        assert merged is fb
+        assert merged.gap_certified is True
+        assert any("should be impossible" in r.message for r in caplog.records), (
+            "the inconsistency must be surfaced, not silently swallowed"
+        )
+
+    def test_a_closed_certified_route_still_wins_on_objective(self):
+        """The guard is one-directional: two certificates compare normally."""
+        route = _sr(obj=9.0, bound=9.0, gap_certified=True, gap=0.0, status="optimal")
+        fb = _sr(obj=5.0, bound=5.0, gap_certified=True, gap=0.0, status="optimal")
+        assert _merge_route_and_fallback(route, fb, True) is route
+
+    def test_minimize_bound_direction(self):
+        """On minimize the bound is a LOWER bound: tighter means larger."""
+        route = _sr(obj=10.0, bound=8.0, gap_certified=True)
+        fb = _sr(obj=9.0, bound=2.0)
+        merged = _merge_route_and_fallback(route, fb, False)
+        assert merged is fb
+        assert merged.bound == pytest.approx(8.0)
+
+    def test_missing_sides_pass_through(self):
+        fb = _sr(obj=1.0)
+        assert _merge_route_and_fallback(None, fb, True) is fb
+        route = _sr(obj=1.0)
+        assert _merge_route_and_fallback(route, None, True) is route
 
 
 @pytest.mark.unit

--- a/python/tests/test_1064_perspective_cuts.py
+++ b/python/tests/test_1064_perspective_cuts.py
@@ -1,0 +1,171 @@
+"""#1064 dual half: perspective strengthening of lifted univariate squares.
+
+The unit tests pin the two pieces that decide soundness -- which columns are
+recognised as semicontinuous, and what reference point the cut is taken at --
+because a wrong answer in either produces a cut that removes feasible points
+without raising anything.
+"""
+
+import numpy as np
+import pytest
+import scipy.sparse as sp
+from discopt._relax.perspective import perspective_reference, semicontinuous_indicators
+
+pytestmark = pytest.mark.unit
+
+
+def _vub(x_coef=1.0, y_coef=-5.0, rhs=0.0, x_lb=0.0, n=2):
+    """A one-row system ``x_coef*x + y_coef*y <= rhs`` with ``x`` col 0, ``y`` col 1."""
+    A = sp.csr_matrix(np.array([[x_coef, y_coef] + [0.0] * (n - 2)]))
+    b = np.array([rhs])
+    bounds = [(x_lb, 5.0), (0.0, 1.0)] + [(-10.0, 10.0)] * (n - 2)
+    integrality = np.array([0, 1] + [0] * (n - 2), dtype=np.int32)
+    return A, b, bounds, integrality
+
+
+class TestSemicontinuousDetection:
+    def test_the_canonical_vub_row_is_detected(self):
+        assert semicontinuous_indicators(*_vub()) == {0: 1}
+
+    def test_a_positive_rhs_is_rejected(self):
+        # ``x - 5y <= 1`` leaves ``x <= 1`` at ``y = 0``; ``x`` is not switched off,
+        # and a perspective cut built on it would cut off the point (1, 1, 0).
+        assert semicontinuous_indicators(*_vub(rhs=1.0)) == {}
+
+    def test_a_negative_x_lower_bound_is_rejected(self):
+        # ``y = 0`` gives ``x <= 0``, not ``x = 0``: at ``x = -3`` the true square
+        # is 9, and ``s >= 0`` from the cut is fine, but ``z`` is built from a
+        # ratio whose sign the derivation does not cover. Refuse the pair.
+        assert semicontinuous_indicators(*_vub(x_lb=-5.0)) == {}
+
+    def test_a_positive_indicator_coefficient_is_rejected(self):
+        # ``x + 5y <= 0`` says nothing about ``x`` when ``y = 0`` beyond ``x <= 0``.
+        assert semicontinuous_indicators(*_vub(y_coef=5.0)) == {}
+
+    def test_a_non_binary_partner_is_rejected(self):
+        A, b, bounds, integrality = _vub()
+        integrality = np.array([0, 0], dtype=np.int32)  # y is continuous now
+        assert semicontinuous_indicators(A, b, bounds, integrality) == {}
+
+    def test_an_integer_partner_with_a_wide_box_is_rejected(self):
+        # ``y in [0, 7]`` integer is not an indicator: the perspective derivation
+        # only covers ``y in {0, 1}``.
+        A, b, bounds, integrality = _vub()
+        bounds = [(0.0, 5.0), (0.0, 7.0)]
+        assert semicontinuous_indicators(A, b, bounds, integrality) == {}
+
+    def test_a_three_term_row_is_not_read_as_a_vub(self):
+        A = sp.csr_matrix(np.array([[1.0, -5.0, 1.0]]))
+        b = np.array([0.0])
+        bounds = [(0.0, 5.0), (0.0, 1.0), (0.0, 5.0)]
+        integrality = np.array([0, 1, 0], dtype=np.int32)
+        assert semicontinuous_indicators(A, b, bounds, integrality) == {}
+
+    def test_no_rows_no_indicators(self):
+        assert semicontinuous_indicators(None, None, [(0.0, 1.0)], np.array([1])) == {}
+
+    def test_an_aux_column_is_never_taken_for_a_binary(self):
+        # ``integrality`` covers originals only; a lifted aux column sits past its
+        # end and must not be read as a switch.
+        A = sp.csr_matrix(np.array([[1.0, -5.0]]))
+        b = np.array([0.0])
+        bounds = [(0.0, 5.0), (0.0, 1.0)]
+        assert semicontinuous_indicators(A, b, bounds, np.array([0], dtype=np.int32)) == {}
+
+
+class TestPerspectiveReference:
+    def test_the_reference_is_the_ratio(self):
+        assert perspective_reference(0.5, 0.25) == pytest.approx(2.0)
+
+    def test_a_vanishing_indicator_declines(self):
+        assert perspective_reference(1e-9, 1e-12) is None
+
+    def test_an_indicator_above_one_is_clamped_to_the_tangent(self):
+        # An LP value slightly above 1 must not weaken the cut below the plain
+        # tangent; clamping keeps the strongest valid reference.
+        assert perspective_reference(3.0, 1.0 + 1e-9) == pytest.approx(3.0)
+
+    def test_non_finite_declines(self):
+        assert perspective_reference(np.nan, 0.5) is None
+        assert perspective_reference(1.0, np.inf) is None
+
+
+class TestCutValidity:
+    """The cut ``s >= 2 z x - z^2 y`` must hold at every point of the original set."""
+
+    @pytest.mark.parametrize("z", [0.0, 0.25, 1.0, 3.7])
+    def test_no_feasible_point_is_cut(self, z):
+        # The semicontinuous set: y in {0,1}; x in [0, 5] with x = 0 when y = 0;
+        # s = x**2 exactly.
+        checked = 0
+        for y in (0.0, 1.0):
+            for x in np.linspace(0.0, 5.0, 51) if y == 1.0 else [0.0]:
+                s = x * x
+                assert s >= 2.0 * z * x - z * z * y - 1e-9, (x, y, z)
+                checked += 1
+        assert checked > 0, "the validity sweep never ran"
+
+    def test_it_dominates_the_plain_tangent(self):
+        # Same reference, y < 1: the perspective right-hand side is strictly larger,
+        # i.e. it is the stronger lower bound on s.
+        z, x, y = 2.0, 1.0, 0.5
+        assert 2 * z * x - z * z * y > 2 * z * x - z * z
+
+
+class TestSeparatorIntegration:
+    """Plumbing: the flag must actually change the rows the separator emits.
+
+    This is a *synthetic* model, so it is evidence that the cut is wired up and
+    tightens what the derivation says it tightens -- not evidence that it helps
+    on the real class. That is what the corpus panel is for (the #727 RLT lesson:
+    a mechanism validated only on a proxy can be a no-op on real instances).
+
+    The model is the textbook semicontinuous square::
+
+        min  s - 4x + 3y   s.t.  s >= x**2,  x <= 5y,  x in [0,5],  y in {0,1}
+
+    whose optimum is -1 at (x, y) = (2, 1). The plain McCormick/tangent
+    relaxation with ``y = x/5`` minimizes ``x**2 - 3.4x`` at ``x = 1.7``, giving
+    ``-2.89``. The perspective ``s >= x**2/y`` is the convex hull here, so its
+    relaxation value is the optimum ``-1`` itself.
+    """
+
+    @staticmethod
+    def _model():
+        from discopt import Model
+
+        m = Model()
+        x = m.continuous("x", lb=0.0, ub=5.0)
+        y = m.binary("y")
+        m.subject_to(x - 5.0 * y <= 0.0)
+        m.minimize(x * x - 4.0 * x + 3.0 * y)
+        return m
+
+    @staticmethod
+    def _root_bound(model, *, perspective: bool):
+        import discopt.solver_tuning as st
+        from discopt._relax.mccormick_lp import MccormickLPRelaxer
+        from discopt._relax.model_utils import flat_variable_bounds
+
+        token = st.set_current(
+            st.SolverTuning(perspective_cuts=perspective) if perspective else st.SolverTuning()
+        )
+        try:
+            lb, ub = flat_variable_bounds(model)
+            res = MccormickLPRelaxer(model).solve_at_node(lb, ub, time_limit=30.0)
+        finally:
+            st.reset_current(token)
+        return res.lower_bound
+
+    def test_the_perspective_bound_is_tighter_and_still_valid(self):
+        model = self._model()
+        plain = self._root_bound(model, perspective=False)
+        persp = self._root_bound(self._model(), perspective=True)
+        assert plain is not None and persp is not None
+        # Soundness first (CLAUDE.md §1): neither may exceed the true optimum.
+        assert plain <= -1.0 + 1e-6, f"plain root bound {plain} is above the optimum -1"
+        assert persp <= -1.0 + 1e-6, f"perspective root bound {persp} is above the optimum -1"
+        # ...and the whole point: it must be strictly tighter.
+        assert persp > plain + 1e-6, (
+            f"perspective did not tighten the root bound: plain={plain} persp={persp}"
+        )


### PR DESCRIPTION
## What

Perspective strengthening for semicontinuous squares, behind
`DISCOPT_PERSPECTIVE_CUTS` (**default-OFF**, per §5 for a bound-changing change).

For a variable `x` that a binary `y` switches off (`y = 0 => x = 0`), the epigraph
`s >= x^2` is weak: it is the convex hull of the square over the *whole* box,
ignoring that half the box is unreachable. The perspective relaxation
`s >= x^2 / y` is the convex hull of the disjunction, and its linearisations are

```
s >= 2 z x - z^2 y      for any reference z
```

valid at both integral values of `y`: at `y = 1` it is the ordinary tangent to
`x^2` at `z`; at `y = 0` semicontinuity forces `x = 0` and the row reads
`s >= 0`. This is what SCIP does automatically (Bestuzheva/Gleixner/Vigerske)
and what MINLPLib's `*persp` variants encode by hand — it is a known gap
between discopt and SCIP on this class, which is what #1064 reports.

## Entry experiment (§4) — run before the panel, on real corpus instances

Hypothesis H3: squfl's squares reach the separator as power-2 `monomial` lifts
whose base column carries a detectable semicontinuity indicator.
Kill criterion: <50% of squfl's square lifts carry an indicator.

Measured on the MINLPLib corpus (`scratchpad/persp_entry.py`, which asserts
`mccormick_lp.__file__` is this worktree per §8 and prints an executed-probe
count per §6):

| instance | power-2 lifts | with an indicator |
|---|---|---|
| squfl015-060 | 900 | 900 (100%) |
| squfl020-150 | 3000 | 3000 (100%) |
| squfl025-040 | 1000 | 1000 (100%) |

`squfl squares=4900 covered=4900 frac=1.000` — **SURVIVES**. This is deliberately
not a synthetic proxy: the #727 RLT lesson was a mechanism with synthetic
root-gain 0.68 and real gain 0.0.

## Why the class needs it — measured root gaps

From the #1059 graduation panel (60 s/instance), the dual bound at the root
against the known optimum:

| instance | root bound | optimum | root gap |
|---|---|---|---|
| squfl015-060 | 152.47 | 366.62 | 58% |
| squfl020-150 | 226.34 | 557.85 | 59% |
| squfl025-040 | 76.87 | 197.33 | 61% |

## Change

- **`python/discopt/_relax/perspective.py`** (new). `semicontinuous_indicators()`
  reads variable-upper-bound rows (`a x + b y <= c` with `a > 0`, `b < 0`,
  `c <= 0` and node `lb(x) >= 0`) off the relaxation's own `A_ub`; every row of a
  valid relaxation holds at every feasible point, so the implication `y = 0 =>
  x = 0` is sound even when the row is a separated cut. `perspective_reference()`
  returns the supporting `z = x0 / min(y0, 1)`, or `None` when the indicator is
  numerically zero.
- **`python/discopt/_relax/mccormick_lp.py`**: `_separate_univariate_square` tries
  the perspective row before the plain tangent, falling back to the tangent when
  no indicator exists or the reference is ill-conditioned. Indicators are
  resolved **once per node**, before the round loop, rather than re-scanning a
  growing matrix eight times.
- **`python/discopt/solver_tuning.py`**: `perspective_cuts` flag.

## Verification

`python/tests/test_1064_perspective_cuts.py` — 19 unit tests. The detector tests
cover each rejection arm separately (positive rhs, negative `lb(x)`, positive `y`
coefficient, non-binary partner, wide integer box, three-term row, and that a
lifted aux column is never mistaken for a binary). The cut-validity tests assert
an executed-comparison count per §6.

Root bound on the canonical semicontinuous square (`min x^2 - 4x + 3y`,
`x - 5y <= 0`, `x in [0,5]`, `y` binary; optimum `-1`):

| | root bound |
|---|---|
| plain tangent | -2.890 |
| perspective | -1.00015 |

100% of the root gap, still valid.

### A sign error this caught

The first implementation wrote `row[y_col] += z*z`. Row form is `A_ub @ v <= b`
and the cut is `s >= 2 z x - z^2 y`, i.e. `2 z x - z^2 y - s <= 0` — the
indicator coefficient is **negative**. The positive sign asserts
`s >= 2 z x + z^2 y`, which is invalid: it cut off the optimum `(x, y, s) =
(2, 1, 4)` and lifted the root bound to `-2.7e-14`, **above** the true optimum.
It was caught only because the integration test asserts soundness
(`bound <= optimum + 1e-6`) *before* it asserts any tightening. The comment at
the call site records this.

## Status

Default-OFF. Graduation to default-ON requires a §5 panel that is both
cert-clean and net-positive; that panel is not in this PR.

Contributes to #1064.
