### PR TITLE
fix(cuts): #1062 the root cut loop must give up when the bound stops moving

### DIFF
--- a/python/discopt/solvers/_root_cuts.py
+++ b/python/discopt/solvers/_root_cuts.py
@@ -45,7 +45,22 @@ import numpy as np
 
 logger = logging.getLogger(__name__)
 
-ROUNDS = 30
+# Round cap. This is a runaway backstop, NOT the working terminator: the stage is
+# bounded by its wall budget and by STALL_ROUNDS below. It used to be 30, which
+# was the *binding* limit on exactly the instances the stage helps — measured on
+# rsyn0840m the loop stopped on the cap with the bound improving in 30 of 30
+# rounds and 43% of its wall budget still unspent (2778.18 -> 861.77 and still
+# falling). Raising it only lets a *productive* loop keep going; an unproductive
+# one now exits after STALL_ROUNDS.
+ROUNDS = 200
+# Consecutive rounds allowed to miss the quality gate's per-unit tolerance before
+# the loop gives up. Measured separation on the probe set is total: the two
+# instances the stage regressed (clay0205hfsg, clay0303hfsg) improved in 0 of 16
+# and 0 of 19 rounds, with the root LP bound pinned at 0.0 from the first round;
+# the two it helped improved in 18 of 20 and 30 of 30. There is no instance in
+# between, so 2 is well clear of both. 2 rather than 1 because a round's cuts can
+# need the NEXT re-convergence to pay off.
+STALL_ROUNDS = 2
 OA_TOL = 1e-6
 OA_MAX_ITERS = 60
 CUT_VIOL_TOL = 1e-6
@@ -72,6 +87,16 @@ class RootCutResult:
     lp_bound: float | None = None  # in the model's objective sense
     rounds_run: int = 0
     productive_rounds: int = 0
+    #: Root LP bound after each round's OA re-convergence, in the model's sense.
+    #: ``productive_rounds`` counts rounds that CHOSE cuts, which is not the same
+    #: thing and is useless as a progress signal: measured on clay0205hfsg the
+    #: loop chose cuts in 16 of 16 rounds and the end-of-loop quality gate then
+    #: discarded every one. The trace is what says whether the bound MOVED.
+    bound_trace: list = field(default_factory=list)
+    #: Rounds whose bound gain cleared the quality gate's own per-unit tolerance.
+    improving_rounds: int = 0
+    #: Why the loop stopped: "budget" | "rounds" | "no_lp" | "no_cuts" | "stall".
+    stop_reason: str = ""
 
 
 # ── linearised root view ─────────────────────────────────────────────────────
@@ -461,12 +486,21 @@ def generate_root_cuts(
     applied: list = []
     productive = 0
     rounds = 0
+    trace: list = [b0]
+    improving = 0
+    stalled = 0
+    stop_reason = "rounds"
+    # Per-round progress is judged against the SAME tolerance the end-of-loop
+    # quality gate uses, so "not improving" here means "on track to be
+    # discarded there" rather than a second, unrelated notion of progress.
+    gate_tol = 1e-6 * max(1.0, abs(b0))
     t0 = _time.perf_counter()
     lb_s = np.where(np.isfinite(root.lb_sep), root.lb_sep, 0.0)
     ub_s = np.where(np.isfinite(root.ub_sep), root.ub_sep, 1e5)
 
     for _rnd in range(ROUNDS):
         if _time.perf_counter() - t0 > time_budget_s:
+            stop_reason = "budget"
             break
         rounds += 1
         a_all = np.vstack([root.A_le] + ([np.array(cuts_a)] if cuts_a else []))
@@ -504,9 +538,28 @@ def generate_root_cuts(
 
         new_obj, x, duals, h = oa_converge()
         if x is None:
+            stop_reason = "no_lp"
             break
+        prev_obj = obj
         obj = new_obj
+        trace.append(obj)
+        round_gain = (prev_obj - obj) if root.sense_max else (obj - prev_obj)
+        if round_gain > gate_tol:
+            improving += 1
+            stalled = 0
+        else:
+            stalled += 1
         if not chosen:
+            stop_reason = "no_cuts"
+            break
+        # Stall exit. Cuts keep being FOUND on these instances — clay0205hfsg
+        # chose cuts in 16 of 16 rounds — they just never move the bound, so
+        # `chosen` cannot detect it and the loop ran to budget exhaustion before
+        # the end-of-loop gate discarded every cut. That cost a quarter of the
+        # whole solve's time limit for nothing, which is the regression, not the
+        # cuts' arithmetic (a valid cut cannot loosen a valid bound).
+        if stalled >= STALL_ROUNDS:
+            stop_reason = "stall"
             break
 
     # Quality gate: keep the stage's output only when the cutting loop actually
@@ -516,10 +569,22 @@ def generate_root_cuts(
     # bound and their per-node row cost is pure regression; skipping them makes
     # the flag a no-op there (trivially sound).
     if obj is None or b0 is None:
-        return RootCutResult(rounds_run=rounds, productive_rounds=productive)
+        return RootCutResult(
+            rounds_run=rounds,
+            productive_rounds=productive,
+            bound_trace=trace,
+            improving_rounds=improving,
+            stop_reason=stop_reason,
+        )
     gain = (b0 - obj) if root.sense_max else (obj - b0)
-    if gain <= 1e-6 * max(1.0, abs(b0)):
-        return RootCutResult(rounds_run=rounds, productive_rounds=productive)
+    if gain <= gate_tol:
+        return RootCutResult(
+            rounds_run=rounds,
+            productive_rounds=productive,
+            bound_trace=trace,
+            improving_rounds=improving,
+            stop_reason=stop_reason,
+        )
 
     # Keep only the cuts binding at the final LP optimum: they carry the final
     # bound; slack cuts only bloat every node NLP. (Validity is unaffected —
@@ -532,4 +597,7 @@ def generate_root_cuts(
         lp_bound=obj,
         rounds_run=rounds,
         productive_rounds=productive,
+        bound_trace=trace,
+        improving_rounds=improving,
+        stop_reason=stop_reason,
     )

--- a/python/tests/test_nlpbb_root_cuts_781.py
+++ b/python/tests/test_nlpbb_root_cuts_781.py
@@ -200,3 +200,134 @@ def test_rsyn0805m_flag_on_sound_and_tighter(monkeypatch):
     # the composed bound is at most the root-cut LP bound (~1577.3 measured);
     # flag-off tree bound at this budget is ~1768 — require a real improvement
     assert r.bound <= 1650.0, f"root-cut bound composition ineffective: {r.bound}"
+
+
+# ── stall termination (#1062): the loop must not spend its budget for nothing ─
+
+
+def test_stalling_loop_exits_after_stall_rounds(monkeypatch):
+    """A loop that keeps FINDING cuts but never MOVES the bound must give up.
+
+    This is the #1062 regression. `chosen` cannot detect the condition — measured
+    on clay0205hfsg the loop chose cuts in 16 of 16 rounds while the root LP
+    bound sat at 0.0 the whole time, so it ran to budget exhaustion (7.4 s, a
+    quarter of the solve's entire 30 s limit) and the end-of-loop quality gate
+    then discarded every cut it had found. The cuts were never the problem — a
+    valid cut cannot loosen a valid bound — the wasted wall was.
+
+    Stubbed rather than corpus-driven so the condition is exact: the LP bound is
+    pinned to a constant and selection always yields a cut, which is precisely
+    "productive by `chosen`, stalled by the bound".
+    """
+    import discopt.solvers._root_cuts as rc
+    from discopt._relax.nlp_evaluator import NLPEvaluator
+
+    m = _build_convex_minlp("max")
+    ev = NLPEvaluator(m)
+    lb = np.array([0.0, 0.0, 0.0, 0.0])
+    ub = np.array([10.0, 10.0, 1.0, 1.0])
+    is_int = np.array([False, False, True, True])
+
+    x_fixed = np.array([1.0, 1.0, 0.5, 0.5])
+    calls = {"lp": 0, "sel": 0}
+
+    def _frozen_lp(root, cuts_a, cuts_b):
+        calls["lp"] += 1
+        return 5.0, x_fixed.copy(), None, None  # bound never moves
+
+    def _always_a_cut(candidates, x, **kw):
+        calls["sel"] += 1
+        a = np.zeros(len(x_fixed))
+        a[0] = 1.0
+        return [(a, 99.0)]
+
+    monkeypatch.setattr(rc, "_solve_lp", _frozen_lp)
+    monkeypatch.setattr(rc, "_select_cuts", _always_a_cut)
+
+    res = rc.generate_root_cuts(m, ev, lb, ub, is_int, is_int.copy(), time_budget_s=30.0)
+
+    assert calls["lp"] > 0 and calls["sel"] > 0, "stubs never ran — probe measured nothing"
+    assert res.stop_reason == "stall", f"stopped on {res.stop_reason!r}, not the stall guard"
+    assert res.improving_rounds == 0
+    assert res.rounds_run == rc.STALL_ROUNDS, (
+        f"ran {res.rounds_run} rounds on a frozen bound; the guard should stop it "
+        f"at {rc.STALL_ROUNDS}. Before #1062 this ran to ROUNDS or to the budget."
+    )
+    # ...and it did not burn the budget it was given.
+    assert res.cuts == [], "a stalled loop must still hand back nothing"
+
+
+def test_loop_never_runs_more_than_stall_rounds_past_its_last_gain(monkeypatch):
+    """General invariant, asserted on the real separators rather than stubs.
+
+    Whatever the instance, once the bound stops moving the loop is allowed at
+    most STALL_ROUNDS more rounds. This is what bounds the stage's wasted wall
+    on every instance, not just the ones in the probe set.
+    """
+    import discopt.solvers._root_cuts as rc
+    from discopt._relax.nlp_evaluator import NLPEvaluator
+
+    checked = 0
+    for sense in ("max", "min"):
+        m = _build_convex_minlp(sense)
+        ev = NLPEvaluator(m)
+        res = rc.generate_root_cuts(
+            m,
+            ev,
+            np.array([0.0, 0.0, 0.0, 0.0]),
+            np.array([10.0, 10.0, 1.0, 1.0]),
+            np.array([False, False, True, True]),
+            np.array([False, False, True, True]),
+            time_budget_s=30.0,
+        )
+        if res.stop_reason == "stall":
+            assert res.rounds_run <= res.improving_rounds + rc.STALL_ROUNDS, (
+                f"{sense}: {res.rounds_run} rounds but only {res.improving_rounds} "
+                f"improving — more than {rc.STALL_ROUNDS} rounds were wasted"
+            )
+        # the trace always carries the baseline plus one entry per completed round
+        assert len(res.bound_trace) <= res.rounds_run + 1
+        checked += 1
+    assert checked == 2, "invariant probe ran on nothing"
+
+
+@pytest.mark.slow
+def test_clay0205hfsg_stage_no_longer_burns_the_time_limit(monkeypatch):
+    """The measured #1062 regression, on the instance that showed it.
+
+    Before the stall guard: 16 rounds, 7.4 s against a 6.0 s budget — 25.8% of a
+    30 s solve's whole limit — and 0 cuts kept. The budget is not the fix, since
+    it was already being overrun; giving up is.
+    """
+    import time
+
+    import discopt.modeling as dm
+    import discopt.solvers._root_cuts as rc
+    from discopt._relax.nlp_evaluator import NLPEvaluator
+    from discopt.modeling.core import VarType
+
+    nl = BENCH_NL / "clay0205hfsg.nl"
+    if not nl.exists():
+        pytest.skip("benchmark corpus not available")
+    m = dm.from_nl(str(nl))
+    lb = np.array([float(v.lb) for v in m._variables])
+    ub = np.array([float(v.ub) for v in m._variables])
+    is_int = np.array([v.var_type in (VarType.INTEGER, VarType.BINARY) for v in m._variables])
+
+    budget = 6.0  # what solver.py hands the stage at time_limit=30
+    t0 = time.perf_counter()
+    res = rc.generate_root_cuts(
+        m,
+        NLPEvaluator(m),
+        lb,
+        ub,
+        is_int,
+        is_int & (lb == 0.0) & (ub == 1.0),
+        time_budget_s=budget,
+    )
+    wall = time.perf_counter() - t0
+
+    assert res.improving_rounds == 0, "instance changed; it used to never move the bound"
+    assert res.stop_reason == "stall"
+    assert res.rounds_run <= rc.STALL_ROUNDS
+    assert wall < 0.25 * budget, f"stage still burned {wall:.2f}s of its {budget}s budget"


### PR DESCRIPTION
## The premise, restated

#1062 says the sub-NLP primal heuristic "never fires on convex MINLPs". That
framing is wrong and was checked before building: `subnlp_calls` is 1–112
depending on the path, and an instrumented run shows the `and not
_model_is_convex` gate is never *reached* — convex models route to OA/NLP-BB
long before it. The heuristic is not the thing holding these instances back.

What is holding them back is the root bound, and the stage meant to close it —
the #781 root cutting loop — has a defect that makes it lose on some instances
and quit early on exactly the ones it helps.

## The defect

`generate_root_cuts` breaks on four conditions: wall budget, the round cap,
a dead LP, and a round that selects no cuts. None of them detect the case that
actually costs: **cuts keep being found while the bound never moves.**
`productive_rounds` does not help — it counts rounds that *chose* cuts.

Entry experiment (CLAUDE.md §4), at `time_limit=30`, stage budget 6.0 s. The
hypothesis, its prediction, and its kill criterion were written down before the
run — see `scratchpad/entry_1062_budget.py`:

| instance | group | rounds | improving | cuts kept | wall | % of TL | stop |
|---|---|---|---|---|---|---|---|
| clay0205hfsg | regressed | 16 | **0** | **0** | 7.43 s | **25.8%** | budget |
| clay0303hfsg | regressed | 19 | **0** | **0** | 2.39 s | 8.0% | no_cuts |
| syn40m | helped | 20 | 18 | 61 | 1.12 s | 3.7% | no_cuts |
| rsyn0840m | helped | 30 | **30** | 69 | 3.50 s | 11.4% | **rounds cap** |

Both `clay*` hold the root LP bound at exactly `0.0` in every trace entry while
choosing cuts in 16 of 16 and 18 of 19 rounds — then the end-of-loop quality gate
discards all of them. `clay0205hfsg` spends a quarter of the entire solve's time
limit to hand back nothing, and overruns its own 6.0 s budget (the budget check
sits at the top of the loop, so a round starting under budget runs to completion).

**That is the regression the #1061 graduation panel charged to this flag**, and it
is a cost effect, not a bound effect — a valid cut cannot loosen a valid dual
bound, so the cuts' arithmetic was never a candidate explanation.

The same table shows the other half: `rsyn0840m` stopped on `ROUNDS = 30` while
improving in **30 of 30** rounds with 43% of its budget unspent. The round cap was
the binding limit precisely on the instances the stage helps.

## The fix

* **Stall exit.** Track the per-round bound and stop after `STALL_ROUNDS = 2`
  consecutive rounds that fail the *same* tolerance the end-of-loop quality gate
  uses — so "not improving" here means "on track to be discarded there", not a
  second unrelated notion of progress. The measured separation is total (0
  improving rounds vs 18/20 and 30/30, nothing in between), so 2 is well clear of
  both groups. 2 rather than 1 because a round's cuts can need the next
  re-convergence to pay off.
* **Round cap raised to 200**, now a runaway backstop rather than the working
  terminator: the budget and the stall guard bound the loop.
* **`RootCutResult` gains `bound_trace`, `improving_rounds`, `stop_reason`.** The
  loop had no per-round progress signal at all, which is why this was invisible
  from the outside — and it is what the stall guard is built on, not decoration.

Same probe after the change:

| instance | rounds | improving | cuts kept | wall | stop |
|---|---|---|---|---|---|
| clay0205hfsg | 2 | 0 | 0 | **0.10 s** (73× less) | stall |
| clay0303hfsg | 2 | 0 | 0 | **0.10 s** (23× less) | stall |
| syn40m | 20 | 18 | 61 | 1.09 s | no_cuts — **bound identical** (366.4403) |
| rsyn0840m | 36 | 35 | 73 | 4.57 s | no_cuts — **bound 861.77 → 852.11** |

The guard never fires on the productive instances; removing the cap let
`rsyn0840m` run to natural cut exhaustion instead of truncation, and its bound
tightened. (syn/rsyn are maximizations, so a falling upper bound is tightening.)

## Verification

* `pytest python/tests/test_nlpbb_root_cuts_781.py` — all pass, including the
  existing exact-enumeration GMI validity gate and the flag-off inertness tests.
* New `test_stalling_loop_exits_after_stall_rounds`: a stubbed loop with the
  bound frozen and selection always yielding a cut — exactly "productive by
  `chosen`, stalled by the bound". **Fails before this change** with
  `AssertionError: stopped on 'rounds', not the stall guard`; passes after.
* New `test_loop_never_runs_more_than_stall_rounds_past_its_last_gain`: the
  general invariant, on the real separators for both senses, so the guarantee is
  not tied to the probe set (§2).
* New slow `test_clay0205hfsg_stage_no_longer_burns_the_time_limit`, skipped when
  the corpus is absent.
* `pytest -m smoke` and the adversarial suite: reported below once run.

## Scope and what this does not yet claim

This changes which valid cuts are added, so it is **bound-changing** under §5 and
`DISCOPT_NLPBB_ROOT_CUTS` stays **default-OFF** here. It removes the specific
`clay*` regression that failed the flag's last graduation panel, and it is the
precondition for re-running that panel — but the graduation itself needs the
corpus-wide differential run (cert-clean **and** net-positive), which is queued
and will be posted before any default flip.

`docs/dev/performance-plan.md` §20 records that panel's REJECT verdict. It stays
accurate: it rejected the flag *as it stood*, and the mechanism it names as the
cause of the `clay*` looseners is the one measured and fixed here.

Contributes to #1062
Contributes to #1061

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017PQaiDVuY5Rs3tga98tnNo
