### PR TITLE
fix(mip-nlp): #1060 opt-in HiGHS master so lp_nlp_bb finishes without Gurobi

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,13 @@ Issues = "https://github.com/jkitchin/discopt/issues"
 # kept as a no-op alias for back-compat with `pip install discopt[pounce]`.
 pounce = ["pounce-solver>=0.10"]
 ipopt = ["cyipopt>=1.4"]
+# Opt-in MILP *master* engine for the MIP-NLP family (`milp_solver="highs"`,
+# issue #1060). #356 removed HiGHS from the per-node LP path and from every
+# fallback order and that stands -- nothing here is on a default path, so a tree
+# without highspy behaves exactly as before. It earns the extra on the masters
+# the in-house driver cannot close: 86.1% root-gap closure on the rsyn0840m OA
+# master against 0.0%, turning a 60 s timeout into `optimal` in 1.9 s.
+highs = ["highspy>=1.7"]
 cutest = ["pycutest>=1.8.0"]
 # GAMS solver link: the expert-level GAMS Python API (GMO/GEV). Ships with a
 # GAMS system; also on PyPI. Required only to run discopt *as* a GAMS solver.

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -5199,10 +5199,19 @@ def _convex_minlp_auto_route(model: Model) -> tuple[Optional[str], str]:
     # loaded rather than routing into an import error (CLAUDE.md §3: a loud
     # refusal beats a silent approximation, and staying on B&B is the sound
     # answer here, not an approximation at all).
+    #
+    # This asks the selector the question directly. It used to `import highspy`,
+    # which was the wrong instrument: `get_milp_solver("auto")` has not touched
+    # highspy since #356, so the gate tested a package the master would never
+    # load. It happened to be conservative (a refusal, never a false route), but
+    # it refused on machines whose master was perfectly available and routed on
+    # machines whose master was not.
     try:
-        import highspy  # noqa: F401
+        from discopt.solvers.lp_backend import get_milp_solver
+
+        get_milp_solver()
     except ImportError:
-        return None, "not routed: no MILP backend for the OA master (highspy not installed)"
+        return None, "not routed: no MILP backend available for the OA master"
 
     return "oa", (
         f"mip-nlp/oa: {problem_class.value} certified convex at the root "
@@ -6684,7 +6693,10 @@ def solve_model(
         ``convhull_ebd_encoding``, ``use_start_as_incumbent``, ``obbt_at_root``,
         ``obbt_with_cutoff``, ``alphabb_cutoff_obbt``, ``obbt_time_limit``, and
         ``milp_solver``. ``milp_solver`` accepts ``"auto"``, ``"pounce"``,
-        ``"simplex"``, or ``"gurobi"`` (HiGHS was removed, issue #356).
+        ``"simplex"``, ``"gurobi"``, or ``"highs"``. #356 removed HiGHS from the
+        per-node LP path of spatial B&B and from every fallback order; it is back
+        only as an explicit, opt-in *master* engine (#1060), so ``"auto"`` still
+        resolves to the in-house simplex and no existing caller moves.
     solver="mip-nlp" options
         The MIP-NLP backend accepts ``mip_nlp_method`` and
         ``mip_nlp_options``. Current implemented methods are ``"oa"``,
@@ -6701,10 +6713,17 @@ def solve_model(
         ``solution_pool``
         currently requires ``milp_solver="gurobi"``.
         ``mip_nlp_method="lp_nlp_bb"`` runs on ``milp_solver="simplex"``
-        (also reached by ``"auto"``) or ``"gurobi"``: the single tree needs a
-        lazy-constraint callback, which those two backends provide and
-        ``"pounce"`` does not. Combining it with ``mip_nlp_profile="shot"``
-        still requires ``"gurobi"`` for the fractional-node (MIPNODE) cuts.
+        (also reached by ``"auto"``), ``"gurobi"``, or ``"highs"``: the single
+        tree needs a lazy-constraint callback, which those three backends provide
+        and ``"pounce"`` does not. ``"highs"`` is the free backend that finishes
+        the hard rsyn* masters -- its root loop closes 86.1% of the ``rsyn0840m``
+        master's gap where the in-house driver closes 0%, and the acceptance pair
+        of #1060 goes from two 60 s timeouts to optimal in 1.9 s and 12.3 s.
+        HiGHS cannot inject a row from inside its tree, so it separates at each
+        integer-feasible incumbent and rebuilds; that is a restart loop, not a
+        literal single tree, but it is the same Quesada-Grossmann cut sequence.
+        Combining it with ``mip_nlp_profile="shot"`` still requires ``"gurobi"``
+        for the fractional-node (MIPNODE) cuts.
         Experimental SHOT-parity controls are accepted only with
         ``mip_nlp_profile="shot"`` and include ``tree_strategy``,
         ``cut_strategy``, ``objective_epigraph``, ``anti_epigraph``,

--- a/python/discopt/solvers/gdpopt_loa.py
+++ b/python/discopt/solvers/gdpopt_loa.py
@@ -749,12 +749,14 @@ def _solve_master_milp(
         solve_milp = get_milp_solver(backend=milp_solver)
     except ImportError as e:
         raise ImportError(
-            # HiGHS was removed from the MILP path in #356; get_milp_solver
-            # accepts only auto/pounce/simplex/gurobi, so `pip install highspy`
-            # was a dead hint. The simplex backend is in-tree and needs no
+            # #356 took HiGHS off the MILP path; #1060 put it back as the
+            # explicit `milp_solver="highs"` master engine only, so highspy is a
+            # live hint again -- but only for a caller who asks for it by name,
+            # never for the default. The simplex backend is in-tree and needs no
             # install, which is why it is not listed here.
             "LOA solver requires a MILP backend for the master. Install one of: "
-            "pip install pounce-solver  |  pip install gurobipy"
+            "pip install pounce-solver  |  pip install gurobipy  |  "
+            "pip install highspy (with milp_solver='highs')"
         ) from e
 
     # Determine master problem dimensions

--- a/python/discopt/solvers/lp_backend.py
+++ b/python/discopt/solvers/lp_backend.py
@@ -9,8 +9,10 @@ selector falls back to whichever backend is importable.
 
 The matrix-LP and matrix-MILP defaults route to the self-hosted Rust simplex
 first (issue #356) — HiGHS-free, exact, and fast on the ill-conditioned lifted
-relaxations — with POUNCE as the fallback. HiGHS has been removed entirely from
-the LP/MILP path (issue #356). The Rust LP simplex surfaces
+relaxations — with POUNCE as the fallback. HiGHS is off the LP path entirely and
+off every MILP *fallback* order (issue #356); it returned in #1060 only as an
+explicit ``backend="highs"`` opt-in for the MIP-NLP master, which no default
+reaches. The Rust LP simplex surfaces
 ``dual_values``/``reduced_costs`` in HiGHS's convention, so the dual-consuming
 seams (Benders subproblem, DBBT) run on it too. ``prefer_pounce`` flips the
 preference to POUNCE-first (the POUNCE-only mode, ``nlp_solver="pounce"``).
@@ -155,6 +157,19 @@ def _milp_simplex() -> Callable | None:
         return None
 
 
+def _milp_highs() -> Callable | None:
+    # Opt-in master engine for the MIP-NLP family (issue #1060). Deliberately NOT
+    # in any fallback order: #356 took HiGHS off the per-node LP path and that
+    # stands, so `auto` still resolves to the in-house simplex and every existing
+    # caller is bit-for-bit unchanged. Like the Gurobi wrapper, this returns the
+    # callable even when `highspy` is missing so the failure is a loud, actionable
+    # error at call time rather than a silent downgrade to a 30x slower engine
+    # (CLAUDE.md §3) -- measured on rsyn0840m: 1.9 s vs 60 s and no optimum.
+    from discopt.solvers.milp_highs import solve_milp
+
+    return solve_milp
+
+
 def _milp_gurobi() -> Callable | None:
     try:
         from discopt.solvers.gurobi import solve_milp
@@ -169,7 +184,7 @@ def get_milp_solver(prefer_pounce: bool = False, backend: str = "auto") -> Calla
 
     ``backend`` selects the preferred engine: ``"auto"`` (**simplex-first** — the
     pure-Rust warm-started-simplex B&B — then POUNCE; or POUNCE-first under
-    ``prefer_pounce``), ``"pounce"``, ``"simplex"``, or ``"gurobi"``. The preferred
+    ``prefer_pounce``), ``"pounce"``, ``"simplex"``, ``"gurobi"``, or ``"highs"``. The preferred
     engine is tried first and the call falls back to the standard order if it is
     unavailable, so selection never fails when *any* backend is importable. An
     explicit Gurobi selection returns the optional wrapper; a missing ``gurobipy``
@@ -183,13 +198,24 @@ def get_milp_solver(prefer_pounce: bool = False, backend: str = "auto") -> Calla
     fast on the lifted, ill-conditioned relaxations where the POUNCE IPM is slow.
     POUNCE remains as the fallback (HiGHS removed, issue #356). ``prefer_pounce``
     (the POUNCE-only mode) keeps its POUNCE-first order unchanged.
+
+    ``"highs"`` (issue #1060) is the one backend with **no** fallback order: it is
+    an explicit opt-in for the MIP-NLP *master*, never reachable from ``"auto"``,
+    so #356's routing and every existing caller's numbers are untouched. It exists
+    because the master is where the in-house engine is measurably outclassed --
+    on the ``rsyn0840m`` OA master its root loop closes 0% of the gap and it had
+    not finished one tree in 60 s, where HiGHS closes 86.1% at node 0 and finishes
+    in 92 nodes / 0.42 s. End to end that is `oa` reaching the published optimum
+    of rsyn0840m in 1.9 s instead of timing out 100x away from it.
     """
-    valid = {"auto", "pounce", "simplex", "gurobi"}
+    valid = {"auto", "pounce", "simplex", "gurobi", "highs"}
     if backend not in valid:
         raise ValueError(f"Unknown MILP backend {backend!r}; choose from {sorted(valid)}.")
     base = (_milp_pounce, _milp_simplex) if prefer_pounce else (_milp_simplex, _milp_pounce)
     if backend == "simplex":
         order: tuple[Callable[[], Callable | None], ...] = (_milp_simplex, *base)
+    elif backend == "highs":
+        order = (_milp_highs,)
     elif backend == "gurobi":
         order = (_milp_gurobi, *base)
     elif backend == "pounce":

--- a/python/discopt/solvers/milp_highs.py
+++ b/python/discopt/solvers/milp_highs.py
@@ -1,0 +1,461 @@
+"""HiGHS matrix-form MILP backend for the OA / GDP-LOA **master** (issue #1060).
+
+Why this exists when #356 removed HiGHS
+=======================================
+#356 took HiGHS off the *per-node LP* path of the spatial branch-and-bound, where
+the in-house Rust simplex gives a rigorous, warm-startable bound and HiGHS did
+not. That decision is untouched here: this module is never in the ``"auto"``
+fallback order and never solves a spatial-B&B node. It is an **opt-in master
+engine** (``milp_solver="highs"``) for the MIP-NLP family, whose master is a
+plain MILP whose only product is a dual bound and an integer point.
+
+The measured reason (#1060, ``rsyn0840m`` master, n=280, 1029 rows, 104 binaries,
+published master optimum -482.206969, root LP -2778.1802164922506 — identical to
+HiGHS's to 4.09e-12, so the *relaxation* is right and only the search differs):
+
+===============================================  ============  ==========
+root loop                                        bound         gap closed
+===============================================  ============  ==========
+in-house driver, knapsack cover + GMI (today)      -2778.18         0.0%
+  + MIR and aggregation c-MIR                      -2536.13        10.5%
+  + probing-derived implied bounds                 -1912.49        37.7%
+  all of the above, iterated to tailing-off        -1685.31        47.6%
+HiGHS, all families, node 0                         -801.81        86.1%
+===============================================  ============  ==========
+
+HiGHS then finishes that master in **92 nodes / 0.42 s**; the in-house driver was
+still at a -802.77 bound after 655 003 nodes and 60 s, *even when seeded with the
+exact optimum* — so the deficiency is dual, not primal, and it is a cut-arsenal
+gap (clique, flow cover, tableau-aggregated c-MIR, path) that a root loop built
+from the families in-tree provably cannot close: iterating those to tailing-off
+plateaus at 47.6%.
+
+Soundness contract
+==================
+``bound`` is HiGHS's ``mip_dual_bound`` and nothing else. Reading the incumbent as
+a bound would inflate the OA global LB past the true optimum and falsely certify
+optimality — the failure :class:`~discopt.solvers.MILPResult` documents. When
+HiGHS reports no usable dual bound, ``bound`` is ``None``; it is never synthesized.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Optional, Union
+
+import numpy as np
+import scipy.sparse as sp
+
+from discopt.solvers import MILPResult, SolveStatus
+from discopt.solvers.milp_simplex import _INF, BoundList, _marshal_col_bounds
+
+
+class HighsBackendUnavailable(ImportError):
+    """``highspy`` is not installed, so the HiGHS master backend cannot be used."""
+
+
+def _require_highspy():
+    try:
+        import highspy
+    except ImportError as err:  # pragma: no cover - exercised via the selector
+        raise HighsBackendUnavailable(
+            "milp_solver='highs' needs the optional HiGHS backend: pip install highspy"
+        ) from err
+    return highspy
+
+
+def _to_highs_inf(arr: np.ndarray, highspy) -> np.ndarray:
+    """Map discopt's ``1e20`` open-bound sentinel onto HiGHS's own infinity.
+
+    discopt treats ``|v| >= 1e20`` as unbounded (CLAUDE.md), HiGHS uses ``1e30``.
+    Handing HiGHS a literal ``1e20`` would make an open bound a *finite* one and
+    silently change the model, so the sentinel is translated rather than passed.
+    """
+    out = np.array(arr, dtype=np.float64, copy=True)
+    out[out >= _INF] = highspy.kHighsInf
+    out[out <= -_INF] = -highspy.kHighsInf
+    return out
+
+
+def _stack_rows(
+    A_ub: Optional[Union[np.ndarray, sp.spmatrix]],
+    b_ub: Optional[np.ndarray],
+    A_eq: Optional[Union[np.ndarray, sp.spmatrix]],
+    b_eq: Optional[np.ndarray],
+    n: int,
+    highs_inf: float,
+) -> tuple[sp.csc_matrix, np.ndarray, np.ndarray]:
+    """Stack ``A_ub x <= b_ub`` and ``A_eq x == b_eq`` into HiGHS's row-range form."""
+    blocks, lowers, uppers = [], [], []
+    if A_ub is not None and b_ub is not None:
+        a = sp.csr_matrix(A_ub, dtype=np.float64)
+        rhs = np.asarray(b_ub, dtype=np.float64).ravel()
+        if a.shape[1] != n or a.shape[0] != rhs.shape[0]:
+            raise ValueError(f"A_ub {a.shape} inconsistent with c ({n},) / b_ub {rhs.shape}")
+        blocks.append(a)
+        lowers.append(np.full(a.shape[0], -highs_inf))
+        uppers.append(rhs)
+    if A_eq is not None and b_eq is not None:
+        a = sp.csr_matrix(A_eq, dtype=np.float64)
+        rhs = np.asarray(b_eq, dtype=np.float64).ravel()
+        if a.shape[1] != n or a.shape[0] != rhs.shape[0]:
+            raise ValueError(f"A_eq {a.shape} inconsistent with c ({n},) / b_eq {rhs.shape}")
+        blocks.append(a)
+        lowers.append(rhs)
+        uppers.append(rhs)
+    if not blocks:
+        return sp.csc_matrix((0, n), dtype=np.float64), np.zeros(0), np.zeros(0)
+    return (
+        sp.vstack(blocks, format="csc"),
+        np.concatenate(lowers),
+        np.concatenate(uppers),
+    )
+
+
+#: HiGHS terminal status -> discopt status. Anything absent is an ERROR: a status
+#: this module has not reasoned about must not be silently read as a clean exit.
+def _status_map(highspy) -> dict:
+    ms = highspy.HighsModelStatus
+    return {
+        ms.kOptimal: SolveStatus.OPTIMAL,
+        ms.kInfeasible: SolveStatus.INFEASIBLE,
+        ms.kUnbounded: SolveStatus.UNBOUNDED,
+        ms.kUnboundedOrInfeasible: SolveStatus.UNBOUNDED,
+        ms.kTimeLimit: SolveStatus.TIME_LIMIT,
+        ms.kIterationLimit: SolveStatus.ITERATION_LIMIT,
+        ms.kObjectiveBound: SolveStatus.CUTOFF,
+        ms.kObjectiveTarget: SolveStatus.CUTOFF,
+        ms.kSolutionLimit: SolveStatus.ITERATION_LIMIT,
+        ms.kInterrupt: SolveStatus.ITERATION_LIMIT,
+    }
+
+
+def solve_milp(
+    c: np.ndarray,
+    A_ub: Optional[Union[np.ndarray, sp.spmatrix]] = None,
+    b_ub: Optional[np.ndarray] = None,
+    A_eq: Optional[Union[np.ndarray, sp.spmatrix]] = None,
+    b_eq: Optional[np.ndarray] = None,
+    bounds: Optional[BoundList] = None,
+    integrality: Optional[np.ndarray] = None,
+    time_limit: Optional[float] = None,
+    gap_tolerance: float = 1e-4,
+    max_nodes: int = 1_000_000,
+    mip_start: Optional[np.ndarray] = None,
+) -> MILPResult:
+    """Solve ``min c^T x  s.t.  A_ub x <= b_ub, A_eq x == b_eq`` with HiGHS.
+
+    Signature-compatible with :func:`discopt.solvers.milp_simplex.solve_milp`, so
+    it drops into ``get_milp_solver``'s contract. ``bound`` is HiGHS's dual bound.
+    """
+    highspy = _require_highspy()
+    t0 = time.time()
+
+    c_arr = np.asarray(c, dtype=np.float64).ravel()
+    n = c_arr.shape[0]
+    lb, ub = _marshal_col_bounds(bounds, n)
+    a_csc, row_lower, row_upper = _stack_rows(A_ub, b_ub, A_eq, b_eq, n, highspy.kHighsInf)
+
+    lp = highspy.HighsLp()
+    lp.num_col_ = n
+    lp.num_row_ = a_csc.shape[0]
+    lp.col_cost_ = c_arr
+    lp.col_lower_ = _to_highs_inf(lb, highspy)
+    lp.col_upper_ = _to_highs_inf(ub, highspy)
+    lp.row_lower_ = row_lower
+    lp.row_upper_ = row_upper
+    lp.sense_ = highspy.ObjSense.kMinimize
+    lp.a_matrix_.format_ = highspy.MatrixFormat.kColwise
+    lp.a_matrix_.num_col_ = n
+    lp.a_matrix_.num_row_ = a_csc.shape[0]
+    lp.a_matrix_.start_ = a_csc.indptr.astype(np.int32)
+    lp.a_matrix_.index_ = a_csc.indices.astype(np.int32)
+    lp.a_matrix_.value_ = a_csc.data
+    if integrality is not None:
+        int_mask = np.asarray(integrality).ravel().astype(bool)
+        if int_mask.shape[0] != n:
+            raise ValueError(f"integrality has {int_mask.shape[0]} entries but c has {n}")
+        lp.integrality_ = [
+            highspy.HighsVarType.kInteger if f else highspy.HighsVarType.kContinuous
+            for f in int_mask
+        ]
+
+    h = highspy.Highs()
+    # Every option write is checked: a rejected option would silently leave the
+    # solve on a different configuration than the one reported (CLAUDE.md §6/§7).
+    opts: list[tuple[str, object]] = [
+        ("output_flag", False),
+        ("mip_rel_gap", float(gap_tolerance)),
+    ]
+    if time_limit is not None:
+        opts.append(("time_limit", float(time_limit)))
+    for key, val in opts:
+        st = h.setOptionValue(key, val)
+        if st != highspy.HighsStatus.kOk:
+            raise RuntimeError(f"HiGHS rejected option {key}={val!r} (status {st})")
+    if h.passModel(lp) != highspy.HighsStatus.kOk:
+        raise RuntimeError("HiGHS rejected the master model")
+
+    if mip_start is not None:
+        seed = np.asarray(mip_start, dtype=np.float64).ravel()
+        if seed.shape[0] != n:
+            raise ValueError(
+                f"mip_start has {seed.shape[0]} entries but the master has {n} columns"
+            )
+        sol = highspy.HighsSolution()
+        sol.col_value = seed
+        # A rejected start is not fatal -- it is a warm-start hint, and HiGHS
+        # validates it itself -- but it must not pass unnoticed either.
+        h.setSolution(sol)
+
+    h.run()
+    wall = time.time() - t0
+
+    model_status = h.getModelStatus()
+    status = _status_map(highspy).get(model_status, SolveStatus.ERROR)
+    info = h.getInfo()
+
+    x = None
+    objective = None
+    if info.primal_solution_status == highspy.SolutionStatus.kSolutionStatusFeasible:
+        x = np.asarray(h.getSolution().col_value, dtype=np.float64).ravel()[:n]
+        objective = float(c_arr @ x)
+
+    # SOUNDNESS: the dual bound comes from HiGHS and is never synthesized from the
+    # incumbent. `mip_dual_bound` is +/-inf before the root LP finishes.
+    bound = None
+    raw_bound = float(info.mip_dual_bound)
+    if np.isfinite(raw_bound):
+        bound = raw_bound
+    if status == SolveStatus.OPTIMAL and objective is not None:
+        # HiGHS may report a dual bound a hair above the incumbent at its own
+        # gap tolerance; a bound is only a bound if it does not cross.
+        bound = objective if bound is None else min(bound, objective)
+
+    gap = None
+    if np.isfinite(info.mip_gap):
+        gap = float(info.mip_gap)
+
+    return MILPResult(
+        status=status,
+        x=x,
+        objective=objective,
+        bound=bound,
+        gap=gap,
+        node_count=int(info.mip_node_count),
+        iterations=int(info.simplex_iteration_count),
+        wall_time=wall,
+    )
+
+
+def solve_milp_with_lazy_cuts(
+    c: np.ndarray,
+    A_ub: Optional[Union[np.ndarray, sp.spmatrix]] = None,
+    b_ub: Optional[np.ndarray] = None,
+    A_eq: Optional[Union[np.ndarray, sp.spmatrix]] = None,
+    b_eq: Optional[np.ndarray] = None,
+    bounds: Optional[BoundList] = None,
+    integrality: Optional[np.ndarray] = None,
+    time_limit: Optional[float] = None,
+    gap_tolerance: float = 1e-4,
+    max_nodes: int = 1_000_000,
+    lazy_callback=None,
+    node_callback=None,
+    terminate_callback=None,
+    mip_start: Optional[np.ndarray] = None,
+) -> MILPResult:
+    """LP/NLP-BB master on HiGHS: separate at integer-feasible nodes, restart on a cut.
+
+    Interface-compatible with
+    :func:`discopt.solvers.milp_simplex.solve_milp_with_lazy_cuts`, so
+    ``solve_lp_nlp_bb`` dispatches to it unchanged.
+
+    **Why this is a restart loop and not a true single tree.** Quesada-Grossmann
+    wants to *inject* a row from inside the tree. HiGHS 1.12 declares
+    ``kCallbackMipDefineLazyConstraints`` but its callback *input* struct exposes
+    only ``user_interrupt`` / ``setSolution`` / ``repairSolution`` — there is no
+    field through which a row can be handed back, so row injection is genuinely
+    unavailable and pretending otherwise would silently drop the caller's cuts.
+    What HiGHS does give is ``kCallbackMipImprovingSolution``: a hook at every
+    integer-feasible incumbent, which is exactly the QG separation trigger. So the
+    tree is rebuilt whenever a cut is actually needed, and only then — strictly
+    fewer restarts than multi-tree OA, which restarts at every master *optimum*
+    whether or not a cut was required.
+
+    That is affordable precisely because of the measurement that motivates this
+    module: HiGHS solves the ``rsyn0840m`` master in 92 nodes / 0.42 s, so a
+    handful of restarts costs a few seconds where the in-house driver had not
+    finished one tree in 60 s.
+
+    **Soundness.** The returned incumbent is only ever a point the separator
+    *accepted*. A point that triggered a cut is a point the OA cuts exclude, so
+    reporting HiGHS's own last incumbent could hand back a MINLP-infeasible
+    solution on a time-limited exit; the accepted point is tracked separately for
+    that reason. ``bound`` is HiGHS's dual bound on the master, which only ever
+    gains valid cuts, so it stays a valid lower bound throughout.
+
+    ``callback_stats["mipsol_calls"] == 0`` means the separator never ran — NOT
+    that it accepted everything (CLAUDE.md §6).
+    """
+    highspy = _require_highspy()
+    t0 = time.time()
+
+    if lazy_callback is None:
+        raise ValueError(
+            "solve_milp_with_lazy_cuts requires lazy_callback; use solve_milp for a "
+            "plain MILP solve"
+        )
+    if node_callback is not None:
+        raise NotImplementedError(
+            "the HiGHS lazy-cut backend has no MIPNODE equivalent: it separates only "
+            "at integer-feasible incumbents, so node_callback (fractional user cuts) "
+            "cannot be honoured. Use milp_solver='gurobi' for that."
+        )
+    if terminate_callback is not None:
+        raise NotImplementedError(
+            "the HiGHS lazy-cut backend enforces time_limit through the HiGHS option "
+            "and has no callback-termination hook; pass time_limit instead."
+        )
+
+    c_arr = np.asarray(c, dtype=np.float64).ravel()
+    n = c_arr.shape[0]
+    lb, ub = _marshal_col_bounds(bounds, n)
+    a_csc, row_lower, row_upper = _stack_rows(A_ub, b_ub, A_eq, b_eq, n, highspy.kHighsInf)
+
+    lp = highspy.HighsLp()
+    lp.num_col_ = n
+    lp.num_row_ = a_csc.shape[0]
+    lp.col_cost_ = c_arr
+    lp.col_lower_ = _to_highs_inf(lb, highspy)
+    lp.col_upper_ = _to_highs_inf(ub, highspy)
+    lp.row_lower_ = row_lower
+    lp.row_upper_ = row_upper
+    lp.sense_ = highspy.ObjSense.kMinimize
+    lp.a_matrix_.format_ = highspy.MatrixFormat.kColwise
+    lp.a_matrix_.num_col_ = n
+    lp.a_matrix_.num_row_ = a_csc.shape[0]
+    lp.a_matrix_.start_ = a_csc.indptr.astype(np.int32)
+    lp.a_matrix_.index_ = a_csc.indices.astype(np.int32)
+    lp.a_matrix_.value_ = a_csc.data
+    if integrality is not None:
+        int_mask = np.asarray(integrality).ravel().astype(bool)
+        if int_mask.shape[0] != n:
+            raise ValueError(f"integrality has {int_mask.shape[0]} entries but c has {n}")
+        lp.integrality_ = [
+            highspy.HighsVarType.kInteger if f else highspy.HighsVarType.kContinuous
+            for f in int_mask
+        ]
+
+    h = highspy.Highs()
+    for key, val in [("output_flag", False), ("mip_rel_gap", float(gap_tolerance))]:
+        if h.setOptionValue(key, val) != highspy.HighsStatus.kOk:
+            raise RuntimeError(f"HiGHS rejected option {key}={val!r}")
+    if h.passModel(lp) != highspy.HighsStatus.kOk:
+        raise RuntimeError("HiGHS rejected the master model")
+
+    if mip_start is not None:
+        seed = np.asarray(mip_start, dtype=np.float64).ravel()
+        if seed.shape[0] != n:
+            raise ValueError(
+                f"mip_start has {seed.shape[0]} entries but the master has {n} columns"
+            )
+        sol = highspy.HighsSolution()
+        sol.col_value = seed
+        h.setSolution(sol)
+
+    counts = {"mipsol_calls": 0, "mipnode_calls": 0, "lazy_cuts": 0, "node_cuts": 0, "restarts": 0}
+    pending: list[tuple[np.ndarray, float]] = []
+    # The accepted incumbent is tracked separately from HiGHS's own: HiGHS's best
+    # solution may be a point the separator VETOED, and returning that as the OA
+    # incumbent would report an infeasible point as feasible (CLAUDE.md §1). Only
+    # a point the separator declined to cut is eligible.
+    best: list[Optional[np.ndarray]] = [None]
+    best_obj: list[Optional[float]] = [None]
+
+    def _callback(callback_type, message, data_out, data_in, user_data):
+        x = np.asarray(data_out.mip_solution, dtype=np.float64).ravel()[:n]
+        counts["mipsol_calls"] += 1
+        # CLAUDE.md §7: a separator that raises must crash the solve, not be read
+        # as "this point is fine" -- an accepted point becomes the OA incumbent.
+        raw = lazy_callback(x)
+        rows = (
+            []
+            if raw is None
+            else [(np.asarray(a, dtype=np.float64).ravel(), float(r)) for a, r in raw]
+        )
+        if rows:
+            pending.extend(rows)
+            counts["lazy_cuts"] += len(rows)
+            data_in.user_interrupt = True
+        else:
+            obj = float(c_arr @ x)
+            if best_obj[0] is None or obj < best_obj[0]:
+                best[0], best_obj[0] = x.copy(), obj
+
+    h.setCallback(_callback, None)
+    h.startCallback(highspy.cb.HighsCallbackType.kCallbackMipImprovingSolution)
+
+    status = SolveStatus.ERROR
+    bound = None
+    nodes = 0
+    iters = 0
+    while True:
+        remaining = None
+        if time_limit is not None:
+            remaining = float(time_limit) - (time.time() - t0)
+            if remaining <= 0.0:
+                status = SolveStatus.TIME_LIMIT
+                break
+            if h.setOptionValue("time_limit", remaining) != highspy.HighsStatus.kOk:
+                raise RuntimeError("HiGHS rejected the remaining time limit")
+        pending.clear()
+        h.run()
+
+        info = h.getInfo()
+        nodes += int(info.mip_node_count)
+        iters += int(info.simplex_iteration_count)
+        raw_bound = float(info.mip_dual_bound)
+        if np.isfinite(raw_bound):
+            bound = raw_bound if bound is None else max(bound, raw_bound)
+
+        if not pending:
+            status = _status_map(highspy).get(h.getModelStatus(), SolveStatus.ERROR)
+            break
+
+        # A cut was requested, so this tree is stale: append the rows and rebuild.
+        counts["restarts"] += 1
+        for coeffs, rhs in pending:
+            if coeffs.shape[0] != n:
+                raise ValueError(f"lazy cut has {coeffs.shape[0]} coefficients, expected {n}")
+            nz = np.flatnonzero(coeffs)
+            if (
+                h.addRow(
+                    -highspy.kHighsInf,
+                    rhs,
+                    int(nz.size),
+                    nz.astype(np.int32),
+                    coeffs[nz],
+                )
+                != highspy.HighsStatus.kOk
+            ):
+                raise RuntimeError("HiGHS rejected a lazy cut row")
+
+    h.stopCallback(highspy.cb.HighsCallbackType.kCallbackMipImprovingSolution)
+    h.clearCallbacks()
+
+    x_out, obj_out = best[0], best_obj[0]
+    if bound is not None and obj_out is not None and bound > obj_out:
+        # Only possible at HiGHS's own gap tolerance; a bound that crosses the
+        # incumbent is not a bound.
+        bound = obj_out
+
+    return MILPResult(
+        status=status,
+        x=x_out,
+        objective=obj_out,
+        bound=bound,
+        node_count=nodes,
+        iterations=iters,
+        wall_time=time.time() - t0,
+        callback_stats={**counts, "terminated": False, "terminate_context": None},
+    )

--- a/python/discopt/solvers/milp_simplex.py
+++ b/python/discopt/solvers/milp_simplex.py
@@ -568,8 +568,16 @@ def _marshal_col_bounds(
     pair means that side is open.
 
     An open side becomes the ``±_INF`` sentinel (``1e20``) — what the Rust LP layer
-    reads as unbounded; ``float("inf")`` is *not* that sentinel and is mapped here
-    too. The previous code built these arrays with
+    reads as unbounded. An **explicit** ``±inf`` is passed through untouched: that
+    is what every pre-#1060 caller already sent (measured: on the McCormick root-LP
+    path, ``None`` never occurs and ``±inf`` does), so clamping it here would be a
+    silent bound-*changing* edit riding along with a marshaling fix. It is not
+    hypothetical — clamping ``hda``'s infinite bounds to ``1e20`` moves its root LP
+    bound from ``-64675.2`` to ``-11308304.4``, 175x weaker, and moves ``contvar``'s
+    too. Narrowing the sentinel convention is its own change under CLAUDE.md §5,
+    with its own differential gate; this function only fixes ``None``.
+
+    The previous code built these arrays with
     ``np.array([hi for _, hi in bounds], dtype=np.float64)``, which turns a ``None``
     into ``nan`` **silently**: every caller holding an open-above column (169 of the
     280 columns of the ``rsyn0840m`` LP/NLP-BB master, issue #1060) had its solve
@@ -595,8 +603,8 @@ def _marshal_col_bounds(
                 "finite, None, or +/-inf (NaN is read as both open and closed by "
                 "different guards -- see issue #1008)"
             )
-        lb[j] = -_INF if lo_f <= -_INF else lo_f
-        ub[j] = _INF if hi_f >= _INF else hi_f
+        lb[j] = lo_f
+        ub[j] = hi_f
     return lb, ub
 
 

--- a/python/discopt/solvers/milp_simplex.py
+++ b/python/discopt/solvers/milp_simplex.py
@@ -924,11 +924,28 @@ def solve_milp_with_lazy_cuts(
     # A caller-supplied start is a plain incumbent candidate: the driver validates
     # it against the constraints AND offers it to the separator before seeding, so
     # an infeasible or lazily-excluded start cannot prune the true optimum.
+    #
+    # The seed is a **structural** point of length ``n_struct``: that is what
+    # ``validate_seed_incumbent`` checks (`if seed.len() != ns { return None }`)
+    # and it derives the slack activity itself from the row residuals. This used
+    # to pad the seed to ``n + m`` with zero slacks, which is the standard-form
+    # layout of every *other* array here but the wrong length for the seed -- so
+    # the validator dropped it on the length test and every ``mip_start`` on this
+    # path was silently ignored (#1060). Rejection there is deliberately silent
+    # (a seed that cannot be proven feasible must never prune the optimum), which
+    # is exactly why a marshaling mistake could not announce itself. A wrong
+    # length is a caller bug, not an unverifiable point, so it is refused here
+    # instead of being quietly dropped downstream.
     seed = None
     if mip_start is not None:
         seed_arr = np.asarray(mip_start, dtype=np.float64).ravel()
-        if seed_arr.shape[0] == n:
-            seed = np.ascontiguousarray(np.concatenate([seed_arr, np.zeros(m)]))
+        if seed_arr.shape[0] != n:
+            raise ValueError(
+                f"mip_start has {seed_arr.shape[0]} entries but the master has {n} "
+                "structural variables; supply a point over the structural columns "
+                "only (the driver derives the slacks from the row residuals)"
+            )
+        seed = np.ascontiguousarray(seed_arr)
 
     from discopt import debug as _debug
 

--- a/python/discopt/solvers/milp_simplex.py
+++ b/python/discopt/solvers/milp_simplex.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 
 import logging
 import time
-from collections.abc import Iterable
+from collections.abc import Iterable, Sequence
 from typing import Callable, NamedTuple, Optional, Union, cast
 
 import numpy as np
@@ -44,6 +44,12 @@ under-estimate (and the Farkas test a rigorous proof). Mirrors the constant in
 :func:`discopt._relax.obbt._ns_safe_lp_lower_bound`."""
 
 _INF = 1e20  # discopt's effective-infinity sentinel for free variable bounds.
+
+# A column bound list in the scipy/``milp_pounce`` shape: ``None`` on a side means
+# that side is open (issue #1060). ``Sequence`` rather than ``list`` so the common
+# ``list[tuple[float, float]]`` of a fully-bounded caller still type-checks --
+# ``list`` is invariant, ``Sequence`` is not.
+BoundList = Sequence[tuple[Optional[float], Optional[float]]]
 
 _U64 = 2.0**-53  # float64 unit roundoff
 
@@ -551,13 +557,56 @@ class _StdForm(NamedTuple):
     lp_kwargs: dict
 
 
+def _marshal_col_bounds(
+    bounds: Optional[BoundList],
+    n: int,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Marshal a scipy-style ``[(lo, hi), ...]`` list into the engine's bound arrays.
+
+    Mirrors :func:`discopt.solvers.milp_pounce.solve_milp`'s documented contract:
+    ``bounds=None`` means ``(0, +inf)`` per variable, and ``None`` on one side of a
+    pair means that side is open.
+
+    An open side becomes the ``±_INF`` sentinel (``1e20``) — what the Rust LP layer
+    reads as unbounded; ``float("inf")`` is *not* that sentinel and is mapped here
+    too. The previous code built these arrays with
+    ``np.array([hi for _, hi in bounds], dtype=np.float64)``, which turns a ``None``
+    into ``nan`` **silently**: every caller holding an open-above column (169 of the
+    280 columns of the ``rsyn0840m`` LP/NLP-BB master, issue #1060) had its solve
+    rejected by the #1008 NaN guard from deep inside the driver, reported against a
+    standard-form column index that does not name the offending variable. NaN is
+    refused here instead — loudly, and in the caller's own index space (§3).
+    """
+    if bounds is None:
+        return np.zeros(n, dtype=np.float64), np.full(n, _INF, dtype=np.float64)
+    if len(bounds) != n:
+        raise ValueError(
+            f"bounds has {len(bounds)} entries but c has {n} columns; "
+            "one (lo, hi) pair per structural variable is required"
+        )
+    lb = np.empty(n, dtype=np.float64)
+    ub = np.empty(n, dtype=np.float64)
+    for j, (lo, hi) in enumerate(bounds):
+        lo_f = -_INF if lo is None else float(lo)
+        hi_f = _INF if hi is None else float(hi)
+        if np.isnan(lo_f) or np.isnan(hi_f):
+            raise ValueError(
+                f"bounds[{j}] = ({lo!r}, {hi!r}) contains NaN; an LP bound must be "
+                "finite, None, or +/-inf (NaN is read as both open and closed by "
+                "different guards -- see issue #1008)"
+            )
+        lb[j] = -_INF if lo_f <= -_INF else lo_f
+        ub[j] = _INF if hi_f >= _INF else hi_f
+    return lb, ub
+
+
 def _marshal_std_form(
     c: np.ndarray,
     A_ub: Optional[Union[np.ndarray, sp.spmatrix]],
     b_ub: Optional[np.ndarray],
     A_eq: Optional[Union[np.ndarray, sp.spmatrix]],
     b_eq: Optional[np.ndarray],
-    bounds: Optional[list[tuple[float, float]]],
+    bounds: Optional[BoundList],
     integrality: Optional[np.ndarray],
 ) -> _StdForm:
     """Marshal ``A_ub x <= b_ub, A_eq x == b_eq`` into the driver's CSC standard form.
@@ -614,14 +663,9 @@ def _marshal_std_form(
     csc_row_idx = np.ascontiguousarray(a_std_sp.indices, dtype=np.int64)
     csc_vals = np.ascontiguousarray(a_std_sp.data, dtype=np.float64)
 
-    if bounds is not None:
-        lb = np.array([lo for lo, _ in bounds], dtype=np.float64)
-        ub = np.array([hi for _, hi in bounds], dtype=np.float64)
-    else:
-        lb = np.zeros(n, dtype=np.float64)
-        ub = np.full(n, 1e20, dtype=np.float64)
+    lb, ub = _marshal_col_bounds(bounds, n)
     lb_std = np.concatenate([lb, np.zeros(m)])
-    ub_std = np.concatenate([ub, np.full(m, 1e20)])
+    ub_std = np.concatenate([ub, np.full(m, _INF)])
     c_std = np.concatenate([c_arr, np.zeros(m)])
 
     if integrality is not None:
@@ -677,7 +721,7 @@ def solve_milp(
     b_ub: Optional[np.ndarray] = None,
     A_eq: Optional[Union[np.ndarray, sp.spmatrix]] = None,
     b_eq: Optional[np.ndarray] = None,
-    bounds: Optional[list[tuple[float, float]]] = None,
+    bounds: Optional[BoundList] = None,
     integrality: Optional[np.ndarray] = None,
     time_limit: Optional[float] = None,
     gap_tolerance: float = 1e-4,
@@ -766,7 +810,7 @@ def solve_milp_with_lazy_cuts(
     b_ub: Optional[np.ndarray] = None,
     A_eq: Optional[Union[np.ndarray, sp.spmatrix]] = None,
     b_eq: Optional[np.ndarray] = None,
-    bounds: Optional[list[tuple[float, float]]] = None,
+    bounds: Optional[BoundList] = None,
     integrality: Optional[np.ndarray] = None,
     time_limit: Optional[float] = None,
     gap_tolerance: float = 1e-4,
@@ -969,7 +1013,7 @@ def solve_lp_warm_std(
     c: np.ndarray,
     A_ub: Optional[Union[np.ndarray, sp.spmatrix]],
     b_ub: Optional[np.ndarray],
-    bounds: Optional[list[tuple[float, float]]],
+    bounds: Optional[BoundList],
     in_basis: Optional[tuple[np.ndarray, np.ndarray]] = None,
     *,
     return_cert: bool = False,
@@ -1036,14 +1080,9 @@ def solve_lp_warm_std(
     else:
         a_std = a_struct.tocsc()
 
-    if bounds is not None:
-        lb = np.array([lo for lo, _ in bounds], dtype=np.float64)
-        ub = np.array([hi for _, hi in bounds], dtype=np.float64)
-    else:
-        lb = np.zeros(n, dtype=np.float64)
-        ub = np.full(n, 1e20, dtype=np.float64)
+    lb, ub = _marshal_col_bounds(bounds, n)
     lb_std = np.concatenate([lb, np.zeros(m)])
-    ub_std = np.concatenate([ub, np.full(m, 1e20)])
+    ub_std = np.concatenate([ub, np.full(m, _INF)])
     c_std = np.concatenate([c_arr, np.zeros(m)])
 
     # #928: a COLD solve carrying a finite deadline starts the DUAL simplex from

--- a/python/discopt/solvers/oa.py
+++ b/python/discopt/solvers/oa.py
@@ -3932,11 +3932,28 @@ def solve_feasibility_pump(
 def _resolve_lp_nlp_bb_backend(milp_solver: str, *, shot_profile: bool) -> str:
     """Pick the single-tree MILP backend for LP/NLP branch-and-bound.
 
-    Returns ``"gurobi"`` or ``"simplex"``. Until #1060 this raised for anything
-    but Gurobi, because the single tree needs a *persistent lazy-constraint
-    callback* and only Gurobi's had one. The in-house Rust MILP driver now has
-    one too (``solve_milp_lazy_csc_py``), so ``"auto"`` and ``"simplex"`` resolve
-    to it and the method no longer requires a commercial license.
+    Returns ``"gurobi"``, ``"simplex"`` or ``"highs"``. Until #1060 this raised for
+    anything but Gurobi, because the single tree needs a *persistent
+    lazy-constraint callback* and only Gurobi's had one. The in-house Rust MILP
+    driver now has one too (``solve_milp_lazy_csc_py``), so ``"auto"`` and
+    ``"simplex"`` resolve to it and the method no longer requires a commercial
+    license.
+
+    ``"highs"`` resolves to the HiGHS separate-and-restart master
+    (:func:`discopt.solvers.milp_highs.solve_milp_with_lazy_cuts`). HiGHS cannot
+    inject a row from inside its tree -- 1.12 declares
+    ``kCallbackMipDefineLazyConstraints`` but its callback input struct has no
+    field to hand one back -- so it separates at ``kCallbackMipImprovingSolution``
+    (the QG trigger: every integer-feasible incumbent) and rebuilds the tree when,
+    and only when, a cut is actually needed. That is not a true single tree and
+    the docstring above says so, but it is what makes the free path *finish*: the
+    in-house driver's root loop closes 0% of the ``rsyn0840m`` master's gap where
+    HiGHS closes 86.1%, and the master engine, not the tree topology, is the
+    measured gap.
+
+    ``"auto"`` deliberately does **not** pick HiGHS. Routing it there would make
+    the default depend on an optional package and would move every existing
+    caller's node counts; the opt-in keeps #356 and the current defaults intact.
 
     ``"pounce"`` still refuses: the POUNCE matrix-MILP B&B exposes no separator
     hook, and silently substituting a different backend would hide that the
@@ -3960,10 +3977,12 @@ def _resolve_lp_nlp_bb_backend(milp_solver: str, *, shot_profile: bool) -> str:
         )
     if backend in {"auto", "simplex"}:
         return "simplex"
+    if backend == "highs":
+        return "highs"
     raise RuntimeError(
         "mip_nlp_method='lp_nlp_bb' requires a MILP backend with a lazy-constraint "
-        "callback: 'gurobi' or 'simplex' (also reachable as 'auto'). Backend "
-        f"{milp_solver!r} exposes no separator hook."
+        "callback: 'gurobi', 'simplex' (also reachable as 'auto') or 'highs'. "
+        f"Backend {milp_solver!r} exposes no separator hook."
     )
 
 
@@ -4478,6 +4497,10 @@ def solve_lp_nlp_bb(
     solve_milp_with_lazy_cuts: Callable[..., MILPResult]
     if lazy_backend == "gurobi":
         from discopt.solvers.gurobi import (
+            solve_milp_with_lazy_cuts as solve_milp_with_lazy_cuts,
+        )
+    elif lazy_backend == "highs":
+        from discopt.solvers.milp_highs import (
             solve_milp_with_lazy_cuts as solve_milp_with_lazy_cuts,
         )
     else:

--- a/python/tests/test_issue_1060_highs_master.py
+++ b/python/tests/test_issue_1060_highs_master.py
@@ -1,0 +1,266 @@
+"""#1060: the opt-in HiGHS master engine for the MIP-NLP family.
+
+Why a HiGHS backend exists at all after #356 removed it: #356 targeted the
+*per-node LP* of spatial branch-and-bound, and that removal stands. This is a
+different seam -- the *master MILP* of the OA / LP-NLP-BB family -- and it is
+where the in-house driver is measurably outclassed. On the ``rsyn0840m`` master
+(gap 2295.97) the in-house root loop closes 0.0% with cover+GMI, 10.5% adding
+MIR/aggregation c-MIR, 37.7% adding probing implied bounds, and plateaus at
+47.6% iterated to tailing-off; HiGHS closes 86.1% at node 0 and finishes the
+tree in 92 nodes / 0.42 s. End to end that is the difference between a 60 s
+timeout at objective -11.41 and ``optimal`` at 325.5545 in 1.9 s.
+
+``"highs"`` is reachable only by naming it. It is in no fallback order, so
+``get_milp_solver()`` and ``milp_solver="auto"`` still resolve to the in-house
+simplex and no existing caller's numbers move -- that invariant is asserted here.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from discopt.solvers import SolveStatus
+from discopt.solvers.lp_backend import get_milp_solver
+
+highspy = pytest.importorskip("highspy", reason="the HiGHS master is an opt-in extra")
+
+from discopt.solvers.milp_highs import (  # noqa: E402
+    _INF,
+    _to_highs_inf,
+    solve_milp,
+    solve_milp_with_lazy_cuts,
+)
+
+# min -x0 - 2 x1  s.t.  x0 + x1 <= 3.5, integer >= 0 and unbounded above.
+# The row keeps it finite: optimum x = (0, 3), objective -6.
+_C = np.array([-1.0, -2.0])
+_A_UB = np.array([[1.0, 1.0]])
+_B_UB = np.array([3.5])
+_INTEGRALITY = np.array([1, 1])
+_BOUNDS = [(0.0, None), (0.0, None)]
+
+
+@pytest.mark.smoke
+def test_highs_is_opt_in_only_and_auto_is_unchanged():
+    """#356's routing must survive: nothing reaches HiGHS without asking for it."""
+    assert get_milp_solver().__module__ == "discopt.solvers.milp_simplex"
+    assert get_milp_solver(backend="auto").__module__ == "discopt.solvers.milp_simplex"
+    assert get_milp_solver(backend="simplex").__module__ == "discopt.solvers.milp_simplex"
+    assert get_milp_solver(backend="highs").__module__ == "discopt.solvers.milp_highs"
+
+
+@pytest.mark.smoke
+def test_plain_solve_matches_the_known_optimum_with_a_sound_bound():
+    res = solve_milp(_C, _A_UB, _B_UB, bounds=_BOUNDS, integrality=_INTEGRALITY)
+    assert res.status == SolveStatus.OPTIMAL
+    assert res.objective == pytest.approx(-6.0, abs=1e-6)
+    assert res.bound is not None and res.bound <= res.objective + 1e-9
+    np.testing.assert_allclose(res.x, [0.0, 3.0], atol=1e-6)
+
+
+@pytest.mark.smoke
+def test_equality_rows_are_marshalled_into_the_two_sided_row_bounds():
+    """``A_eq``/``b_eq`` become ``row_lower == row_upper``, not another ``<=``."""
+    # min x0 + x1 s.t. x0 + x1 == 2, 0 <= x <= 5 integer.
+    res = solve_milp(
+        np.array([1.0, 1.0]),
+        None,
+        None,
+        A_eq=np.array([[1.0, 1.0]]),
+        b_eq=np.array([2.0]),
+        bounds=[(0.0, 5.0), (0.0, 5.0)],
+        integrality=np.array([1, 1]),
+    )
+    assert res.status == SolveStatus.OPTIMAL
+    assert res.objective == pytest.approx(2.0, abs=1e-6)
+
+
+@pytest.mark.smoke
+def test_the_1e20_sentinel_becomes_the_highs_infinity_not_a_finite_bound():
+    """discopt's open-bound sentinel is 1e20; HiGHS's is 1e30 (#1060).
+
+    Passing 1e20 through as a literal makes it an ordinary *finite* bound to
+    HiGHS, which silently narrows the feasible set. The mapping is the seam
+    between the two conventions and has to be exact in both directions.
+    """
+    out = _to_highs_inf(np.array([-_INF, -1e21, -3.0, 0.0, 7.0, _INF, 1e25]), highspy)
+    inf = highspy.kHighsInf
+    assert out.tolist() == [-inf, -inf, -3.0, 0.0, 7.0, inf, inf]
+    # And a genuinely finite bound must not be inflated.
+    assert out[2] == -3.0 and out[4] == 7.0
+
+
+@pytest.mark.smoke
+def test_infeasible_and_unbounded_are_reported_not_guessed():
+    infeas = solve_milp(
+        np.array([1.0]),
+        np.array([[1.0], [-1.0]]),
+        np.array([-2.0, -3.0]),  # x <= -2 and x >= 3
+        bounds=[(None, None)],
+        integrality=np.array([1]),
+    )
+    assert infeas.status == SolveStatus.INFEASIBLE
+    assert infeas.objective is None
+
+    unb = solve_milp(np.array([-1.0]), None, None, bounds=[(0.0, None)], integrality=np.array([1]))
+    assert unb.status == SolveStatus.UNBOUNDED
+    # No objective and no bound: an unbounded master has neither, and inventing
+    # one here is how a false certificate gets manufactured downstream.
+    assert unb.objective is None and unb.bound is None
+
+
+# --- the single-tree (Quesada-Grossmann) entry point ------------------------
+
+
+@pytest.mark.smoke
+def test_lazy_separator_sees_every_integer_feasible_point():
+    seen: list[np.ndarray] = []
+
+    res = solve_milp_with_lazy_cuts(
+        _C,
+        _A_UB,
+        _B_UB,
+        bounds=_BOUNDS,
+        integrality=_INTEGRALITY,
+        lazy_callback=lambda x: seen.append(np.asarray(x, dtype=float).copy()),
+    )
+    assert res.status == SolveStatus.OPTIMAL
+    assert res.objective == pytest.approx(-6.0, abs=1e-6)
+    # CLAUDE.md §6: a separator that never fired makes every other assertion here
+    # vacuous, and a callback that is silently never registered looks identical
+    # to one that accepts everything.
+    assert seen, "lazy separator never saw an integer-feasible point"
+    assert res.callback_stats["mipsol_calls"] == len(seen)
+
+
+@pytest.mark.smoke
+def test_a_vetoed_point_is_cut_off_and_never_returned_as_the_incumbent():
+    """The soundness core: HiGHS's own best solution may be one we rejected.
+
+    HiGHS keeps the interrupted tree's incumbent, which is exactly the point the
+    separator asked to remove. Returning it would report an OA-infeasible point
+    as the master solution (CLAUDE.md §1), so the wrapper tracks the accepted
+    incumbent itself. Here (0, 3) is optimal for the master but forbidden by the
+    separator's cut ``x1 <= 2``; the answer must be (1, 2) at -5.
+    """
+    calls: list[np.ndarray] = []
+
+    def _veto_x1_above_two(x):
+        calls.append(np.asarray(x, dtype=float).copy())
+        if x[1] > 2.0 + 1e-6:
+            return [(np.array([0.0, 1.0]), 2.0)]  # x1 <= 2
+        return None
+
+    res = solve_milp_with_lazy_cuts(
+        _C,
+        _A_UB,
+        _B_UB,
+        bounds=_BOUNDS,
+        integrality=_INTEGRALITY,
+        lazy_callback=_veto_x1_above_two,
+    )
+    assert res.status == SolveStatus.OPTIMAL
+    assert res.objective == pytest.approx(-5.0, abs=1e-6)
+    np.testing.assert_allclose(res.x, [1.0, 2.0], atol=1e-6)
+    assert res.x[1] <= 2.0 + 1e-6, "returned the point the separator cut off"
+    # The cut path really ran: at least one cut and one rebuild.
+    assert res.callback_stats["lazy_cuts"] >= 1
+    assert res.callback_stats["restarts"] >= 1
+    assert any(c[1] > 2.0 + 1e-6 for c in calls), "the vetoing branch never fired"
+    assert res.bound is not None and res.bound <= res.objective + 1e-9
+
+
+@pytest.mark.smoke
+def test_a_raising_separator_crashes_the_solve_rather_than_accepting_the_point():
+    """CLAUDE.md §7 applied to the callback: a broken separator is not an ack."""
+
+    class _Boom(RuntimeError):
+        pass
+
+    def _raise(x):
+        raise _Boom("separator failed")
+
+    with pytest.raises(_Boom):
+        solve_milp_with_lazy_cuts(
+            _C,
+            _A_UB,
+            _B_UB,
+            bounds=_BOUNDS,
+            integrality=_INTEGRALITY,
+            lazy_callback=_raise,
+        )
+
+
+@pytest.mark.smoke
+def test_mip_start_is_a_structural_seed_and_a_wrong_length_is_refused():
+    res = solve_milp_with_lazy_cuts(
+        _C,
+        _A_UB,
+        _B_UB,
+        bounds=_BOUNDS,
+        integrality=_INTEGRALITY,
+        lazy_callback=lambda x: None,
+        mip_start=np.array([1.0, 1.0]),
+    )
+    assert res.status == SolveStatus.OPTIMAL
+    assert res.objective == pytest.approx(-6.0, abs=1e-6)
+
+    with pytest.raises(ValueError, match="mip_start has 3 entries"):
+        solve_milp_with_lazy_cuts(
+            _C,
+            _A_UB,
+            _B_UB,
+            bounds=_BOUNDS,
+            integrality=_INTEGRALITY,
+            lazy_callback=lambda x: None,
+            mip_start=np.array([1.0, 1.0, 0.0]),
+        )
+
+
+@pytest.mark.smoke
+def test_a_wrong_length_cut_is_refused_instead_of_being_padded():
+    """A short coefficient row would silently become a cut on the wrong columns."""
+    with pytest.raises(ValueError, match="lazy cut has 1 coefficients"):
+        solve_milp_with_lazy_cuts(
+            _C,
+            _A_UB,
+            _B_UB,
+            bounds=_BOUNDS,
+            integrality=_INTEGRALITY,
+            lazy_callback=lambda x: [(np.array([1.0]), 0.0)],
+        )
+
+
+@pytest.mark.smoke
+def test_hooks_this_backend_cannot_honour_are_refused_loudly():
+    """HiGHS has no fractional-node or terminate hook; silence would lose cuts.
+
+    Accepting a ``node_callback`` and never calling it would make the SHOT
+    profile's MIPNODE cuts vanish with no diagnostic -- the caller would read a
+    weaker search as an algorithmic result (CLAUDE.md §3).
+    """
+    for kw in ({"node_callback": lambda x: None}, {"terminate_callback": lambda: False}):
+        with pytest.raises(NotImplementedError):
+            solve_milp_with_lazy_cuts(
+                _C,
+                _A_UB,
+                _B_UB,
+                bounds=_BOUNDS,
+                integrality=_INTEGRALITY,
+                lazy_callback=lambda x: None,
+                **kw,
+            )
+
+
+@pytest.mark.smoke
+def test_lp_nlp_bb_accepts_highs_and_still_refuses_a_hookless_backend():
+    """The public seam #1060's acceptance criterion is written against."""
+    from discopt.solvers.oa import _resolve_lp_nlp_bb_backend
+
+    assert _resolve_lp_nlp_bb_backend("highs", shot_profile=False) == "highs"
+    assert _resolve_lp_nlp_bb_backend("auto", shot_profile=False) == "simplex"
+    with pytest.raises(RuntimeError, match="no separator hook"):
+        _resolve_lp_nlp_bb_backend("pounce", shot_profile=False)
+    # The SHOT profile needs MIPNODE cuts, which HiGHS cannot provide.
+    with pytest.raises(RuntimeError):
+        _resolve_lp_nlp_bb_backend("highs", shot_profile=True)

--- a/python/tests/test_issue_1060_open_bounds_marshal.py
+++ b/python/tests/test_issue_1060_open_bounds_marshal.py
@@ -99,12 +99,20 @@ def test_lazy_cut_entry_point_shares_the_open_bound_marshal():
 
 
 @pytest.mark.smoke
-def test_infinite_bounds_map_to_the_sentinel_not_to_float_inf():
-    """``float("inf")`` is not the Rust layer's unbounded sentinel; ``1e20`` is."""
+def test_open_bound_becomes_the_sentinel_and_explicit_inf_is_passed_through():
+    """Only ``None`` is remapped; an explicit ``inf`` must reach the engine as-is.
+
+    Clamping ``±inf`` to the ``1e20`` sentinel *looks* like a tidy-up of the same
+    convention, but it is bound-changing and measurably harmful: on the McCormick
+    root-LP path ``None`` never occurs and ``±inf`` does, and clamping moves
+    ``hda``'s root bound from -64675.2 to -11308304.4 (175x weaker) and
+    ``contvar``'s from 185534.9 to 191103.6. Narrowing the sentinel convention is
+    its own change under CLAUDE.md §5; this marshal only fixes ``None`` (#1060).
+    """
     lb, ub = _marshal_col_bounds([(-np.inf, np.inf), (None, None), (-1.5, 2.5)], 3)
-    assert lb.tolist() == [-_INF, -_INF, -1.5]
-    assert ub.tolist() == [_INF, _INF, 2.5]
-    assert np.isfinite(lb).all() and np.isfinite(ub).all()
+    assert lb.tolist() == [-np.inf, -_INF, -1.5]
+    assert ub.tolist() == [np.inf, _INF, 2.5]
+    assert not np.isnan(lb).any() and not np.isnan(ub).any()
 
 
 @pytest.mark.smoke

--- a/python/tests/test_issue_1060_open_bounds_marshal.py
+++ b/python/tests/test_issue_1060_open_bounds_marshal.py
@@ -144,3 +144,59 @@ def test_finite_bounds_are_unchanged_bound_neutral():
     )
     assert res.status == SolveStatus.OPTIMAL
     assert res.objective == pytest.approx(-6.0, abs=1e-6)
+
+
+# --- the second #1060 marshal defect: the mip_start seed --------------------
+#
+# ``solve_milp_with_lazy_cuts`` padded ``mip_start`` to ``n + m`` with zero
+# slacks -- the standard-form layout of every other array it marshals, but the
+# wrong length for the seed. ``validate_seed_incumbent`` requires exactly
+# ``n_struct`` and rejects anything else *silently* (an unprovable seed must
+# never prune the optimum), so every mip_start on this path was discarded with
+# no diagnostic. The observable is the driver's pre-search separator call: a
+# validated seed is offered to the lazy separator before the search starts.
+
+
+@pytest.mark.smoke
+def test_mip_start_reaches_the_driver_and_is_offered_to_the_separator():
+    """A length-``n`` seed must actually seed; before the fix it was dropped."""
+    seen: list[np.ndarray] = []
+
+    def _accept_everything(x):
+        seen.append(np.asarray(x, dtype=np.float64).copy())
+        return None
+
+    res = _skip_without_backend(
+        solve_milp_with_lazy_cuts,
+        _C,
+        _A_UB,
+        _B_UB,
+        bounds=[(0.0, None), (0.0, None)],
+        integrality=_INTEGRALITY,
+        lazy_callback=_accept_everything,
+        mip_start=np.array([1.0, 1.0]),  # feasible (sum 2 <= 3.5), objective -3
+    )
+    assert seen, "lazy separator never saw an integer-feasible point"
+    # The seed is the *first* point the separator sees: it is offered before the
+    # search begins. With the old zero-padded seed this first call was some
+    # node's LP solution instead, never (1, 1).
+    assert seen[0].shape == (2,)
+    np.testing.assert_allclose(seen[0], [1.0, 1.0])
+    # Seeding is an optimization, never a certificate change.
+    assert res.status == SolveStatus.OPTIMAL
+    assert res.objective == pytest.approx(-6.0, abs=1e-6)
+
+
+@pytest.mark.smoke
+def test_mip_start_of_the_wrong_length_is_refused_loudly():
+    """A wrong-length seed is a caller bug; silent-drop hid #1060 for good."""
+    with pytest.raises(ValueError, match="mip_start has 3 entries"):
+        solve_milp_with_lazy_cuts(
+            _C,
+            _A_UB,
+            _B_UB,
+            bounds=[(0.0, None), (0.0, None)],
+            integrality=_INTEGRALITY,
+            lazy_callback=lambda x: None,
+            mip_start=np.array([1.0, 1.0, 0.0]),
+        )

--- a/python/tests/test_issue_1060_open_bounds_marshal.py
+++ b/python/tests/test_issue_1060_open_bounds_marshal.py
@@ -1,0 +1,146 @@
+"""#1060: an open (``None``) column bound must not become NaN in the simplex marshal.
+
+:func:`discopt.solvers.milp_simplex.solve_milp` mirrors
+:func:`discopt.solvers.milp_pounce.solve_milp`, whose documented contract is that
+``bounds`` entries may be ``None`` (that side is open) and that ``bounds=None``
+means ``(0, +inf)`` per variable. The simplex marshal built its arrays with
+``np.array([hi for _, hi in bounds], dtype=np.float64)``, which turns ``None``
+into ``nan`` silently — the #1008 guard then rejected the whole solve from inside
+the Rust driver, naming a standard-form column index rather than the variable.
+
+This is on the single-tree ``lp_nlp_bb`` path: 169 of the 280 columns of the
+``rsyn0840m`` master have no finite upper bound, so *every* free-backend solve of
+that master died here before reaching the B&B.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from discopt.solvers import SolveStatus
+from discopt.solvers.milp_simplex import (
+    _INF,
+    SimplexBackendUnavailable,
+    _marshal_col_bounds,
+    solve_milp,
+    solve_milp_with_lazy_cuts,
+)
+
+# min -x0 - 2 x1  s.t.  x0 + x1 <= 3.5,  x0, x1 integer >= 0 (no upper bound).
+# The `<=` row bounds both columns from above, so the open side is genuine but
+# the MILP is finite: x = (0, 3), objective -6.
+_C = np.array([-1.0, -2.0])
+_A_UB = np.array([[1.0, 1.0]])
+_B_UB = np.array([3.5])
+_INTEGRALITY = np.array([1, 1])
+
+
+def _skip_without_backend(fn, *args, **kwargs):
+    try:
+        return fn(*args, **kwargs)
+    except SimplexBackendUnavailable:  # pragma: no cover - build-dependent
+        pytest.skip("Rust simplex MILP binding not built")
+
+
+@pytest.mark.smoke
+def test_open_upper_bound_solves_instead_of_raising_on_nan():
+    """``(0, None)`` is an open upper bound, not a NaN bound."""
+    res = _skip_without_backend(
+        solve_milp,
+        _C,
+        _A_UB,
+        _B_UB,
+        bounds=[(0.0, None), (0.0, None)],
+        integrality=_INTEGRALITY,
+    )
+    assert res.status == SolveStatus.OPTIMAL
+    assert res.objective == pytest.approx(-6.0, abs=1e-6)
+
+
+@pytest.mark.smoke
+def test_open_lower_bound_solves():
+    """``(None, hi)`` is an open lower bound; the row keeps the MILP finite."""
+    # min x0  s.t.  -x0 <= 2  =>  x0 >= -2, optimum -2.
+    res = _skip_without_backend(
+        solve_milp,
+        np.array([1.0]),
+        np.array([[-1.0]]),
+        np.array([2.0]),
+        bounds=[(None, 10.0)],
+        integrality=np.array([1]),
+    )
+    assert res.status == SolveStatus.OPTIMAL
+    assert res.objective == pytest.approx(-2.0, abs=1e-6)
+
+
+@pytest.mark.smoke
+def test_lazy_cut_entry_point_shares_the_open_bound_marshal():
+    """The single-tree entry point (#1060's actual caller) takes the same path."""
+    seen: list[np.ndarray] = []
+
+    def _accept_everything(x):
+        seen.append(np.asarray(x, dtype=float).copy())
+        return None
+
+    res = _skip_without_backend(
+        solve_milp_with_lazy_cuts,
+        _C,
+        _A_UB,
+        _B_UB,
+        bounds=[(0.0, None), (0.0, None)],
+        integrality=_INTEGRALITY,
+        lazy_callback=_accept_everything,
+    )
+    assert res.status == SolveStatus.OPTIMAL
+    assert res.objective == pytest.approx(-6.0, abs=1e-6)
+    # CLAUDE.md §6: prove the separator actually ran, so this arm really did
+    # traverse the lazy-cut entry point rather than short-circuiting somewhere.
+    assert seen, "lazy separator never saw an integer-feasible point"
+
+
+@pytest.mark.smoke
+def test_infinite_bounds_map_to_the_sentinel_not_to_float_inf():
+    """``float("inf")`` is not the Rust layer's unbounded sentinel; ``1e20`` is."""
+    lb, ub = _marshal_col_bounds([(-np.inf, np.inf), (None, None), (-1.5, 2.5)], 3)
+    assert lb.tolist() == [-_INF, -_INF, -1.5]
+    assert ub.tolist() == [_INF, _INF, 2.5]
+    assert np.isfinite(lb).all() and np.isfinite(ub).all()
+
+
+@pytest.mark.smoke
+def test_bounds_none_means_zero_to_infinity():
+    """Matches the ``milp_pounce`` contract for an omitted bound list."""
+    lb, ub = _marshal_col_bounds(None, 4)
+    assert lb.tolist() == [0.0] * 4
+    assert ub.tolist() == [_INF] * 4
+
+
+@pytest.mark.smoke
+def test_nan_bound_is_refused_in_the_callers_index_space():
+    """A NaN is a caller bug; refuse loudly and name the *caller's* index (§3)."""
+    with pytest.raises(ValueError, match=r"bounds\[1\]"):
+        _marshal_col_bounds([(0.0, 1.0), (0.0, float("nan"))], 2)
+
+
+@pytest.mark.smoke
+def test_length_mismatch_is_refused():
+    with pytest.raises(ValueError, match="2 entries but c has 3 columns"):
+        _marshal_col_bounds([(0.0, 1.0), (0.0, 1.0)], 3)
+
+
+@pytest.mark.smoke
+def test_finite_bounds_are_unchanged_bound_neutral():
+    """The fix must be bound-neutral for the finite-bound callers that worked."""
+    lb, ub = _marshal_col_bounds([(0.0, 1.0), (-3.0, 7.0)], 2)
+    assert lb.tolist() == [0.0, -3.0]
+    assert ub.tolist() == [1.0, 7.0]
+    res = _skip_without_backend(
+        solve_milp,
+        _C,
+        _A_UB,
+        _B_UB,
+        bounds=[(0.0, 10.0), (0.0, 10.0)],
+        integrality=_INTEGRALITY,
+    )
+    assert res.status == SolveStatus.OPTIMAL
+    assert res.objective == pytest.approx(-6.0, abs=1e-6)


### PR DESCRIPTION
Closes #1060.

## What was wrong

`lp_nlp_bb` already ran without Gurobi before this PR, but it did not reach the
issue's acceptance bar on either instance: both timed out at 60 s, 100x away from
the published optimum. Three separate defects, in the order they bite:

1. **The simplex marshal turned an open bound into NaN.** `bounds` entries may be
   `None` (that side is open) per the `milp_pounce` contract, and
   `np.array([hi for _, hi in bounds])` makes `None` a `nan`. 169 of the 280
   columns of the `rsyn0840m` master have no finite upper bound, so *every* free
   solve of that master died in the #1008 NaN guard before reaching the B&B, and
   the error named a standard-form column index rather than a variable.
2. **`mip_start` was zero-padded to `n + m`.** That is the standard-form layout of
   every other array on that path but the wrong length for a seed, and
   `validate_seed_incumbent` rejects a wrong-length seed *silently* (an unprovable
   seed must never prune the optimum). Every `mip_start` on this path was dropped
   with no diagnostic. Now a length-`n` structural seed is passed, and a
   wrong-length one raises.
3. **The master engine, which is the real gap.** Details below.

## The real gap: the master, not the tree

Measured on the `rsyn0840m` OA master (n=280, 1029 rows, 104 binaries, master
optimum -482.206969):

- Our root LP matches HiGHS's to **4.09e-12** — the relaxation is right; only the
  search differs.
- Seeded with the *exact* optimum, the in-house driver still sat at bound
  -802.77 after **655 003 nodes / 60 s** — so the deficiency is **dual, not
  primal**, and a primal heuristic cannot close it.
- Root-loop gap closure (gap 2295.97):

  | root loop | bound | gap closed |
  |---|---|---|
  | in-house, knapsack cover + GMI (today) | -2778.18 | 0.0% |
  | + MIR and aggregation c-MIR | -2536.13 | 10.5% |
  | + probing-derived implied bounds | -1912.49 | 37.7% |
  | all of the above, iterated to tailing-off | -1685.31 | **47.6% (plateau)** |
  | HiGHS, all families, node 0 | -801.81 | **86.1%** |

  HiGHS then finishes that master in **92 nodes / 0.42 s**.

That killed "build a better in-house root cut loop" (the plateau is 47.6% against
a needed 86%) and pointed at the engine. #356 had removed HiGHS from
`get_milp_solver` entirely, so every free OA/`lp_nlp_bb` master ran on exactly the
engine being outclassed.

## What changed

- **New `discopt/solvers/milp_highs.py`** — a matrix-form HiGHS MILP backend with
  `solve_milp` and `solve_milp_with_lazy_cuts`, interface-compatible with the
  simplex ones.
- **`milp_solver="highs"`** is wired through `lp_backend.get_milp_solver`, `oa.py`'s
  `_resolve_lp_nlp_bb_backend`, and the lazy-cut dispatch.
- **`highs` extra** in `pyproject.toml`.

**#356 is not reverted.** That removal targeted the *per-node LP* of spatial B&B
and it stands: `"highs"` is the one backend with **no** fallback order, so
`get_milp_solver()` and `milp_solver="auto"` still resolve to the in-house simplex
and no existing caller's node counts or bounds move. There is a test asserting
exactly that.

**On the single tree.** HiGHS 1.12 declares `kCallbackMipDefineLazyConstraints`,
but its callback *input* struct exposes only
`repairSolution / setSolution / user_has_solution / user_interrupt / user_solution`
— there is no field through which a row can be handed back, so true in-tree row
injection is genuinely unavailable and claiming otherwise would silently drop the
caller's cuts. What it does give is `kCallbackMipImprovingSolution`, a hook at
every integer-feasible incumbent, which is exactly the Quesada-Grossmann
separation trigger. So this separates there and rebuilds **only when a cut is
actually needed** — strictly fewer restarts than multi-tree OA, which restarts at
every master optimum whether a cut was required or not — and it is affordable
because a full master solve is 0.42 s. The docstring says this plainly rather than
calling it a single tree.

**Soundness.** The returned incumbent is only ever a point the separator
*accepted*: HiGHS's own best solution at an interrupt is precisely the point we
asked to cut off, and returning it would hand back a MINLP-infeasible point as the
master solution. `bound` is `mip_dual_bound` and nothing else, never synthesized,
and clamped to the incumbent so it can never cross it.

## Verification

**Acceptance (#1060's own criterion, on the public seam)** —
`mip_nlp_method="lp_nlp_bb"`, 60 s, in-house arm interleaved as the control
(load gate `2.82 6.16 7.86`):

| instance (published optimum) | `milp_solver="simplex"` | `milp_solver="highs"` |
|---|---|---|
| rsyn0840m (325.554507) | feasible, obj -11.413, 60.8 s | **optimal, 325.5545067815349, 5.2 s** |
| rsyn0820m02m (1092.091101) | feasible, obj -39.531, 62.3 s | **optimal, 1092.0911003690503, 25.7 s** |

The certificate invariant was asserted on every arm in the model's own sense
(rsyn* are MAXIMIZE, so the dual bound is an *upper* bound). Probe:
`probe_1060_accept.py`, `ACCEPTANCE MET`, `CHECKS_EXECUTED 15`, exit 0. Run
twice; the HiGHS arms reproduced at 5.5/5.2 s and 26.3/25.7 s.

**Regression tests** — `python/tests/test_issue_1060_open_bounds_marshal.py` (10)
and `python/tests/test_issue_1060_highs_master.py` (12), both smoke-marked --
22 passed. The
HiGHS suite covers the sentinel-to-`kHighsInf` mapping (1e20 vs 1e30 — passing our
sentinel through as a literal would silently narrow the feasible set), a separator
that actually vetoes the master optimum, a raising separator crashing the solve
rather than being read as an acknowledgement, refusals for hooks HiGHS cannot
honour, and the opt-in-only routing invariant.

## Also fixed along the way

Three stale HiGHS references that had drifted out of true:

- `solver.py`'s #1059 auto-route gated on `import highspy`, but
  `get_milp_solver("auto")` has not touched highspy since #356 — it tested a
  package the master would never load. Conservative (a refusal, never a false
  route), but it refused on machines whose master was fine and routed on machines
  whose master was not. It now asks the selector directly.
- `gdpopt_loa.py`'s "`pip install highspy` was a dead hint" comment.
- `lp_backend`'s module docstring.

## Retraction (CLAUDE.md §11)

An earlier claim in this session that "root strength is not the lever" is
**retracted**: the attribution probe behind it never checked `setOptionValue`'s
return, so all four arms ran with cuts ON. What survives from that probe is only
that *presolve alone* is not the lever. The corrected root-loop measurement is the
table above, and it says root strength is very much the lever.


## Suites run

- `pytest python/tests/ -m smoke` — **1102 passed, 1 skipped, 2 xpassed** (113 s)
- `pytest -m slow python/tests/test_adversarial_recent_fixes.py` — **19 passed** (147 s)
- `ruff check python/`, `ruff format --check`, `mypy` — clean
- No Rust was touched, so `cargo test -p discopt-core` was not required.
