### PR TITLE
feat(nlp-bb): #1061 #1062 graduate DISCOPT_NLPBB_ROOT_CUTS to default-ON

### DIFF
--- a/docs/dev/performance-plan.md
+++ b/docs/dev/performance-plan.md
@@ -3687,3 +3687,47 @@ an optimum, and cannot turn a certified instance uncertified. The panel's
 cert-clean verdict therefore survives the change a fortiori. Its net-positive
 column is measured on the pre-fix build and is not re-run; the fix touches only
 the terminal point of a solve, not the search.
+
+### 21.2 `rsyn0820m02m`: the row-count hypothesis is falsified, and the cost is per-node NLP effort
+
+The graduation panel's net-positive column is a population statistic, so it is
+worth naming what it is averaging over. Re-running #1062's four named instances
+plus `rsyn0820m02m` (which is **not** in the 153-instance panel) at 60 s, both
+arms adjacent per instance, found one clear loser:
+
+| instance | OFF | ON |
+|---|---|---|
+| `rsyn0820m02m` (max, opt 1092.09) | obj 244.20, 31 nodes | obj **-39.53**, **3 nodes** |
+
+**Hypothesis (stated before measuring):** the stage appends so many rows that
+per-node NLP cost collapses throughput. **Kill criterion:** if the applied cut
+count is small relative to the model's rows, the hypothesis is wrong.
+
+**Falsified.** `$SP/probe_0820.py`, `CHECKS_EXECUTED 4`:
+
+```
+rsyn0820m02m: declared rows=1074 vars=510
+root-cut stage: n_cuts=69 rounds=26 productive=26 stop='budget'
+                lp_bound=5220.25 stage_wall=10.6s
+rows after solve = 1143  (+69 cut rows, 6.4% of the model)
+result: status=feasible obj=-39.531 bound=4786.63 nodes=3 subnlp=1 wall=60.2
+stage consumed 10.6s of a 60s budget (18%)
+```
+
+69 cuts on 1074 rows cannot be a 10x throughput effect by row count. The stage's
+own wall is bounded and behaved (`max(2, min(10, 0.2*T))`, 10.6 s of 60 s), so
+the lost time is in the tree: **~1.9 s/node OFF vs ~16 s/node ON**, an ~8.5x
+per-node cost increase bought by 6.4% more rows. The cost is therefore in how
+much *effort* each node NLP spends on the cut-tightened feasible region, not in
+its size. Every round here was productive (26/26) and the loop stopped on
+budget, so the stall detector had nothing to catch — this is not the #1062 stall.
+
+No soundness consequence: the bound stays valid (4786.63 >= 1092.09) in both
+arms, and the panel's `RAISED` count is 0.
+
+**Not acted on in the graduation PR, deliberately.** Any change to the cut cap
+or the per-node effort limit is itself bound-changing and would invalidate the
+153-instance panel that the graduation rests on. Recorded here as the entry
+measurement for whoever tunes the cut stage next: the lever to test first is
+per-node NLP iteration effort under appended GMI/c-MIR rows, **not** the cut
+count.

--- a/docs/dev/performance-plan.md
+++ b/docs/dev/performance-plan.md
@@ -3437,6 +3437,11 @@ Per §5 the flag is now **default-ON**, with `DISCOPT_PERSPECTIVE_OA_CUT=0` kept
 as the opt-out and the plain-tangent path intact.
 ## 20. #1061 root cuts: `DISCOPT_NLPBB_ROOT_CUTS` is sound but not helpful — stays OFF (rejected 2026-08-20)
 
+> **Superseded by §21 (2026-08-20).** The re-run panel below — on a build with
+> the #1062 stall fix and the #1098 `gap_certified` correction — passes both §5
+> bars, and the flag is now default-ON. §20 is retained as the record of the
+> verdict *for the build it was run on* (CLAUDE.md §11), not as current policy.
+
 **Why this was run.** #1061 reports discopt's root dual bound sitting 27.1x above
 the reference optimum on `syn40m` and 8.5x on `rsyn0840m`. The root cutting-plane
 stage (#781, `DISCOPT_NLPBB_ROOT_CUTS`, default-OFF) was the nearest built lever,
@@ -3542,3 +3547,143 @@ rounds with its bound tightening 861.77 → 852.11.
 measured cause of the panel's `cert-clean` failure, which makes a re-run
 meaningful; the flag stays default-OFF until a fresh §5 panel clears **both**
 bars. Until that panel is scored, §20's verdict is the operative one.
+
+**Update (2026-08-20): that panel has now been scored — see §21.** It clears both
+bars and the flag graduated default-ON, so the sentence above ("§20's verdict is
+the operative one") no longer holds; it was correct when written and is retracted
+here rather than edited, per CLAUDE.md §11.
+
+## 21. #1061/#1062 root cuts, re-run: `DISCOPT_NLPBB_ROOT_CUTS` passes both §5 bars and graduates ON (2026-08-20)
+
+**Why this was re-run.** §20 rejected the flag on a panel that failed *both* §5
+bars. Two things changed underneath that verdict:
+
+1. **#1062's stall fix.** The convex B&B's stalled node abstained instead of
+   being excluded (#1082), which suppressed the sub-NLP primal heuristic on
+   exactly the convex models this flag targets. §20's panel predates it.
+2. **#1098's `gap_certified` narrowing.** The §20-era field carried *two*
+   meanings. On the OA/mip-nlp route it meant "the printed gap is arithmetically
+   valid" — true at a 430% open gap. On the NLP-BB route (`solver.py`) any
+   `feasible` exit cleared it, i.e. "the gap is *closed*". A differential panel
+   whose two arms take different routes therefore reads a **false certification
+   regression** whenever the flag changes which route wins.
+
+**The panel.** Flag ON vs OFF over the in-repo corpus, 6 shards, 60 s/instance,
+arms adjacent per instance (§9), threads pinned. **153 instances with complete
+pairs in both arms**; every shard reported a non-zero executed-comparison count
+and no tracebacks (§6).
+
+| gate | result |
+|---|---|
+| dual bound | tighter **22**, looser 9, flat 122 |
+| primal shortfall | better **6**, worse **1**, same 102 |
+| node count | OFF 111 702 → ON 96 860 (**−13.3%**); 58 instances >2% fewer, 2 more, 93 within 2% |
+| total wall | OFF 5744.0 s, ON 5774.8 s (**+0.5%**) |
+| bound above its reference optimum (`RAISED`) | **0 instances** |
+| certification regression (#1098 semantics) | **0 instances** |
+| proven-optimal count | OFF 69, ON 69 (no certificate lost) |
+| **CERT-CLEAN** | **PASS** |
+| **NET-POSITIVE** | **PASS** |
+
+**The two flagged regressions were artifacts, and this was verified rather than
+asserted.** The raw scorer — reading the pre-#1098 `gap_certified` straight out
+of the logs — flagged `rsyn0805m02m` and `syn40m`. Re-adjudicating all 153 pairs
+under the corrected predicate (`gap_certified == (status == "optimal")`, which is
+what #1098 makes both routes report) gives:
+
+```
+raw cert regressions (pre-#1098 logs) : ['rsyn0805m02m', 'syn40m']
+cert regressions under #1098 semantics: []
+  -> INVENTED by the loose reading    : ['rsyn0805m02m', 'syn40m']
+  -> HIDDEN by the loose reading      : []
+```
+
+The "hidden" column matters: a *narrowing* can in principle expose a regression
+the loose reading concealed (OFF stays certified, ON turns out to have been an
+open gap mislabelled). Zero were hidden, so the correction only removes false
+positives here.
+
+`syn40m` is the clearest case — the ON arm is better on **every real quantity**
+and lost only the label:
+
+| arm | route | status | objective | bound | `gap_certified` |
+|---|---|---|---|---|---|
+| OFF | OA (`mip_nlp_trace` present) | feasible | 55.713 (17.7% short) | 292.22 | True |
+| ON | NLP-BB (no `mip_nlp_trace`) | feasible | **67.71325557 = the optimum** | **187.88** | False |
+
+Turning root cuts on makes the NLP-BB answer better, so it wins route selection
+(`_route_is_better`) and inherits that route's stricter label. Confirmed by direct
+re-run of both instances × both arms on the post-#1098 build: both report
+`gap_certified=False` in *both* arms, so there is no regression, and ON is better
+on both (`syn40m` objective 55.713 → 67.713; `rsyn0805m02m` 1059.08 → 1226.09
+with a tighter bound 4386.54 → 4373.31).
+
+**Verdict.** Both bars pass, so under §5 the flag graduates default-ON, keeping
+the `DISCOPT_NLPBB_ROOT_CUTS=0` opt-out and the legacy path intact. This
+supersedes §20's rejection: §20 remains the correct verdict *for the build it was
+run on* (pre-#1062-stall-fix, pre-#1098), and is retained per §11 rather than
+edited away.
+
+### 21.1 The panel was not the last gate: the smoke suite caught a false certificate the corpus could not see
+
+Flipping the default to ON with the panel in hand failed `pytest -m smoke`
+immediately, on `test_945_nlp_box_and_gap_closure.py::
+test_default_solve_path_does_not_certify_a_super_optimal_incumbent`:
+
+```
+flag=0: status=optimal obj=2.999999998034762  super-optimal by 1.965e-09
+flag=1: status=optimal obj=2.998978315393790  super-optimal by 1.022e-03
+```
+
+on the MindtPy constraint-qualification fixture `(x-3)^2 <= 50(1-y)`, whose
+exact optimum is 3.0. This is CLAUDE.md §1's worst class — a certificate on a
+point that cannot exist — and it outranks §5: a flag does not graduate onto the
+default path while an in-repo gate demonstrates one.
+
+**Why 153 corpus instances missed it.** The corpus oracle (`minlplib.solu`) is
+compared at a relative tolerance, and the error here is 3.4e-4 relative. It is
+also structural rather than statistical: it needs an *active degenerate* row,
+where the constraint residual is quadratic in the variable error, so 1e-6 of
+violation is 1e-3 of `x`. A panel over well-posed instances has no power against
+it. The lesson generalizes past this flag: **a corpus panel is a §5 instrument,
+not a §1 one.** The §1 gates are the suites.
+
+**The chain, measured end to end** (`$SP/cq_probe{2,3,4}.py`, each printing an
+executed-comparison count per §6):
+
+1. Root cuts tighten the root LP to 2.998981, so the node-1 NLP relaxation
+   returns `x = 2.998978` at `y = 1 - 2.1e-8`. That point is genuinely feasible
+   — the sliver of `y` buys `50 * 2.1e-8 = 1.05e-6` of big-M slack, exactly
+   covering `(x-3)^2 = 1.04e-6`.
+2. `y` is integral within tolerance, so the node is integer-feasible and the
+   relaxation value equals the incumbent: gap 0 at **node 1**.
+3. Snapping `y` to 1 removes that slack: row 0 is now violated by 1.044e-6. The
+   1e-6 exit gate sees 9.938e-7 after the `1e-9 * 50` term-scaled forgiveness,
+   and passes it by 0.6%.
+4. The terminal refine (integers fixed, `bound_relax_factor=0`) returned
+   `x = 2.9999999931`, violation **4.8e-17** — the honest point — and the
+   adoption rule **rejected it**, because its objective differs from the
+   incumbent's by 1.02e-3, outside the rule's ±1e-4 window.
+
+Step 4 is the defect, and it is not specific to root cuts: the ±1e-4 objective
+window is the wrong arbiter when the two points *disagree*, because it keeps
+whichever is more optimistic — including one the refine has just shown to be
+unattainable at that integer assignment. Root cuts only supply a relaxation
+tight enough to land on the degenerate boundary, where the flaw is visible.
+
+Fixed on `feat/1061-1062-graduate-nlpbb-root-cuts`: when the objectives disagree
+beyond the window, both points are measured with the same arbiter the exit gate
+uses (`_nonlinear_point_excess`, declared rows and declared box) and a *strictly
+more feasible* point is adopted even though its objective is worse. It cannot
+admit a point the exit gate would refuse, and when the two agree within the
+window the original branch still applies — so nothing moves on a healthy solve.
+After it, flag ON reports `obj = 2.9999999931` with row 0 residual 4.7e-17, and
+`pytest -m smoke` is 1079 passed / 1 skipped / 2 xpassed.
+
+**Does this invalidate §21's panel?** No, and the direction matters: the fix can
+only ever *replace* an incumbent with a strictly more feasible one at the same
+integer assignment. It cannot loosen a bound, cannot manufacture a bound above
+an optimum, and cannot turn a certified instance uncertified. The panel's
+cert-clean verdict therefore survives the change a fortiori. Its net-positive
+column is measured on the pre-fix build and is not re-run; the fix touches only
+the terminal point of a solve, not the search.

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -15446,7 +15446,7 @@ def _solve_nlp_bb(
             gap_certified=_gap_certified,
         )
 
-    # --- Root cutting-plane stage (#781, DISCOPT_NLPBB_ROOT_CUTS, default-OFF) ---
+    # --- Root cutting-plane stage (#781, DISCOPT_NLPBB_ROOT_CUTS, default-ON) ---
     # Generates integrality-valid cuts (GMI from the HiGHS tableau + c-MIR +
     # cover under pooled top-K selection) over the OA root LP and appends them
     # as model constraints BEFORE the evaluator/tree are built, so every node
@@ -16636,7 +16636,6 @@ def _solve_nlp_bb(
                 and nlp_refined.x is not None
                 and np.all(np.isfinite(nlp_refined.x))
                 and nlp_refined.objective is not None
-                and abs(float(nlp_refined.objective) - obj_val) <= 1e-4 * (1.0 + abs(obj_val))
             ):
                 refined = np.asarray(nlp_refined.x, dtype=float).copy()
                 # Keep integer columns pinned at their (rounded) incumbent
@@ -16644,9 +16643,69 @@ def _solve_nlp_bb(
                 for off, sz in zip(int_offsets, int_sizes):
                     for k in range(int(sz)):
                         refined[off + k] = round(float(sol_flat[off + k]))
-                sol_flat = refined
-                x_dict = _unpack_solution(model, sol_flat)
-                obj_val = float(nlp_refined.objective)
+                # --- adoption rule (#1061) ---
+                # The original rule was a single ±1e-4 objective window: adopt
+                # only a refined point whose objective essentially matches the
+                # incumbent's. That window is the wrong arbiter when the two
+                # points DISAGREE, because it silently keeps whichever one is
+                # more optimistic -- including one the refine has just shown to
+                # be unattainable at this integer assignment.
+                #
+                # Measured on the MindtPy constraint-qualification fixture
+                # ``(x-3)^2 <= 50(1-y)`` (exact optimum 3.0) with the root-cut
+                # stage on: the node relaxation returned x = 2.998978 at
+                # y = 1-2.1e-8 -- feasible only because that sliver of y buys
+                # 1.05e-6 of big-M slack. Snapping y to 1 leaves the row
+                # violated by 1.04e-6, which clears the 1e-6 exit gate on the
+                # 1e-9 term-scaled forgiveness of the row's own ``50``. The
+                # refine (bound_relax_factor=0, integers fixed) returned
+                # x = 2.9999999931 -- violation 4.8e-17 -- and the window
+                # REJECTED it at |Δobj| = 1.02e-3, so the solve reported
+                # ``optimal`` at 1.02e-3 BELOW an exact optimum: CLAUDE.md §1's
+                # worst class, a certificate on a point that cannot exist.
+                #
+                # So the tie-break is feasibility, not objective proximity: a
+                # STRICTLY more feasible point wins even when its objective is
+                # worse, because the incumbent's advantage was bought with
+                # constraint violation. Both excesses come from the same arbiter
+                # the exit gate uses (declared rows, declared box), so this
+                # cannot admit a point the gate below refuses. When the two
+                # points agree to within the window, the original branch still
+                # applies and nothing moves.
+                _ref_obj = float(nlp_refined.objective)
+                _adopt = abs(_ref_obj - obj_val) <= 1e-4 * (1.0 + abs(obj_val))
+                if not _adopt:
+                    _inc_exc, _, _ = _nonlinear_point_excess(
+                        evaluator,
+                        sol_flat,
+                        cl_list,
+                        cu_list,
+                        n_rows=_declared_rows,
+                        box=_declared_box,
+                    )
+                    _ref_exc, _, _ = _nonlinear_point_excess(
+                        evaluator,
+                        refined,
+                        cl_list,
+                        cu_list,
+                        n_rows=_declared_rows,
+                        box=_declared_box,
+                    )
+                    _adopt = _ref_exc < _inc_exc and _ref_exc <= _NLPBB_EXIT_ABS_TOL
+                    if _adopt:
+                        logger.info(
+                            "NLP-BB: adopting the refined incumbent on FEASIBILITY "
+                            "(excess %.3e -> %.3e) though its objective is %.6g vs "
+                            "%.6g; the incumbent's edge was constraint violation.",
+                            _inc_exc,
+                            _ref_exc,
+                            _ref_obj,
+                            obj_val,
+                        )
+                if _adopt:
+                    sol_flat = refined
+                    x_dict = _unpack_solution(model, sol_flat)
+                    obj_val = _ref_obj
             nlp_recovered = _solve_node_nlp_kkt(
                 evaluator, sol_flat, fix_lb, fix_ub, constraint_bounds, recover_opts
             )

--- a/python/discopt/solvers/_root_cuts.py
+++ b/python/discopt/solvers/_root_cuts.py
@@ -31,8 +31,13 @@ Soundness contract (CLAUDE.md §1):
   * Everything is failure-safe: any error returns "no cuts" and the solve
     proceeds exactly as with the flag off.
 
-Default OFF (bound-changing, CLAUDE.md §5); graduation requires the Regime-2
-panel (cert-clean + net-positive).
+Default **ON** since 2026-08-20. The bound-changing Regime-2 panel (CLAUDE.md
+§5) passed both bars on 153 in-repo corpus instances -- cert-clean (0 bounds
+above a reference optimum, 0 certification regressions, proven-optimal 69 both
+arms) and net-positive (dual bound tighter on 22 / looser on 9, primal shortfall
+better on 6 / worse on 1, total nodes -13.3%, wall +0.5%). The record is
+``docs/dev/performance-plan.md`` §21; ``DISCOPT_NLPBB_ROOT_CUTS=0`` opts out and
+takes the untouched legacy path.
 """
 
 from __future__ import annotations
@@ -74,9 +79,18 @@ POOL_MAX = 4000
 
 
 def nlpbb_root_cuts_enabled() -> bool:
-    """Whether the ``DISCOPT_NLPBB_ROOT_CUTS`` opt-in flag is set (default OFF)."""
-    val = os.environ.get("DISCOPT_NLPBB_ROOT_CUTS", "0").strip().lower()
-    return val not in ("", "0", "false", "off", "no")
+    """Whether the root cutting-plane stage runs (``DISCOPT_NLPBB_ROOT_CUTS``).
+
+    **Default ON** since the 2026-08-20 graduation panel (issues #1061/#1062;
+    ``docs/dev/performance-plan.md`` §21). Set the variable to ``0``/``off``/
+    ``false``/``no`` to opt out and take the legacy no-root-cut path.
+
+    Empty is deliberately NOT an off-value: it is what an unset variable expands
+    to, and a graduated default-ON path must not be switched off by an accident
+    of shell quoting (#993). Same shape as ``_gdp_config_primal_enabled``.
+    """
+    val = os.environ.get("DISCOPT_NLPBB_ROOT_CUTS", "").strip().lower()
+    return val not in ("0", "false", "off", "no")
 
 
 def flat_column_terms(model) -> list:

--- a/python/tests/test_945_nlp_box_and_gap_closure.py
+++ b/python/tests/test_945_nlp_box_and_gap_closure.py
@@ -175,6 +175,45 @@ def test_default_solve_path_does_not_certify_a_super_optimal_incumbent():
 
 
 @pytest.mark.smoke
+def test_refine_adopts_the_more_feasible_point_over_the_lower_objective(monkeypatch):
+    """#1061: the terminal refine's adoption rule must tie-break on FEASIBILITY.
+
+    The rule was a single ±1e-4 objective window, which keeps whichever of the
+    two points is more optimistic whenever they disagree. With the root-cut
+    stage on, this fixture's node relaxation returns ``x = 2.998978`` at
+    ``y = 1 - 2.1e-8`` -- feasible only because that sliver of ``y`` buys
+    1.05e-6 of big-M slack from ``50*(1-y)``. Snapping ``y`` to 1 leaves the row
+    violated by 1.04e-6, which clears the 1e-6 exit gate on the 1e-9 term-scaled
+    forgiveness of the row's own coefficient 50. The refine (integers fixed,
+    ``bound_relax_factor=0``) returned ``x = 2.9999999931``, violation 4.8e-17 --
+    and the window rejected it at ``|dobj| = 1.02e-3``. The solve then reported
+    ``optimal`` 1.02e-3 below an exact optimum of 3.0.
+
+    Pinned with the flag set explicitly, so this stays a test of the adoption
+    rule rather than of whatever ``DISCOPT_NLPBB_ROOT_CUTS`` happens to default
+    to. Fails on the pre-fix tree with ``objective = 2.99897831539379``.
+    """
+    monkeypatch.setenv("DISCOPT_NLPBB_ROOT_CUTS", "1")
+    m = dm.Model("refine_feasibility_tiebreak")
+    x = m.continuous("x", lb=1.0, ub=10.0)
+    y = m.binary("y")
+    m.subject_to((x - 3.0) ** 2 <= 50.0 * (1 - y))
+    m.subject_to(x * dm.log(x) + 5.0 <= 50.0 * y)
+    m.minimize(x)
+    res = m.solve(time_limit=60)
+
+    assert res.objective is not None
+    assert res.objective >= 3.0 - 1e-6, (
+        f"objective {res.objective!r} is below the exact optimum 3.0 -- the refine's "
+        "feasible point was rejected in favour of a violating one"
+    )
+    # And the point itself, not just its objective: the row must actually hold.
+    xv = float(np.asarray(res.x["x"]).ravel()[0])
+    yv = float(np.asarray(res.x["y"]).ravel()[0])
+    assert (xv - 3.0) ** 2 - 50.0 * (1.0 - yv) <= 1e-9, "reported point violates row 0"
+
+
+@pytest.mark.smoke
 def test_every_primal_heuristic_requests_the_incumbent_options():
     """The whole module is a point producer, so the seed is a module-wide rule.
 

--- a/python/tests/test_nlpbb_root_cuts_781.py
+++ b/python/tests/test_nlpbb_root_cuts_781.py
@@ -5,7 +5,8 @@ Soundness gates:
     MILPs, every emitted cut must be violated at the LP vertex and satisfied
     by every integer assignment's full continuous completion (LP certificate
     per integer corner — no sampling gap);
-  * flag OFF is inert (no constraints added, no behavior change);
+  * ``DISCOPT_NLPBB_ROOT_CUTS=0`` is inert (no constraints added, no behavior
+    change) -- the legacy path §5 requires graduation to leave intact;
   * flag ON preserves the optimum and never reports an unsound bound
     (min: bound <= opt; max: bound >= opt), on both senses;
   * the slow named regression runs the real convex-synthesis instance.
@@ -35,10 +36,10 @@ OPT_RSYN0805M = 1296.120603  # minlplib.solu (maximize)
 
 
 def _flag(monkeypatch, on: bool) -> None:
-    if on:
-        monkeypatch.setenv("DISCOPT_NLPBB_ROOT_CUTS", "1")
-    else:
-        monkeypatch.delenv("DISCOPT_NLPBB_ROOT_CUTS", raising=False)
+    # The flag graduated default-ON (2026-08-20), so "off" has to be the explicit
+    # opt-out value -- deleting the variable now selects ON and would have turned
+    # every flag-OFF arm below into a second flag-ON arm silently.
+    monkeypatch.setenv("DISCOPT_NLPBB_ROOT_CUTS", "1" if on else "0")
 
 
 # ── GMI separator: exact validity by enumeration ─────────────────────────────
@@ -177,6 +178,41 @@ def test_generate_root_cuts_direct_sound(monkeypatch):
     x_opt = np.array([float(np.atleast_1d(r.x[nm])[0]) for nm in ("f0", "f1", "y0", "y1")])
     for alpha, rhs in res.cuts:
         assert float(alpha @ x_opt) <= rhs + 1e-6, "cut removes the optimal solution"
+
+
+@pytest.mark.smoke
+def test_flag_is_default_on_with_an_opt_out():
+    """§5: the root-cut stage graduated default-ON, and the opt-out still works.
+
+    It shipped default-OFF pending its differential panel (#781). That panel was
+    re-run on 2026-08-20 -- after #1082 unblocked the sub-NLP primal heuristic on
+    convex models and #1098 made ``gap_certified`` mean the same thing on both
+    solve routes -- over 153 in-repo corpus instances at 60 s each, and passed
+    both bars: cert-clean (0 bounds above a reference optimum, 0 certification
+    regressions, proven-optimal 69 in both arms) and net-positive (dual bound
+    tighter on 22 / looser on 9, primal shortfall better on 6 / worse on 1, total
+    nodes -13.3%, wall +0.5%). Recorded in ``docs/dev/performance-plan.md`` §21.
+
+    §5 requires the ``=0`` opt-out and the legacy path to survive graduation, so
+    both halves are pinned here, not just the new default.
+    """
+    saved = os.environ.pop("DISCOPT_NLPBB_ROOT_CUTS", None)
+    try:
+        assert nlpbb_root_cuts_enabled() is True, "graduated: unset must mean ON"
+        for off in ("0", "off", "false", "no", "OFF", " no "):
+            os.environ["DISCOPT_NLPBB_ROOT_CUTS"] = off
+            assert nlpbb_root_cuts_enabled() is False, f"{off!r} must opt out"
+        # Empty is ON, not OFF, and that is the point: ``export X="$UNSET"`` exports
+        # an empty string, and a graduated default-ON path must not be switched off
+        # by an accident of shell quoting while reading in every log as "not set"
+        # (#993, same lesson on DISCOPT_GDP_CONFIG_PRIMAL).
+        for on in ("1", "true", "yes", "on", "", "  "):
+            os.environ["DISCOPT_NLPBB_ROOT_CUTS"] = on
+            assert nlpbb_root_cuts_enabled() is True, f"{on!r} must leave it ON"
+    finally:
+        os.environ.pop("DISCOPT_NLPBB_ROOT_CUTS", None)
+        if saved is not None:
+            os.environ["DISCOPT_NLPBB_ROOT_CUTS"] = saved
 
 
 # ── the real class (benchmark corpus; slow) ──────────────────────────────────


### PR DESCRIPTION
Graduates the root cutting-plane stage (`DISCOPT_NLPBB_ROOT_CUTS`, #781) to
**default-ON**, and fixes the CLAUDE.md §1 defect that flipping the default
exposed.

## Why this closes #1061 and #1062

Both issues were opened against a premise that measurement has since moved.

**#1061** asked for OBBT on the unbounded big-M columns, on the theory that the
27x root bound came from `ub=inf`. PR #1094 falsified that: SCIP's *first* LP on
`syn40m` is 761.83 — **weaker** than discopt's 295.7 — yet SCIP reaches a root
bound of 67.746 against an optimum of 67.713 using ~500 root cuts (gomorymi 133,
cmir 133, flowcover 37, impliedbounds 28, nonlinear-OA 165). The lever is root
cut separation, not bound tightening. This PR turns that lever on by default.

**#1062** asked why the sub-NLP primal heuristic reports `subnlp_calls=0`. The
mechanism was fixed by #1082 (a stalled convex-B&B node abstained instead of
being excluded, suppressing the heuristic on exactly this class); what was
missing was the relaxation quality to reach an integer-feasible point worth
refining. Root cuts supply it.

## The §5 graduation panel

Flag ON vs OFF over the in-repo corpus, 6 shards, 60 s/instance, arms adjacent
per instance (§9), threads pinned. **153 instances with complete pairs in both
arms**; every shard printed a non-zero executed-comparison count, no tracebacks
(§6). Full record: `docs/dev/performance-plan.md` §21.

| gate | result |
|---|---|
| dual bound | tighter **22**, looser 9, flat 122 |
| primal shortfall | better **6**, worse **1**, same 102 |
| node count | OFF 111 702 -> ON 96 860 (**-13.3%**); 58 instances >2% fewer, 2 more, 93 within 2% |
| total wall | OFF 5744.0 s, ON 5774.8 s (**+0.5%**) |
| bound above its reference optimum | **0 instances** |
| certification regression (#1098 semantics) | **0 instances** |
| proven-optimal count | OFF 69, ON 69 |
| **CERT-CLEAN** | **PASS** (`CHECKS_EXECUTED 153`) |
| **NET-POSITIVE** | **PASS** |

The raw scorer, reading the pre-#1098 `gap_certified` straight out of the logs,
flagged `rsyn0805m02m` and `syn40m`. Re-adjudicating all 153 pairs under the
corrected predicate that #1098 makes both routes report:

```
raw cert regressions (pre-#1098 logs) : ['rsyn0805m02m', 'syn40m']
cert regressions under #1098 semantics: []
  -> INVENTED by the loose reading    : ['rsyn0805m02m', 'syn40m']
  -> HIDDEN by the loose reading      : []
```

Zero hidden matters: a narrowing can in principle *expose* a regression the
loose reading concealed. None were. `syn40m` is the clear case — the ON arm is
better on every real quantity and lost only the label, because turning root cuts
on makes the NLP-BB answer good enough to win route selection and inherit that
route's stricter label.

This supersedes §20's rejection of the same flag. §20 remains the correct verdict
for the build it ran on (pre-#1082, pre-#1098) and is retained per §11 rather
than edited away.

## The panel was not the last gate (§21.1)

Flipping the default failed `pytest -m smoke` immediately, on
`test_default_solve_path_does_not_certify_a_super_optimal_incumbent`:

```
flag=0: status=optimal obj=2.999999998034762  super-optimal by 1.965e-09
flag=1: status=optimal obj=2.998978315393790  super-optimal by 1.022e-03
```

A certificate on a point that cannot exist — §1's worst class, and it outranks
§5. **The corpus panel had no power against it**: the oracle is compared at a
relative tolerance and this error is 3.4e-4 relative, and the defect is
structural — it needs an *active degenerate* row, where the residual is quadratic
in the variable error, so 1e-6 of violation is 1e-3 of `x`. A corpus panel is a
§5 instrument, not a §1 one.

The chain, measured end to end (probes each print an executed-comparison count):

1. Root cuts tighten the root LP to 2.998981, so the node-1 NLP relaxation
   returns `x = 2.998978` at `y = 1 - 2.1e-8`. That point is genuinely feasible:
   the sliver of `y` buys `50 * 2.1e-8 = 1.05e-6` of big-M slack, exactly
   covering `(x-3)^2 = 1.04e-6`.
2. `y` is integral within tolerance, so the node is integer-feasible and the
   relaxation value equals the incumbent: gap 0 at node 1.
3. Snapping `y` to 1 removes the slack: row 0 is violated by 1.044e-6. The 1e-6
   exit gate sees 9.938e-7 after term-scaled forgiveness and passes it by 0.6%.
4. The terminal refine (integers fixed, `bound_relax_factor=0`) returned
   `x = 2.9999999931`, violation **4.8e-17** — the honest point — and the
   adoption rule **rejected it**, because its objective differs from the
   incumbent's by 1.02e-3, outside the rule's +/-1e-4 window.

Step 4 is the defect and is not root-cut-specific: the objective window is the
wrong arbiter when the two points *disagree*, because it keeps whichever is more
optimistic — including one the refine has just shown to be unattainable at that
integer assignment. Root cuts only supply a relaxation tight enough to land on
the degenerate boundary where the flaw is visible.

Fixed in `1558e7eb`: when the objectives disagree beyond the window, both points
are measured with the same arbiter the exit gate uses
(`_nonlinear_point_excess`, declared rows and declared box) and a *strictly more
feasible* point is adopted even though its objective is worse. It cannot admit a
point the exit gate would refuse, and when the two agree within the window the
original branch still applies, so nothing moves on a healthy solve. After it,
flag ON reports `obj = 2.9999999931` with row 0 residual 4.7e-17.

This does not invalidate the panel: the fix can only replace an incumbent with a
strictly more feasible one at the same integer assignment. It cannot loosen a
bound, manufacture a bound above an optimum, or turn a certified instance
uncertified, so the cert-clean verdict survives a fortiori.

## Acceptance against the issues' own "done" criteria

Measured at 60 s/instance, both arms adjacent per instance (§9), probes printing
an executed-check count (§6): `CHECKS_EXECUTED 10` and `CHECKS_EXECUTED 8`.

**#1061 — "the root-bound ratios come down materially on the syn/rsyn class."**

| instance | issue root bound | now (ON) | ratio |
|---|---|---|---|
| syn40m | 1833.91 (27.1x) | **417.32** | **6.16x** |
| rsyn0840m | 2778.18 (8.5x) | **1214.16** | **3.73x** |
| syn20m02m | 4884.23 (2.8x) | n/a | now `optimal`, 0 nodes, 5.4 s |
| rsyn0805m | 2111.02 (1.6x) | n/a | now `optimal`, 0 nodes, 1.1 s |

The bottom two no longer have a spatial root at all — #1059's routing sends them
to MIP-NLP, where they close. Soundness on all five instances x both arms: no
bound past a published optimum, no super-optimal incumbent.

The issue asked specifically for OBBT. It does not get OBBT, and that is
deliberate: #1094 measured that bound tightening is not the lever (SCIP's first
LP is *weaker* than ours and it still reaches the optimum via cuts). The issue's
"what done means" clause — the measured ratio reduction — is what this delivers.

**#1062 — "`subnlp_calls > 0` on an instance that currently reports zero", and
"incumbent quality improves measurably."**

| instance | issue baseline | OFF | ON | `subnlp_calls` (OFF/ON) |
|---|---|---|---|---|
| rsyn0805m | 1116.458 (13.9% short) | 1296.121 (0.0%) | 1296.121 (**0.0%**) | 3 / 3 |
| syn40m | 33.197 (51.0% short) | 59.848 (11.6%) | **67.71325557** (0.0%) | 112 / 112 |
| rsyn0840m | 37.587 (88.5% short) | 37.587 (88.5%) | **151.969** (53.3%) | 56 / 32 |
| syn20m02m | 636.720 (63.7% short) | 1752.133 (0.0%) | 1752.133 (**0.0%**) | 2 / 2 |

Attribution, stated plainly: the counter is non-zero in **both** arms, so what
un-stuck the heuristic was #1082 (already on `main`), not this flag. What this
PR adds is the second criterion — incumbent quality. `rsyn0840m` is the clean
demonstration: its OFF arm still returns the issue's baseline number to six
figures (37.5869) and the ON arm reaches 151.97.

**The cost, reported rather than buried.** `rsyn0820m02m` — an instance named in
#1062's text but *not* in the 153-instance panel — regresses with the flag on:
244.20 -> -39.53, 31 nodes -> 3 nodes in the same 60 s. I stated the obvious hypothesis (too many
appended rows) with a kill criterion, and the measurement killed it: the stage
applied **69 cuts to a 1074-row model** (+6.4%) in 10.6 s of the 60 s budget,
with 26 of 26 rounds productive. 69 rows cannot be a 10x throughput effect by
size. The cost is per-node *effort* -- ~1.9 s/node OFF vs ~16 s/node ON -- not
model size, and it is recorded as such in `docs/dev/performance-plan.md` §21.2
rather than guessed at. Changing the cut cap or the per-node effort limit is
itself bound-changing and would invalidate the very panel this PR rests on, so
it is deliberately not attempted here. The panel's
own single primal regression, re-derived from the 306 `WIDE` records, is
`rsyn0830m` (18.8% -> 26.3% short). Both are inside what §5's net-positive bar
weighs (better 6 / worse 1) rather than exceptions to it, and neither is a
soundness failure: the bounds stay valid in every case.


## Verification

- `pytest -m smoke python/tests` -> **1080 passed, 1 skipped, 2 xpassed**, 9138 deselected (112.46 s), run after merging `origin/main` (#1098)
- `pytest -m slow python/tests/test_adversarial_recent_fixes.py` -> 19 passed (147.77 s)
- `ruff check python/` -> All checks passed; `ruff format --check` clean; mypy clean (pre-commit)
- New regression tests, each verified failing-before / passing-after:
  - `test_945_nlp_box_and_gap_closure.py::test_refine_adopts_the_more_feasible_point_over_the_lower_objective`
  - `test_nlpbb_root_cuts_781.py::test_flag_is_default_on_with_an_opt_out`
- `test_nlpbb_root_cuts_781.py::_flag` was corrected: it used `monkeypatch.delenv`
  for the OFF arm, which after graduation selects **ON** and would have turned
  every flag-OFF arm in that file into a second flag-ON arm silently.

Closes #1061
Closes #1062

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017PQaiDVuY5Rs3tga98tnNo
