### PR TITLE
feat(milp): #1060 re-fire the continuous-repair dive while the tree has no incumbent

### DIFF
--- a/crates/discopt-core/src/bnb/milp_driver.rs
+++ b/crates/discopt-core/src/bnb/milp_driver.rs
@@ -208,6 +208,85 @@ pub trait MilpLazyHook: Sync {
 /// never a false `Optimal`.
 const LAZY_REQUEUE_CAP: u32 = 1000;
 
+/// Hard cap on how many *non-root* continuous-repair dives one MILP solve may
+/// run (#1060). The dive only fires while the search has no incumbent at all, so
+/// on a model where it succeeds it stops by itself after one or two firings; the
+/// cap bounds the other case — a model where the dive can never repair anything —
+/// so a hopeless dive cannot become a per-node tax on a million-node search.
+const DIVE_NO_INCUMBENT_CAP: usize = 64;
+
+/// Batch stride for the no-incumbent dive schedule (#1060), read once from
+/// `DISCOPT_MILP_DIVE_STRIDE`.
+///
+/// `0` restores the legacy root-only dive exactly. Any `n > 0` lets the dive
+/// re-fire on the first node of every `n`-th batch **while the tree holds no
+/// incumbent** — the regime in which every node is doing bound-free work anyway,
+/// because there is nothing to prune against.
+///
+/// Why this exists: `try_dive_repair`'s own comment predicts that on a
+/// weak-relaxation (big-M) master "rounding ... finds no incumbent at all and the
+/// search runs with no bound-based pruning (tree explosion)" — and then runs the
+/// dive only at the root. Measured on the Quesada-Grossmann single-tree master
+/// for `rsyn0840m` (issue #1060): 150,193 nodes, exactly **one** integer-feasible
+/// candidate reaching the lazy callback in 60 s, final incumbent 103.5% short of
+/// the reference optimum. `rsyn0805m`, which does solve, surfaces 24.
+///
+/// Read once per process: the schedule changes which nodes are explored, so
+/// flipping it mid-solve would make an A/B measurement incomparable with itself.
+fn dive_stride() -> usize {
+    static STRIDE: std::sync::OnceLock<usize> = std::sync::OnceLock::new();
+    *STRIDE.get_or_init(|| {
+        let raw = std::env::var("DISCOPT_MILP_DIVE_STRIDE").unwrap_or_default();
+        parse_dive_stride(&raw).unwrap_or_else(|e| panic!("{e}"))
+    })
+}
+
+/// The parse table behind [`dive_stride`]. An unrecognized value is **refused**,
+/// not defaulted: an A/B arm whose value silently reads as the default makes the
+/// harness measure one arm twice (the `DISCOPT_LP_REFAC_INTERVAL` precedent).
+fn parse_dive_stride(raw: &str) -> Result<usize, String> {
+    let t = raw.trim();
+    if t.is_empty() {
+        return Ok(DIVE_STRIDE_DEFAULT);
+    }
+    t.parse::<usize>().map_err(|_| {
+        format!("DISCOPT_MILP_DIVE_STRIDE: expected a non-negative integer, got {t:?}")
+    })
+}
+
+/// Default batch stride. Default-off (`0` = legacy root-only) until the CLAUDE.md
+/// §5 differential panel graduates it.
+const DIVE_STRIDE_DEFAULT: usize = 0;
+
+/// Does this batch get a continuous-repair dive away from the root?
+///
+/// Pure so the schedule can be asserted directly rather than inferred from a
+/// solve's node count (CLAUDE.md §6). Four independent gates, all of which must
+/// hold:
+///
+/// * `stride > 0` — the feature is on at all. `0` is the legacy root-only dive,
+///   under which this function is `false` for every batch and the driver is
+///   byte-identical to the version before the schedule existed.
+/// * `!has_incumbent` — the tree holds nothing to prune against, so every node in
+///   the batch is doing bound-free work. Once any incumbent lands, the ordinary
+///   search (warm starts, cuts, reduced-cost fixing) is strictly the better use of
+///   the budget and the schedule switches itself off.
+/// * `nonroot_dives < DIVE_NO_INCUMBENT_CAP` — a model the dive can never repair
+///   cannot turn it into a per-node tax.
+/// * `batch_index % stride == 0` — spread the budget over batches instead of
+///   spending it all in the first few.
+fn dive_batch_eligible(
+    stride: usize,
+    batch_index: usize,
+    has_incumbent: bool,
+    nonroot_dives: usize,
+) -> bool {
+    stride > 0
+        && !has_incumbent
+        && nonroot_dives < DIVE_NO_INCUMBENT_CAP
+        && batch_index % stride == 0
+}
+
 /// Options for the MILP driver.
 pub struct MilpOptions {
     /// Number of structural (model) variables; columns `[n_struct, n)` are slacks.
@@ -769,6 +848,12 @@ pub fn solve_milp_lazy_hooked(
         }};
     }
 
+    // #1060 no-incumbent dive schedule. Both counters live in the sequential
+    // driver loop (never inside the parallel node map), so the schedule is a pure
+    // function of batch order and the search stays deterministic.
+    let mut batch_index: usize = 0;
+    let mut nonroot_dives: usize = 0;
+
     'search: loop {
         if fire_dbg!(MilpCheckpoint::IterStart) {
             gap_certified = false;
@@ -866,6 +951,24 @@ pub fn solve_milp_lazy_hooked(
         // search stays deterministic.
         // `ctx` is scoped to the map so its immutable borrow of `tm` ends before
         // the mutable reduce below.
+        // #1060: does this batch get a continuous-repair dive away from the root?
+        // Only while the tree holds NO incumbent — with nothing to prune against,
+        // every node in the batch is doing bound-free work, so spending one node's
+        // budget on the one heuristic that can produce a first feasible point is
+        // the cheapest thing in the batch. The moment an incumbent exists the
+        // schedule switches off on its own.
+        let this_batch = batch_index;
+        batch_index += 1;
+        let dive_batch = dive_batch_eligible(
+            dive_stride(),
+            this_batch,
+            tm.incumbent().is_some(),
+            nonroot_dives,
+        );
+        if dive_batch {
+            nonroot_dives += 1;
+        }
+
         let outputs: Vec<NodeOutput> = {
             let ctx = NodeCtx {
                 b_w: &b_w,
@@ -905,18 +1008,42 @@ pub fn solve_milp_lazy_hooked(
                 if batch.node_ids.len() >= PAR_MIN_BATCH {
                     (0..batch.node_ids.len())
                         .into_par_iter()
-                        .map(|k| solve_node(batch.node_ids[k], &batch.lb[k], &batch.ub[k], &ctx))
+                        .map(|k| {
+                            solve_node(
+                                batch.node_ids[k],
+                                &batch.lb[k],
+                                &batch.ub[k],
+                                &ctx,
+                                dive_batch && k == 0,
+                            )
+                        })
                         .collect()
                 } else {
                     (0..batch.node_ids.len())
-                        .map(|k| solve_node(batch.node_ids[k], &batch.lb[k], &batch.ub[k], &ctx))
+                        .map(|k| {
+                            solve_node(
+                                batch.node_ids[k],
+                                &batch.lb[k],
+                                &batch.ub[k],
+                                &ctx,
+                                dive_batch && k == 0,
+                            )
+                        })
                         .collect()
                 }
             }
             #[cfg(not(feature = "parallel"))]
             {
                 (0..batch.node_ids.len())
-                    .map(|k| solve_node(batch.node_ids[k], &batch.lb[k], &batch.ub[k], &ctx))
+                    .map(|k| {
+                        solve_node(
+                            batch.node_ids[k],
+                            &batch.lb[k],
+                            &batch.ub[k],
+                            &ctx,
+                            dive_batch && k == 0,
+                        )
+                    })
                     .collect()
             }
         };
@@ -1280,7 +1407,18 @@ struct NodeOutput {
 /// separation, and strong branching. Pure given `ctx` (the immutable working LP
 /// plus a read-only tree snapshot), so it is safe to call concurrently across a
 /// batch. Returns a [`NodeOutput`] the caller folds into the tree sequentially.
-fn solve_node(id: NodeId, lb_k: &[f64], ub_k: &[f64], ctx: &NodeCtx<'_>) -> NodeOutput {
+///
+/// `dive_slot` is the caller's per-node permission to run the continuous-repair
+/// dive away from the root (#1060). The caller grants it to exactly one node per
+/// eligible batch, chosen by position and not by thread order, so the schedule is
+/// the same on every run — the determinism the batch map relies on.
+fn solve_node(
+    id: NodeId,
+    lb_k: &[f64],
+    ub_k: &[f64],
+    ctx: &NodeCtx<'_>,
+    dive_slot: bool,
+) -> NodeOutput {
     // Deadline guard BEFORE the expensive LP solve. The loop-top check only stops
     // *dispatching* new batches; a single batch of N nodes whose per-node LP costs
     // ~seconds (e.g. a dense lifted McCormick relaxation) would otherwise run the
@@ -1559,18 +1697,37 @@ fn solve_node(id: NodeId, lb_k: &[f64], ub_k: &[f64], ctx: &NodeCtx<'_>) -> Node
                     ctx.n_w,
                     ctx.obj_const,
                 );
-                // Continuous-repair fractional dive at the root: plain rounding
-                // never re-solves the continuous variables for the rounded
-                // integer assignment, so on weak-relaxation (big-M) models it
-                // finds no incumbent at all and the search runs with no
-                // bound-based pruning (tree explosion). The dive fixes integers
-                // one at a time and re-solves between fixes, repairing the
-                // continuous variables and avoiding infeasible combinations. Run
-                // only at the root (when rounding found nothing) so its cost is
-                // bounded; the warm-started search + cuts take over thereafter.
-                if out.incumbent.is_none() && is_root {
+                // Continuous-repair fractional dive: plain rounding never
+                // re-solves the continuous variables for the rounded integer
+                // assignment, so on weak-relaxation (big-M) models it finds no
+                // incumbent at all and the search runs with no bound-based
+                // pruning (tree explosion). The dive fixes integers one at a time
+                // and re-solves between fixes, repairing the continuous variables
+                // and avoiding infeasible combinations.
+                //
+                // It runs at the root, and — when `DISCOPT_MILP_DIVE_STRIDE` is
+                // on — again on scheduled batches for as long as the tree holds
+                // NO incumbent (#1060). Root-only was the whole story before, and
+                // it leaves exactly one chance to find a first feasible point: if
+                // the root dive misses, or (on the single-tree LP/NLP-BB master)
+                // its candidate is cut off by the lazy separator, the search then
+                // runs to its node limit with nothing to prune against. The
+                // caller grants the slot to one node per eligible batch and stops
+                // granting it the moment an incumbent exists, so the cost is
+                // bounded and the warm-started search + cuts still take over.
+                //
+                // Sound at any node: the dive fixes within `[lb_k, ub_k]`, a
+                // restriction of the root box, so any point it returns is feasible
+                // for the model — and `inject_incumbent` re-validates it besides.
+                if out.incumbent.is_none() && (is_root || dive_slot) {
                     let _t = crate::profile::Timer::new(crate::profile::Phase::DiveRepair);
                     out.incumbent = try_dive_repair(ctx, lb_k, ub_k, &sol.x, &sol.basis);
+                    if !is_root {
+                        crate::profile::incr(crate::profile::Ctr::DiveOffRoot);
+                        if out.incumbent.is_some() {
+                            crate::profile::incr(crate::profile::Ctr::DiveOffRootHits);
+                        }
+                    }
                 }
             }
             // Node-level cover separation: a fractional node exposes violated
@@ -2940,6 +3097,73 @@ pub fn solve_milp_csc(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // ---- #1060: the no-incumbent continuous-repair dive schedule ----
+
+    #[test]
+    fn dive_stride_zero_is_the_legacy_root_only_dive() {
+        // The shipped default. Every batch must be ineligible, which is what makes
+        // an unset `DISCOPT_MILP_DIVE_STRIDE` bit-identical to the driver before
+        // the schedule existed -- the claim the golden/determinism panels below
+        // silently rest on.
+        let mut checks = 0;
+        for b in 0..64 {
+            assert!(
+                !dive_batch_eligible(0, b, false, 0),
+                "batch {b} eligible at stride 0"
+            );
+            checks += 1;
+        }
+        assert_eq!(DIVE_STRIDE_DEFAULT, 0);
+        assert_eq!(checks, 64);
+    }
+
+    #[test]
+    fn dive_schedule_stops_the_moment_an_incumbent_exists() {
+        // The whole justification for diving off-root is that there is nothing to
+        // prune against. With an incumbent in hand the ordinary search is the
+        // better use of the node budget, so the schedule must switch itself off.
+        assert!(dive_batch_eligible(8, 0, false, 0));
+        assert!(!dive_batch_eligible(8, 0, true, 0));
+        assert!(dive_batch_eligible(8, 16, false, 3));
+        assert!(!dive_batch_eligible(8, 16, true, 3));
+    }
+
+    #[test]
+    fn dive_schedule_honors_stride_and_cap() {
+        let stride = 8;
+        let eligible: Vec<usize> = (0..40)
+            .filter(|&b| dive_batch_eligible(stride, b, false, 0))
+            .collect();
+        assert_eq!(eligible, vec![0, 8, 16, 24, 32]);
+        // A model the dive can never repair must not pay for it forever.
+        assert!(!dive_batch_eligible(
+            stride,
+            0,
+            false,
+            DIVE_NO_INCUMBENT_CAP
+        ));
+        assert!(!dive_batch_eligible(
+            stride,
+            800,
+            false,
+            DIVE_NO_INCUMBENT_CAP + 5
+        ));
+    }
+
+    #[test]
+    fn dive_stride_parse_refuses_garbage_instead_of_defaulting() {
+        // An A/B arm whose value silently reads as the default makes the harness
+        // measure one arm twice (the DISCOPT_LP_REFAC_INTERVAL precedent).
+        assert_eq!(parse_dive_stride("").unwrap(), DIVE_STRIDE_DEFAULT);
+        assert_eq!(parse_dive_stride("  ").unwrap(), DIVE_STRIDE_DEFAULT);
+        assert_eq!(parse_dive_stride("0").unwrap(), 0);
+        assert_eq!(parse_dive_stride("8").unwrap(), 8);
+        assert_eq!(parse_dive_stride(" 12 ").unwrap(), 12);
+        for bad in ["-1", "eight", "1.5", "8x"] {
+            assert!(parse_dive_stride(bad).is_err(), "{bad:?} must be refused");
+        }
+    }
 
     fn opts(ns: usize, int_cols: Vec<usize>) -> MilpOptions {
         MilpOptions {

--- a/crates/discopt-core/src/profile.rs
+++ b/crates/discopt-core/src/profile.rs
@@ -102,6 +102,14 @@ timed_phases!(
 
 // Pivot categorization for the cold-primal simplex (degeneracy analysis).
 counters!(
+    // #1060 continuous-repair dive schedule. `DiveOffRoot` counts dives run away
+    // from the root (the no-incumbent schedule; always 0 at the default stride 0),
+    // `DiveOffRootHits` how many of those returned a repaired incumbent. The pair
+    // is the audit: a schedule that fires and never repairs is pure overhead and
+    // must not graduate, and without a counter that case reads exactly like a
+    // schedule that never fired (CLAUDE.md §6).
+    DiveOffRoot,
+    DiveOffRootHits,
     Phase1Pivots,
     Phase2Pivots,
     DegeneratePivots,

--- a/crates/discopt-core/tests/dive_schedule_default_off.rs
+++ b/crates/discopt-core/tests/dive_schedule_default_off.rs
@@ -1,0 +1,72 @@
+//! #1060, the other half: with `DISCOPT_MILP_DIVE_STRIDE` unset, the driver must
+//! behave exactly as it did before the schedule existed — the dive runs at the
+//! root and nowhere else.
+//!
+//! This is what makes the shipped default a no-op rather than a silent behavior
+//! change, and it is the reason the golden/determinism panels in
+//! `milp_driver.rs` still hold unmodified. See `dive_schedule_off_root.rs` for
+//! the on-arm and for why the two halves are separate binaries.
+
+use discopt_core::bnb::milp_driver::{solve_milp, MilpOptions};
+use discopt_core::lp::crossover::LpView;
+use discopt_core::lp::simplex::SimplexOptions;
+use discopt_core::profile::{counter, Ctr};
+
+const N: usize = 20;
+
+#[test]
+fn stride_unset_never_dives_away_from_the_root() {
+    std::env::remove_var("DISCOPT_MILP_DIVE_STRIDE");
+    std::env::set_var("DISCOPT_PROFILE", "1");
+
+    let a: Vec<f64> = vec![2.0; N];
+    let c: Vec<f64> = vec![1.0; N];
+    let l: Vec<f64> = vec![0.0; N];
+    let u: Vec<f64> = vec![1.0; N];
+    let b: Vec<f64> = vec![7.0];
+    let lp = LpView {
+        a: &a,
+        m: 1,
+        n: N,
+        c: &c,
+        l: &l,
+        u: &u,
+    };
+    let opts = MilpOptions {
+        n_struct: N,
+        integer_cols: (0..N).collect(),
+        max_nodes: 4_000,
+        time_limit_s: Some(60.0),
+        gap_tol: 1e-9,
+        root_cuts: 0,
+        cut_rounds: 0,
+        gmi_cuts: false,
+        cut_select: false,
+        node_cuts: false,
+        max_pool_cuts: 0,
+        heuristics: true,
+        presolve: true,
+        strong_branch: false,
+        node_propagation: true,
+        reduced_cost_fixing: true,
+        sb_max_cands: 0,
+        sb_node_budget: 0,
+        initial_incumbent: None,
+        simplex: SimplexOptions::default(),
+    };
+    let res = solve_milp(&lp, &b, 0.0, &opts);
+
+    // The same search that fires dives in the on-arm must fire none here. The
+    // sibling test proves this model does reach many no-incumbent batches, so a
+    // zero here is the default being off — not the probe failing to run.
+    assert_eq!(
+        counter(Ctr::DiveOffRoot),
+        0,
+        "off-root dive ran at the default stride"
+    );
+    assert!(
+        !res.obj.is_finite(),
+        "objective {} for a parity-infeasible model",
+        res.obj
+    );
+}

--- a/crates/discopt-core/tests/dive_schedule_off_root.rs
+++ b/crates/discopt-core/tests/dive_schedule_off_root.rs
@@ -1,0 +1,134 @@
+//! #1060: the continuous-repair dive must be able to re-fire away from the root.
+//!
+//! `try_dive_repair` is the only heuristic in the MILP driver that re-solves the
+//! continuous variables for a rounded integer assignment, so on a weak-relaxation
+//! (big-M) model it is the only thing that can produce a *first* feasible point.
+//! It used to run at the root and nowhere else, which leaves the search exactly
+//! one chance: measured on the Quesada-Grossmann single-tree master for
+//! `rsyn0840m`, 150,193 nodes produced exactly one integer-feasible candidate,
+//! and once the lazy separator cut that one off the search ran to its node limit
+//! with nothing to prune against.
+//!
+//! This file pins the schedule end to end: with `DISCOPT_MILP_DIVE_STRIDE` on,
+//! dives actually happen off-root, they stay under the hard cap, and — on a model
+//! with no integer point at all — the search still refuses to invent an
+//! incumbent. Its sibling `dive_schedule_default_off.rs` pins the other half:
+//! unset, not one off-root dive runs.
+//!
+//! Env-var state is process-global and `dive_stride()` latches it in a `OnceLock`,
+//! so the two halves are separate test binaries (one `#[test]` each) rather than
+//! two cases in one file.
+
+use discopt_core::bnb::milp_driver::{solve_milp, MilpOptions, MilpStatus};
+use discopt_core::lp::crossover::LpView;
+use discopt_core::lp::simplex::SimplexOptions;
+use discopt_core::profile::{counter, Ctr};
+
+/// `min sum x  s.t.  sum_j 2*x_j = 7,  x binary`.
+///
+/// LP-feasible (x = 7/40 componentwise) but integer-**in**feasible: the left side
+/// is even for every integer point and the right side is odd. Parity is invisible
+/// to bound propagation, so the driver cannot fathom it at the root — it has to
+/// branch, which is what gives the schedule several batches to fire in. Nothing
+/// here is keyed to a named instance (CLAUDE.md §2); the property under test is
+/// "the search spends many nodes holding no incumbent", which is the regime the
+/// schedule exists for.
+const N: usize = 20;
+
+fn build() -> (Vec<f64>, Vec<f64>, Vec<f64>, Vec<f64>, Vec<f64>) {
+    let a: Vec<f64> = vec![2.0; N];
+    let c: Vec<f64> = vec![1.0; N];
+    let l: Vec<f64> = vec![0.0; N];
+    let u: Vec<f64> = vec![1.0; N];
+    let b: Vec<f64> = vec![7.0];
+    (a, b, c, l, u)
+}
+
+fn options() -> MilpOptions {
+    MilpOptions {
+        n_struct: N,
+        integer_cols: (0..N).collect(),
+        // Bounded so the test is fast: parity infeasibility needs full enumeration,
+        // and the assertions below are about the schedule, not the certificate.
+        max_nodes: 4_000,
+        time_limit_s: Some(60.0),
+        gap_tol: 1e-9,
+        root_cuts: 0,
+        cut_rounds: 0,
+        gmi_cuts: false,
+        cut_select: false,
+        node_cuts: false,
+        max_pool_cuts: 0,
+        heuristics: true,
+        presolve: true,
+        strong_branch: false,
+        node_propagation: true,
+        reduced_cost_fixing: true,
+        sb_max_cands: 0,
+        sb_node_budget: 0,
+        initial_incumbent: None,
+        simplex: SimplexOptions::default(),
+    }
+}
+
+#[test]
+fn stride_on_fires_the_dive_away_from_the_root_and_stays_capped() {
+    // Must be set before the first `solve_milp`: the stride is latched once per
+    // process, and `solve_milp` calls `profile::init_from_env`.
+    std::env::set_var("DISCOPT_MILP_DIVE_STRIDE", "1");
+    std::env::set_var("DISCOPT_PROFILE", "1");
+
+    let (a, b, c, l, u) = build();
+    let lp = LpView {
+        a: &a,
+        m: 1,
+        n: N,
+        c: &c,
+        l: &l,
+        u: &u,
+    };
+    let res = solve_milp(&lp, &b, 0.0, &options());
+
+    let mut checks = 0;
+
+    // 1. The schedule actually fired off-root. Without this the rest of the file
+    //    would pass on a driver where the feature is silently dead.
+    let dives = counter(Ctr::DiveOffRoot);
+    assert!(dives > 0, "no off-root dive ran; the schedule never fired");
+    checks += 1;
+
+    // 2. It stayed under the hard cap. This model has no integer point, so the
+    //    dive can never succeed — exactly the case that must not become a
+    //    per-node tax on a large search.
+    assert!(
+        dives <= 64,
+        "off-root dives ({dives}) exceeded the hard cap"
+    );
+    checks += 1;
+
+    // 3. A dive that cannot repair must report nothing, not something.
+    assert_eq!(
+        counter(Ctr::DiveOffRootHits),
+        0,
+        "a model with no integer point reported a repaired incumbent"
+    );
+    checks += 1;
+
+    // 4. Soundness: diving off-root must never manufacture an incumbent. The
+    //    dive fixes inside the node box, a restriction of the root box, so any
+    //    point it returns is feasible for the model — and there is none here.
+    assert!(
+        !matches!(res.status, MilpStatus::Optimal | MilpStatus::Feasible),
+        "status {:?} claims a feasible point for a parity-infeasible model",
+        res.status
+    );
+    checks += 1;
+    assert!(
+        !res.obj.is_finite(),
+        "objective {} reported for a parity-infeasible model",
+        res.obj
+    );
+    checks += 1;
+
+    assert_eq!(checks, 5, "CHECKS_EXECUTED");
+}


### PR DESCRIPTION
## What this changes

`try_dive_repair` is the only heuristic in the MILP driver that re-solves the
continuous variables for a rounded integer assignment, so on a weak-relaxation
(big-M) master it is the only thing that can produce a **first** feasible point.
Its own comment says exactly that — *"on weak-relaxation (big-M) models
[rounding] finds no incumbent at all and the search runs with no bound-based
pruning (tree explosion)"* — and then it runs at the root and nowhere else.

This PR adds a bounded schedule that lets it re-fire **while the tree holds no
incumbent at all**, default-off behind `DISCOPT_MILP_DIVE_STRIDE`.

## The diagnosis (measurement first)

Single-tree Quesada–Grossmann master, `milp_solver="simplex"`, 60 s limit:

| instance | result | lazy calls | nodes | requeues |
|---|---|---|---|---|
| `rsyn0805m` (solves) | optimal, 1.7 s | 24 | 2,383 | 9 |
| `syn20m02m` (near) | 0.213% short | 1,775 | 41,665 | 41 |
| `rsyn0840m` (fails) | **103.506% short** | **1** | 150,193 | **0** |

The failing instance surfaces exactly **one** integer-feasible candidate in 150k
nodes. That one is the root dive: its fixed NLP was feasible (that is where the
final incumbent came from), the lazy separator then cut it off, and the search
ran to its node limit with nothing left to prune against.

Hypothesis and kill criterion were recorded before the run: *"if instances where
free `lp_nlp_bb` does reach optimal also show `mipsol_calls ≈ 1`, callback count
is not the discriminator and this diagnosis dies."* 24 and 1,775 vs 1 — not
killed.

## The schedule

`dive_batch_eligible(stride, batch_index, has_incumbent, nonroot_dives)` — pure,
so the schedule is asserted directly rather than inferred from a node count
(CLAUDE.md §6). Four gates, all must hold:

* `stride > 0` — the feature is on. `0` is the legacy root-only dive.
* `!has_incumbent` — nothing to prune against, so every node in the batch is
  doing bound-free work anyway. The moment any incumbent lands the schedule
  switches itself off.
* `nonroot_dives < 64` — a model the dive can never repair cannot turn it into a
  per-node tax.
* `batch_index % stride == 0` — spread the budget rather than spend it at once.

Both counters live in the sequential driver loop and the slot is granted to one
node **by position** (`k == 0`), never by thread order, so the rayon-parallel
node map stays deterministic.

**Soundness.** The dive fixes within the node's own box, a restriction of the
root box, so any point it returns is feasible for the model; `inject_incumbent`
re-validates it besides. It cannot loosen a dual bound — it only ever proposes
primal points.

## Verification

* `cargo test -p discopt-core` — **628 lib tests pass**, including the golden,
  branching and determinism panels. That is the evidence that the shipped
  default is byte-identical to the previous driver.
* Two new integration tests pin both arms end to end on a parity-infeasible MILP
  (`sum 2·x = 7`, x binary — LP-feasible, no integer point, invisible to bound
  propagation, so the driver must branch): with the stride on, off-root dives
  happen, stay under the cap, report no false repair, and produce no incumbent;
  with it unset, not one off-root dive runs.
* New `DiveOffRoot` / `DiveOffRootHits` profile counters: a schedule that fires
  and never repairs is pure overhead, and without the pair that case reads
  exactly like a schedule that never fired.

## Status

Default-off pending the CLAUDE.md §5 differential panel (cert-clean **and**
net-positive). The corpus A/B is queued; this PR lands the mechanism, the tests
and the instrument.

Contributes to #1060

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017PQaiDVuY5Rs3tga98tnNo
