### PR TITLE
fix(lp): #1061 the simplex must price free columns in both directions

### DIFF
--- a/crates/discopt-core/src/lp/simplex/primal.rs
+++ b/crates/discopt-core/src/lp/simplex/primal.rs
@@ -987,6 +987,19 @@ impl<'a> Simplex<'a> {
     }
 
     /// Bound value a nonbasic column sits at (lower or upper).
+    /// Is column `j` **free** — open on both sides?
+    ///
+    /// The engine has no `FREE` nonbasic status: `run`'s initializer parks a
+    /// free column under `AT_LOWER` and [`Self::nb_value`] special-cases it to
+    /// sit at 0. That encoding is only half the contract, because `AT_LOWER`
+    /// also *means* "can only increase" everywhere a direction is derived from
+    /// the status. A free column can move BOTH ways, so every such site has to
+    /// ask this question instead of reading `stat` alone (#1061).
+    #[inline]
+    fn is_free(&self, j: usize) -> bool {
+        self.lb[j] <= -INF && self.ub[j] >= INF
+    }
+
     fn nb_value(&self, j: usize) -> f64 {
         match self.stat[j] {
             AT_UPPER => self.ub[j],
@@ -1471,7 +1484,14 @@ impl<'a> Simplex<'a> {
                 let at_lower = self.stat[j] == AT_LOWER;
                 // A column at its lower bound can only increase (dir +1); at upper only
                 // decrease (dir −1). Skip if the reducing direction is not available.
-                if (dir_by_sign > 0.0 && at_lower) || (dir_by_sign < 0.0 && !at_lower) {
+                // A FREE column is parked under `AT_LOWER` but is open on both sides, so
+                // both directions are available to it — the same status-vs-freedom
+                // conflation the pricing loop had (#1061); without this it is skipped
+                // whenever the artificial needs it to move DOWN.
+                let available = self.is_free(j)
+                    || (dir_by_sign > 0.0 && at_lower)
+                    || (dir_by_sign < 0.0 && !at_lower);
+                if available {
                     best = arj.abs();
                     q = Some(j);
                     q_dir = dir_by_sign;
@@ -1988,6 +2008,7 @@ impl<'a> Simplex<'a> {
             // choose entering: Devex (max dⱼ²/γⱼ over improving cols), with a
             // Bland's-rule fallback (first improving) once a stall is detected.
             let mut enter: Option<usize> = None;
+            let mut enter_dj = 0.0f64;
             let mut best_score = 0.0f64;
             let _t_sweep = crate::profile::Timer::new(crate::profile::Phase::PriceSweep);
             for j in 0..self.na {
@@ -1995,17 +2016,37 @@ impl<'a> Simplex<'a> {
                     continue;
                 }
                 let dj = cost[j] - self.col_dot(j, &y, art_sign);
-                let improving = (self.stat[j] == AT_LOWER && dj < -self.tol)
-                    || (self.stat[j] == AT_UPPER && dj > self.tol);
+                // A free column sits at 0 under an `AT_LOWER` label and may move
+                // in EITHER direction, so it improves on any nonzero reduced
+                // cost. Reading the label alone (`AT_LOWER` ⇒ only `dj < 0`
+                // improves) made a free column with `dj > 0` invisible to
+                // pricing, and the loop below then exited "optimal" with that
+                // improving direction untaken (#1061). Two ways that surfaced:
+                // in phase 1 the artificials stopped short of zero, so a
+                // FEASIBLE LP looked infeasible, the Farkas ray rightly refused
+                // to certify it, and the solve returned `Numerical` — which is
+                // what silently disabled `bootstrap_finite_bounds` on every
+                // model carrying free columns; in phase 2 the same premature
+                // exit would certify a non-optimal point as `Optimal`, i.e. a
+                // relaxation "lower bound" ABOVE the true LP optimum, which the
+                // feasibility-only audit in `assemble` cannot catch.
+                let improving = if self.is_free(j) {
+                    dj.abs() > self.tol
+                } else {
+                    (self.stat[j] == AT_LOWER && dj < -self.tol)
+                        || (self.stat[j] == AT_UPPER && dj > self.tol)
+                };
                 if improving {
                     if bland {
                         enter = Some(j);
+                        enter_dj = dj;
                         break;
                     }
                     let score = dj * dj / gamma[j];
                     if score > best_score {
                         best_score = score;
                         enter = Some(j);
+                        enter_dj = dj;
                     }
                 }
             }
@@ -2021,7 +2062,22 @@ impl<'a> Simplex<'a> {
                     return Ok(()); // optimal
                 }
             };
-            let dir = if self.stat[q] == AT_LOWER { 1.0 } else { -1.0 };
+            // Direction of travel. For a bounded column the status fixes it
+            // (at lower ⇒ up, at upper ⇒ down); for a free column the status
+            // carries no such information, so take the descent direction from
+            // the sign of its reduced cost — `dj < 0` improves by increasing,
+            // `dj > 0` by decreasing.
+            let dir = if self.is_free(q) {
+                if enter_dj < 0.0 {
+                    1.0
+                } else {
+                    -1.0
+                }
+            } else if self.stat[q] == AT_LOWER {
+                1.0
+            } else {
+                -1.0
+            };
 
             // direction α = B⁻¹ A_q
             let mut alpha = self.column(q, art_sign);
@@ -2599,6 +2655,83 @@ mod tests {
     fn solve(a: &[f64], m: usize, n: usize, b: &[f64], c: &[f64], l: &[f64], u: &[f64]) -> LpSolve {
         let lp = LpView { a, m, n, c, l, u };
         solve_lp(&lp, b, &SimplexOptions::default())
+    }
+
+    /// #1061: a **free** column must be priced in both directions.
+    ///
+    /// The engine parks a free column under `AT_LOWER` and lets `nb_value` sit it
+    /// at 0, but `AT_LOWER` elsewhere *means* "may only increase". Pricing read the
+    /// label, so a free column whose reduced cost was POSITIVE — improving by
+    /// decreasing — was never selected and the loop exited "optimal" with an
+    /// improving direction still on the table.
+    ///
+    /// Both columns here are free and neither is a row singleton, so the crash
+    /// basis cannot pre-empt phase 1: both rows start with a basic artificial. At
+    /// that basis the phase-1 duals give x0 a reduced cost of +2, the only
+    /// improving move. Before the fix phase 1 stopped with the artificials at 5 and
+    /// 3, the Farkas ray (rightly) refused to certify a FEASIBLE LP infeasible, and
+    /// the solve came back `Numerical`. The system has one solution, so `Optimal`
+    /// here is not a tolerance judgement: x0 = -4, x1 = -1.
+    #[test]
+    fn a_free_column_with_a_positive_reduced_cost_still_prices_in() {
+        // row 0:  x0 + x1 = -5
+        // row 1:  x0 - x1 = -3
+        let a = [1.0, 1.0, 1.0, -1.0];
+        let c = [1.0, 0.0];
+        let l = [-INF, -INF];
+        let u = [INF, INF];
+        let b = [-5.0, -3.0];
+        let sol = solve(&a, 2, 2, &b, &c, &l, &u);
+        assert_eq!(
+            sol.status,
+            LpStatus::Optimal,
+            "feasible LP with a free column must solve, got {:?}",
+            sol.status
+        );
+        assert!(
+            (sol.x[0] - (-4.0)).abs() < 1e-9,
+            "x0 = {}, want -4",
+            sol.x[0]
+        );
+        assert!(
+            (sol.x[1] - (-1.0)).abs() < 1e-9,
+            "x1 = {}, want -1",
+            sol.x[1]
+        );
+        assert!(
+            (sol.obj - (-4.0)).abs() < 1e-9,
+            "obj = {}, want -4",
+            sol.obj
+        );
+    }
+
+    /// The same conflation seen from the objective side — and the reason this is a
+    /// SOUNDNESS bug, not just a stalled solve.
+    ///
+    /// `x0` is free and appears in both rows, so the crash basis cannot pick it up;
+    /// the two slacks are row singletons, crash in, and leave phase 1 with nothing
+    /// to do. Phase 2 therefore starts with `x0` nonbasic at 0 carrying reduced cost
+    /// +1 — improving only by DECREASING. Reading the `AT_LOWER` label, pricing saw
+    /// no improving column and returned `Optimal` at 0, while the true optimum is
+    /// -10. `assemble`'s audit checks feasibility alone and 0 IS feasible, so the
+    /// wrong value was certified: a relaxation lower bound 10 above the LP optimum,
+    /// which is exactly what lets a branch-and-bound prune the true optimum.
+    #[test]
+    fn phase_two_must_not_certify_optimal_with_a_free_column_still_improving() {
+        // row 0:  x0 + s0 = 0        row 1:  x0 + s1 = 0
+        // x0 free, s0, s1 in [0, 10]  =>  min x0 = -10.
+        let a = [1.0, 1.0, 0.0, 1.0, 0.0, 1.0];
+        let c = [1.0, 0.0, 0.0];
+        let l = [-INF, 0.0, 0.0];
+        let u = [INF, 10.0, 10.0];
+        let b = [0.0, 0.0];
+        let sol = solve(&a, 2, 3, &b, &c, &l, &u);
+        assert_eq!(sol.status, LpStatus::Optimal, "status {:?}", sol.status);
+        assert!(
+            (sol.obj - (-10.0)).abs() < 1e-9,
+            "obj = {}, want -10 (the premature exit certifies 0)",
+            sol.obj
+        );
     }
 
     /// The #956 T2′ exact-`x_B` refresh must be a pure accuracy change: it replaces

--- a/python/tests/test_1061_free_column_pricing.py
+++ b/python/tests/test_1061_free_column_pricing.py
@@ -1,0 +1,84 @@
+"""#1061: a free column must never be certified optimal at its parked value.
+
+The primal simplex has no ``FREE`` nonbasic status -- ``run()`` parks a free
+column under ``AT_LOWER`` and ``nb_value`` special-cases it to sit at 0.  Before
+the fix, pricing read that label literally ("may only increase"), so a free
+column with ``dj > tol`` -- improving by *decreasing* -- was invisible and the
+loop exited ``Optimal`` at the parked point.
+
+The Rust unit tests in ``lp/simplex/primal.rs`` guard the pricing rule itself.
+This guards the consequence on real corpus data, which is where it actually bit:
+``bootstrap_finite_bounds`` finitizes an open bound by solving ``min x_i`` and
+trusting ``SolveStatus.OPTIMAL``, so a false ``Optimal`` becomes a variable bound
+the LP never proved, and from there a ``gap_certified=True`` root bound.
+
+Probe instance: ``wallfix`` (MINLPLib, 6 vars, 0 discrete).  Its objective is
+``x0`` and ``x0`` is free in both directions; nothing in the root relaxation
+bounds it below, so ``min x0`` is genuinely UNBOUNDED.  Measured 2026-08-20:
+without the fix that LP returned ``OPTIMAL objective=0.0`` -- exactly the parked
+value -- which finitized ``x0 >= -1e-06`` and certified the root.  With the fix
+it returns ``UNBOUNDED`` and the solver correctly declines to certify.
+
+If a future relaxation legitimately bounds ``x0`` below on this instance, this
+probe must be re-derived rather than relaxed: the invariant under test is "no
+``Optimal`` at the parked value", not "wallfix is uncertifiable".
+"""
+
+import os
+
+import numpy as np
+import pytest
+from discopt.modeling.core import from_nl
+
+CORPUS = os.path.expanduser("~/Dropbox/projects/discopt-minlp-benchmark/minlplib/nl")
+INSTANCE = os.path.join(CORPUS, "wallfix.nl")
+
+
+@pytest.mark.skipif(not os.path.exists(INSTANCE), reason="MINLPLib corpus not present")
+def test_free_column_bootstrap_lp_is_not_certified_optimal_at_its_parked_value():
+    import discopt._relax.obbt as obbt
+    from discopt.solvers import SolveStatus
+
+    model = from_nl(INSTANCE)
+    x0 = model._variables[0]
+    lb0 = float(np.asarray(x0.lb).reshape(-1)[0])
+    ub0 = float(np.asarray(x0.ub).reshape(-1)[0])
+    assert not np.isfinite(lb0) and not np.isfinite(ub0), (
+        f"probe precondition broken: {x0.name} is no longer free ({lb0}, {ub0})"
+    )
+
+    seen = []
+    real_get = obbt.get_exact_lp_solver
+
+    def instrumented(*args, **kwargs):
+        inner = real_get(*args, **kwargs)
+        if inner is None:
+            return None
+
+        def call(**kw):
+            result = inner(**kw)
+            costs = np.asarray(kw["c"], dtype=float).reshape(-1)
+            nonzero = np.nonzero(costs)[0]
+            # Only the probe that MINIMIZES the free column over a box that is
+            # still open in both directions. Anything else is a different LP.
+            if nonzero.size == 1 and nonzero[0] == 0 and costs[0] > 0:
+                lo, hi = kw["bounds"][0]
+                if not np.isfinite(lo) and not np.isfinite(hi):
+                    seen.append((result.status, result.objective))
+            return result
+
+        return call
+
+    obbt.get_exact_lp_solver = instrumented
+    try:
+        model.solve(time_limit=30)
+    finally:
+        obbt.get_exact_lp_solver = real_get
+
+    # SS6: a silent zero-interception run would "pass" while measuring nothing.
+    assert seen, "intercepted no `min x0` LP over the open box -- probe measured nothing"
+    for status, objective in seen:
+        assert status is not SolveStatus.OPTIMAL, (
+            f"free column certified {status} objective={objective!r} on an LP that is "
+            "unbounded below -- the #1061 defect is back"
+        )

--- a/python/tests/test_amp.py
+++ b/python/tests/test_amp.py
@@ -1437,8 +1437,20 @@ def test_unsafe_tan_objective_still_falls_back(caplog):
     # asymptote (unbounded below), so the engine refuses a bound rather than
     # inventing one — objective_bound_valid is False and no objective is reported.
     assert milp_model._objective_bound_valid is False
-    assert result.status == "optimal"
     assert result.objective is None
+
+    # ...and the LP status is "unbounded", which is the literal truth about this
+    # relaxation, not a softer answer. The un-envelopable tan aux is the only cost
+    # column: cost +1, bounds (-inf, +inf), appearing in NO row — so `min 1*y` over
+    # a free unconstrained y is unbounded below by definition. This assertion read
+    # "optimal" until #1061, which is exactly the mis-report uniform_relax.py's
+    # obj_bound_valid comment names ("the LP is unbounded below — yet the warm-
+    # started Rust simplex can mis-report a finite 'optimal'", issue #15): pricing
+    # tested the AT_LOWER/AT_UPPER label, and a free column parked under AT_LOWER
+    # with a positive reduced cost improves by DECREASING, so its improving
+    # direction was invisible and the loop exited "optimal". The refusal above is
+    # what kept that from becoming a false bound; now the status is right too.
+    assert result.status == "unbounded"
 
 
 def test_x_exp_objective_uses_lifted_product_relaxation(caplog):


### PR DESCRIPTION
## The defect

The primal simplex has **no `FREE` nonbasic status**. `run()`'s initializer parks a
free column (`lb <= -INF && ub >= INF`) under `AT_LOWER`, and `nb_value` special-cases
it to sit at 0. That encoding is only half the contract: everywhere a *direction* is
derived from the status, `AT_LOWER` also means **"may only increase"**.

Pricing read the label:

```rust
let improving = (self.stat[j] == AT_LOWER && dj < -self.tol)
             || (self.stat[j] == AT_UPPER && dj >  self.tol);
```

A free column improves on **any** nonzero reduced cost — `dj < 0` by increasing,
`dj > 0` by decreasing. Under the test above, a free column with `dj > tol` was
invisible to pricing, and the loop then exited "no improving column ⇒ optimal"
with an improving direction still on the table.

This is a **soundness** bug, and it surfaced two different ways:

- **Phase 1** stops with artificials still positive, so a *feasible* LP looks
  infeasible. The Farkas certifier then (correctly) refuses to certify the
  infeasibility, and the solve returns `Numerical`.
- **Phase 2** certifies a non-optimal point as `Optimal` — a relaxation "lower
  bound" **above** the true LP optimum. `assemble`'s audit is feasibility-only, so
  it cannot catch this: the premature point *is* feasible.

`uniform_relax.py` already names this failure in a comment, attributing it to issue
 #15: *"the LP is unbounded below — yet the warm-started Rust simplex can mis-report
a finite 'optimal'"*. That is this bug.

## Why it mattered for #1061

#1061 reports discopt's root dual bound 27.1x above the reference optimum on the
syn/rsyn family. discopt already ships OBBT (`_relax/obbt.py::bootstrap_finite_bounds`),
whose job is exactly to finitize those unbounded big-M columns — but it **silently
no-op'd on this entire class**, because its exact-LP oracle came back `numerical` in
~1 ms. The oracle was refusing, honestly, on an LP the engine could not price.

Diagnosis chain (each step falsifiable, and one hypothesis *was* falsified):

| step | measurement |
|---|---|
| magnitude sweep | `OPTIMAL(-40)` at 1e4…1e18, `ERROR` at 1e20/inf — looked like `INF`-sentinel arithmetic |
| profile counters at 1e20 | `LpInfeasUncertified=2`, `FarkasRejectOpen=8`, `Phase1Pivots=24` (vs 50) — phase 1 stops early, Farkas honestly refuses |
| P1DIAG instrument | `infeas0=2.0`, `max\|xb\|=1.0` — **sentinel-cancellation hypothesis falsified**, nothing overflowed |
| per-column dump | the blocking columns are `lb=-1e20, ub=+1e20` (**free**), labeled `AT_LOWER`, with `dj=+0.4` |

Recorded per CLAUDE.md §4/§11: the `INF`-sentinel hypothesis I opened with was
**wrong**, and the P1DIAG measurement is what killed it.

## The fix

One new predicate, three call sites that were reading `stat` where they needed to ask
about *freedom*:

- `fn is_free(&self, j)` — `lb[j] <= -INF && ub[j] >= INF`.
- **Pricing**: a free column improves on `dj.abs() > tol`.
- **Entering direction**: for a free column the status carries no direction, so take it
  from the sign of the reduced cost (`dj < 0` ⇒ +1, `dj > 0` ⇒ −1).
- **`drive_out_basic_artificials`**: a free column is available in *both* directions —
  the same conflation, which previously skipped it whenever the artificial needed it
  to move **down**.

No tolerance was touched, no guard weakened, no special case keyed to a problem shape.

## Verification

**Rust unit tests — new, and they fail before / pass after.** Proven by flipping
`is_free` to return `false` (an exact behavioral revert of all three sites):

| test | before the fix | after |
|---|---|---|
| `a_free_column_with_a_positive_reduced_cost_still_prices_in` | `Numerical` on a **feasible** LP | `Optimal`, x = (−4, −1) |
| `phase_two_must_not_certify_optimal_with_a_free_column_still_improving` | `Optimal` with `obj = 0` | `Optimal` with `obj = −10` (the truth) |

Both are designed so the **crash basis cannot pre-empt phase 1** — an earlier draft of
the second test passed both ways because its columns were row singletons that crashed
straight into the basis, i.e. it measured nothing (CLAUDE.md §6). The free column has
two nonzeros in each; the singletons are the slacks.

**The false certificate, end to end.** Through the Python entry point
`solve_lp_warm_std`, on the LP `min x0 s.t. x0 + s0 <= 0, x0 + s1 <= 0`,
`x0` free, `s0, s1 in [0, 10]` — `s0 >= 0` forces `x0 <= 0` and nothing bounds
`x0` below, so it is **unbounded below**:

| build | status | objective | bound |
|---|---|---|---|
| base (`is_free` -> `false`) | `OPTIMAL` | `0.0` | **`0.0`** |
| this PR | `UNBOUNDED` | `None` | `None` |

A finite `bound` on an unbounded-below LP is a false dual bound, reported as
certified. That is the whole argument for this change.

**Suites** (all in this worktree, `discopt.__file__` asserted under `wt1061p1`):

| suite | result |
|---|---|
| `cargo test -p discopt-core --lib` | **626 passed, 0 failed** (624 + the 2 new) |
| `pytest -m smoke` | **1078 passed, 1 skipped, 2 xpassed, 0 failed** (112.7 s) |
| `pytest -m slow python/tests/test_adversarial_recent_fixes.py` | **19 passed** (147.2 s) |

`test_unbounded_relaxation_soundness.py::test_467_free_variable_root_not_falsely_optimal_{lp,nlp}_route`
— the closest existing guards — pass unchanged.

**One smoke expectation is updated, and it is updated toward the truth.**
`test_amp.py::test_unsafe_tan_objective_still_falls_back` asserted
`result.status == "optimal"`. Dumping that relaxation's LP directly: the
un-envelopable `tan` aux is the **only** cost column, with cost `+1`, bounds
`(-inf, +inf)`, and it appears in **no row** — `min 1*y` over a free unconstrained
`y` is unbounded below by definition. The assertion is now `"unbounded"`. The
refusal the test exists to protect is untouched and still asserted:
`_objective_bound_valid is False` and `result.objective is None`. No guard,
tolerance, or fallback was weakened.

## Retraction: this does NOT move #1061's headline number (CLAUDE.md §11)

Earlier in this work I reported that with the fix `syn20m02m` and `rsyn0805m`
solve to proven optimality at 0 nodes, and attributed that to this change. **The
controlled A/B falsifies the attribution.** Interleaved arms at a 30 s limit, arm
selected by which build is installed and verified by a behavioral load gate (the
script asserts the minimal free-column LP behaves as the claimed arm demands):

| instance | ref | root bound base → fixed | nodes base → fixed | status |
|---|---:|---|---|---|
| `syn40m` | 67.71 | 1833.91 → 1833.91 | 383 → 351 | feasible both |
| `rsyn0840m` | 325.55 | 2778.18 → 2778.18 | 63 → 63 | feasible both |
| `syn20m02m` | 1752.13 | — → — | **0 → 0** | **optimal both** |
| `rsyn0805m` | 1296.12 | — → — | **0 → 0** | **optimal both** |

`syn20m02m` and `rsyn0805m` were already solving at 0 nodes on the base build. The
root ratios are unchanged: `syn40m` 27.08x and `rsyn0840m` 8.53x in **both** arms,
reproducing the issue's tabulated 27.1x and 8.5x exactly.

The OBBT bootstrap probe I ran (`finitized` 0 → 162 on `syn20m02m`) called
`bootstrap_finite_bounds` directly; on the real solve path presolve had already
derived those finite bounds by another route (visible in the run log: *"declared
inf, presolve derived 40"*), so the oracle repair had nothing left to win there.

**So this PR is `Contributes to #1061`, not `Closes` it.** It fixes a real
soundness defect that #1061's investigation uncovered; #1061's 27.1x root gap is a
property of the big-M relaxation itself and stays open.

## Scope

Bound-changing corpus-wide by nature (it changes which column the simplex prices),
so a corpus differential panel — flag-free, since a correctness fix does not ship
behind an opt-in — is running and its cert-clean result will be posted here before
merge.
