### PR TITLE
fix(cuts): #1061 root cuts must reach vector-block models; reframe OBBT premise

### DIFF
--- a/docs/dev/performance-plan.md
+++ b/docs/dev/performance-plan.md
@@ -3296,3 +3296,65 @@ named, delivered upstream, and it is worth taking because the LP layer is now
 genuinely fast rather than because the solver got faster. §16's conclusion stands
 unchanged: discopt's gap to BARON is node-NLP and Python marshaling (69% and
 82.5% respectively per `baron-gap-plan.md` §1.3), not LU throughput.
+
+## 19. #1061 root cuts: `DISCOPT_NLPBB_ROOT_CUTS` is sound but not helpful — stays OFF (rejected 2026-08-20)
+
+**Why this was run.** #1061 reports discopt's root dual bound sitting 27.1x above
+the reference optimum on `syn40m` and 8.5x on `rsyn0840m`. The root cutting-plane
+stage (#781, `DISCOPT_NLPBB_ROOT_CUTS`, default-OFF) was the nearest built lever,
+and PR #1094 fixed a real defect in it: `_root_cuts` switched *itself* off on any
+model whose objective arrived as a vector block, so on that whole class the stage
+had never run at all. With the stage actually reaching those models, the §5
+graduation gate became answerable for the first time.
+
+**The panel.** Flag ON vs OFF over the in-repo corpus, 6 shards, 60 s/instance,
+**153 instances with complete pairs in both arms**.
+
+| gate | result |
+|---|---|
+| dual bound | tighter 31, looser **13**, flat 109 |
+| primal shortfall | better 4, worse **6**, same 93 |
+| total wall | OFF 3015.9 s, ON 3020.8 s (+0.2%) |
+| bound above its reference optimum (`RAISED`) | **0 instances** |
+| certification regression | **`clay0303hfsg`** (`gap_certified` True → False) |
+| **CERT-CLEAN** | **FAIL** |
+| **NET-POSITIVE** | **FAIL** |
+
+**Both bars fail, and they fail for different reasons.** Soundness in the narrow
+sense holds — no bound in the ON arm rose above its reference optimum in 153
+pairs, so the cuts are valid. But §5's cert-clean bar is broader than "no false
+bound": `clay0303hfsg` regresses from `gap_certified=True` to uncertified, which
+is a certificate lost, and that alone disqualifies the flag.
+
+**The looseners are a coherent family, not scatter.** Every large regression is
+`clay*`:
+
+| instance | dual bound OFF → ON |
+|---|---|
+| `clay0205hfsg` | 1889.99 → **26.89** |
+| `clay0304m` | 39347.56 → **6545.0** |
+| `clay0303hfsg` | 26669.11 → **19513.27** |
+| `clay0304hfsg` | 3915.87 → **1840.0** |
+
+plus two primal losses on the same family (`clay0205m` 0.0% → 233.4% short,
+`clay0304m` 0.0% → 4.62% short). A cut round cannot *loosen* a valid dual bound
+on its own; what it does is spend root budget and move the trajectory, and on
+`clay*` that trade is severely negative. The gains, meanwhile, are real but small
+and concentrated in the `fo*`/`m*`/`no*` families (e.g. `fo9_ar2_1` 14.34 → 20.38,
+`fo7_ar3_1` 8.08 → 11.10) — 31 tighter against 13 looser is not the broad win §5
+asks for, and the primal column is net *negative*.
+
+**Verdict: `DISCOPT_NLPBB_ROOT_CUTS` stays default-OFF.** This is the
+`DISCOPT_CUT_INHERIT` shape exactly — sound is not the same as helpful — and §5
+says a cert-clean-but-neutral flag stays off. Here it is not even cert-clean. PR
+#1094's fix ships on its own merits (the stage silently disabling itself on
+vector-block models is a defect whether or not the flag ever graduates) and
+carries `Contributes to #1061`, not `Closes`.
+
+**What this does NOT establish.** It does not say root cuts are the wrong idea for
+the syn/rsyn class; it says *this* implementation, at this budget, is not ready to
+default on. And it leaves #1061's headline untouched: the 27.1x on `syn40m` is a
+property of the big-M relaxation itself. The lever that *does* move #1061 turned
+out to be elsewhere entirely — a free-column pricing defect in the simplex that
+silently disabled OBBT's exact-LP oracle on this whole class — and it ships on its
+own branch (`fix/1061-phase1-open-column`), not here.

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -15466,13 +15466,12 @@ def _solve_nlp_bb(
     if _model_is_convex and rens_enabled and _lns_enabled:
         try:
             from discopt.solvers._root_cuts import (
+                flat_column_terms,
                 generate_root_cuts,
                 nlpbb_root_cuts_enabled,
             )
 
-            if nlpbb_root_cuts_enabled() and all(
-                getattr(v, "size", 1) == 1 for v in model._variables
-            ):
+            if nlpbb_root_cuts_enabled():
                 from discopt.modeling.core import Constraint as _RCConstraint
 
                 _rc_is_int = np.zeros(n_vars, bool)
@@ -15486,11 +15485,11 @@ def _solve_nlp_bb(
                     model, _rc_ev, lb, ub, _rc_is_int, _rc_is_bin, time_budget_s=_rc_budget
                 )
                 jax_time += time.perf_counter() - t_jax_start
-                _rc_blocks = model._variables
+                _rc_cols = flat_column_terms(model)
                 for _rc_a, _rc_r in _rc.cuts:
                     _rc_body = None
                     for _j in np.nonzero(np.abs(_rc_a) > 1e-15)[0]:
-                        _term = float(_rc_a[_j]) * _rc_blocks[int(_j)]
+                        _term = float(_rc_a[_j]) * _rc_cols[int(_j)]
                         _rc_body = _term if _rc_body is None else _rc_body + _term
                     if _rc_body is None:
                         continue

--- a/python/discopt/solvers/_root_cuts.py
+++ b/python/discopt/solvers/_root_cuts.py
@@ -64,6 +64,45 @@ def nlpbb_root_cuts_enabled() -> bool:
     return val not in ("", "0", "false", "off", "no")
 
 
+def flat_column_terms(model) -> list:
+    """One modeling term per *flat* column, in the model's own column order.
+
+    ``generate_root_cuts`` returns each cut as a dense coefficient vector over
+    flat columns. Writing that vector back as a ``Constraint`` needs an
+    expression per column, and a block variable of size ``n`` occupies ``n``
+    consecutive columns in C order -- the same flattening the evaluator and the
+    FBBT bound vectors use (``np.concatenate([np.asarray(x[v.name]).ravel()
+    for v in model._variables])``).
+
+    Indexing ``model._variables`` directly by flat column is only correct when
+    every block is scalar. The call site used to *gate on* that
+    (``all(size == 1)``), which silently disabled the whole root-cut stage for
+    any model built with vector variables -- a modeling style, not a problem
+    class, so the restriction violated CLAUDE.md SS2. Unravelling here removes
+    it: ``.nl`` and ``.gms`` imports (all-scalar blocks) are unchanged, and
+    array-API models now get the same cuts.
+    """
+    cols: list = []
+    for v in model._variables:
+        size = int(getattr(v, "size", 1))
+        if size == 1:
+            cols.append(v)
+            continue
+        shape = getattr(v, "shape", None)
+        if shape is None:
+            shape = (size,)
+        shape = tuple(int(d) for d in shape)
+        if int(np.prod(shape)) != size:
+            raise ValueError(
+                f"variable {getattr(v, 'name', '?')!r}: shape {shape} does not "
+                f"match size {size}; cannot map flat columns"
+            )
+        for k in range(size):
+            idx = tuple(int(t) for t in np.unravel_index(k, shape))
+            cols.append(v[idx[0] if len(idx) == 1 else idx])
+    return cols
+
+
 @dataclass
 class RootCutResult:
     """Applied cuts (``alpha·x <= rhs`` each) and the final root-LP dual bound."""

--- a/python/tests/test_nlpbb_root_cuts_781.py
+++ b/python/tests/test_nlpbb_root_cuts_781.py
@@ -200,3 +200,89 @@ def test_rsyn0805m_flag_on_sound_and_tighter(monkeypatch):
     # the composed bound is at most the root-cut LP bound (~1577.3 measured);
     # flag-off tree bound at this budget is ~1768 — require a real improvement
     assert r.bound <= 1650.0, f"root-cut bound composition ineffective: {r.bound}"
+
+
+# ── vector variable blocks: the stage must not silently switch itself off ────
+
+
+def _build_convex_minlp_vector() -> Model:
+    """The same fixed-charge model as ``_build_convex_minlp('min')``, written
+    with *vector* variable blocks instead of four scalars.
+
+    Identical feasible set and objective, so the two forms must get the same
+    optimum -- and, once flat columns are unravelled, the same root-cut stage.
+    """
+    m = Model("rc_vec")
+    f = m.continuous("f", shape=2, lb=0.0, ub=10.0)
+    y = m.binary("y", shape=2)
+    m.subject_to(f[0] - 8.0 * y[0] <= 0.0)
+    m.subject_to(f[1] - 8.0 * y[1] <= 0.0)
+    m.subject_to(f[0] + f[1] >= 3.0)
+    m.subject_to(f[0] * f[0] + f[1] * f[1] <= 16.0)
+    m.minimize(f[0] + 2.0 * f[1] + 2.5 * y[0] + 2.5 * y[1])
+    return m
+
+
+def test_flat_column_terms_covers_blocks_in_column_order():
+    """One term per flat column, blocks unravelled in C order.
+
+    The flat layout is ``concatenate([asarray(x[v.name]).ravel() for v in
+    model._variables])``, so a ``(2, 3)`` block owns six consecutive columns
+    row-major. Asserting the *count* alone would pass for a wrong order, so
+    each term is checked to name its own block.
+    """
+    from discopt.solvers._root_cuts import flat_column_terms
+
+    m = Model("flatmap")
+    a = m.continuous("a", lb=0.0, ub=1.0)
+    m.continuous("b", shape=(2, 3), lb=0.0, ub=1.0)
+    m.binary("c", shape=4)
+    m.minimize(a)
+
+    cols = flat_column_terms(m)
+    assert len(cols) == 1 + 6 + 4, "one term per flat column"
+    assert cols[0] is a, "scalar blocks are passed through unwrapped"
+    checks = 0
+    for j, expected in (
+        [(0, "a")] + [(1 + k, "b") for k in range(6)] + [(7 + k, "c") for k in range(4)]
+    ):
+        term = cols[j]
+        base = getattr(term, "base", term)
+        assert getattr(base, "name", None) == expected, (
+            f"flat column {j} should belong to block {expected!r}"
+        )
+        checks += 1
+    assert checks == 11, "CHECKS_EXECUTED must cover every flat column"
+
+
+def test_root_cuts_fire_on_vector_variable_blocks(monkeypatch):
+    """Regression: the stage used to be gated on ``all(size == 1)``.
+
+    That gate is a *modeling-style* restriction, not a problem-class one -- it
+    silently disabled every root cut for array-API models while reporting a
+    normal solve (CLAUDE.md §2, §6). Fails before the unravel fix (0 cuts
+    added), passes after.
+    """
+    _flag(monkeypatch, False)
+    base = _build_convex_minlp_vector().solve(time_limit=30, nlp_bb=True)
+    assert base.objective is not None
+    n_before = len(_build_convex_minlp_vector()._constraints)
+
+    _flag(monkeypatch, True)
+    m = _build_convex_minlp_vector()
+    r = m.solve(time_limit=30, nlp_bb=True)
+    added = len(m._constraints) - n_before
+    assert added > 0, "root-cut stage must reach models built from vector blocks"
+    # ...and the cuts must be sound: same optimum, dual bound below it (min).
+    assert r.objective == pytest.approx(base.objective, abs=1e-4, rel=1e-4)
+    if r.bound is not None:
+        assert r.bound <= base.objective + 1e-4
+
+
+def test_vector_and_scalar_forms_agree(monkeypatch):
+    """The two spellings of one model must reach the same optimum with cuts on."""
+    _flag(monkeypatch, True)
+    scalar = _build_convex_minlp("min").solve(time_limit=30, nlp_bb=True)
+    vector = _build_convex_minlp_vector().solve(time_limit=30, nlp_bb=True)
+    assert scalar.objective is not None and vector.objective is not None
+    assert scalar.objective == pytest.approx(vector.objective, abs=1e-4, rel=1e-4)


### PR DESCRIPTION
## What this is

Two things, in order: a generality fix to the NLP-BB root cutting-plane stage,
and — pending the panel now running — the §5 graduation of
`DISCOPT_NLPBB_ROOT_CUTS`.

## Part 1 — the stage silently switched itself off on vector variable blocks

`_solve_nlp_bb`'s root-cut stage was gated on
`all(getattr(v, "size", 1) == 1 for v in model._variables)`. Any model built
with array variables got **zero** root cuts and a normal-looking result with a
weaker bound — a silent no-op of exactly the shape CLAUDE.md §6 is about, and a
restriction on *modeling style* rather than on a problem class (§2).

The gate was there because the write-back indexed `model._variables` by flat
column, which is only right when every block is scalar.
`flat_column_terms(model)` now unravels each block in C order — the same
flattening the evaluator and the FBBT bound vectors use — and raises loudly on a
shape/size mismatch rather than emitting a misaligned cut row.

`.nl` / `.gms` imports produce all-scalar blocks (`syn40m` = 130 blocks of size
1), so nothing on the corpus moves; array-API models gain the stage.

## Part 2 — why this issue was reframed

#1061 was filed as "unbounded big-M variables give a 27x root bound, so do
OBBT". That premise is **falsified** by measurement against SCIP:

* SCIP's *first* LP on `syn40m` is **761.83** — weaker than discopt's **295.7**,
  from the same unbounded box.
* SCIP still reaches a root dual bound of **67.746** against an optimum of
  **67.713**, and it does it with roughly 500 root cuts
  (gomorymi 133 applied, cmir 133, flowcover 37, impliedbounds 28,
  nonlinear-OA 165; 1900 root LP iterations vs 153 for the first LP).

Tighter variable bounds are not the lever. Root cut separation is — and discopt
already has GMI + c-MIR + cover separation behind `DISCOPT_NLPBB_ROOT_CUTS`
(#781), default OFF.

## Entry experiment (kill criterion stated before the run)

From `gate3_1061.py`: *"if the flag leaves the bound within a few percent of its
OFF value — or reports 0 cuts applied — root GMI/cMIR is NOT the lever on this
class and this diagnosis dies."*

Paired at 60 s, both entry paths, `root_cuts_applied` read from the solver's own
INFO line (§6 — the probe is proven to have fired):

| instance | path | flag | cuts | gap % | bound/opt |
|---|---|---|---|---|---|
| syn40m | default | 0 | – | 17.722 | 4.308 |
| syn40m | default | 1 | 42 | **0.000** | 2.775 |
| syn40m | bb | 0 | – | 35.769 | 16.969 |
| syn40m | bb | 1 | 42 | **0.000** | 1.721 |
| rsyn0840m | default | 0 | – | 78.390 | 3.531 |
| rsyn0840m | default | 1 | 73 | 60.124 | 3.536 |

Not killed: 42 cuts applied, `syn40m` closes to the published optimum
(67.71325557 vs 67.71325586) on both entry paths. This also settles the open
question from #1059 — the default route for this class does reach
`_solve_nlp_bb`, so the cut stage is not stranded behind the OA route.

## Tests

* `test_flat_column_terms_covers_blocks_in_column_order` — one term per flat
  column *and* each term names its own block, so a wrong order cannot pass on
  count alone; 11 executed checks.
* `test_root_cuts_fire_on_vector_variable_blocks` — fails before the change
  (`assert 0 > 0`), passes after; optimum preserved, dual bound stays below it.
* `test_vector_and_scalar_forms_agree` — the two spellings of one model agree.
* Full file: 9 passed. `ruff check` + `ruff format` clean.

All test runs used `PYTHONPATH` pinned to this worktree with an asserted load
gate on both `discopt.__file__` and the `flat_column_terms` marker (§8).

## Status

Part 1 is complete. Part 2 (the graduation commit) lands here once the §5
graduation panel finishes; this PR will say `Closes #1061` only when it does.
Until then: **Contributes to #1061**, and it leaves #1062 open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017PQaiDVuY5Rs3tga98tnNo
