### PR TITLE
fix(1059): the declared-box check is a property of the model, not of the family

### DIFF
--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -7133,6 +7133,53 @@ def solve_model(
         )
     gurobi_options = kwargs.pop("gurobi_options", None) if _solver == "gurobi" else None
 
+    # --- #1059: check the declared box BEFORE dispatching to a solver family ---
+    # This block used to sit ~1700 lines below, past the point where six of the
+    # eight families return. Measured on a convex MINLP with an unbounded ``x``:
+    # ``solver="bb"``, ``nlp_bb=True`` and a route-declining option all warned;
+    # ``solver="mip-nlp"`` and a bare (auto-routed) ``.solve()`` did not. So the
+    # user-facing "very large or infinite declared bounds" warning, and the
+    # nonlinear-tightening infeasibility proof beside it, were never a property
+    # of the model -- they were a property of which family happened to run. The
+    # #1059 auto-route made that reachable from a plain ``.solve()``, which is
+    # what exposed it, but ``solver="mip-nlp"``, ``"amp"``, ``"gp"``,
+    # ``"gp-minlp"``, ``"direct"`` and ``"surrogate"`` had the same hole all
+    # along; fixing the class rather than the route is CLAUDE.md §2.
+    #
+    # Moved, not duplicated: the late call site is gone, so this still runs
+    # exactly once per solve and #863's sharing invariant is intact. Running it
+    # here also runs it on the model the *user declared*, before GDP
+    # reformulation invents auxiliary binaries that were never declared -- which
+    # is what a warning about declared bounds should be reporting on.
+    #
+    # All solver paths (LP IPM, QP IPM, NLP) use barrier methods that struggle
+    # with bounds beyond ~1e15. Both consumers below take the SAME nonlinear
+    # tightening of the SAME declared box, so it is computed once and shared
+    # (#863): measured on watercontamination0202 the second run was 39.78 s of
+    # bit-identical repeat work against a 30 s budget. See
+    # ``_declared_box_tightening``.
+    #
+    # #875: sharing halved the phase but left it unbounded -- the surviving call
+    # was still ~27 s of a 30 s time_limit, because the pass had no budget
+    # parameter. Same shape as the root presolve budget: a share of
+    # ``time_limit``, clamped to what is actually left. Truncation only weakens
+    # the box.
+    _nbt_budget_s = min(min(max(0.15 * float(time_limit), 2.0), 30.0), _remaining_budget())
+    _declared_tightening = _declared_box_tightening(
+        model, deadline=time.perf_counter() + _nbt_budget_s
+    )
+    _check_finite_bounds(model, _declared_tightening)
+    nonlinear_infeasibility = _detect_nonlinear_bound_infeasibility(model, _declared_tightening)
+    if nonlinear_infeasibility is not None:
+        logger.info(
+            "Nonlinear bound tightening proved model infeasible: %s", nonlinear_infeasibility
+        )
+        return SolveResult(
+            status="infeasible",
+            wall_time=time.perf_counter() - _solve_t0,
+            gap_certified=True,
+        )
+
     # --- #1059: auto-route a convexity-certified MINLP to the MIP-NLP family ---
     # Only when the caller expressed no preference -- neither an explicit
     # solver= (including solver="bb"), nor any option this family would drop.
@@ -8833,33 +8880,9 @@ def solve_model(
     else:
         logger.info("Using Ipopt (via cyipopt)")
 
-    # --- Check for very large variable bounds ---
-    # All solver paths (LP IPM, QP IPM, NLP) use barrier methods that
-    # struggle with bounds beyond ~1e15. Check once before any dispatch.
-    # Both of these consume the SAME nonlinear tightening of the SAME declared box
-    # on an unmodified model, so run it once and share it (#863): measured on
-    # watercontamination0202 the second run was 39.78 s of bit-identical repeat work
-    # against a 30 s budget. See _declared_box_tightening.
-    #
-    # #875: sharing halved the phase but left it unbounded — the surviving call was
-    # still ~27 s of a 30 s time_limit, because the pass had no budget parameter.
-    # Same shape as the root presolve budget below: a share of ``time_limit``,
-    # clamped to what is actually left. Truncation only weakens the box.
-    _nbt_budget_s = min(min(max(0.15 * float(time_limit), 2.0), 30.0), _remaining_budget())
-    _declared_tightening = _declared_box_tightening(
-        model, deadline=time.perf_counter() + _nbt_budget_s
-    )
-    _check_finite_bounds(model, _declared_tightening)
-    nonlinear_infeasibility = _detect_nonlinear_bound_infeasibility(model, _declared_tightening)
-    if nonlinear_infeasibility is not None:
-        logger.info(
-            "Nonlinear bound tightening proved model infeasible: %s", nonlinear_infeasibility
-        )
-        return SolveResult(
-            status="infeasible",
-            wall_time=time.perf_counter() - t_start,
-            gap_certified=True,
-        )
+    # The declared-box check that used to live here now runs before the
+    # solver-family dispatch; see "#1059: check the declared box BEFORE" above.
+    # It still runs exactly once per solve (#863) -- it was moved, not added.
 
     _pure_continuous = _is_pure_continuous(model)
     _pure_continuous_convexity_known = False

--- a/python/tests/test_1059_declared_box_before_dispatch.py
+++ b/python/tests/test_1059_declared_box_before_dispatch.py
@@ -1,0 +1,220 @@
+"""The declared-box check must be a property of the model, not of the family.
+
+``_check_finite_bounds`` (the "very large or infinite declared bounds" warning)
+and ``_detect_nonlinear_bound_infeasibility`` (which can prove infeasibility
+outright) used to run ~1700 lines into ``solve_model`` -- past the point where
+six of the eight solver families have already returned. Measured on a convex
+MINLP with an unbounded ``x``:
+
+===========================  =======
+call                         warned
+===========================  =======
+``solve()`` (auto-routed)    no
+``solve(solver="mip-nlp")``  no
+``solve(solver="bb")``       yes
+``solve(nlp_bb=True)``       yes
+===========================  =======
+
+So whether a user heard about their own unbounded variable depended on which
+engine happened to run. The #1059 auto-route is what surfaced it -- a bare
+``.solve()`` on a convex model started going to ``mip-nlp`` -- but
+``solver="mip-nlp"``, ``"amp"``, ``"gp"``, ``"gp-minlp"``, ``"direct"`` and
+``"surrogate"`` had the same hole before the route existed. The check now runs
+once, before the dispatch.
+
+``test_863_shared_declared_box_tightening.py`` is the other half of this
+contract: it pins that moving the call did not turn one pass into two.
+"""
+
+from __future__ import annotations
+
+import warnings
+
+import discopt.modeling as dm
+import pytest
+
+WARN_MATCH = "very large or infinite declared bounds"
+
+
+def _unbounded_convex_minlp():
+    """Convex MINLP whose ``x`` has no declared bounds -- the warning's subject.
+
+    ``x <= 20`` is a *constraint*, not a bound, so the declared box stays
+    ``(-inf, +inf)`` and the model is still solvable to optimality. The warning
+    must fire even though nothing goes wrong numerically; that is the point of
+    warning rather than failing.
+    """
+    m = dm.Model("unbounded_x")
+    m.continuous("x")
+    m.binary("y")
+    x, y = m._variables[0], m._variables[1]
+    m.minimize(dm.exp(x) + 3 * y)
+    m.subject_to(x + y >= 1)
+    m.subject_to(x <= 20)
+    return m
+
+
+def _warned(**solve_kwargs) -> tuple[bool, str]:
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        result = _unbounded_convex_minlp().solve(time_limit=20, **solve_kwargs)
+    hit = any(WARN_MATCH in str(w.message) for w in caught)
+    return hit, result.status
+
+
+@pytest.mark.parametrize(
+    "label,kwargs",
+    [
+        ("default (auto-routed to mip-nlp)", {}),
+        ("solver='mip-nlp'", {"solver": "mip-nlp"}),
+        ("solver='bb'", {"solver": "bb"}),
+        ("nlp_bb=True", {"nlp_bb": True}),
+        ("an option that declines the route", {"node_callback": lambda *a, **k: None}),
+    ],
+)
+def test_every_entry_point_warns_about_an_unbounded_declared_box(label, kwargs):
+    """The first two rows failed before the check was hoisted."""
+    warned, status = _warned(**kwargs)
+    assert status == "optimal", f"{label}: model did not solve ({status})"
+    assert warned, f"{label}: no unbounded-declared-box warning"
+
+
+def test_the_warning_stays_quiet_on_a_properly_bounded_model():
+    """The complement: a bounded model must not learn to warn.
+
+    Without this the test above is satisfiable by warning unconditionally.
+    """
+    m = dm.Model("bounded")
+    x = m.continuous("x", lb=0, ub=20)
+    y = m.binary("y")
+    m.minimize(dm.exp(x) + 3 * y)
+    m.subject_to(x + y >= 1)
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        result = m.solve(time_limit=20)
+    assert result.status == "optimal"
+    assert not any(WARN_MATCH in str(w.message) for w in caught)
+
+
+def test_the_check_runs_before_the_family_dispatch_not_inside_one():
+    """Structural pin: the routed path must reach the check.
+
+    The behavioural tests above would also pass if someone re-implemented the
+    warning separately inside ``solve_mip_nlp``. Spying on the shared pass
+    itself pins that the *one* hoisted call site is what the routed solve hits
+    -- which is what keeps #863's run-once property and this one from drifting
+    apart.
+    """
+    import discopt.solver as _solver
+
+    real = _solver._declared_box_tightening
+    calls: list[int] = []
+
+    def _counting(*a, **kw):
+        calls.append(1)
+        return real(*a, **kw)
+
+    _solver._declared_box_tightening = _counting
+    try:
+        with pytest.warns(UserWarning, match=WARN_MATCH):
+            result = _unbounded_convex_minlp().solve(time_limit=20)
+    finally:
+        _solver._declared_box_tightening = real
+
+    assert result.status == "optimal"
+    assert result.algorithm_route is not None and "mip-nlp" in result.algorithm_route, (
+        "this model is no longer auto-routed, so it no longer covers the routed path"
+    )
+    assert len(calls) == 1, f"declared-box pass ran {len(calls)} times (expected exactly 1)"
+
+
+# ── Soundness: the pass now sees rows it never saw before ─────────────────────
+#
+# Running before the dispatch also means running before ``reformulate_gdp``, so
+# the tightening pass is handed ``_DisjunctiveConstraint`` / ``_IndicatorConstraint``
+# rows that previously reached it only in already-reformulated big-M form. A
+# disjunction means "at least ONE disjunct holds" and an indicator binds only at
+# its active value; reading either unconditionally would let the pass prove an
+# infeasibility that is not real. A false ``infeasible`` is the one outcome
+# CLAUDE.md §1 allows no slack for, so it gets its own tests rather than being
+# argued about in a comment.
+
+
+@pytest.mark.parametrize("build_name", ["disjunction", "indicator", "either_or"])
+def test_gdp_rows_never_yield_a_false_infeasibility(build_name):
+    """Each model is feasible, and each is a trap for a conjunctive reading."""
+    import discopt.solver as _solver
+
+    if build_name == "disjunction":
+        # x <= 1 AND x >= 9 is infeasible; "x <= 1 OR x >= 9" is not.
+        m = dm.Model("contradictory_disjuncts")
+        x = m.continuous("x", lb=0, ub=10)
+        low = m.make_disjunct("low")
+        low.subject_to(x <= 1)
+        high = m.make_disjunct("high")
+        high.subject_to(x >= 9)
+        m.add_disjunction([low, high], name="mode")
+        m.minimize(x)
+        expected = 0.0
+    elif build_name == "indicator":
+        # w <= 1 binds only at z = 1, and contradicts w >= 2 if read always.
+        m = dm.Model("indicator")
+        z = m.binary("z")
+        w = m.continuous("w", lb=0, ub=10)
+        m.subject_to(w >= 2)
+        m.if_then(z, [w <= 1], name="only_if_z")
+        m.minimize(w)
+        expected = 2.0
+    else:
+        m = dm.Model("either_or")
+        v = m.continuous("v", lb=0, ub=10)
+        m.either_or([[v <= 1], [v >= 9]], name="mode")
+        m.minimize(v)
+        expected = 0.0
+
+    tightening = _solver._declared_box_tightening(m)
+    if tightening is not None:
+        assert not tightening[2].infeasible, (
+            f"{build_name}: tightening claimed infeasible on a feasible model "
+            f"({tightening[2].infeasibility_reason})"
+        )
+    assert _solver._detect_nonlinear_bound_infeasibility(m) is None
+
+    result = m.solve(time_limit=30)
+    assert result.status == "optimal", f"{build_name}: {result.status}"
+    assert result.objective == pytest.approx(expected, abs=1e-6)
+
+
+def test_an_infeasibility_proof_still_short_circuits_from_the_new_position():
+    """The early-``infeasible`` return must survive the move.
+
+    The real pass proves infeasibility only on models too large for a unit test,
+    so the proof is injected -- the same idiom as
+    ``test_863...::test_infeasibility_proof_is_still_reported``. What is under
+    test here is the *call site*: that a proof produced before the dispatch still
+    ends the solve, including on the auto-routed path that never reached the old
+    position.
+    """
+    import discopt.solver as _solver
+
+    class _Stats:
+        infeasible = True
+        infeasibility_reason = "synthetic empty interval"
+        n_tightened = 0
+        applied_rules = ()
+
+    real = _solver._declared_box_tightening
+
+    def _infeasible(model, *a, **kw):
+        lb, ub, _ = real(model, *a, **kw)
+        return lb, ub, _Stats()
+
+    _solver._declared_box_tightening = _infeasible
+    try:
+        result = _unbounded_convex_minlp().solve(time_limit=20)
+    finally:
+        _solver._declared_box_tightening = real
+
+    assert result.status == "infeasible"
+    assert result.gap_certified is True

--- a/python/tests/test_863_shared_declared_box_tightening.py
+++ b/python/tests/test_863_shared_declared_box_tightening.py
@@ -166,13 +166,14 @@ def test_solve_runs_the_declared_box_pass_once(monkeypatch):
         return real(*a, **kw)
 
     monkeypatch.setattr(_solver, "_declared_box_tightening", _counting)
-    # solver="bb": the declared-box pass lives downstream of the solver-family
-    # dispatch, so it belongs to the default path. Since #1059 this model is
-    # auto-routed to the MIP-NLP family, which never reaches the pass -- so a
-    # bare .solve() here counts 0, which is a different (and separately tracked)
-    # fact about the route, not the duplicate-work property this test pins.
+    # A bare ``.solve()`` again, and deliberately so. This was briefly pinned to
+    # ``solver="bb"`` because the pass sat downstream of the solver-family
+    # dispatch and the #1059 auto-route therefore skipped it entirely -- the
+    # count was 0, not 2. The pass now runs *before* the dispatch, so every
+    # family gets it and the shared-once property this test pins is once again a
+    # property of ``solve()`` rather than of one path through it.
     with pytest.warns(UserWarning, match="very large or infinite declared bounds"):
-        m.solve(time_limit=30, solver="bb")
+        m.solve(time_limit=30)
     assert len(calls) == 1, (
         f"solve() built the declared-box tightening {len(calls)} times (expected 1)"
     )

--- a/python/tests/test_direct.py
+++ b/python/tests/test_direct.py
@@ -62,17 +62,48 @@ def test_exhausted_budget_is_a_limit_not_infeasible():
 
     DIRECT cannot prove infeasibility. Claiming it would be exactly the kind of
     false certificate the contract exists to prevent, so this pins the negative.
+
+    The infeasible row is deliberately *opaque* -- wrapped in a ``custom`` call
+    the bound-tightening pass cannot read. It used to be the plain algebraic
+    ``x[0] + x[1] >= 10.0``, which since the declared-box check moved above the
+    solver-family dispatch is proved infeasible before DIRECT ever starts. That
+    proof is sound and belongs to presolve, not to DIRECT (see
+    ``test_a_sound_presolve_proof_short_circuits_before_direct_runs``), but it
+    means the algebraic form no longer exercises DIRECT's own exit -- the thing
+    this test is about. Hiding the row behind a black box restores that.
     """
     model = dm.Model("no_feasible_point")
     x = model.continuous("x", shape=2, lb=0.0, ub=1.0)
     model.minimize(dm.custom(lambda v: v[0] + v[1], name="lin")(x))
-    # A constraint no point in the box satisfies.
-    model.subject_to(x[0] + x[1] >= 10.0)
+    # A constraint no point in the box satisfies, opaque to bound tightening.
+    model.subject_to(dm.custom(lambda v: v[0] + v[1], name="sumc")(x) >= 10.0)
     result = model.solve(solver="direct", max_evals=200, time_limit=_TIME_LIMIT)
     assert result.status != "infeasible", result.status
     assert result.status in ("iteration_limit", "time_limit"), result.status
     assert result.objective is None
     assert result.gap_certified is False
+
+
+@pytest.mark.smoke
+def test_a_sound_presolve_proof_short_circuits_before_direct_runs():
+    """The other side: a *provable* infeasibility must not be spent on 200 evals.
+
+    ``x in [0,1]^2`` with ``x[0] + x[1] >= 10`` is infeasible by inspection, and
+    bound tightening says so
+    (``separable_quadratic_upper_bound ... minimum separable quadratic activity
+    exceeds the upper bound``). Since that check runs before the solver-family
+    dispatch, ``solver="direct"`` now returns the proof instead of searching a
+    box with nothing in it. This is not DIRECT claiming infeasibility -- the
+    certificate is algebraic and holds whatever the black-box objective does --
+    so ``gap_certified`` is legitimately ``True``.
+    """
+    model = dm.Model("provably_infeasible")
+    x = model.continuous("x", shape=2, lb=0.0, ub=1.0)
+    model.minimize(dm.custom(lambda v: v[0] + v[1], name="lin")(x))
+    model.subject_to(x[0] + x[1] >= 10.0)
+    result = model.solve(solver="direct", max_evals=200, time_limit=_TIME_LIMIT)
+    assert result.status == "infeasible"
+    assert result.gap_certified is True
 
 
 @pytest.mark.smoke


### PR DESCRIPTION
`_check_finite_bounds` -- the user-facing "very large or infinite declared
bounds" warning -- and `_detect_nonlinear_bound_infeasibility` beside it ran
~1700 lines into `solve_model`, past the point where six of the eight solver
families have already returned. So whether a user was told about their own
unbounded variable depended on which engine happened to run.

Measured on a convex MINLP whose `x` has no declared bounds:

    solve()                    warned=False   <- auto-routed to mip-nlp
    solve(solver="mip-nlp")    warned=False
    solve(solver="bb")         warned=True
    solve(nlp_bb=True)         warned=True
    solve(node_callback=...)   warned=True    <- option declines the route

The #1059 auto-route is what exposed this -- a bare `.solve()` on a convex model
started going to `mip-nlp` -- but `"mip-nlp"`, `"amp"`, `"gp"`, `"gp-minlp"`,
`"direct"` and `"surrogate"` all dispatch before the old position and had the
same hole before the route existed. Fixing the family rather than the route
would have left five of them broken (CLAUDE.md S2), so the check moves above the
dispatch instead.

Moved, not duplicated. The late call site is deleted, so the pass still runs
exactly once per solve and #863's sharing invariant is intact --
`test_863_shared_declared_box_tightening.py` is the pin for that, and its
`solver="bb"` workaround (added two commits ago precisely because the routed
solve counted 0 rather than 1) is reverted back to a bare `.solve()`.

Running before the dispatch also means running before `reformulate_gdp`, which
has two consequences. The good one: the warning now reports on the box the user
actually declared, rather than one containing auxiliary big-M binaries nobody
wrote. The one that needed checking: the tightening pass is now handed
`_DisjunctiveConstraint` / `_IndicatorConstraint` rows it previously saw only in
reformulated form, and a disjunction read conjunctively could prove an
infeasibility that is not real. That is the one outcome S1 gives no slack, so it
was measured rather than argued: three feasible models built as traps for a
conjunctive reading -- contradictory disjuncts (`x <= 1` OR `x >= 9`), an
indicator whose body contradicts a hard row unless read conditionally, and the
`either_or` form -- all report `infeasible=False` and solve to the right
optimum. Those three are now tests.

New `test_1059_declared_box_before_dispatch.py` (11 tests): the five entry
points above, a bounded-model complement so the suite cannot be satisfied by
warning unconditionally, a spy proving the routed solve reaches the single
hoisted call site exactly once, the three GDP soundness traps, and an injected
proof confirming the early-`infeasible` return still short-circuits from the new
position. Three fail with the hoist reverted.

Verified: the 11 new tests; `test_863_shared_declared_box_tightening.py`,
`test_875_nbt_call_site_budget.py`, `test_875_root_setup_budget.py` -> 31
passed. `ruff check python/` clean, `ruff format` clean, mypy clean on
`solver.py`. The full local fast lane was deliberately NOT run: the #1064
graduation panel began measuring on this machine and a concurrent `-n 4` pytest
is exactly the self-inflicted load S9 warns about. CI covers that lane.

Closes #1059's declared-box residual.

