### PR TITLE
fix(correctness): an open gap must not report gap_certified=True

### DIFF
--- a/python/discopt/solvers/oa.py
+++ b/python/discopt/solvers/oa.py
@@ -4553,6 +4553,17 @@ def solve_lp_nlp_bb(
         if master_bound_valid and bound is not None
         else ("heuristic" if bound is not None else "unavailable")
     )
+    # ``gap_certified`` means the gap is CLOSED and rests on a valid bound -- not
+    # merely that the printed gap is arithmetically well-formed. The looser
+    # reading (``master_bound_valid`` alone) reported ``gap_certified=True``
+    # alongside a 424% open gap on ``syn40m``, which ``result_io.summary_text``
+    # renders with no "(uncertified)" marker, and which the NLP-BB path spells
+    # the opposite way (``solver.py``: any ``feasible`` exit clears it). One
+    # field with two meanings is what made a cross-route comparison meaningless.
+    # Bound validity keeps its own signal in ``master_bound_valid`` /
+    # ``bound_validity``; this narrows ``gap_certified`` only, and only ever
+    # from True to False.
+    gap_is_certified = bool(master_bound_valid and gap is not None and gap <= gap_tolerance)
     single_tree_trace: dict[str, object] = {
         "schema_version": 1,
         "solver": "mip-nlp",
@@ -4590,7 +4601,7 @@ def solve_lp_nlp_bb(
         },
         "termination_reason": termination_reason,
         "master_bound_valid": bool(master_bound_valid),
-        "gap_certified": bool(master_bound_valid),
+        "gap_certified": gap_is_certified,
         "bound_validity": trace_bound_validity,
         "final_lb": _trace_value(bound),
         "final_ub": _trace_value(incumbent_obj),
@@ -4608,7 +4619,7 @@ def solve_lp_nlp_bb(
             node_count=master_result.node_count,
             mip_count=1,
             subnlp_calls=nlp_subproblem_count,
-            gap_certified=master_bound_valid,
+            gap_certified=gap_is_certified,
             mip_nlp_trace=single_tree_trace,
         )
 
@@ -4622,7 +4633,7 @@ def solve_lp_nlp_bb(
         node_count=master_result.node_count,
         mip_count=1,
         subnlp_calls=nlp_subproblem_count,
-        gap_certified=master_bound_valid,
+        gap_certified=gap_is_certified,
         mip_nlp_trace=single_tree_trace,
     )
 
@@ -5558,7 +5569,10 @@ def solve_oa(
             else None
         )
         local_cut_count = sum(1 for record in cut_provenance.records if not record.global_valid)
-        gap_certified = bool(bound_valid and final_gap is not None)
+        # Same narrowing as the single-tree builder above: a valid-but-OPEN
+        # gap is not a certificate. ``bound_valid`` remains the validity
+        # signal, still exported as ``master_bound_valid``/``bound_validity``.
+        gap_certified = bool(bound_valid and final_gap is not None and final_gap <= gap_tolerance)
         summary = {
             "mip_count": int(mip_count),
             "nlp_subproblem_count": int(nlp_subproblem_count),
@@ -7503,6 +7517,17 @@ def solve_oa(
         status = "optimal" if _certified_gap_converged() and not has_unresolved else "feasible"
         if termination_reason in {"cycling", "stalling"}:
             status = "feasible"
+        # ``gap_certified`` must agree with ``status``: it is the field a user
+        # reads (and ``result_io.summary_text`` renders) to decide whether the
+        # reported gap is a certificate. Deriving it from ``reported_gap is not
+        # None`` instead made it True on any run that merely *had* a gap --
+        # ``syn40m`` returned ``status="feasible"`` with an 84% gap and
+        # ``gap_certified=True``, printed with no "(uncertified)" marker. The
+        # NLP-BB path already spells this the strict way (``solver.py``: a
+        # ``feasible`` exit clears it), so the loose reading also made
+        # ``gap_certified`` incomparable across the two routes. Bound validity
+        # is a separate question and keeps its own signal in the trace's
+        # ``master_bound_valid`` / ``bound_validity``.
         return SolveResult(
             status=status,
             objective=_obj_sign * incumbent_obj,
@@ -7513,7 +7538,7 @@ def solve_oa(
             mip_count=mip_count,
             subnlp_calls=nlp_subproblem_count,
             mip_nlp_trace=_build_mip_nlp_trace(final_reason),
-            gap_certified=bool(reported_gap is not None and not has_unresolved),
+            gap_certified=(status == "optimal"),
         )
 
     if has_unresolved:

--- a/python/tests/test_1061_gap_certified_implies_closed_gap.py
+++ b/python/tests/test_1061_gap_certified_implies_closed_gap.py
@@ -1,0 +1,86 @@
+"""``gap_certified`` must imply the gap is actually CLOSED (#1061 follow-on).
+
+The OA / mip-nlp route used to derive the flag from ``reported_gap is not None
+and not has_unresolved`` -- "a gap was computed", not "the gap is a
+certificate". Measured on the 153-instance convex panel (2026-08-20), **19 of
+153** instances came back ``gap_certified=True`` on an *open* gap, the widest
+being ``syn40m`` at a 430% relative gap. ``result_io.summary_text`` renders that
+field as the "(uncertified)" marker, so those rows printed to a user as
+certified.
+
+It also made the flag incomparable across routes: the NLP-BB path spells the
+strict meaning (``solver.py``: any ``feasible`` exit clears ``_gap_certified``,
+keeping bound *validity* in ``_tree_bound_valid``). One field, two meanings, so
+a differential panel that switched routes read a certification "regression"
+where the newly-selected result was strictly better on bound, incumbent and gap.
+
+The invariant under test is one-directional and route-independent:
+
+    gap_certified  =>  gap is not None and gap <= gap_tolerance
+
+Bound validity is a *different* question and is deliberately NOT asserted here;
+it keeps its own signal in the trace (``master_bound_valid`` /
+``bound_validity``), which stays ``"global"`` for a valid-but-open bound.
+"""
+
+import os
+
+import pytest
+from discopt.modeling.core import from_nl
+
+CORPUS = os.path.expanduser("~/Dropbox/projects/discopt-minlp-benchmark/minlplib/nl")
+GAP_TOL = 1e-4
+
+# Convex big-M/GDP instances that do not close inside a short budget, so the
+# time-limited exit carries a valid bound AND an open gap -- the state that
+# produced the false certificate. Gate probes only (CLAUDE.md SS2): the
+# assertion is the general invariant, not a per-instance expectation.
+PROBES = ["syn40m", "rsyn0805m02m"]
+
+
+@pytest.mark.slow
+@pytest.mark.parametrize("name", PROBES)
+def test_open_gap_is_never_reported_as_certified(name):
+    path = os.path.join(CORPUS, name + ".nl")
+    if not os.path.exists(path):
+        pytest.skip("MINLPLib corpus not present")
+
+    result = from_nl(path).solve(
+        solver="mip-nlp", mip_nlp_method="oa", time_limit=20, gap_tolerance=GAP_TOL
+    )
+
+    # SS6: this probe is only meaningful on a run that actually left a gap open.
+    # A build that closes it has not exercised the defect, so say so loudly
+    # rather than passing silently on a measurement that never happened.
+    assert result.gap is not None and result.gap > GAP_TOL, (
+        f"probe precondition broken: {name} closed its gap "
+        f"(gap={result.gap!r}, status={result.status!r}) -- re-derive the probe"
+    )
+
+    assert not result.gap_certified, (
+        f"{name} reports gap_certified=True at gap={result.gap:.4g} "
+        f"(status={result.status!r}) -- an open gap is not a certificate"
+    )
+
+    # The bound is still valid; only the *certificate* claim was withdrawn.
+    trace = getattr(result, "mip_nlp_trace", None)
+    if isinstance(trace, dict) and trace.get("final_lb") is not None:
+        assert trace.get("bound_validity") == "global", (
+            "narrowing gap_certified must not downgrade bound validity: "
+            f"bound_validity={trace.get('bound_validity')!r}"
+        )
+        assert trace.get("master_bound_valid") is True
+
+
+@pytest.mark.slow
+def test_gap_certified_agrees_with_optimal_status():
+    """``gap_certified`` and ``status == 'optimal'`` must not disagree."""
+    path = os.path.join(CORPUS, "syn40m.nl")
+    if not os.path.exists(path):
+        pytest.skip("MINLPLib corpus not present")
+    result = from_nl(path).solve(
+        solver="mip-nlp", mip_nlp_method="oa", time_limit=20, gap_tolerance=GAP_TOL
+    )
+    assert result.gap_certified == (result.status == "optimal"), (
+        f"status={result.status!r} but gap_certified={result.gap_certified!r}"
+    )

--- a/python/tests/test_mip_nlp.py
+++ b/python/tests/test_mip_nlp.py
@@ -876,7 +876,13 @@ def test_mip_nlp_shot_convex_bounding_filters_local_cuts(monkeypatch):
     assert trace["final_lb"] == pytest.approx(-2.0)
     assert trace["heuristic_lb"] == pytest.approx(-1.0)
     assert result.bound == pytest.approx(-2.0)
-    assert result.gap_certified is True
+    # This scenario stops at ``max_iterations=1`` with incumbent 0.0 against a
+    # bound of -2.0 -- a wide-open gap. ``gap_certified`` means the gap is
+    # CLOSED, so it must be False here; the rigour of the bound is a separate
+    # question and is asserted directly below (that is what this test is about).
+    assert result.gap is not None and result.gap > 1e-4
+    assert result.gap_certified is False
+    assert trace["master_bound_valid"] is True
 
 
 def test_mip_nlp_shot_convex_bounding_skips_nonrigorous_no_good_cuts(monkeypatch):


### PR DESCRIPTION
## What

`gap_certified` on the OA / mip-nlp route meant "a gap was computed", not "the
gap is a certificate". It was derived from `reported_gap is not None and not
has_unresolved`, so any run that merely *had* a gap reported `True`.

Measured on the 153-instance convex panel (2026-08-20): **19 of 153 instances
returned `gap_certified=True` on an open gap**, the widest being `syn40m` at a
**430% relative gap**. `result_io.summary_text` renders that field as the
`(uncertified)` marker, so those rows printed to a user as certified:

```
status:    feasible
objective: 55.713256
bound:     342.51035
gap:       0.8373            <- no "(uncertified)" marker
```

## Why it matters beyond the printout

The NLP-BB path spells the strict meaning: `solver.py` clears `_gap_certified`
on *any* `feasible` exit and keeps bound validity separately in
`_tree_bound_valid`. So one field carried two documented meanings, and a
differential panel whose two arms took different routes read a certification
"regression" where the newly-selected result was strictly better on bound,
incumbent and gap. This defect is what blocked the `DISCOPT_NLPBB_ROOT_CUTS`
graduation gate.

It had already cost one measured bug: `_route_result_is_certified` (#1059) has
a docstring explaining that reading this field as "finished" was "a measured
defect" which threw away 29.8 s of a 60 s budget on `syn40m`.

## Change

Both OA trace builders now require the gap to be closed to the caller's own
`gap_tolerance`, and the returned `SolveResult.gap_certified` is tied to
`status == "optimal"` so the two cannot disagree. **This only ever narrows the
flag from True to False.**

Bound validity is a different question and is deliberately untouched:
`master_bound_valid` / `bound_validity` still report `"global"` for a
valid-but-open bound, and the new test asserts that narrowing the certificate
does not downgrade the bound.

## Verification

A/B on `syn40m` (OA route, 20 s, `gap_tolerance=1e-4`), with the marker asserted
absent then present per CLAUDE.md SS8:

| | `status` | `gap` | `gap_certified` | `bound_validity` |
|---|---|---|---|---|
| before | feasible | 0.8373 | **True** | global |
| after | feasible | 0.8372 | False | global |

New regression test `test_1061_gap_certified_implies_closed_gap.py` locks the
one-directional, route-independent invariant

```
gap_certified  =>  gap is not None and gap <= gap_tolerance
```

and carries a SS6 precondition assert so a build that closes the gap fails
loudly rather than passing on a measurement that never happened.

Suites run:

- `pytest -m smoke` — 1078 passed, 1 skipped, 2 xpassed (195.0 s)
- `pytest -m slow python/tests/test_adversarial_recent_fixes.py` — 19 passed (148.6 s)
- OA-focused files (`test_oa`, `test_oa_internals_units`, `test_gbd`,
  `test_decomposition_adversarial`, `test_c35_oa_nogood_nlp_failure`,
  `test_objective_epigraph`) — 126 passed
- Rust untouched, so no `cargo test` needed.

Contributes to #1061 and #1062; it unblocks their graduation panel, which is
the follow-up PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017PQaiDVuY5Rs3tga98tnNo
