### PR TITLE
fix(#1064): perspective-strengthen the OA objective cut; make both expression extractors iterative

### DIFF
--- a/docs/dev/performance-plan.md
+++ b/docs/dev/performance-plan.md
@@ -3379,3 +3379,59 @@ measured `sep_calls = 0` / `nodes_via_mccormick = 0` on reformed models — it n
 fired, because the reformed model does not reach the McCormick path where the
 separator was installed. Dropped rather than relocated, since §19.3 removes the
 reformulation it depended on.
+
+### 19.5 The §5 graduation panel: `DISCOPT_PERSPECTIVE_OA_CUT` is now default-ON (2026-08-20)
+
+Twenty instances, flag OFF then ON back-to-back per instance (interleaved, §9),
+60 s each, threads pinned. Every `squfl*` in the corpus, plus the four
+non-`squfl` instances the detector fires on (`st_miqp2`, `st_miqp4`, `st_test3`,
+`meanvar-orl400_05_e_8`) and the two it does *not*
+(`watercontamination0202/0303`, `persp_applied = 0`) as the neutral control.
+All twenty are MINIMIZE, so a **higher** bound is tighter.
+
+| instance | applied | gap OFF | gap ON | bound OFF | bound ON | nodes OFF→ON |
+|---|---|---|---|---|---|---|
+| squfl010-025 | 5750 | −0.000 | −0.000 | 214.11 | 214.11 | 371→371 |
+| squfl010-040 | 8000 | −0.000 | −0.000 | 240.60 | 240.60 | 293→293 |
+| squfl010-080 | 8000 | −0.000 | −0.000 | 509.71 | 509.71 | 593→593 |
+| squfl015-060 | 9000 | 68.945 | **2.446** | 307.51 | 307.51 | 1055→1055 |
+| squfl015-080 | 10800 | 104.047 | **15.645** | 296.72 | 296.72 | 703→703 |
+| squfl020-040 | 8800 | 85.592 | **0.000** | 183.76 | **184.14** | 1503→1535 |
+| squfl020-050 | 9000 | 129.453 | **2.284** | 165.44 | 165.44 | 1151→1151 |
+| squfl020-150 | 18000 | 114.749 | **14.082** | 253.21 | **346.46** | 31→31 |
+| squfl025-025 | 8125 | 44.806 | **−0.000** | 141.58 | 141.58 | 2303→2303 |
+| squfl025-030 | 10500 | 29.997 | **0.543** | 151.04 | 151.04 | 1503→1503 |
+| squfl025-040 | 11000 | 114.854 | **18.488** | 127.70 | 127.70 | 1023→1023 |
+| squfl030-100 | 15000 | 317.248 | **14.137** | 123.89 | **189.55** | 3→3 |
+| squfl030-150 | 9000 | 243.690 | **10.209** | 158.93 | **238.17** | 3→3 |
+| squfl040-080 | 9600 | 498.274 | **35.569** | 91.49 | **132.45** | 3→3 |
+| meanvar-orl400_05_e_8 | 800 | 6.433 | 6.433 | 98.12 | 98.12 | 31→31 |
+| st_miqp2 | 11 | 0.000 | 0.000 | 2 | 2 | 0→0 |
+| st_miqp4 | 6 | 0.000 | 0.000 | −4574 | −4574 | 0→0 |
+| st_test3 | 1 | 0.000 | 0.000 | −7 | −7 | 0→0 |
+| watercontamination0202 | 0 | — | — | none | none | 0→0 |
+| watercontamination0303 | 0 | — | — | none | none | 0→0 |
+
+```
+gap: better=11 worse=0 unchanged=7
+dual bound: tighter=5 looser=0
+nodes: more=1 fewer=0
+CERT-CLEAN: PASS   NET-POSITIVE: PASS   GRADUATE: YES   CHECKS_EXECUTED 20
+```
+
+**Bar 1 (cert-clean).** No bound above its reference optimum, no `optimal →
+non-optimal` regression (the three `optimal` instances stay optimal, bit-equal),
+no dual bound loosened, no arm losing a bound the other had, and no `infeasible`
+where the OFF arm found a point. **Bar 2 (net-positive).** The gap improves on
+11 of 18 scored instances and worsens on none; five dual bounds tighten. The two
+instances #1064 reported as returning *nothing* after 600 s — `squfl020-150` and
+`squfl025-040` — both return incumbents at 60 s.
+
+The single node-count change (`squfl020-040`, 1503→1535) is expected and not a
+§5 regime-1 violation: this is a bound-*changing* flag, so the tree is allowed to
+move. `watercontamination*` applies zero cuts and is byte-identical on both arms,
+which is the §6 evidence that "no change" there means "the detector correctly
+declined", not "the panel never ran".
+
+Per §5 the flag is now **default-ON**, with `DISCOPT_PERSPECTIVE_OA_CUT=0` kept
+as the opt-out and the plain-tangent path intact.

--- a/docs/dev/performance-plan.md
+++ b/docs/dev/performance-plan.md
@@ -3296,3 +3296,86 @@ named, delivered upstream, and it is worth taking because the LP layer is now
 genuinely fast rather than because the solver got faster. §16's conclusion stands
 unchanged: discopt's gap to BARON is node-NLP and Python marshaling (69% and
 82.5% respectively per `baron-gap-plan.md` §1.3), not LU throughput.
+
+## 19. #1064 `squfl` primal gap: the structure was never *seen*, and the model rewrite trades the certificate for the incumbent (2026-08-19)
+
+The `squfl` family (separable quadratic uncapacitated facility location) returned
+incumbents 69–115% above optimum at 600 s. The issue framed this as "no incumbent
+after 600 s"; that headline was already resolved by earlier work — every instance
+now returns a feasible point — so the residual was *quality*, and it root-caused to
+two things, neither of them the relaxation.
+
+### 19.1 The recursion limit was silently reclassifying models (fixed)
+
+A `.nl` body is a left-leaning `((((a+b)+c)+d)+…)` chain, one AST node per term.
+`_extract_quadratic_terms._walk` and `_extract_linear_coefficients_sparse._walk`
+both recursed once per term, so a long body raised `RecursionError` — and the
+callers report that as *"not quadratic"* / *"not linear"*, which is
+indistinguishable from a genuinely nonlinear body. A convex separable MIQP
+therefore lost its Hessian and its semicontinuity structure **purely because it was
+long**, with no diagnostic anywhere.
+
+Measured over all 1610 MINLPLib `.nl` instances: 2 hit the quadratic walk
+(`squfl025-040` at 1000 terms, `squfl015-080` at 1200), **17** hit the linear one
+(`sporttournament30`…`40`, `edgecross10-060`…`24-057`, `autocorr_bern*`, `ibs2`).
+After the work-stack rewrite the same scan reports `ERRORS 0`.
+
+This is the §6 lesson in a production code path rather than an instrument: the
+failure mode was not a wrong answer, it was a *capability that silently did not
+exist*, reported as a legitimate classification.
+
+Bit-identity (§5 regime 1) was preserved deliberately — children are pushed onto
+the work stack in reverse so they pop in source order, keeping the floating-point
+accumulation order unchanged. SHA-256 over the extracted `(Q, c, const)` and
+`(terms, const)` matches on every corpus instance the recursive walk could process
+at all; the only hashes that move are the ones that previously raised (`ibs2` goes
+from `{ok: 1810, RecursionError: 1}` to `{ok: 1811}`).
+
+### 19.2 The OA objective cut was the plain tangent; perspective-strengthening it is where the primal gain is
+
+The OA master's objective epigraph row is the aggregate tangent
+`grad^T x − eta <= rhs`. It discards the perspective of every separable convex
+square over a semicontinuous variable. For binary `y` with a model row `x <= u*y`,
+`y = 0` forces `x = 0`, so the Frangioni–Gentile cut `eta >= 2q z x − q z² y` is
+valid using **only** `y ∈ {0,1}` — no box enters, so it is globally valid and safe
+to keep across nodes (unlike anything read off a node relaxation's rows).
+
+In row form, strengthening term `i` subtracts `q_i x̄_i²` from *both*
+`coeffs[y_col_i]` and `rhs`. At `y_i = 1` the two cancel and the row is identical to
+the plain tangent; at `y_i = 0` it reads `eta >= 0` instead of `eta >= −q x̄²`.
+
+Measured at 60 s, interleaved, with a §6 counter proving the strengthening fired.
+**Same bound and same node count on both arms** — the gain is purely primal:
+
+| instance | applied | obj OFF → ON | bound | nodes | gap OFF → ON |
+|---|---|---|---|---|---|
+| squfl010-025 | 5750 | 214.111 → 214.111 | 214.111 | 371 | −0.0% → −0.0% (optimal both) |
+| squfl015-060 | 9000 | 619.389 → 375.591 | 307.514 | 1055 | 68.9% → **2.4%** |
+| squfl015-080 | 10800 | 821.264 → 465.460 | 296.717 | 703 | 104.0% → **15.6%** |
+| squfl025-040 | 11000 | 423.980 → 233.818 | 127.705 | 1023 | 114.9% → **18.5%** |
+
+Structure population: exactly **20 of 1610** corpus instances (§2 — the fix is to
+the class, and every other instance is a provable no-op because the detector
+returns an empty term list).
+
+### 19.3 FALSIFIED: the model rewrite. It is strictly better on the primal and strictly worse on the certificate
+
+The obvious formulation-level move is to lift `q x²` to `q s` and add `x² <= s y`.
+Its primal effect is larger than the cut's — 68.9% → 0.00%, 114.8% → 0.00%,
+114.9% → 0.05% — and it is tempting for exactly that reason.
+
+It is not shipped. The lifted row `x² <= s y` is a **nonconvex** quadratic
+constraint, so the rewritten model leaves the convex relaxation and routes to the
+spatial path. The dual bound came out **looser on every** `squfl` instance. That is
+a certification regression under §5, and §1 settles it: a change that improves the
+incumbent while degrading the certificate is a regression, however large the primal
+number looks. The primal-only figure is the trap here — read alone it reports a
+1000× improvement on a change that makes the solver worse at its actual job.
+
+### 19.4 FALSIFIED: a spatial row separator for the same structure
+
+A separator that added perspective rows at the node relaxation was built and
+measured `sep_calls = 0` / `nodes_via_mccormick = 0` on reformed models — it never
+fired, because the reformed model does not reach the McCormick path where the
+separator was installed. Dropped rather than relocated, since §19.3 removes the
+reformulation it depended on.

--- a/python/discopt/_relax/perspective.py
+++ b/python/discopt/_relax/perspective.py
@@ -1,0 +1,284 @@
+"""Perspective structure for semicontinuous convex squares (#1064).
+
+A convex MIQP whose continuous variables are *switched off* by binaries carries
+structure the plain relaxation throws away. On the MINLPLib ``squfl`` family
+(separable quadratic uncapacitated facility location) every continuous ``x`` is
+tied to a binary ``y`` by a variable-upper-bound row ``x - U*y <= 0``, so
+``y = 0`` forces ``x = 0``: ``x`` is *semicontinuous*.
+
+For such an ``x`` the epigraph of ``q*x**2`` may be replaced by the
+**perspective** ``q*x**2/y``, the convex hull of
+``{(x, s, y) : y in {0,1}, x = 0 if y = 0, s >= q*x**2}``. Its linearizations are
+the Frangioni-Gentile perspective cuts: for any reference ``z``,
+
+    s >= 2*q*z*x - q*z**2 * y                                             (P)
+
+valid on the two integral values of ``y``:
+
+* ``y = 1``: the ordinary tangent to a convex function -- a global
+  underestimator;
+* ``y = 0``: semicontinuity gives ``x = 0``, so the true term is ``0`` and (P)
+  reads ``s >= 0``.
+
+and (P) dominates the plain tangent everywhere in ``y <= 1``, strictly wherever
+``y < 1`` and ``z != 0``. This is what SCIP does automatically (Bestuzheva,
+Gleixner and Vigerske, "A computational study of perspective cuts") and what
+MINLPLib's hand-written ``squfl*persp`` variants encode by hand; see
+``docs/references.bib``.
+
+This module only *detects* the structure. Applying it is
+``discopt.solvers.oa._strengthen_objective_cut_perspective``, which uses (P) to
+strengthen the OA master's objective epigraph row.
+
+**Why a cut and not a model rewrite.** Rewriting ``q*x**2`` to ``q*s`` with
+``x**2 <= s*y`` was built first and measured: on ``squfl015-060`` /
+``squfl020-150`` / ``squfl025-040`` at 60 s the primal gap collapses from
++68.9% / +114.8% / +114.9% to 0.00% / 0.00% / 0.05%, but the added row is
+nonconvex-quadratic, so the model leaves the convex relaxation for the spatial
+path and **the dual bound gets looser on every one**. Trading a certificate for
+an incumbent is a certification regression under CLAUDE.md §5, so the rewrite
+was dropped. The cut below gives up nothing: the model is untouched and the row
+it strengthens is one the master already carried.
+
+Nothing here is keyed to a problem name or shape (CLAUDE.md §2): the detector
+reads the model's own linear constraints and objective Hessian.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+
+import numpy as np
+
+from discopt.modeling.core import (
+    Constraint,
+    Model,
+    ObjectiveSense,
+    Variable,
+    VarType,
+)
+
+from .term_classifier import _compute_var_offset
+
+logger = logging.getLogger(__name__)
+
+__all__ = ["perspective_objective_terms", "perspective_oa_cut_enabled"]
+
+#: Coefficients below this are treated as structurally zero when reading the
+#: objective Hessian. Matches the classifier's own quadratic-term tolerance.
+_ZERO_TOL = 1e-12
+#: Refuse an indicator upper bound past this magnitude: a semicontinuous variable
+#: with a bound that large is not really switched off by its indicator, and
+#: ``q*U**2`` would swamp the row it is added to.
+_U_CAP = 1e15
+
+
+class _Candidate:
+    """One ``q*x**2`` term whose ``x`` is semicontinuous."""
+
+    __slots__ = ("var", "elem", "flat", "ind_var", "ind_elem", "u", "q")
+
+    def __init__(self, var, elem, flat, ind_var, ind_elem, u, q=0.0):
+        self.var = var
+        self.elem = elem
+        self.flat = flat
+        self.ind_var = ind_var
+        self.ind_elem = ind_elem
+        self.u = u
+        #: the term's coefficient in ``q*x**2``, MINIMIZE convention.
+        self.q = float(q)
+
+
+def _flat_index(var: Variable, elem: int, model: Model) -> int:
+    return _compute_var_offset(var, model) + elem
+
+
+def _bound(var: Variable, elem: int, which: str) -> float:
+    return float(np.asarray(getattr(var, which)).flat[elem])
+
+
+def _is_binary(var: Variable, elem: int) -> bool:
+    if var.var_type == VarType.BINARY:
+        return True
+    if var.var_type != VarType.INTEGER:
+        return False
+    return _bound(var, elem, "lb") >= -_ZERO_TOL and _bound(var, elem, "ub") <= 1.0 + _ZERO_TOL
+
+
+def _semicontinuity_rows(model: Model) -> dict[int, tuple[Variable, int, float]]:
+    """Map ``flat(x) -> (indicator, elem, U)`` for every row ``a*x - b*y <= 0``.
+
+    Only two-term rows with zero constant qualify, because anything else is not
+    the switch-off implication the perspective hull needs. A variable governed by
+    two different indicators keeps the *tightest* ``U``: both rows hold, so the
+    smaller bound is the one the disjunction may assume.
+    """
+    from .problem_classifier import _extract_linear_coefficients_sparse, _NotLinearError
+
+    n = sum(v.size for v in model._variables)
+    flat_to_ref: dict[int, tuple[Variable, int]] = {}
+    for v in model._variables:
+        base = _compute_var_offset(v, model)
+        for e in range(v.size):
+            flat_to_ref[base + e] = (v, e)
+
+    found: dict[int, tuple[Variable, int, float]] = {}
+    for con in model._constraints:
+        if not isinstance(con, Constraint) or con.sense not in ("<=", ">="):
+            continue
+        try:
+            terms, const = _extract_linear_coefficients_sparse(con.body, model, n)
+        except _NotLinearError:
+            # The extractor's own "this row is not linear" signal, and the only
+            # failure this loop may absorb: a nonlinear body simply is not the
+            # ``x <= U*y`` implication we are scanning for, and skipping it costs
+            # at most a missed candidate (fewer lifts, never an unsound one).
+            # Anything else propagates -- a swallowed failure here would read as
+            # "this model has no semicontinuous structure" (CLAUDE.md §7).
+            continue
+        if len(terms) != 2 or abs(const) > _ZERO_TOL:
+            continue
+        sign = 1.0 if con.sense == "<=" else -1.0
+        (i, ai), (j, aj) = terms.items()
+        ai, aj = sign * ai, sign * aj
+        # Orient as  ai*x + aj*y <= 0  with ai > 0 > aj, i.e.  x <= (-aj/ai) y.
+        for (xi, cx), (yi, cy) in ((((i, ai), (j, aj))), (((j, aj), (i, ai)))):
+            if cx <= _ZERO_TOL or cy >= -_ZERO_TOL:
+                continue
+            xvar, xelem = flat_to_ref[xi]
+            yvar, yelem = flat_to_ref[yi]
+            if not _is_binary(yvar, yelem):
+                continue
+            if xvar.var_type == VarType.BINARY:
+                continue  # a binary's square is linear; nothing to strengthen
+            u = -cy / cx
+            if not np.isfinite(u) or u <= _ZERO_TOL or u > _U_CAP:
+                continue
+            prev = found.get(xi)
+            if prev is None or u < prev[2]:
+                found[xi] = (yvar, yelem, u)
+    return found
+
+
+def _objective_hessian(model: Model):
+    """``(Q, n)`` for the objective in MINIMIZE convention, or ``None``.
+
+    ``Q`` follows the classifier's ``0.5 x'Qx`` convention, so a term ``q*x^2``
+    appears as ``Q[j, j] = 2q``.
+    """
+    from .problem_classifier import _extract_quadratic_coefficients, dense_Q
+
+    if model._objective is None:
+        return None
+    n = sum(v.size for v in model._variables)
+    try:
+        Q, _c, _d = _extract_quadratic_coefficients(model._objective.expression, model, n)
+    except Exception as exc:
+        logger.debug("perspective reform: objective is not quadratic (%s)", exc)
+        return None
+    Q = dense_Q(Q)
+    if model._objective.sense == ObjectiveSense.MAXIMIZE:
+        Q = -Q
+    return Q, n
+
+
+def find_candidates(model: Model) -> list[_Candidate]:
+    """Every ``q*x**2`` in the objective whose ``x`` is semicontinuous.
+
+    Each gate is a soundness condition, not a heuristic:
+
+    * ``Q[j, j] > 0`` -- the term must be *convex* in MINIMIZE convention.
+      Minimization then drives the lifted ``s`` down onto ``x^2``; with a
+      negative coefficient it would be driven up to its bound instead and the
+      rewrite would cut off the true optimum.
+    * ``Q[j, k] == 0`` for ``k != j`` -- the term must be *separable*. A
+      cross-term means ``x`` also appears in a product this pass does not lift,
+      and replacing only the square would not be an identity.
+    * ``lb(x) >= 0`` -- the indicator row gives ``x <= U*y``, so ``y = 0`` yields
+      ``x <= 0``. Only a nonnegative ``x`` is thereby *pinned to zero*; if ``x``
+      could go negative the perspective row ``x^2 <= s*y`` would forbid points
+      the original model allows.
+    """
+    hess = _objective_hessian(model)
+    if hess is None:
+        return []
+    Q, _n = hess
+    if Q.ndim != 2 or Q.shape[0] != Q.shape[1]:
+        return []
+    rows = _semicontinuity_rows(model)
+    if not rows:
+        return []
+
+    out: list[_Candidate] = []
+    for v in model._variables:
+        if v.var_type == VarType.BINARY:
+            continue
+        base = _compute_var_offset(v, model)
+        for e in range(v.size):
+            flat = base + e
+            hit = rows.get(flat)
+            if hit is None:
+                continue
+            if flat >= Q.shape[0]:
+                continue
+            if Q[flat, flat] <= _ZERO_TOL:
+                continue
+            off = np.abs(Q[flat, :]).sum() - abs(Q[flat, flat])
+            if off > _ZERO_TOL:
+                continue
+            if _bound(v, e, "lb") < -_ZERO_TOL:
+                continue
+            ind_var, ind_elem, u = hit
+            out.append(_Candidate(v, e, flat, ind_var, ind_elem, u, 0.5 * float(Q[flat, flat])))
+    return out
+
+
+def perspective_objective_terms(model: Model) -> list[tuple[int, int, float]]:
+    """``(x_col, y_col, q)`` per separable convex square over a semicontinuous ``x``.
+
+    The row this feeds is the OA master's objective epigraph tangent, one
+    aggregate row per expansion point ``xbar``::
+
+        eta >= f(xbar) + grad f(xbar)^T (x - xbar)
+
+    For a separable convex square over a semicontinuous ``x`` that term's own
+    contribution to the tangent, ``2*q*xbar*x - q*xbar**2``, is dominated by the
+    perspective cut ``2*q*xbar*x - q*xbar**2 * y`` (module docstring). Summing
+    the perspective form over the qualifying terms and the ordinary tangent over
+    the rest keeps the whole row a valid underestimator of ``f``, hence a valid
+    master cut, and nothing about a node box enters -- so the row is globally
+    valid exactly as the tangent it replaces was.
+
+    In row form the master cut is ``grad^T x - eta <= rhs``; strengthening term
+    ``i`` subtracts ``q_i*xbar_i**2`` from **both** the ``y_i`` coefficient and
+    the right-hand side. At ``y_i = 1`` the two cancel and the row is unchanged,
+    which is the algebraic statement of "identical to the tangent at ``y = 1``".
+
+    Returns ``[]`` when the model has no such structure, so the caller pays one
+    Hessian read per solve and nothing else.
+    """
+    out: list[tuple[int, int, float]] = []
+    for cand in find_candidates(model):
+        if not (cand.q > _ZERO_TOL) or not np.isfinite(cand.q):
+            continue
+        y_col = _flat_index(cand.ind_var, cand.ind_elem, model)
+        out.append((int(cand.flat), int(y_col), float(cand.q)))
+    return out
+
+
+def perspective_oa_cut_enabled() -> bool:
+    """Is the #1064 perspective strengthening of the OA objective cut switched on?
+
+    **Default OFF.** Strengthening a master cut is bound-changing under
+    CLAUDE.md §5 regime 2 -- the master's optimum is the OA dual bound, so a
+    tighter row moves it by construction -- and it stays opt-in until the
+    corpus-wide differential panel clears both bars. Unlike the *rewrite* it
+    replaces, it cannot lose a certificate by changing which relaxation the
+    model gets: the model is untouched and the row it strengthens is one the
+    master already carried.
+
+    ``DISCOPT_PERSPECTIVE_OA_CUT=0`` is the opt-out once it graduates. Read per
+    call, not cached at import, so a test can flip it without reloading.
+    """
+    return os.environ.get("DISCOPT_PERSPECTIVE_OA_CUT", "0").strip() not in ("", "0")

--- a/python/discopt/_relax/perspective.py
+++ b/python/discopt/_relax/perspective.py
@@ -270,15 +270,19 @@ def perspective_objective_terms(model: Model) -> list[tuple[int, int, float]]:
 def perspective_oa_cut_enabled() -> bool:
     """Is the #1064 perspective strengthening of the OA objective cut switched on?
 
-    **Default OFF.** Strengthening a master cut is bound-changing under
-    CLAUDE.md §5 regime 2 -- the master's optimum is the OA dual bound, so a
-    tighter row moves it by construction -- and it stays opt-in until the
-    corpus-wide differential panel clears both bars. Unlike the *rewrite* it
-    replaces, it cannot lose a certificate by changing which relaxation the
-    model gets: the model is untouched and the row it strengthens is one the
-    master already carried.
+    **Default ON (graduated).** Strengthening a master cut is bound-changing
+    under CLAUDE.md §5 regime 2 -- the master's optimum is the OA dual bound, so
+    a tighter row moves it by construction. Unlike the *rewrite* it replaces, it
+    cannot lose a certificate by changing which relaxation the model gets: the
+    model is untouched and the row it strengthens is one the master already
+    carried.
 
-    ``DISCOPT_PERSPECTIVE_OA_CUT=0`` is the opt-out once it graduates. Read per
-    call, not cached at import, so a test can flip it without reloading.
+    It shipped default-OFF and graduated on the differential panel over the full
+    affected population -- every corpus instance that carries the structure --
+    which cleared both §5 bars: PANEL_CERT_CLEAN and PANEL_NET_POSITIVE (see the
+    commit and ``docs/dev/performance-plan.md`` §19 for the table).
+
+    ``DISCOPT_PERSPECTIVE_OA_CUT=0`` is the opt-out. Read per call, not cached at
+    import, so a test can flip it without reloading.
     """
-    return os.environ.get("DISCOPT_PERSPECTIVE_OA_CUT", "0").strip() not in ("", "0")
+    return os.environ.get("DISCOPT_PERSPECTIVE_OA_CUT", "1").strip() not in ("", "0")

--- a/python/discopt/_relax/problem_classifier.py
+++ b/python/discopt/_relax/problem_classifier.py
@@ -365,7 +365,7 @@ def _extract_linear_coefficients_sparse(expr, model: Model, n: int):
             raise _NotLinearError(f"variable slot {i} outside the model's {n} flat slots")
         terms[i] = terms.get(i, 0.0) + v
 
-    def _walk(node, scale=1.0, allow_array=False):
+    def _walk(root, root_scale=1.0, root_allow_array=False):
         # ``allow_array`` is True only inside a ``sum(...)`` reduction, where a
         # size>1 (sub)expression contributes a single scalar row (its element sum
         # with a *uniform* scale). Outside a sum, encountering a size>1 array node
@@ -373,133 +373,148 @@ def _extract_linear_coefficients_sparse(expr, model: Model, n: int):
         # extractor would collapse it to one summed row (C-29), certifying an
         # infeasible point. Refuse instead so extract_lp_data() routes the body to
         # the per-component autodiff extractor (one LP row per element).
+        #
+        # **Iterative, not recursive (#1064).** A ``.nl`` body is a left-leaning
+        # ``((((a+b)+c)+d)+...)`` chain one node deep per term, so a recursive walk
+        # needs one Python frame per term and dies on ordinary corpus instances:
+        # ``sporttournament40``, ``edgecross24-057`` and 15 others raised
+        # ``RecursionError`` here, which the caller reports as "this row is not
+        # linear" -- indistinguishable from a genuinely nonlinear row. Children are
+        # pushed in reverse so they pop in source order, keeping the floating-point
+        # accumulation into ``terms``/``const`` bit-identical (CLAUDE.md §5 regime 1).
         nonlocal const
 
-        if isinstance(node, Constant):
-            val = node.value
-            if val.ndim == 0 or val.size == 1:
-                const += scale * float(val.reshape(()))
-            else:
-                raise _NotLinearError("Array constant in unexpected position")
-            return
+        stack: list[tuple[object, float, bool]] = [(root, root_scale, root_allow_array)]
+        while stack:
+            node, scale, allow_array = stack.pop()
 
-        if isinstance(node, Variable):
-            offset = _compute_var_offset(node, model)
-            if node.size == 1:
-                _add(offset, scale)
-            elif allow_array:
-                # Inside sum(): sum(scale * x) = scale * Σ x_j (uniform scale).
-                for j in range(node.size):
-                    _add(offset + j, scale)
-            else:
-                raise _NotLinearError(
-                    "Array variable in scalar position (vector-valued body); "
-                    "routing to the per-component extractor"
-                )
-            return
-
-        if isinstance(node, IndexExpression):
-            if isinstance(node.base, Variable):
-                var = node.base
-                offset = _compute_var_offset(var, model)
-                idx = node.index
-                if isinstance(idx, (int, np.integer)):
-                    _add(offset + int(idx), scale)
-                elif (
-                    isinstance(idx, tuple)
-                    and len(idx) == 1
-                    and isinstance(idx[0], (int, np.integer))
-                ):
-                    _add(offset + int(idx[0]), scale)
+            if isinstance(node, Constant):
+                val = node.value
+                if val.ndim == 0 or val.size == 1:
+                    const += scale * float(val.reshape(()))
                 else:
-                    # Multi-dimensional index: flatten
-                    try:
-                        flat_idx = np.ravel_multi_index(
-                            idx if isinstance(idx, tuple) else (idx,), var.shape
-                        )
-                    except (TypeError, ValueError):
-                        # Sliced/partial subscript (vectorized term): this scalar
-                        # extractor cannot express it; classify as not-linear.
-                        raise _NotLinearError(f"non-scalar index {idx!r} on {var.name}") from None
-                    _add(offset + int(flat_idx), scale)
-                return
-            raise _NotLinearError(f"IndexExpression on non-variable: {type(node.base)}")
+                    raise _NotLinearError("Array constant in unexpected position")
+                continue
 
-        if isinstance(node, BinaryOp):
-            if node.op == "+":
-                _walk(node.left, scale, allow_array)
-                _walk(node.right, scale, allow_array)
-                return
-            if node.op == "-":
-                _walk(node.left, scale, allow_array)
-                _walk(node.right, -scale, allow_array)
-                return
-            if node.op == "*":
-                # One side must be a scalar constant for linearity. A size>1 array
-                # constant here raises _NotLinearError from _eval_const (the scale
-                # would differ per element), which routes to the per-component
-                # extractor rather than collapsing.
-                if _is_const_expr(node.left):
-                    cval = _eval_const(node.left)
-                    _walk(node.right, scale * cval, allow_array)
-                    return
-                if _is_const_expr(node.right):
-                    cval = _eval_const(node.right)
-                    _walk(node.left, scale * cval, allow_array)
-                    return
-                raise _NotLinearError("Product of two variable expressions")
-            if node.op == "/":
-                if _is_const_expr(node.right):
-                    cval = _eval_const(node.right)
-                    _walk(node.left, scale / cval, allow_array)
-                    return
-                raise _NotLinearError("Division by variable expression")
-            raise _NotLinearError(f"Non-linear operator: {node.op}")
+            if isinstance(node, Variable):
+                offset = _compute_var_offset(node, model)
+                if node.size == 1:
+                    _add(offset, scale)
+                elif allow_array:
+                    # Inside sum(): sum(scale * x) = scale * Σ x_j (uniform scale).
+                    for j in range(node.size):
+                        _add(offset + j, scale)
+                else:
+                    raise _NotLinearError(
+                        "Array variable in scalar position (vector-valued body); "
+                        "routing to the per-component extractor"
+                    )
+                continue
 
-        if isinstance(node, UnaryOp):
-            if node.op == "neg":
-                _walk(node.operand, -scale, allow_array)
-                return
-            raise _NotLinearError(f"Non-linear unary op: {node.op}")
+            if isinstance(node, IndexExpression):
+                if isinstance(node.base, Variable):
+                    var = node.base
+                    offset = _compute_var_offset(var, model)
+                    idx = node.index
+                    if isinstance(idx, (int, np.integer)):
+                        _add(offset + int(idx), scale)
+                    elif (
+                        isinstance(idx, tuple)
+                        and len(idx) == 1
+                        and isinstance(idx[0], (int, np.integer))
+                    ):
+                        _add(offset + int(idx[0]), scale)
+                    else:
+                        # Multi-dimensional index: flatten
+                        try:
+                            flat_idx = np.ravel_multi_index(
+                                idx if isinstance(idx, tuple) else (idx,), var.shape
+                            )
+                        except (TypeError, ValueError):
+                            # Sliced/partial subscript (vectorized term): this scalar
+                            # extractor cannot express it; classify as not-linear.
+                            raise _NotLinearError(
+                                f"non-scalar index {idx!r} on {var.name}"
+                            ) from None
+                        _add(offset + int(flat_idx), scale)
+                    continue
+                raise _NotLinearError(f"IndexExpression on non-variable: {type(node.base)}")
 
-        if isinstance(node, SumOverExpression):
-            for term in node.terms:
-                _walk(term, scale, allow_array)
-            return
+            if isinstance(node, BinaryOp):
+                if node.op == "+":
+                    stack.append((node.right, scale, allow_array))
+                    stack.append((node.left, scale, allow_array))
+                    continue
+                if node.op == "-":
+                    stack.append((node.right, -scale, allow_array))
+                    stack.append((node.left, scale, allow_array))
+                    continue
+                if node.op == "*":
+                    # One side must be a scalar constant for linearity. A size>1 array
+                    # constant here raises _NotLinearError from _eval_const (the scale
+                    # would differ per element), which routes to the per-component
+                    # extractor rather than collapsing.
+                    if _is_const_expr(node.left):
+                        cval = _eval_const(node.left)
+                        stack.append((node.right, scale * cval, allow_array))
+                        continue
+                    if _is_const_expr(node.right):
+                        cval = _eval_const(node.right)
+                        stack.append((node.left, scale * cval, allow_array))
+                        continue
+                    raise _NotLinearError("Product of two variable expressions")
+                if node.op == "/":
+                    if _is_const_expr(node.right):
+                        cval = _eval_const(node.right)
+                        stack.append((node.left, scale / cval, allow_array))
+                        continue
+                    raise _NotLinearError("Division by variable expression")
+                raise _NotLinearError(f"Non-linear operator: {node.op}")
 
-        if isinstance(node, SumExpression):
-            # sum(expr) reduces expr to a scalar: element-collapse is legitimate
-            # here (uniform scale), so allow array nodes beneath this point.
-            _walk(node.operand, scale, allow_array=True)
-            return
+            if isinstance(node, UnaryOp):
+                if node.op == "neg":
+                    stack.append((node.operand, -scale, allow_array))
+                    continue
+                raise _NotLinearError(f"Non-linear unary op: {node.op}")
 
-        if isinstance(node, MatMulExpression):
-            # Handle Constant @ Variable or Variable @ Constant
-            if isinstance(node.left, Constant) and isinstance(node.right, Variable):
-                mat = node.left.value
-                var = node.right
-                offset = _compute_var_offset(var, model)
-                # mat @ var => result is mat @ x[offset:offset+size]
-                # For 1-D mat (dot product), coefficients are mat elements
-                if mat.ndim == 1:
-                    for j in range(var.size):
-                        _add(offset + j, scale * float(mat[j]))
-                elif mat.ndim == 2:
-                    # Returns vector; this should be used inside a sum
+            if isinstance(node, SumOverExpression):
+                for term in reversed(node.terms):
+                    stack.append((term, scale, allow_array))
+                continue
+
+            if isinstance(node, SumExpression):
+                # sum(expr) reduces expr to a scalar: element-collapse is legitimate
+                # here (uniform scale), so allow array nodes beneath this point.
+                stack.append((node.operand, scale, True))
+                continue
+
+            if isinstance(node, MatMulExpression):
+                # Handle Constant @ Variable or Variable @ Constant
+                if isinstance(node.left, Constant) and isinstance(node.right, Variable):
+                    mat = node.left.value
+                    var = node.right
+                    offset = _compute_var_offset(var, model)
+                    # mat @ var => result is mat @ x[offset:offset+size]
+                    # For 1-D mat (dot product), coefficients are mat elements
+                    if mat.ndim == 1:
+                        for j in range(var.size):
+                            _add(offset + j, scale * float(mat[j]))
+                    elif mat.ndim == 2:
+                        # Returns vector; this should be used inside a sum
+                        raise _NotLinearError("MatMul returning vector in scalar context")
+                    continue
+                if isinstance(node.right, Constant) and isinstance(node.left, Variable):
+                    mat = node.right.value
+                    var = node.left
+                    offset = _compute_var_offset(var, model)
+                    if mat.ndim == 1:
+                        for j in range(var.size):
+                            _add(offset + j, scale * float(mat[j]))
+                        continue
                     raise _NotLinearError("MatMul returning vector in scalar context")
-                return
-            if isinstance(node.right, Constant) and isinstance(node.left, Variable):
-                mat = node.right.value
-                var = node.left
-                offset = _compute_var_offset(var, model)
-                if mat.ndim == 1:
-                    for j in range(var.size):
-                        _add(offset + j, scale * float(mat[j]))
-                    return
-                raise _NotLinearError("MatMul returning vector in scalar context")
-            raise _NotLinearError("MatMul between non-trivial expressions")
+                raise _NotLinearError("MatMul between non-trivial expressions")
 
-        raise _NotLinearError(f"Unhandled expression type: {type(node).__name__}")
+            raise _NotLinearError(f"Unhandled expression type: {type(node).__name__}")
 
     _walk(expr)
     return terms, const
@@ -608,154 +623,174 @@ def _extract_quadratic_terms(expr, model: Model, n: int):
             return resolve_scalar_slot(node, model)
         return None
 
-    def _walk(node, scale=1.0, allow_array=False):
+    def _walk(root, root_scale=1.0, root_allow_array=False):
         # See _extract_linear_coefficients._walk: ``allow_array`` is True only
         # inside a sum() reduction, where a size>1 array variable legitimately
         # collapses to a single scalar term. Outside a sum, an array variable in
         # scalar position means a vector-valued body that must NOT be collapsed to
         # one row (C-29) — refuse so the caller routes to the autodiff extractor.
+        #
+        # **Iterative, not recursive (#1064).** A ``.nl`` objective is a
+        # left-leaning ``((((a+b)+c)+d)+...)`` chain one node deep per term, so a
+        # recursive walk needs one Python frame per term and dies on the ordinary
+        # case: ``squfl025-040`` (1000 terms) and ``squfl015-080`` (1200) both
+        # raised ``RecursionError`` here, which ``_extract_quadratic_coefficients``
+        # reports as "not quadratic". A genuinely convex separable MIQP therefore
+        # failed to be *recognised* as one — no Hessian, no convex route, no
+        # perspective structure — purely because its objective was long. The work
+        # stack removes the depth limit; nothing else about the walk changes.
+        #
+        # Children are pushed in reverse so they pop in source order: the
+        # accumulations into ``c``/``const``/``q_terms`` are floating-point sums,
+        # and reordering them would perturb the last ulp of every extracted
+        # coefficient — a bound-neutral change under CLAUDE.md §5 regime 1 must be
+        # bit-identical, so the order is preserved deliberately.
         nonlocal const
 
-        if isinstance(node, Constant):
-            val = node.value
-            if val.ndim == 0 or val.size == 1:
-                const += scale * float(val.reshape(()))
-            else:
-                raise _NotQuadraticError("Array constant in unexpected position")
-            return
+        stack: list[tuple[object, float, bool]] = [(root, root_scale, root_allow_array)]
+        while stack:
+            node, scale, allow_array = stack.pop()
 
-        if isinstance(node, (Variable, IndexExpression)):
-            idx = _get_var_index(node)
-            if idx is not None:
-                c[idx] += scale
-                return
-            if isinstance(node, Variable) and node.size > 1:
-                if not allow_array:
-                    raise _NotQuadraticError(
-                        "Array variable in scalar position (vector-valued body); "
-                        "routing to the per-component extractor"
-                    )
-                offset = _compute_var_offset(node, model)
-                for j in range(node.size):
-                    c[offset + j] += scale
-                return
-            raise _NotQuadraticError(f"Cannot extract index from {node}")
+            if isinstance(node, Constant):
+                val = node.value
+                if val.ndim == 0 or val.size == 1:
+                    const += scale * float(val.reshape(()))
+                else:
+                    raise _NotQuadraticError("Array constant in unexpected position")
+                continue
 
-        if isinstance(node, BinaryOp):
-            if node.op == "+":
-                _walk(node.left, scale, allow_array)
-                _walk(node.right, scale, allow_array)
-                return
-            if node.op == "-":
-                _walk(node.left, scale, allow_array)
-                _walk(node.right, -scale, allow_array)
-                return
-            if node.op == "*":
-                # Check: const * expr, expr * const, or var * var
-                if _is_const_expr(node.left):
-                    cval = _eval_const(node.left)
-                    _walk(node.right, scale * cval, allow_array)
-                    return
-                if _is_const_expr(node.right):
-                    cval = _eval_const(node.right)
-                    _walk(node.left, scale * cval, allow_array)
-                    return
-                # var * var => quadratic term
-                # Q is the Hessian: f = 0.5 x'Qx, so d²(c*xi*xj)/dxi dxj = c,
-                # but d²(c*xi²)/dxi² = 2c. We store the Hessian directly.
-                idx_l = _get_var_index(node.left)
-                idx_r = _get_var_index(node.right)
-                if idx_l is not None and idx_r is not None:
-                    if idx_l == idx_r:
-                        _qadd(idx_l, idx_r, 2.0 * scale)
-                    else:
-                        _qadd(idx_l, idx_r, scale)
-                        _qadd(idx_r, idx_l, scale)
-                    return
-                # Handle (const * var) * var or var * (const * var):
-                # e.g., (Q[i,j] * x[i]) * x[j] from left-to-right evaluation
-                cv_l = _try_extract_const_var(node.left, model)
-                if cv_l is not None and idx_r is not None:
-                    cval, idx_l2 = cv_l
-                    if idx_l2 == idx_r:
-                        _qadd(idx_l2, idx_r, 2.0 * scale * cval)
-                    else:
-                        _qadd(idx_l2, idx_r, scale * cval)
-                        _qadd(idx_r, idx_l2, scale * cval)
-                    return
-                cv_r = _try_extract_const_var(node.right, model)
-                if cv_r is not None and idx_l is not None:
-                    cval, idx_r2 = cv_r
-                    if idx_l == idx_r2:
-                        _qadd(idx_l, idx_r2, 2.0 * scale * cval)
-                    else:
-                        _qadd(idx_l, idx_r2, scale * cval)
-                        _qadd(idx_r2, idx_l, scale * cval)
-                    return
-                raise _NotQuadraticError("Product of non-simple variable expressions")
-            if node.op == "/":
-                if _is_const_expr(node.right):
-                    cval = _eval_const(node.right)
-                    _walk(node.left, scale / cval, allow_array)
-                    return
-                raise _NotQuadraticError("Division by variable expression")
-            if node.op == "**":
-                # x**2 => quadratic
-                if _is_const_expr(node.right):
-                    pval = _eval_const(node.right)
-                    if abs(pval - 2.0) < 1e-12:
-                        idx = _get_var_index(node.left)
-                        if idx is not None:
-                            _qadd(idx, idx, 2.0 * scale)  # x^2 = 0.5 * 2 * x^2
-                            return
-                    if abs(pval - 1.0) < 1e-12:
-                        _walk(node.left, scale, allow_array)
-                        return
-                    if abs(pval) < 1e-12:
-                        const += scale
-                        return
-                raise _NotQuadraticError(f"Power with exponent {node.right}")
-            raise _NotQuadraticError(f"Unknown binary op: {node.op}")
+            if isinstance(node, (Variable, IndexExpression)):
+                idx = _get_var_index(node)
+                if idx is not None:
+                    c[idx] += scale
+                    continue
+                if isinstance(node, Variable) and node.size > 1:
+                    if not allow_array:
+                        raise _NotQuadraticError(
+                            "Array variable in scalar position (vector-valued body); "
+                            "routing to the per-component extractor"
+                        )
+                    offset = _compute_var_offset(node, model)
+                    for j in range(node.size):
+                        c[offset + j] += scale
+                    continue
+                raise _NotQuadraticError(f"Cannot extract index from {node}")
 
-        if isinstance(node, UnaryOp):
-            if node.op == "neg":
-                _walk(node.operand, -scale, allow_array)
-                return
-            raise _NotQuadraticError(f"Non-linear unary op: {node.op}")
+            if isinstance(node, BinaryOp):
+                if node.op == "+":
+                    stack.append((node.right, scale, allow_array))
+                    stack.append((node.left, scale, allow_array))
+                    continue
+                if node.op == "-":
+                    stack.append((node.right, -scale, allow_array))
+                    stack.append((node.left, scale, allow_array))
+                    continue
+                if node.op == "*":
+                    # Check: const * expr, expr * const, or var * var
+                    if _is_const_expr(node.left):
+                        cval = _eval_const(node.left)
+                        stack.append((node.right, scale * cval, allow_array))
+                        continue
+                    if _is_const_expr(node.right):
+                        cval = _eval_const(node.right)
+                        stack.append((node.left, scale * cval, allow_array))
+                        continue
+                    # var * var => quadratic term
+                    # Q is the Hessian: f = 0.5 x'Qx, so d²(c*xi*xj)/dxi dxj = c,
+                    # but d²(c*xi²)/dxi² = 2c. We store the Hessian directly.
+                    idx_l = _get_var_index(node.left)
+                    idx_r = _get_var_index(node.right)
+                    if idx_l is not None and idx_r is not None:
+                        if idx_l == idx_r:
+                            _qadd(idx_l, idx_r, 2.0 * scale)
+                        else:
+                            _qadd(idx_l, idx_r, scale)
+                            _qadd(idx_r, idx_l, scale)
+                        continue
+                    # Handle (const * var) * var or var * (const * var):
+                    # e.g., (Q[i,j] * x[i]) * x[j] from left-to-right evaluation
+                    cv_l = _try_extract_const_var(node.left, model)
+                    if cv_l is not None and idx_r is not None:
+                        cval, idx_l2 = cv_l
+                        if idx_l2 == idx_r:
+                            _qadd(idx_l2, idx_r, 2.0 * scale * cval)
+                        else:
+                            _qadd(idx_l2, idx_r, scale * cval)
+                            _qadd(idx_r, idx_l2, scale * cval)
+                        continue
+                    cv_r = _try_extract_const_var(node.right, model)
+                    if cv_r is not None and idx_l is not None:
+                        cval, idx_r2 = cv_r
+                        if idx_l == idx_r2:
+                            _qadd(idx_l, idx_r2, 2.0 * scale * cval)
+                        else:
+                            _qadd(idx_l, idx_r2, scale * cval)
+                            _qadd(idx_r2, idx_l, scale * cval)
+                        continue
+                    raise _NotQuadraticError("Product of non-simple variable expressions")
+                if node.op == "/":
+                    if _is_const_expr(node.right):
+                        cval = _eval_const(node.right)
+                        stack.append((node.left, scale / cval, allow_array))
+                        continue
+                    raise _NotQuadraticError("Division by variable expression")
+                if node.op == "**":
+                    # x**2 => quadratic
+                    if _is_const_expr(node.right):
+                        pval = _eval_const(node.right)
+                        if abs(pval - 2.0) < 1e-12:
+                            idx = _get_var_index(node.left)
+                            if idx is not None:
+                                _qadd(idx, idx, 2.0 * scale)  # x^2 = 0.5 * 2 * x^2
+                                continue
+                        if abs(pval - 1.0) < 1e-12:
+                            stack.append((node.left, scale, allow_array))
+                            continue
+                        if abs(pval) < 1e-12:
+                            const += scale
+                            continue
+                    raise _NotQuadraticError(f"Power with exponent {node.right}")
+                raise _NotQuadraticError(f"Unknown binary op: {node.op}")
 
-        if isinstance(node, SumOverExpression):
-            for term in node.terms:
-                _walk(term, scale, allow_array)
-            return
+            if isinstance(node, UnaryOp):
+                if node.op == "neg":
+                    stack.append((node.operand, -scale, allow_array))
+                    continue
+                raise _NotQuadraticError(f"Non-linear unary op: {node.op}")
 
-        if isinstance(node, SumExpression):
-            # sum(expr) reduces to a scalar: array collapse legitimate below here.
-            _walk(node.operand, scale, allow_array=True)
-            return
+            if isinstance(node, SumOverExpression):
+                for term in reversed(node.terms):
+                    stack.append((term, scale, allow_array))
+                continue
 
-        if isinstance(node, MatMulExpression):
-            # Handle Constant @ Variable for linear parts of QP constraints
-            if isinstance(node.left, Constant) and isinstance(node.right, Variable):
-                mat = node.left.value
-                var = node.right
-                offset = _compute_var_offset(var, model)
-                if mat.ndim == 1:
-                    for j in range(var.size):
-                        c[offset + j] += scale * float(mat[j])
-                    return
-                raise _NotQuadraticError("MatMul returning vector")
-            if isinstance(node.right, Constant) and isinstance(node.left, Variable):
-                mat = node.right.value
-                var = node.left
-                offset = _compute_var_offset(var, model)
-                if mat.ndim == 1:
-                    for j in range(var.size):
-                        c[offset + j] += scale * float(mat[j])
-                    return
-                raise _NotQuadraticError("MatMul returning vector")
-            raise _NotQuadraticError("MatMul between non-trivial expressions")
+            if isinstance(node, SumExpression):
+                # sum(expr) reduces to a scalar: array collapse legitimate below here.
+                stack.append((node.operand, scale, True))
+                continue
 
-        raise _NotQuadraticError(f"Unhandled expression type: {type(node).__name__}")
+            if isinstance(node, MatMulExpression):
+                # Handle Constant @ Variable for linear parts of QP constraints
+                if isinstance(node.left, Constant) and isinstance(node.right, Variable):
+                    mat = node.left.value
+                    var = node.right
+                    offset = _compute_var_offset(var, model)
+                    if mat.ndim == 1:
+                        for j in range(var.size):
+                            c[offset + j] += scale * float(mat[j])
+                        continue
+                    raise _NotQuadraticError("MatMul returning vector")
+                if isinstance(node.right, Constant) and isinstance(node.left, Variable):
+                    mat = node.right.value
+                    var = node.left
+                    offset = _compute_var_offset(var, model)
+                    if mat.ndim == 1:
+                        for j in range(var.size):
+                            c[offset + j] += scale * float(mat[j])
+                        continue
+                    raise _NotQuadraticError("MatMul returning vector")
+                raise _NotQuadraticError("MatMul between non-trivial expressions")
+
+            raise _NotQuadraticError(f"Unhandled expression type: {type(node).__name__}")
 
     _walk(expr)
     return q_terms, c, const

--- a/python/discopt/solvers/oa.py
+++ b/python/discopt/solvers/oa.py
@@ -1223,6 +1223,17 @@ def _decompose_model(model: Model) -> _DecomposedProblem:
     # back the tape evaluator (default-ON since #75) and only falls back to JAX
     # when the model is not tape-representable.
     evaluator = make_evaluator(model)
+    # #1064: the perspective strengthening of the objective epigraph cut needs
+    # the model's ``q*x**2``-over-semicontinuous-``x`` structure, which is a
+    # property of the model and not of any node, so it is read once here and
+    # carried on the evaluator -- ``_add_oa_cuts`` is reached from a dozen call
+    # sites and receives the evaluator but not the model. ``_BoundsProxy``
+    # forwards unknown attributes to the evaluator it wraps, so a bounds-scoped
+    # copy sees the same table. See ``_relax.perspective.perspective_objective_terms``.
+    if _perspective_oa_terms_enabled():
+        from discopt._relax.perspective import perspective_objective_terms
+
+        evaluator._perspective_oa_terms = perspective_objective_terms(model)
     oa_convexity = classify_oa_cut_convexity(model)
     n_vars = evaluator.n_variables
     n_cons = evaluator.n_constraints
@@ -2198,6 +2209,53 @@ def _append_master_cut(
         )
 
 
+#: #1064 §6 telemetry: how many perspective strengthenings were actually
+#: applied to objective epigraph rows this process. A panel arm that reports
+#: zero here measured the control twice, whatever the flag said.
+_PERSPECTIVE_OA_CUT_APPLIED: list[int] = [0]
+
+
+def _perspective_oa_terms_enabled() -> bool:
+    """Thin re-export so ``oa.py`` does not import ``solver.py`` (cycle)."""
+    from discopt._relax.perspective import perspective_oa_cut_enabled
+
+    return perspective_oa_cut_enabled()
+
+
+def _strengthen_objective_cut_perspective(coeffs, rhs, x_star, n_vars, terms):
+    """Perspective-strengthen an OA objective epigraph row in place-safe form.
+
+    ``coeffs``/``rhs`` are the row ``grad^T x - eta <= rhs``. For each
+    ``(x_col, y_col, q)`` whose ``x`` is semicontinuous with indicator ``y``,
+    the tangent's own constant ``-q*xbar**2`` is replaced by ``-q*xbar**2 * y``:
+    subtract ``q*xbar**2`` from the ``y`` coefficient and from ``rhs``. At
+    ``y = 1`` the two cancel and the row is unchanged; at ``y = 0``
+    semicontinuity forces ``x = 0`` and the row correctly reads ``eta >= 0``
+    instead of the tangent's slack ``eta >= -q*xbar**2``.
+
+    Returns ``(coeffs, rhs, n_applied)``. ``n_applied`` is the CLAUDE.md §6
+    executed count: a silent zero here is a strengthening that never happened,
+    which is exactly how a no-op reads as a pass.
+    """
+    applied = 0
+    for x_col, y_col, q in terms:
+        if not (0 <= x_col < n_vars and 0 <= y_col < n_vars):
+            # The master row is laid out over the model's flat columns; an index
+            # past them means the two layouts disagree and the shift would land
+            # on the wrong variable. Refuse the term rather than guess.
+            continue
+        xbar = float(x_star[x_col])
+        if not np.isfinite(xbar):
+            continue
+        shift = q * xbar * xbar
+        if not np.isfinite(shift) or shift <= 0.0:
+            continue  # xbar == 0: the tangent is already the perspective cut
+        coeffs[y_col] -= shift
+        rhs -= shift
+        applied += 1
+    return coeffs, rhs, applied
+
+
 def _add_oa_cuts(
     evaluator,
     x_star,
@@ -2316,11 +2374,24 @@ def _add_oa_cuts(
         obj_value = float(evaluator.evaluate_objective(x_star))
         obj_support = np.concatenate([np.asarray(x_star, dtype=np.float64), [obj_value]])
         obj_cut = generate_objective_oa_cut(evaluator, x_star, n_master, z_index=n_vars)
+        obj_coeffs_row = obj_cut.coeffs.copy()
+        obj_rhs = float(obj_cut.rhs)
+        # #1064: strengthen the aggregate tangent with the perspective of every
+        # separable convex square over a semicontinuous variable. Globally valid
+        # (see ``_relax.perspective``), so ``global_valid=True`` below is
+        # unchanged, and a no-op when the model has no such structure.
+        _persp_terms = getattr(evaluator, "_perspective_oa_terms", None)
+        if _persp_terms:
+            obj_coeffs_row, obj_rhs, _n_persp = _strengthen_objective_cut_perspective(
+                obj_coeffs_row, obj_rhs, x_star, n_vars, _persp_terms
+            )
+            if _n_persp:
+                _PERSPECTIVE_OA_CUT_APPLIED[0] += _n_persp
         _append_master_cut(
             oa_A_rows,
             oa_b_rows,
-            obj_cut.coeffs.copy(),
-            obj_cut.rhs,
+            obj_coeffs_row,
+            obj_rhs,
             oa_cut_relaxable,
             relaxable=False,
             cut_provenance=cut_provenance,

--- a/python/tests/test_1064_perspective_oa_cut.py
+++ b/python/tests/test_1064_perspective_oa_cut.py
@@ -1,0 +1,257 @@
+"""#1064: perspective strengthening of the OA objective epigraph cut.
+
+Two independent defects are covered here, both found while chasing the ``squfl``
+family's 69-115% primal gap:
+
+1. Both ``_extract_quadratic_terms`` and ``_extract_linear_coefficients_sparse``
+   recursed once per ``+`` in a sum chain, so a long enough objective or
+   constraint body raised ``RecursionError``. The caller reports that as "not
+   quadratic" / "not linear" -- indistinguishable from a genuinely nonlinear
+   body, so a convex separable MIQP silently lost its Hessian and its
+   semicontinuity structure purely because it was long. 17 of the 1610
+   MINLPLib instances hit the linear one (``sporttournament*``,
+   ``edgecross*``, ``autocorr_bern*``, ``ibs2``); 2 hit the quadratic one.
+2. The OA master's objective epigraph cut was the plain aggregate tangent, which
+   throws away the perspective of every separable convex square over a
+   semicontinuous variable (Frangioni-Gentile).
+"""
+
+import numpy as np
+import pytest
+from discopt import Model
+from discopt._relax.perspective import (
+    perspective_oa_cut_enabled,
+    perspective_objective_terms,
+)
+from discopt._relax.problem_classifier import (
+    _extract_linear_coefficients_sparse,
+    _extract_quadratic_coefficients,
+    dense_Q,
+)
+from discopt.solvers.oa import _strengthen_objective_cut_perspective
+
+
+def _semicontinuous_model(n=3, u=5.0, q=None):
+    """``min sum q_i x_i^2 - 4 x_i + 3 y_i`` with ``x_i <= u*y_i``."""
+    q = q or [1.0] * n
+    m = Model()
+    xs = [m.continuous(f"x{i}", lb=0.0, ub=u) for i in range(n)]
+    ys = [m.binary(f"y{i}") for i in range(n)]
+    for x, y in zip(xs, ys):
+        m.subject_to(x - u * y <= 0.0)
+    m.minimize(sum(q[i] * xs[i] * xs[i] - 4.0 * xs[i] + 3.0 * ys[i] for i in range(n)))
+    return m, xs, ys
+
+
+class TestLongSumExtraction:
+    """Defect 1: a long objective must not defeat quadratic extraction."""
+
+    def test_long_separable_objective_extracts(self):
+        # 3000 summed terms => a 3000-deep left-leaning ``+`` chain, well past
+        # CPython's default recursion limit. Before the fix this raised
+        # RecursionError, which the caller reports as "not quadratic".
+        n = 3000
+        m = Model()
+        x = [m.continuous(f"x{i}", lb=0.0, ub=1.0) for i in range(n)]
+        m.minimize(sum((i + 1) * x[i] * x[i] for i in range(n)))
+        Q, c, const = _extract_quadratic_coefficients(m._objective.expression, m, n)
+        Qd = dense_Q(Q) if not isinstance(Q, np.ndarray) else Q
+        # ``0.5 x'Qx`` convention: a term ``k*x^2`` lands as ``Q[k,k] = 2k``.
+        assert Qd.shape == (n, n)
+        np.testing.assert_allclose(np.diag(Qd), 2.0 * np.arange(1, n + 1))
+        assert abs(const) < 1e-12
+        np.testing.assert_allclose(c, np.zeros(n), atol=1e-12)
+
+    def test_short_chain_unchanged(self):
+        """The iterative walk must agree with the hand-computed answer exactly."""
+        m = Model()
+        x = m.continuous("x", lb=0.0, ub=1.0)
+        y = m.continuous("y", lb=0.0, ub=1.0)
+        m.minimize(3.0 * x * x + 2.0 * x * y - 5.0 * y + 7.0)
+        Q, c, const = _extract_quadratic_coefficients(m._objective.expression, m, 2)
+        Qd = dense_Q(Q) if not isinstance(Q, np.ndarray) else Q
+        np.testing.assert_array_equal(Qd, np.array([[6.0, 2.0], [2.0, 0.0]]))
+        np.testing.assert_array_equal(np.asarray(c), np.array([0.0, -5.0]))
+        assert const == 7.0
+
+    def test_long_linear_constraint_body_extracts(self):
+        """The *linear* extractor has the same defect and the same fix.
+
+        Reached in production via ``_relax.perspective._semicontinuity_rows``,
+        which reads every row of the model to find ``x <= u*y``. A single long
+        row used to abort that scan with ``RecursionError``.
+        """
+        n = 3000
+        m = Model()
+        x = [m.continuous(f"x{i}", lb=0.0, ub=1.0) for i in range(n)]
+        m.subject_to(sum((i + 1) * x[i] for i in range(n)) - 12.5 <= 0.0)
+        terms, const = _extract_linear_coefficients_sparse(m._constraints[0].body, m, n)
+        assert len(terms) == n
+        assert all(terms[i] == float(i + 1) for i in range(n))
+        assert const == -12.5
+
+    def test_linear_walk_preserves_signs_and_scales(self):
+        """Nested ``-``/``*``/``/``/unary-minus must survive the work stack.
+
+        The recursive walk carried the running ``scale`` down the call stack; the
+        iterative one carries it on the stack entry. A sign dropped in that
+        translation would be silent, so pin the exact coefficients.
+        """
+        m = Model()
+        a = m.continuous("a", lb=-10.0, ub=10.0)
+        b = m.continuous("b", lb=-10.0, ub=10.0)
+        c = m.continuous("c", lb=-10.0, ub=10.0)
+        m.subject_to(2.0 * a - (3.0 * b - c) + (-(4.0 * a)) + b / 2.0 - 6.0 <= 0.0)
+        terms, const = _extract_linear_coefficients_sparse(m._constraints[0].body, m, 3)
+        assert terms[0] == 2.0 - 4.0  # 2a from the head, -4a from the unary minus
+        assert terms[1] == -3.0 + 0.5  # -3b from the subtraction, +b/2
+        assert terms[2] == 1.0  # -(-c) from the nested subtraction
+        assert const == -6.0
+
+
+class TestPerspectiveTermDetection:
+    def test_detects_semicontinuous_squares(self):
+        m, xs, ys = _semicontinuous_model(n=3)
+        terms = perspective_objective_terms(m)
+        assert sorted((x, y) for x, y, _q in terms) == [(0, 3), (1, 4), (2, 5)]
+        assert all(abs(q - 1.0) < 1e-12 for _x, _y, q in terms)
+
+    def test_declines_without_an_indicator_row(self):
+        m = Model()
+        x = m.continuous("x", lb=0.0, ub=5.0)
+        m.binary("y")  # present but never bounds x
+        m.minimize(x * x)
+        assert perspective_objective_terms(m) == []
+
+    def test_declines_a_concave_term(self):
+        m = Model()
+        x = m.continuous("x", lb=0.0, ub=5.0)
+        y = m.binary("y")
+        m.subject_to(x - 5.0 * y <= 0.0)
+        m.minimize(-1.0 * x * x)
+        assert perspective_objective_terms(m) == []
+
+    def test_declines_a_cross_term(self):
+        """A non-separable square is not a perspective candidate."""
+        m = Model()
+        x = m.continuous("x", lb=0.0, ub=5.0)
+        z = m.continuous("z", lb=0.0, ub=5.0)
+        y = m.binary("y")
+        m.subject_to(x - 5.0 * y <= 0.0)
+        m.minimize(x * x + x * z)
+        assert perspective_objective_terms(m) == []
+
+
+class TestCutStrengthening:
+    """The row transform itself: valid, exact at ``y = 1``, tighter below it."""
+
+    def _row(self, q, xbar, n_vars=2, x_col=0, y_col=1):
+        # Plain tangent of ``q x^2`` at ``xbar``: ``2 q xbar x - eta <= q xbar^2``.
+        coeffs = np.zeros(n_vars + 1)
+        coeffs[x_col] = 2.0 * q * xbar
+        coeffs[n_vars] = -1.0
+        rhs = q * xbar * xbar
+        return coeffs, rhs
+
+    def test_identity_at_y_equals_one(self):
+        q, xbar = 2.0, 1.5
+        plain_c, plain_r = self._row(q, xbar)
+        strong_c, strong_r, applied = _strengthen_objective_cut_perspective(
+            self._row(q, xbar)[0], self._row(q, xbar)[1], np.array([xbar, 1.0]), 2, [(0, 1, q)]
+        )
+        assert applied == 1
+        for x in (0.0, 0.5, 1.5, 3.0):
+            pt = np.array([x, 1.0, q * x * x])
+            assert abs((strong_c @ pt - strong_r) - (plain_c @ pt - plain_r)) < 1e-12
+
+    def test_valid_at_y_equals_zero(self):
+        q, xbar = 2.0, 1.5
+        strong_c, strong_r, applied = _strengthen_objective_cut_perspective(
+            self._row(q, xbar)[0], self._row(q, xbar)[1], np.array([xbar, 1.0]), 2, [(0, 1, q)]
+        )
+        assert applied == 1
+        # Semicontinuity: y = 0 forces x = 0, hence eta >= 0.
+        pt = np.array([0.0, 0.0, 0.0])
+        assert strong_c @ pt <= strong_r + 1e-12
+
+    def test_strictly_tighter_at_fractional_y(self):
+        q, xbar = 2.0, 1.5
+        plain_c, plain_r = self._row(q, xbar)
+        strong_c, strong_r, _ = _strengthen_objective_cut_perspective(
+            self._row(q, xbar)[0], self._row(q, xbar)[1], np.array([xbar, 1.0]), 2, [(0, 1, q)]
+        )
+        pt = np.array([0.75, 0.5, 0.0])
+        assert (strong_c @ pt - strong_r) > (plain_c @ pt - plain_r) + 1e-9
+
+    @pytest.mark.parametrize("xbar", [0.0, 0.25, 1.0, 4.0])
+    @pytest.mark.parametrize("yval", [0.0, 1.0])
+    def test_never_cuts_a_feasible_point(self, xbar, yval):
+        """Every point satisfying semicontinuity and ``eta >= q x^2`` survives."""
+        q = 3.0
+        strong_c, strong_r, _ = _strengthen_objective_cut_perspective(
+            self._row(q, xbar)[0], self._row(q, xbar)[1], np.array([xbar, 1.0]), 2, [(0, 1, q)]
+        )
+        checked = 0
+        for x in (0.0, 0.5, 2.0, 5.0):
+            if yval == 0.0 and x != 0.0:
+                continue  # not feasible: y = 0 forces x = 0
+            pt = np.array([x, yval, q * x * x])
+            assert strong_c @ pt <= strong_r + 1e-9, (xbar, yval, x)
+            checked += 1
+        assert checked > 0
+
+    def test_refuses_an_out_of_range_column(self):
+        """A column past the master's own width is a layout disagreement, not a
+        cut to guess at."""
+        q, xbar = 2.0, 1.5
+        _c, _r, applied = _strengthen_objective_cut_perspective(
+            self._row(q, xbar)[0], self._row(q, xbar)[1], np.array([xbar, 1.0]), 2, [(0, 9, q)]
+        )
+        assert applied == 0
+
+
+class TestFlag:
+    def test_default_off(self, monkeypatch):
+        monkeypatch.delenv("DISCOPT_PERSPECTIVE_OA_CUT", raising=False)
+        assert perspective_oa_cut_enabled() is False
+
+    def test_opt_in(self, monkeypatch):
+        monkeypatch.setenv("DISCOPT_PERSPECTIVE_OA_CUT", "1")
+        assert perspective_oa_cut_enabled() is True
+
+    def test_zero_is_off(self, monkeypatch):
+        monkeypatch.setenv("DISCOPT_PERSPECTIVE_OA_CUT", "0")
+        assert perspective_oa_cut_enabled() is False
+
+
+@pytest.mark.slow
+class TestEndToEnd:
+    def test_flag_on_does_not_lose_the_optimum(self, monkeypatch):
+        """A small semicontinuous MIQP must solve to the same optimum either way."""
+        monkeypatch.setenv("DISCOPT_PERSPECTIVE_OA_CUT", "0")
+        m_off, _x, _y = _semicontinuous_model(n=3, q=[1.0, 2.0, 0.5])
+        r_off = m_off.solve(time_limit=30)
+        monkeypatch.setenv("DISCOPT_PERSPECTIVE_OA_CUT", "1")
+        m_on, _x2, _y2 = _semicontinuous_model(n=3, q=[1.0, 2.0, 0.5])
+        r_on = m_on.solve(time_limit=30)
+        assert r_off.objective is not None and r_on.objective is not None
+        assert r_on.objective <= r_off.objective + 1e-6
+        if r_off.bound is not None and r_on.bound is not None:
+            # A strengthened cut may only tighten the dual bound, never loosen it
+            # past the optimum it is reported against.
+            assert r_on.bound <= r_on.objective + 1e-6
+
+    def test_no_structure_is_a_no_op(self, monkeypatch):
+        """Without semicontinuous squares the flag must change nothing."""
+        from discopt.solvers import oa as _oa
+
+        m = Model()
+        x = m.continuous("x", lb=-2.0, ub=2.0)
+        y = m.binary("y")
+        m.subject_to(x + y >= 0.5)
+        m.minimize(x * x + y)
+        monkeypatch.setenv("DISCOPT_PERSPECTIVE_OA_CUT", "1")
+        before = _oa._PERSPECTIVE_OA_CUT_APPLIED[0]
+        r = m.solve(time_limit=30)
+        assert r.objective is not None
+        assert _oa._PERSPECTIVE_OA_CUT_APPLIED[0] == before

--- a/python/tests/test_1064_perspective_oa_cut.py
+++ b/python/tests/test_1064_perspective_oa_cut.py
@@ -211,15 +211,17 @@ class TestCutStrengthening:
 
 
 class TestFlag:
-    def test_default_off(self, monkeypatch):
+    def test_default_on_after_graduation(self, monkeypatch):
+        """Graduated default-ON on the §5 panel over the full affected population."""
         monkeypatch.delenv("DISCOPT_PERSPECTIVE_OA_CUT", raising=False)
-        assert perspective_oa_cut_enabled() is False
+        assert perspective_oa_cut_enabled() is True
 
     def test_opt_in(self, monkeypatch):
         monkeypatch.setenv("DISCOPT_PERSPECTIVE_OA_CUT", "1")
         assert perspective_oa_cut_enabled() is True
 
-    def test_zero_is_off(self, monkeypatch):
+    def test_zero_is_the_opt_out(self, monkeypatch):
+        """The opt-out must survive graduation -- §5 requires the legacy path stay reachable."""
         monkeypatch.setenv("DISCOPT_PERSPECTIVE_OA_CUT", "0")
         assert perspective_oa_cut_enabled() is False
 


### PR DESCRIPTION
## What

Two independent, general defects behind the `squfl` convex-MIQP family's 69–115%
primal gap (#1064).

### 1. Recursive expression walks died on ordinary corpus instances

A `.nl` body is a left-leaning `((((a+b)+c)+d)+…)` chain — one AST node per term —
so `_extract_quadratic_terms._walk` and `_extract_linear_coefficients_sparse._walk`
each needed one Python frame per term. Both raised `RecursionError`, which the
callers report as *"not quadratic"* / *"not linear"* — **indistinguishable from a
genuinely nonlinear body**. A convex separable MIQP therefore lost its Hessian and
its semicontinuity structure purely because its objective was long.

Measured over all **1610** MINLPLib `.nl` instances: 2 hit the quadratic walk
(`squfl025-040`, `squfl015-080`), **17** hit the linear one (`sporttournament30…40`,
`edgecross*`, `autocorr_bern*`, `ibs2`). After the fix the corpus scan reports
`ERRORS 0`.

Both walks now use an explicit work stack. Children are pushed in reverse so they
pop in source order, keeping the floating-point accumulation **bit-identical**
(CLAUDE.md §5 regime 1).

### 2. The OA master's objective epigraph cut was the plain aggregate tangent

It threw away the perspective of every separable convex square over a
semicontinuous variable. For binary `y` with a row `x <= u*y`, `y = 0` forces
`x = 0`, so the Frangioni–Gentile cut

```
eta >= 2q*z*x - q*z^2*y
```

is valid using only `y in {0,1}` — **no box enters**, hence globally valid and safe
to keep across nodes. In the master's row form `grad^T x - eta <= rhs`,
strengthening term `i` subtracts `q_i*xbar_i^2` from **both** `coeffs[y_col_i]` and
`rhs`: at `y_i = 1` the two cancel and the row is *identical* to the plain tangent;
at `y_i = 0` it reads `eta >= 0` instead of `eta >= -q*xbar^2`. Strictly tighter for
`y_i < 1`.

New `_relax/perspective.py` detects the structure **once per solve** from
`model._constraints` — a property of the model, valid in every box, unlike a node
relaxation's rows. Behind `DISCOPT_PERSPECTIVE_OA_CUT`, now **default ON** -- the
§5 graduation panel below passes both bars.

## Structure population (CLAUDE.md §2 — not a single-instance fix)

Exactly **20 of 1610** corpus instances carry the structure: `squfl*` (14),
`watercontamination0202/0303`, `st_miqp2`, `st_miqp4`, `st_test3`,
`meanvar-orl400_05_e_8`. Every other instance is a provable no-op — the detector
returns an empty term list and the cut path is not entered.

## Falsified and dropped (§4 / §11)

Lifting `q*x^2` to `q*s` with `x^2 <= s*y` rewrites the model into a **nonconvex
QCQP**, which leaves the convex relaxation for the spatial path. Its primal gain was
large (68.9% → 0.00%, 114.8% → 0.00%, 114.9% → 0.05%) but the **dual bound came out
looser on every** `squfl` instance — a certification regression under §5. It trades
the certificate for the incumbent, so it is not shipped. Recorded in the new
module's docstring.

Also dropped: a spatial row separator (`wt1064persp`), measured `sep_calls=0` /
`nodes_via_mccormick=0` on reformed models — it never fired.

## Measurements

60 s, interleaved, §6 counter (`persp_applied`) proving the strengthening actually
fired. **Same bound and same node count on both arms** — the gain is purely primal
and there is no certification regression:

| instance | flag | applied | obj | bound | nodes | status | gap |
|---|---|---|---|---|---|---|---|
| squfl010-025 | 0 | 0 | 214.111 | 214.111 | 371 | optimal | −0.0% |
| squfl010-025 | 1 | 5750 | 214.111 | 214.111 | 371 | optimal | −0.0% |
| squfl015-060 | 0 | 0 | 619.389 | 307.514 | 1055 | feasible | 68.9% |
| squfl015-060 | 1 | 9000 | **375.591** | 307.514 | 1055 | feasible | **2.4%** |
| squfl015-080 | 0 | 0 | 821.264 | 296.717 | 703 | feasible | 104.0% |
| squfl015-080 | 1 | 10800 | **465.460** | 296.717 | 703 | feasible | **15.6%** |
| squfl025-040 | 0 | 0 | 423.980 | 127.705 | 1023 | feasible | 114.9% |
| squfl025-040 | 1 | 11000 | **233.818** | 127.705 | 1023 | feasible | **18.5%** |

`bound_above_ref = false` on every row.

### Validity (§5 feasible-point sampling)

200 semicontinuity-respecting points per instance, checked against **both** the
strengthened and the plain row: **0 violations**, `applied == len(terms)` on every
instance, and `STRICTLY_TIGHTER == n_instances` at fractional `y`
(`squfl010-025` tighter by 3290.68; `squfl015-060` by 11085).

### Bit-identity (§5 regime 1) for the extractor rewrites

SHA-256 over the extracted `(Q, c, const)` and `(terms, const)` across corpus
instances. Every instance the recursive walk could process hashes **identically**;
the only hashes that move are the ones that previously raised `RecursionError`
(e.g. `ibs2` goes from `{ok: 1810, RecursionError: 1}` to `{ok: 1811}`).

## Tests run

- `pytest -m smoke` — **1076 passed**, 1 skipped, 2 xpassed
- `pytest -m slow python/tests/test_adversarial_recent_fixes.py` — **19 passed**
- new `python/tests/test_1064_perspective_oa_cut.py` — **23 passed**

The two new linear-extractor tests were confirmed to **fail before** the change
(`RecursionError: maximum recursion depth exceeded` against `main`) and pass after.

No Rust was touched, so `cargo test` is not applicable to this change.

## §5 graduation panel (20 instances, 60 s, interleaved OFF/ON per instance)

Every `squfl*` in the corpus, plus the four non-`squfl` instances the detector
fires on and the two it declines (`watercontamination0202/0303`,
`persp_applied = 0`) as the neutral control. All twenty are MINIMIZE, so a
**higher** bound is tighter.

| instance | applied | gap OFF | gap ON | bound OFF | bound ON | nodes |
|---|---|---|---|---|---|---|
| squfl010-025 | 5750 | -0.000 | -0.000 | 214.11 | 214.11 | 371 -> 371 |
| squfl010-040 | 8000 | -0.000 | -0.000 | 240.60 | 240.60 | 293 -> 293 |
| squfl010-080 | 8000 | -0.000 | -0.000 | 509.71 | 509.71 | 593 -> 593 |
| squfl015-060 | 9000 | 68.945 | **2.446** | 307.51 | 307.51 | 1055 -> 1055 |
| squfl015-080 | 10800 | 104.047 | **15.645** | 296.72 | 296.72 | 703 -> 703 |
| squfl020-040 | 8800 | 85.592 | **0.000** | 183.76 | **184.14** | 1503 -> 1535 |
| squfl020-050 | 9000 | 129.453 | **2.284** | 165.44 | 165.44 | 1151 -> 1151 |
| squfl020-150 | 18000 | 114.749 | **14.082** | 253.21 | **346.46** | 31 -> 31 |
| squfl025-025 | 8125 | 44.806 | **-0.000** | 141.58 | 141.58 | 2303 -> 2303 |
| squfl025-030 | 10500 | 29.997 | **0.543** | 151.04 | 151.04 | 1503 -> 1503 |
| squfl025-040 | 11000 | 114.854 | **18.488** | 127.70 | 127.70 | 1023 -> 1023 |
| squfl030-100 | 15000 | 317.248 | **14.137** | 123.89 | **189.55** | 3 -> 3 |
| squfl030-150 | 9000 | 243.690 | **10.209** | 158.93 | **238.17** | 3 -> 3 |
| squfl040-080 | 9600 | 498.274 | **35.569** | 91.49 | **132.45** | 3 -> 3 |
| meanvar-orl400_05_e_8 | 800 | 6.433 | 6.433 | 98.12 | 98.12 | 31 -> 31 |
| st_miqp2 | 11 | 0.000 | 0.000 | 2 | 2 | 0 -> 0 |
| st_miqp4 | 6 | 0.000 | 0.000 | -4574 | -4574 | 0 -> 0 |
| st_test3 | 1 | 0.000 | 0.000 | -7 | -7 | 0 -> 0 |
| watercontamination0202 | 0 | -- | -- | none | none | 0 -> 0 |
| watercontamination0303 | 0 | -- | -- | none | none | 0 -> 0 |

```
gap: better=11 worse=0 unchanged=7
dual bound: tighter=5 looser=0
nodes: more=1 fewer=0
CERT-CLEAN: PASS   NET-POSITIVE: PASS   GRADUATE: YES   CHECKS_EXECUTED 20
```

**Bar 1 (cert-clean)**: no bound above its reference optimum, no `optimal ->
non-optimal` regression, no dual bound loosened, no arm losing a bound the other
had, no `infeasible` where the other arm found a point. **Bar 2 (net-positive)**:
gap improves on 11 of 18 scored instances and worsens on none; five dual bounds
tighten. The two instances #1064 reported as returning nothing after 600 s --
`squfl020-150` and `squfl025-040` -- both return incumbents at 60 s.

The one node-count change (`squfl020-040`, 1503 -> 1535) is expected: this is a
bound-*changing* flag under §5 regime 2, so the tree is allowed to move.
`watercontamination*` applies zero cuts and is byte-identical on both arms, which
is the §6 evidence that "no change" there means the detector correctly declined
rather than that the panel never ran.

Flag is now default-ON with `DISCOPT_PERSPECTIVE_OA_CUT=0` as the opt-out; the
plain-tangent path is untouched. Panel table also recorded in
`docs/dev/performance-plan.md` §19.5.

Re-ran with the flag default-ON: `pytest -m smoke` 1076 passed / 1 skipped /
2 xpassed; adversarial suite 19 passed; `test_1064_perspective_oa_cut.py`
23 passed.

Closes #1064

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017PQaiDVuY5Rs3tga98tnNo

