### PR TITLE
fix(build): make build wrote a file Python never imported

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,8 +55,23 @@ PRE_COMMIT  ?= pre-commit
 PROJECT_DIR := $(shell pwd)
 RESULTS_DIR := $(PROJECT_DIR)/results
 NOTEBOOK    := docs/notebooks/benchmarks_by_class.ipynb
-EXT_SUFFIX  := $(shell $(PYTHON) -c "import sysconfig; print(sysconfig.get_config_var('EXT_SUFFIX') or '.so')")
+# The extension `maturin` actually emits. `crates/discopt-python` builds an
+# **abi3** wheel, so the artifact is `_rust.abi3.so` on every CPython 3.x --
+# NOT the interpreter-specific `sysconfig` EXT_SUFFIX (`.cpython-312-darwin.so`)
+# this used to ask for. Naming the wrong file made `make build` a silent no-op:
+# maturin wrote `_rust.abi3.so`, the copy-from-site-packages step found nothing
+# (an editable maturin install leaves no `.so` in purelib), and the trailing
+# `touch` then stamped a *stale* `_rust.cpython-312-darwin.so` as fresh. Python
+# prefers the interpreter-specific name over `.abi3.so`, so the stale file kept
+# shadowing every new build while `make build` reported success. Measured
+# 2026-08-19 in the primary checkout: three days and two Rust PRs of drift, with
+# `solve_milp_lazy_csc_py` (#1060's native single-tree entry) missing from the
+# module that was actually imported.
+EXT_SUFFIX  := .abi3.so
 SO_TARGET   := python/discopt/_rust$(EXT_SUFFIX)
+#: Interpreter-specific names Python would import in preference to `SO_TARGET`.
+#: Any of these left over from an older build shadows the real extension.
+SO_SHADOWS  := $(wildcard python/discopt/_rust.cpython-*.so)
 
 # Timestamp for output files
 TS := $(shell date -u +%Y-%m-%dT%H-%M-%S)
@@ -172,8 +187,18 @@ $(SO_TARGET): $(RUST_SRCS)
 		cp "$$SP/discopt/_rust$(EXT_SUFFIX)" $(SO_TARGET); \
 		echo "==> Copied .so from site-packages"; \
 	fi
-	@touch $(SO_TARGET)
-	@echo "==> Rust extension ready"
+	@# A leftover interpreter-specific build shadows $(SO_TARGET) on import and
+	@# would keep serving stale Rust after a successful rebuild. Remove it.
+	@for f in $(SO_SHADOWS); do \
+		echo "==> Removing stale shadowing extension $$f"; rm -f "$$f"; \
+	done
+	@# No `touch`: stamping a target the build did not actually produce is what
+	@# made this rule report success while the extension never changed. Fail
+	@# loudly instead, and prove the freshly built module is importable.
+	@test -f $(SO_TARGET) || { echo "ERROR: $(MATURIN) produced no $(SO_TARGET)"; exit 1; }
+	@PYTHONPATH=python $(PYTHON) -c "import discopt._rust as r; \
+	  assert r.__file__.endswith('$(EXT_SUFFIX)'), 'imported ' + r.__file__; \
+	  print('==> Rust extension ready:', r.__file__)"
 
 build: $(SO_TARGET)
 

--- a/python/tests/test_rust_extension_not_shadowed.py
+++ b/python/tests/test_rust_extension_not_shadowed.py
@@ -1,0 +1,56 @@
+"""A stale interpreter-specific ``.so`` must never shadow the built extension.
+
+``crates/discopt-python`` builds an **abi3** wheel, so ``maturin develop`` emits
+``python/discopt/_rust.abi3.so``. CPython's extension finder prefers the
+interpreter-specific name (``_rust.cpython-312-darwin.so``) over the abi3 one,
+so a leftover file under that name wins every import -- silently, and forever,
+because nothing rebuilds it.
+
+That happened. The ``Makefile`` named ``python/discopt/_rust$(EXT_SUFFIX)`` with
+``EXT_SUFFIX`` read from ``sysconfig``, i.e. the interpreter-specific name that
+maturin does not produce. ``make build`` therefore ran maturin (which wrote the
+abi3 file), found nothing to copy, and ``touch``-ed the *stale* file to satisfy
+the rule -- reporting "Rust extension ready" while every ``import discopt._rust``
+kept loading three-day-old Rust. Measured 2026-08-19 in the primary checkout:
+``solve_milp_lazy_csc_py`` (the native single-tree entry added days earlier) was
+absent from the module actually imported, and two probes were run and believed
+against it before the shadow was found.
+
+CLAUDE.md §8 says to verify which code you loaded. This is that check, made
+permanent: no measurement in this tree can be trusted while a shadow exists.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import discopt._rust
+import pytest
+
+_PKG = Path(discopt.__file__).resolve().parent
+
+
+@pytest.mark.smoke
+def test_no_interpreter_specific_extension_shadows_the_abi3_build():
+    shadows = sorted(p.name for p in _PKG.glob("_rust.cpython-*.so"))
+    abi3 = _PKG / "_rust.abi3.so"
+    if not abi3.exists():
+        # An installed (non-editable) tree may ship only one extension; there is
+        # nothing to shadow. Assert that is the situation rather than passing
+        # vacuously -- exactly one extension must be present.
+        assert len(shadows) <= 1, f"several extensions and no abi3 build: {shadows}"
+        return
+    assert not shadows, (
+        f"stale extension(s) {shadows} shadow {abi3.name}; "
+        "`import discopt._rust` is loading them instead of the current build. "
+        "Remove them and re-run `make build`."
+    )
+
+
+@pytest.mark.smoke
+def test_the_imported_extension_is_the_one_on_disk():
+    """Guards the above from passing for the wrong reason: with no shadow, the
+    module actually imported must be the file the build writes."""
+    loaded = Path(discopt._rust.__file__).resolve()
+    assert loaded.parent == _PKG, f"imported {loaded}, expected inside {_PKG}"
+    assert loaded.suffixes[-2:] in ([".abi3", ".so"], [".so"]), loaded.name


### PR DESCRIPTION
## The bug

`maturin develop` emits an **abi3** extension (`python/discopt/_rust.abi3.so`),
but the Makefile's `SO_TARGET` asked `sysconfig` for `EXT_SUFFIX` — the
interpreter-specific `.cpython-312-darwin.so`, which maturin does not produce.
The rule ran maturin (writing the abi3 file), found nothing to copy from purelib
(an editable maturin install leaves no `.so` there), and then `touch`-ed the
*stale* interpreter-specific file to satisfy the target.

CPython's extension finder prefers the interpreter-specific name over the abi3
one, so every `import discopt._rust` kept loading the stale build while
`make build` printed `==> Rust extension ready`.

## Evidence

Measured 2026-08-19 in the primary checkout:

```
-rwxr-xr-x  3517904 Aug 19 22:05  python/discopt/_rust.abi3.so             <- fresh, ignored
-rwxr-xr-x  3512992 Aug 19 22:05  python/discopt/_rust.cpython-312-darwin.so  <- 3 days old, only touched

$ python -c "import discopt._rust as r; print(hasattr(r,'solve_milp_lazy_csc_py'))"
False        # the native single-tree entry added in #1068
$ mv python/discopt/_rust.cpython-312-darwin.so /tmp/ && python -c "...same..."
True
```

The shadow was three days and two Rust PRs old. Two probes for #1060/#1062 were
run and partially believed against it before it was found; those results are
discarded.

## Changes

- `SO_TARGET` is now `python/discopt/_rust.abi3.so`, the artifact maturin emits.
- The recipe removes any leftover `_rust.cpython-*.so` shadow after a build.
- The trailing `touch` is gone. Stamping a target the build did not produce is
  precisely what made this rule report success. The rule fails loudly if no
  `.so` appeared, and imports the module to assert the abi3 file is what CPython
  resolves — CLAUDE.md §8 enforced inside the build itself.
- New smoke regression test `python/tests/test_rust_extension_not_shadowed.py`.

## Verification

- `pytest python/tests/test_rust_extension_not_shadowed.py` — **2 passed**.
- Same test with the real stale `.so` restored — **2 failed** (fails before,
  passes after).
- `make build` on an up-to-date tree — `Nothing to be done`.
- Import assertion the recipe runs — prints the abi3 path.
- `SO_SHADOWS` detection proven with a synthetic `_rust.cpython-999-fake.so`:
  matched when present, empty when absent.
- ruff check + ruff format clean.

No Rust or solver code is touched, so this is bound-neutral by construction.
