### PR TITLE
perf(milp): warm-start the root cut loop so real cut budgets are affordable

### DIFF
--- a/crates/discopt-core/src/bnb/milp_driver.rs
+++ b/crates/discopt-core/src/bnb/milp_driver.rs
@@ -703,12 +703,74 @@ pub fn solve_milp_lazy_hooked(
             if total_cuts >= opts.root_cuts {
                 break;
             }
+            crate::profile::incr(crate::profile::Ctr::RootCutRounds);
             let root = {
                 let _t = crate::profile::Timer::new(crate::profile::Phase::RootSolve);
-                // Solve the root relaxation directly from the working CSC (T3b5: no
-                // dense matrix). Bit-identical to `solve_lp_root` (gated by
-                // `driver_matches_golden`).
-                solve_lp_root_csc(&csc_w, m_w, n_w, &c_w, &l_w, &u_w, &b_w, &node_simplex)
+                // Re-optimize from the PREVIOUS round's optimal basis instead of
+                // re-deriving the augmented LP from scratch. Appending a cut adds a
+                // row and its surplus slack; `extend_basis` makes that slack basic,
+                // which leaves the basis nonsingular and still dual-feasible (the
+                // slack's cost is 0), so a warm DUAL re-solve is the textbook
+                // re-optimizer — it pivots in the few violated cut rows rather than
+                // running a fresh primal phase-1 over the whole matrix.
+                //
+                // The loop already kept `root_basis` for the post-loop root node; it
+                // simply never fed it back in, so every round paid a cold solve.
+                // Measured on the rsyn0840m OA master at `root_cuts=500,
+                // cut_rounds=15`: 14 cold root solves = 23.1 s of the 24.2 s cut
+                // loop, 16127 phase-1 pivots, `EntryColsWarm = 0`.
+                //
+                // Bound-safe: the LP optimum does not depend on the starting basis,
+                // and the warm solve falls back to the cold `solve_lp_root_csc` on
+                // IterLimit/Numerical exactly as the node path does. Only which
+                // optimal vertex is reached — hence which Gomory cuts are read off
+                // the basis — can differ, the same latitude the post-loop
+                // `root_warm_basis` path already has.
+                // Borrowed, not taken: a round whose LP comes back non-Optimal
+                // breaks out of the loop *without* refreshing `root_basis`, and the
+                // post-loop root node still wants the last good basis to warm-start
+                // from. Taking it here would silently cold-solve that root.
+                match root_basis.as_ref() {
+                    Some(&(ref b, basis_n)) => {
+                        crate::profile::incr(crate::profile::Ctr::RootCutWarmReopt);
+                        let b = if basis_n < n_w {
+                            extend_basis(b.clone(), n_w)
+                        } else {
+                            b.clone()
+                        };
+                        let lp = LpView {
+                            a: &[],
+                            m: m_w,
+                            n: n_w,
+                            c: &c_w,
+                            l: &l_w,
+                            u: &u_w,
+                        };
+                        let warm = solve_lp_warm_scaled_csc(
+                            &lp,
+                            &b_w,
+                            &b,
+                            &warm_root_opts(&node_simplex, m_w, n_w),
+                            &csc_w,
+                        );
+                        match warm.status {
+                            LpStatus::IterLimit | LpStatus::Numerical => solve_lp_root_csc(
+                                &csc_w,
+                                m_w,
+                                n_w,
+                                &c_w,
+                                &l_w,
+                                &u_w,
+                                &b_w,
+                                &node_simplex,
+                            ),
+                            _ => warm,
+                        }
+                    }
+                    None => {
+                        solve_lp_root_csc(&csc_w, m_w, n_w, &c_w, &l_w, &u_w, &b_w, &node_simplex)
+                    }
+                }
             };
             lp_iters += root.iters;
             if root.status != LpStatus::Optimal {
@@ -3532,6 +3594,93 @@ mod tests {
     }
 
     #[test]
+    fn root_cut_rounds_reoptimize_warm_instead_of_cold_solving() {
+        // The root cut loop kept each round's optimal basis for the post-loop root
+        // node but never fed it back into the NEXT round, so every round re-derived
+        // the augmented LP with a cold primal phase-1. Measured on the rsyn0840m OA
+        // master at `root_cuts=500, cut_rounds=15`: 14 cold root solves = 23.1 s of
+        // the 24.2 s cut loop, 16127 phase-1 pivots, and the enclosing solve could
+        // never close the gap. Warm-starting the rounds makes real cut budgets
+        // affordable (same instance: 22559 nodes to a certified optimum).
+        //
+        // The invariant: however many rounds run, only the FIRST derives its basis
+        // from scratch; every later round re-optimizes from the previous round's
+        // optimum, which `RootCutWarmReopt` records.
+        //
+        // `RootCutRounds` is asserted `>= 3` so the check cannot pass vacuously on a
+        // fixture that happens to finish in one round (CLAUDE.md §6) -- with a single
+        // round `EntryCols == 1` holds with or without the fix.
+        let _g = crate::profile::test_guard();
+        // 3 knapsack rows over 8 binaries with coefficients chosen so the LP
+        // relaxation stays fractional across several GMI rounds.
+        // 8 binaries + one explicit surplus slack per row (`Σ a·x + s = b`, the
+        // standard form this driver's `LpView` takes).
+        let n = 11;
+        let a = vec![
+            7.0, 5.0, 4.0, 3.0, 9.0, 6.0, 5.0, 4.0, 1.0, 0.0, 0.0, //
+            3.0, 8.0, 6.0, 7.0, 4.0, 5.0, 9.0, 3.0, 0.0, 1.0, 0.0, //
+            6.0, 4.0, 9.0, 5.0, 3.0, 8.0, 4.0, 7.0, 0.0, 0.0, 1.0,
+        ];
+        let c = vec![
+            -9.0, -7.0, -8.0, -6.0, -10.0, -8.0, -7.0, -6.0, 0.0, 0.0, 0.0,
+        ];
+        let l = vec![0.0; n];
+        let mut u = vec![1.0; n];
+        u[8] = INF;
+        u[9] = INF;
+        u[10] = INF;
+        let lp = LpView {
+            a: &a,
+            m: 3,
+            n,
+            c: &c,
+            l: &l,
+            u: &u,
+        };
+        let b = [15.0, 17.0, 16.0];
+        let mut o = opts(8, (0..8).collect());
+        o.root_cuts = 200;
+        o.cut_rounds = 12;
+        o.cut_select = true;
+        o.gmi_cuts = true;
+
+        // Reference optimum from the same driver with cuts switched off entirely:
+        // the cut loop may never move the certified objective.
+        let mut o_ref = opts(8, (0..8).collect());
+        o_ref.root_cuts = 0;
+        let r_ref = solve_milp(&lp, &b, 0.0, &o_ref);
+        assert_eq!(r_ref.status, MilpStatus::Optimal);
+
+        // The driver calls `profile::init_from_env()` on entry, which overwrites a
+        // bare `set_enabled(true)` with "is DISCOPT_PROFILE set?" -- so arming the
+        // counters here means arming the env var, under TEST_LOCK.
+        std::env::set_var("DISCOPT_PROFILE", "1");
+        crate::profile::reset();
+        let r = solve_milp(&lp, &b, 0.0, &o);
+        let rounds = crate::profile::counter(crate::profile::Ctr::RootCutRounds);
+        let warm_reopt = crate::profile::counter(crate::profile::Ctr::RootCutWarmReopt);
+        std::env::remove_var("DISCOPT_PROFILE");
+        crate::profile::set_enabled(false);
+        assert_eq!(r.status, MilpStatus::Optimal);
+        assert!(
+            (r.obj - r_ref.obj).abs() < 1e-6,
+            "cut loop moved the optimum: {} vs {}",
+            r.obj,
+            r_ref.obj
+        );
+        assert!(
+            rounds >= 3,
+            "fixture ran only {rounds} cut round(s); the cold-solve check would be vacuous"
+        );
+        assert_eq!(
+            warm_reopt,
+            rounds - 1,
+            "{rounds} cut rounds but only {warm_reopt} warm re-optimizes; every round \
+             after the first must start from the previous round's optimal basis"
+        );
+    }
+
+    #[test]
     fn presolve_matches_no_presolve() {
         // Equality-constrained MILP where FBBT actually fires:
         //   min -x0 - 2x1 - x2  s.t.  x0 + x1 + x2 = 3,  2x1 + x2 + s = 4,
@@ -3956,6 +4105,17 @@ mod sparse_milp_diff {
     /// sensitive discriminator: a different root-solve pivot path drifts it even when
     /// the B&B tree is a single node. A change to any value here is a red flag — the
     /// sparse path is a pure representation change and must reproduce these exactly.
+    ///
+    /// `lp_iters` was re-baselined once, for two compounding reasons, both measured
+    /// on this panel with status/nodes/obj/bound bit-identical throughout:
+    ///   1. `primal.rs` used to `assemble` every cold solve with a hardcoded
+    ///      `iters: 0`, so the primal contributed nothing to this sum (CLAUDE.md §6).
+    ///      With the honest pivot count: binary_knapsack 1 → 5, cuts_firing 1 → 8.
+    ///   2. The root cut loop now warm dual re-optimizes each round from the previous
+    ///      round's optimal basis instead of cold-solving the augmented LP, which is
+    ///      the whole point of the change: binary_knapsack 5 → 2, cuts_firing 8 → 2.
+    /// The recorded values are therefore the *real* pivot counts of the *current*
+    /// engine; the old ones were an under-report of a slower path.
     #[test]
     fn driver_matches_golden() {
         for case in panel() {
@@ -3963,7 +4123,7 @@ mod sparse_milp_diff {
             let (status, obj, bound, nodes, iters): (MilpStatus, f64, f64, usize, usize) =
                 match case.name {
                     "pure_lp" => (MilpStatus::Optimal, -1.0, -1.0, 1, 0),
-                    "binary_knapsack" => (MilpStatus::Optimal, -10.0, -10.0, 1, 1),
+                    "binary_knapsack" => (MilpStatus::Optimal, -10.0, -10.0, 1, 2),
                     "general_integer" => (MilpStatus::Optimal, -3.0, -3.0, 1, 1),
                     "infeasible" => (MilpStatus::Infeasible, f64::INFINITY, f64::INFINITY, 0, 0),
                     "unbounded" => (
@@ -3973,7 +4133,7 @@ mod sparse_milp_diff {
                         1,
                         0,
                     ),
-                    "cuts_firing_knapsack" => (MilpStatus::Optimal, -16.0, -16.0, 1, 1),
+                    "cuts_firing_knapsack" => (MilpStatus::Optimal, -16.0, -16.0, 1, 2),
                     other => panic!("unhandled case {other}"),
                 };
             assert_eq!(r.status, status, "{}: status", case.name);

--- a/crates/discopt-core/src/lp/simplex/dual.rs
+++ b/crates/discopt-core/src/lp/simplex/dual.rs
@@ -519,6 +519,7 @@ impl<'a> PreparedDual<'a> {
         let _t_prep = crate::profile::Timer::new(crate::profile::Phase::DualPrepare);
         let (m, n, l, u, c) = (lp.m, lp.n, lp.l, lp.u, lp.c);
         if start.basic_vars.len() != m {
+            crate::profile::incr(crate::profile::Ctr::DualPrepRejectShape);
             return None;
         }
         let tol = opts.tol;
@@ -529,6 +530,7 @@ impl<'a> PreparedDual<'a> {
         }
         let stat = start.col_status.clone();
         if stat.len() != n {
+            crate::profile::incr(crate::profile::Ctr::DualPrepRejectShape);
             return None;
         }
 
@@ -543,6 +545,7 @@ impl<'a> PreparedDual<'a> {
             })
             .collect();
         if lu.factorize_sparse(m, &cols).is_err() {
+            crate::profile::incr(crate::profile::Ctr::DualPrepRejectSingular);
             return None; // singular warm basis → fall back to cold
         }
 
@@ -555,6 +558,7 @@ impl<'a> PreparedDual<'a> {
         {
             let mut y: Vec<f64> = basis.iter().map(|&j| c[j]).collect();
             if lu.btran(&mut y).is_err() {
+                crate::profile::incr(crate::profile::Ctr::DualPrepRejectSingular);
                 return None;
             }
             for j in 0..n {
@@ -571,11 +575,13 @@ impl<'a> PreparedDual<'a> {
                     dj >= -tol
                 };
                 if !ok {
+                    crate::profile::incr(crate::profile::Ctr::DualPrepRejectDualInf);
                     return None; // dual-infeasible warm start → cold fallback
                 }
             }
         }
 
+        crate::profile::incr(crate::profile::Ctr::DualPrepAccept);
         Some(PreparedDual {
             m,
             n,
@@ -2057,7 +2063,20 @@ mod tests {
             col_status: vec![AT_LOWER, AT_LOWER, BASIC, BASIC],
         };
 
+        // Arm the counters so the fallback can be observed directly. `iters == 0`
+        // used to stand in for "the cold primal ran", but only because the primal
+        // hardcoded `iters: 0` for every solve -- a broken instrument doubling as a
+        // test oracle (CLAUDE.md §6). Now that it reports its real pivot count, the
+        // mechanism is asserted by name instead.
+        let _g = crate::profile::test_guard();
+        // `set_enabled` (not the env var) is what arms the counters here: nothing on
+        // this path calls `init_from_env`, so exporting `DISCOPT_PROFILE` would leave
+        // `ENABLED` false and the assertion below would read 0 for the wrong reason.
+        crate::profile::set_enabled(true);
+        crate::profile::reset();
         let warm = solve_lp_warm(&lp, &b, &bad, &opts());
+        let rejects = crate::profile::counter(crate::profile::Ctr::DualPrepRejectDualInf);
+        crate::profile::set_enabled(false);
         let cold = solve_lp(&lp, &b, &opts());
         assert_eq!(cold.status, LpStatus::Optimal);
         assert_eq!(warm.status, LpStatus::Optimal);
@@ -2069,10 +2088,14 @@ mod tests {
             warm.obj,
             cold.obj
         );
-        // iters==0 confirms the cold fallback ran (the dual path sets iters>0).
+        // The dual-infeasible warm basis must have been REFUSED by
+        // `PreparedDual::prepare`, which is what routes the solve to the cold
+        // primal. Asserting the refusal directly (rather than inferring it from an
+        // iteration count) also proves the probe fired.
         assert_eq!(
-            warm.iters, 0,
-            "precondition should have forced cold fallback"
+            rejects, 1,
+            "precondition should have forced cold fallback: prepare refused \
+             {rejects} dual-infeasible warm starts, expected 1"
         );
     }
 

--- a/crates/discopt-core/src/lp/simplex/primal.rs
+++ b/crates/discopt-core/src/lp/simplex/primal.rs
@@ -900,6 +900,14 @@ struct Simplex<'a> {
     /// Pivots between exact re-derivations of `x_B`; `0` = only on refactorization.
     /// Seeded from [`xb_refresh_cadence`]; a test sets it directly.
     xb_refresh: usize,
+    /// Simplex pivots executed by this solve, reported as [`LpSolve::iters`].
+    ///
+    /// `assemble` used to hardcode `iters: 0`, so EVERY cold primal solve told the
+    /// caller it had done no work. The MILP driver sums that field into its
+    /// `lp_iters` return, which is how a run that executed 327k pivots reported
+    /// 212 iterations — an instrument that measured nothing and was believed
+    /// (CLAUDE.md §6). Purely observational: nothing reads it back.
+    total_pivots: usize,
 }
 
 impl<'a> Simplex<'a> {
@@ -957,6 +965,7 @@ impl<'a> Simplex<'a> {
             no_expand: false,
             last_xb: Vec::new(),
             xb_refresh: xb_refresh_cadence(),
+            total_pivots: 0,
         }
     }
 
@@ -2235,6 +2244,7 @@ impl<'a> Simplex<'a> {
             } else {
                 crate::profile::Ctr::Phase2Pivots
             });
+            self.total_pivots += 1;
             if bland {
                 crate::profile::incr(crate::profile::Ctr::BlandActivations);
             }
@@ -2625,7 +2635,7 @@ impl<'a> Simplex<'a> {
                 col_status,
                 basic_vars,
             },
-            iters: 0,
+            iters: self.total_pivots,
             dual,
             ray,
         }
@@ -2633,6 +2643,7 @@ impl<'a> Simplex<'a> {
 
     fn failed(self) -> LpSolve {
         let n = self.n;
+        let iters = self.total_pivots;
         LpSolve {
             status: LpStatus::Numerical,
             x: vec![0.0; n],
@@ -2641,7 +2652,7 @@ impl<'a> Simplex<'a> {
                 col_status: vec![AT_LOWER; n],
                 basic_vars: Vec::new(),
             },
-            iters: 0,
+            iters,
             dual: Vec::new(),
             ray: Vec::new(),
         }

--- a/crates/discopt-core/src/profile.rs
+++ b/crates/discopt-core/src/profile.rs
@@ -331,6 +331,21 @@ counters!(
     EntryDense,
     EntryCols,
     EntryColsWarm,
+    // Root cut-loop accounting: rounds executed, and how many of them re-optimized
+    // from the previous round's optimal basis instead of cold-solving the augmented
+    // LP. Every round after the first must be warm; a gap between the two means the
+    // loop is paying a fresh primal phase-1 per cut round (measured on the
+    // `rsyn0840m` OA master: 14 cold root solves = 23.1 s of a 24.2 s cut loop).
+    RootCutRounds,
+    RootCutWarmReopt,
+    // Why a warm DUAL re-optimize was refused, forcing the primal fallback. On the
+    // `rsyn0840m` OA master with a real root cut pool, 588 of 589 node LPs took the
+    // primal path at 556 pivots each -- these separate "the shape is wrong" from
+    // "the basis is singular" from "the basis is dual-infeasible".
+    DualPrepRejectShape,
+    DualPrepRejectSingular,
+    DualPrepRejectDualInf,
+    DualPrepAccept,
     ExpandResetArmed,
     ExpandResetRetries,
     ExpandResetRescues,

--- a/crates/discopt-python/src/lp_bindings.rs
+++ b/crates/discopt-python/src/lp_bindings.rs
@@ -1416,6 +1416,14 @@ fn run_milp_hooked<'py>(
             // F2: warm dual-simplex stall guard (size-derived cap → cold fallback).
             warm_stall_guard: true,
             warm_stall_cap_override: None,
+            // P1.0 (measured OFF, deliberately): turning this on makes the primal
+            // emit a FULL length-`m` basis of real columns instead of dropping the
+            // slot a degenerate basic artificial occupies, which stops
+            // `PreparedDual::prepare` rejecting the node basis on shape (measured
+            // 619/620 rejections on the rsyn0840m OA master). But once the root cut
+            // loop stopped cold-solving every round, flipping it was *exactly*
+            // neutral on node count and wall — so per CLAUDE.md §5 it stays OFF
+            // (sound but not net-positive is not a graduation).
             expel_zero_artificials: false,
             bank_deadline_duals: false,
             recover_unstable_pivot: false,


### PR DESCRIPTION
## What

The MILP driver's root cut loop kept each round's optimal basis for the
post-loop root node but never fed it back into the **next** round, so every
round re-derived the augmented LP with a cold primal phase-1.

Appending a cut adds exactly one row and its surplus slack (`coeffs·x − s = rhs`,
`s ≥ 0`); `extend_basis` makes that slack basic, which leaves the prior basis
nonsingular and still dual-feasible (the slack's cost is 0). A warm **dual**
re-solve is therefore the textbook re-optimizer — it pivots in the few violated
cut rows instead of running a fresh phase-1 over the whole matrix. The loop now
does that, falling back to the cold `solve_lp_root_csc` on `IterLimit`/`Numerical`
exactly as the node path already does.

This is the gap behind *"we cannot be using HiGHS because our solver is too
weak"*: the `lp_nlp_bb` convex-MINLP master fell back to HiGHS because discopt's
own MILP dual side could not afford a real cut budget.

## Measurement

`rsyn0840m` OA master (n=280, 1118 rows, 104 integers, reference optimum
**−482.206969**). Every arm asserted `bound ≤ optimum` and, when it claimed
optimality, `objective ≥ optimum − 1e-4`.

| | before | after |
|---|---|---|
| root cut loop, `rc=500 r=15` | 24.2 s of cold solves | **6.1 s for the whole run** |
| `Phase1Pivots` in the root probe | 16127 | **0** |
| full solve `rc=200 r=5` | never closed (630k nodes, bound stuck −802.77) | **optimal −482.207**, 127329 nodes |
| full solve `rc=500 r=15` | — | **optimal −482.207, 22559 nodes** |
| root gap closed (`rc=500 r=15`) | — | **78.0 %** (HiGHS on the same master: 86.1 %) |

Cut budgets that were previously unaffordable now pay off. **Node counts are the
figures to trust** — they are load-independent; the wall numbers were taken under
measurable background load (CLAUDE.md §9).

## The instrument that hid this

`primal.rs`'s `assemble`/`failed` hardcoded `iters: 0`, so **every** cold primal
solve reported doing no work. The driver sums that field into `lp_iters`, which
is how a run that executed 327k pivots reported 212 iterations — an instrument
that measured nothing and was believed (CLAUDE.md §6). It made the cut budgets
look free during the earlier investigation. `Simplex` now counts its pivots and
reports them; the field is purely observational, nothing reads it back.

## Classification (CLAUDE.md §5)

Bound-changing in the strict sense: the LP *optimum* does not depend on the
starting basis, but which optimal **vertex** is reached can, and Gomory cuts are
read off that basis — so the cut pool, and hence the tree, can differ. It is the
same latitude the post-loop `root_warm_basis` path already had. No new
relaxation, no new cut family, no weakened guard.

## Verification

- `cargo test -p discopt-core`: **636 passed, 0 failed**.
- New regression test `root_cut_rounds_reoptimize_warm_instead_of_cold_solving`
  asserts `RootCutWarmReopt == RootCutRounds − 1` (with `rounds >= 3` so it
  cannot pass vacuously) and that the cut loop does not move the certified
  optimum vs a `root_cuts=0` reference solve. Fails before the change
  (*"12 cut rounds but only 0 warm re-optimizes"*), passes after.
- `driver_matches_golden`: status / nodes / objective / bound **bit-identical**
  on all six panel cases. Only `lp_iters` moved, and the doc comment records both
  causes with the intermediate measurement (binary_knapsack 1 → 5 from the honest
  count, 5 → 2 from the warm loop; cuts_firing 1 → 8 → 2).
- `dual_infeasible_warm_start_falls_back_to_cold` asserted `warm.iters == 0` as a
  *proxy* for "the cold fallback ran" — a proxy that only held because the primal
  under-reported. It now arms the profiler and asserts `DualPrepRejectDualInf == 1`,
  i.e. the mechanism itself. (Not a weakened check: a broken instrument was
  doubling as the test oracle.)
- `pytest -m smoke`: **1104 passed, 1 skipped, 2 xpassed**.
- Adversarial suite and a corpus soundness panel (dual bound vs `minlplib.solu`
  oracle on every in-repo instance, plus the convex-MINLP families the change
  serves) are running; results will be posted in a follow-up comment before merge.

## `expel_zero_artificials` stays OFF

Along the way I found a second real defect: `primal.rs`'s basis extractor drops a
basis slot when a basic artificial has no zero-valued singleton substitute,
emitting `basic_vars.len() < m`, which makes `PreparedDual::prepare` reject the
node basis on shape (measured: 619/620 rejections, 556 pivots/LP on this master).
The existing `expel_zero_artificials` option fixes that — but once the root loop
was warm, flipping it was **exactly neutral** on node count and wall. Sound but
not net-positive is not a graduation (CLAUDE.md §5), so it stays off; the comment
at the call site now records that measurement instead of implying the option is on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017PQaiDVuY5Rs3tga98tnNo
