### PR TITLE
perf(bnb): #1066 reduced-cost fixing reuses the LP's own duals instead of refactorizing the basis

### DIFF
--- a/crates/discopt-core/src/bnb/milp_driver.rs
+++ b/crates/discopt-core/src/bnb/milp_driver.rs
@@ -1673,6 +1673,12 @@ fn solve_node(
     };
     if let Some(s) = ctx.scaling {
         s.unscale_x(&mut sol.x);
+        // NOTE (#1066): `sol.dual` deliberately stays in the SCALED space here. The
+        // `LpStatus::Infeasible` arm below verifies the Farkas ray against the scaled
+        // working CSC (`ctx.csc`, `ctx.sb`, `sl`/`su`) and unscaling it there would
+        // mix coordinate systems, fail every verification, and stop the driver from
+        // fathoming provably empty nodes. Reduced-cost fixing wants the unscaled
+        // duals instead, so it unscales its own copy at the call site.
     }
     drop(_t_node);
     let sol = sol;
@@ -1718,11 +1724,26 @@ fn solve_node(
             // with any FBBT tightening already in `out.tightened`). Pure bound
             // contraction — never touches the node's own valid LP bound.
             if ctx.opts.reduced_cost_fixing && !feasible {
+                let _t_rcf = crate::profile::Timer::new(crate::profile::Phase::RedCostFix);
+                // #1066: the solve exports the row duals in the scaled space (`ŷ`);
+                // `reduced_cost_fix` reads them against the UNSCALED working matrix
+                // `ctx.csc_rc` / cost `ctx.c_w`, so map this copy back with the same
+                // exact power-of-two factors `unscale_x` uses. `sol.dual` itself is
+                // left scaled for the Farkas arm (see the note after the node solve).
+                let rc_dual: std::borrow::Cow<'_, [f64]> = match ctx.scaling {
+                    Some(s) => {
+                        let mut d = sol.dual.clone();
+                        s.unscale_dual(&mut d);
+                        std::borrow::Cow::Owned(d)
+                    }
+                    None => std::borrow::Cow::Borrowed(&sol.dual),
+                };
                 if let Some((rl, ru)) = reduced_cost_fix(
                     ctx.csc_rc,
                     ctx.m_w,
                     ctx.c_w,
                     &sol.basis,
+                    &rc_dual,
                     sol.obj + ctx.obj_const,
                     ctx.inc_snapshot.unwrap_or(f64::INFINITY),
                     &full_l,
@@ -2223,6 +2244,16 @@ fn strong_branch(
     (best, pivots, obs)
 }
 
+/// Opt-out (`DISCOPT_MILP_RC_FIX_REFACTOR=1`) that forces reduced-cost fixing to
+/// re-derive the node duals from a fresh sparse LU instead of reusing the ones the
+/// LP solve already exported. Off by default; it exists so the reuse path and the
+/// legacy refactor path can be run against each other on the same binary (the
+/// differential test in this module, and any interleaved A/B timing per CLAUDE.md §9).
+fn rc_fix_force_refactor() -> bool {
+    static ON: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *ON.get_or_init(|| std::env::var("DISCOPT_MILP_RC_FIX_REFACTOR").is_ok_and(|v| v.trim() == "1"))
+}
+
 /// Reduced-cost (objective) fixing at a node. Given the node's optimal basis,
 /// its LP dual bound `node_obj` (= `z`), and the incumbent `incumbent` (= `U`,
 /// both in the engine's minimize sense), tighten each nonbasic integer
@@ -2244,6 +2275,7 @@ fn reduced_cost_fix(
     m: usize,
     c: &[f64],
     basis: &Basis,
+    dual: &[f64],
     node_obj: f64,
     incumbent: f64,
     l: &[f64],
@@ -2262,28 +2294,45 @@ fn reduced_cost_fix(
         return None; // node should be pruned anyway; nothing improving here
     }
 
-    // Node duals y = B⁻ᵀ c_B via the *sparse* LU (factorize O(nnz) + btran), the
-    // same path the dual simplex uses — not a dense m×m refactor. The earlier dense
-    // `solve_dense` was O(m³) per node: trivial on few-row knapsacks but ruinous on
-    // 800–1500-row covering LPs, where it dominated the whole solve. The basis is
-    // scaling-invariant and `sp`/`c` are unscaled, so `y` is the unscaled dual the
-    // integer bound fixing needs. A singular basis ⇒ `None` (sound: just no fixing).
-    let mut lu = FeralLU::new();
-    let cols: Vec<Vec<(usize, f64)>> = basis
-        .basic_vars
-        .iter()
-        .map(|&bv| {
-            let (rows, vals) = sp.col(bv);
-            rows.iter().zip(vals).map(|(&r, &v)| (r, v)).collect()
-        })
-        .collect();
-    if lu.factorize_sparse(m, &cols).is_err() {
-        return None;
-    }
-    let mut y: Vec<f64> = basis.basic_vars.iter().map(|&bv| c[bv]).collect();
-    if lu.btran(&mut y).is_err() || !y.iter().all(|v| v.is_finite()) {
-        return None;
-    }
+    // Node duals `y = B⁻ᵀ c_B`. The LP solve already computed exactly this vector
+    // from its own final factorization and exported it as `LpSolve::dual` (both the
+    // warm dual and the cold primal fill it on `Optimal`), so #1066 takes it as-is
+    // instead of rebuilding the basis' sparse LU from scratch. That rebuild was a
+    // second full factorization *per node* — on rsyn0820m02m it was 47% of every LU
+    // factorization in the solve — spent recomputing a value already in hand.
+    //
+    // The fallback below is not dead: `dual` is empty when the solve's own btran
+    // failed, and `DISCOPT_MILP_RC_FIX_REFACTOR=1` forces it so the two paths can be
+    // differentially tested against each other. It uses the *sparse* LU (factorize
+    // O(nnz) + btran), not a dense m×m refactor: the earlier dense `solve_dense` was
+    // O(m³) per node, trivial on few-row knapsacks but ruinous on 800–1500-row
+    // covering LPs. Either way the basis is scaling-invariant and `sp`/`c` are
+    // unscaled, so `y` is the unscaled dual the integer bound fixing needs, and a
+    // singular basis ⇒ `None` (sound: just no fixing).
+    let y: Vec<f64> =
+        if !rc_fix_force_refactor() && dual.len() == m && dual.iter().all(|v| v.is_finite()) {
+            crate::profile::incr(crate::profile::Ctr::RcFixDualReuse);
+            dual.to_vec()
+        } else {
+            crate::profile::incr(crate::profile::Ctr::RcFixRefactor);
+            let mut lu = FeralLU::new();
+            let cols: Vec<Vec<(usize, f64)>> = basis
+                .basic_vars
+                .iter()
+                .map(|&bv| {
+                    let (rows, vals) = sp.col(bv);
+                    rows.iter().zip(vals).map(|(&r, &v)| (r, v)).collect()
+                })
+                .collect();
+            if lu.factorize_sparse(m, &cols).is_err() {
+                return None;
+            }
+            let mut y: Vec<f64> = basis.basic_vars.iter().map(|&bv| c[bv]).collect();
+            if lu.btran(&mut y).is_err() || !y.iter().all(|v| v.is_finite()) {
+                return None;
+            }
+            y
+        };
 
     let mut new_l = l[..ns].to_vec();
     let mut new_u = u[..ns].to_vec();
@@ -3160,6 +3209,191 @@ pub fn solve_milp_csc(
 mod tests {
     use super::*;
 
+    // ---- #1066: reduced-cost fixing reuses the LP's own duals ----
+
+    /// A small covering-style LP with integer structurals, in the driver's working
+    /// form `A x = b, l <= x <= u` (explicit slacks), plus an incumbent loose enough
+    /// that the gap actually admits fixings.
+    fn rc_fix_fixture() -> (
+        SparseCols,
+        usize,
+        usize,
+        Vec<f64>,
+        Vec<f64>,
+        Vec<f64>,
+        Vec<f64>,
+    ) {
+        // min  4a + 3b + 5c   s.t.  a + b + c >= 1,  a + 2b + 4c >= 1,  0 <= . <= 3
+        // Rows carry surplus columns (coefficient -1) to reach equality form.
+        //
+        // The upper bound is 3, not 1, on purpose: with a unit box the optimum puts
+        // `b` ON its bound, so every integer column comes back nonbasic-at-bound or
+        // basic-and-skipped and reduced-cost fixing has nothing to fix. Here the
+        // optimum is `b = 1` (basic, interior), `a = c = 0` at their lower bounds
+        // with strictly positive reduced costs 1 and 2 -- so the fixing actually
+        // bites and a test over this fixture is not vacuous (CLAUDE.md §6).
+        let (ns, m) = (3usize, 2usize);
+        let n = ns + m;
+        let mut dense = vec![0.0f64; m * n];
+        let rows = [[1.0, 1.0, 1.0], [1.0, 2.0, 4.0]];
+        for (i, r) in rows.iter().enumerate() {
+            for (j, v) in r.iter().enumerate() {
+                dense[i * n + j] = *v;
+            }
+            dense[i * n + ns + i] = -1.0;
+        }
+        let sp = SparseCols::from_dense(&dense, m, n);
+        let c = vec![4.0, 3.0, 5.0, 0.0, 0.0];
+        let b = vec![1.0, 1.0];
+        let l = vec![0.0; n];
+        let u = vec![3.0, 3.0, 3.0, INF, INF];
+        (sp, m, ns, c, b, l, u)
+    }
+
+    #[test]
+    fn rc_fix_reuses_the_solve_duals_and_matches_the_refactor_path() {
+        // The #1066 claim: the duals the LP solve exports ARE `y = B^-T c_B`, so
+        // reusing them must produce exactly the fixings the from-scratch sparse
+        // refactorization produced. If the two disagree the reuse is not a
+        // bound-neutral refactor and must not ship.
+        let (sp, m, ns, c, b, l, u) = rc_fix_fixture();
+        let n = l.len();
+        let opts = SimplexOptions::default();
+        let sol = crate::lp::simplex::solve_lp_cols(sp.clone(), m, n, &c, &l, &u, &b, &opts);
+        assert_eq!(sol.status, LpStatus::Optimal, "fixture LP must solve");
+        assert_eq!(
+            sol.dual.len(),
+            m,
+            "Optimal must export row duals (#1066 rests on it)"
+        );
+        let is_int = vec![true, true, true, false, false];
+
+        let mut checks = 0;
+        let mut fixed = 0;
+        // Sweep incumbents so the gap ranges from tight (fixings bite) to loose
+        // (none do): both regimes must agree, not just the one that happens to fix.
+        for k in 0..12 {
+            let incumbent = sol.obj + 0.25 * k as f64;
+            let reuse = reduced_cost_fix(
+                &sp, m, &c, &sol.basis, &sol.dual, sol.obj, incumbent, &l, &u, ns, &is_int,
+                opts.tol,
+            );
+            // An empty `dual` is exactly what a failed btran leaves behind, and it
+            // is what drives the legacy from-scratch factorization branch.
+            let refac = reduced_cost_fix(
+                &sp,
+                m,
+                &c,
+                &sol.basis,
+                &[],
+                sol.obj,
+                incumbent,
+                &l,
+                &u,
+                ns,
+                &is_int,
+                opts.tol,
+            );
+            assert_eq!(
+                reuse.is_some(),
+                refac.is_some(),
+                "k={k}: the two dual sources disagree on whether anything was fixed"
+            );
+            if let (Some((rl, ru)), Some((fl, fu))) = (reuse, refac) {
+                assert_eq!(rl, fl, "k={k}: lower bounds differ between dual sources");
+                assert_eq!(ru, fu, "k={k}: upper bounds differ between dual sources");
+                fixed += 1;
+            }
+            checks += 1;
+        }
+        assert_eq!(checks, 12, "probe must have compared every incumbent");
+        // Agreement on twelve `None`s would be agreement about nothing: at least one
+        // rung must actually have produced a fixing for the comparison to mean
+        // anything (CLAUDE.md §6).
+        assert!(
+            fixed >= 1,
+            "no incumbent on the ladder produced a fixing at all"
+        );
+    }
+
+    #[test]
+    fn rc_fix_with_solve_duals_does_not_factorize() {
+        // The point of the change is the factorization it removes; without a probe
+        // for it the reuse could silently fall through to the legacy branch on every
+        // node and read exactly like a working optimization (CLAUDE.md §6).
+        //
+        // The discriminator is a deliberately SINGULAR basis: `basic_vars` is every
+        // column set to the same index, so `factorize_sparse` cannot succeed. Only
+        // the legacy branch touches `basic_vars` (the reuse branch reads `dual` and
+        // `col_status` alone), so "still returns a fixing" is proof that no
+        // factorization was attempted. This is checked on the return value rather
+        // than a `profile` counter on purpose: `ENABLED` and the counter arrays are
+        // process-global and `solve_milp` calls `init_from_env()` on entry, so any
+        // driver test on a sibling thread disarms a counter-based probe mid-flight
+        // and it reads 0 -- the exact §6 failure the counters were added to catch.
+        let (sp, m, ns, c, b, l, u) = rc_fix_fixture();
+        let n = l.len();
+        let opts = SimplexOptions::default();
+        let sol = crate::lp::simplex::solve_lp_cols(sp.clone(), m, n, &c, &l, &u, &b, &opts);
+        assert_eq!(sol.status, LpStatus::Optimal);
+        assert_eq!(
+            sol.dual.len(),
+            m,
+            "Optimal must export row duals (#1066 rests on it)"
+        );
+        let is_int = vec![true, true, true, false, false];
+
+        let mut singular = sol.basis.clone();
+        for bv in singular.basic_vars.iter_mut() {
+            *bv = 0;
+        }
+        // Sweep the same incumbent ladder as the sibling test: with the basis
+        // sabotaged, the legacy path can never return a fixing, while the reuse path
+        // must still return the ones the intact basis produced -- at least one of
+        // them, or the probe would pass vacuously on a ladder where nothing fixes.
+        let mut reuse_fixed = 0;
+        let mut refac_attempts = 0;
+        for k in 0..12 {
+            let incumbent = sol.obj + 0.25 * k as f64;
+            assert!(
+                reduced_cost_fix(
+                    &sp,
+                    m,
+                    &c,
+                    &singular,
+                    &[],
+                    sol.obj,
+                    incumbent,
+                    &l,
+                    &u,
+                    ns,
+                    &is_int,
+                    opts.tol,
+                )
+                .is_none(),
+                "k={k}: a singular basis must defeat the refactor path -- otherwise \
+                 this test cannot tell the two paths apart"
+            );
+            refac_attempts += 1;
+            if reduced_cost_fix(
+                &sp, m, &c, &singular, &sol.dual, sol.obj, incumbent, &l, &u, ns, &is_int, opts.tol,
+            )
+            .is_some()
+            {
+                reuse_fixed += 1;
+            }
+        }
+        assert_eq!(
+            refac_attempts, 12,
+            "probe must have exercised every incumbent"
+        );
+        assert!(
+            reuse_fixed >= 1,
+            "with the solve's own duals in hand, reduced-cost fixing must produce a \
+             fixing without ever factorizing the basis (0/12 did)"
+        );
+    }
+
     // ---- #1060: the no-incumbent continuous-repair dive schedule ----
 
     #[test]
@@ -3798,6 +4032,87 @@ mod tests {
         assert!(
             !verify_farkas_infeasible(&[1.0], &a2, &b2, &l2, &u2, 1, 2),
             "a feasible box must not be certified empty by any ray"
+        );
+    }
+
+    /// #1066 regression. The driver verifies the node's Farkas ray against the
+    /// *scaled* batch CSC (`ctx.csc`, `ctx.sb`, scaled node bounds), so `sol.dual`
+    /// must stay in solve-space coordinates all the way to that arm. An earlier cut
+    /// of the reduced-cost-fixing change unscaled `sol.dual` in place right after
+    /// the node solve; the ray then no longer matched the matrix it was checked
+    /// against, every verification failed, and provably empty nodes stopped being
+    /// fathomed — sound (the bound only ever got weaker) but ruinous, turning a
+    /// one-node refutation into a full branch-out. Pinned here on node count.
+    ///
+    /// The model is LP-infeasible but not row-wise infeasible (`x0 + x1 >= 1.5` and
+    /// `x0 + x1 <= 0.5` with `x0, x1` binary), with presolve and node propagation
+    /// off so nothing but the LP's own certificate can refute it, and a 1e8 value
+    /// range so `Scaling::from_sparse` actually returns `Some` — asserted in the
+    /// fixture, because without it the scaled path is never entered and the test
+    /// proves nothing.
+    #[test]
+    fn rc_fix_dual_unscale_does_not_break_the_node_farkas_fathom() {
+        // The two refuting rows carry deliberately non-unit magnitudes (2^-10 and
+        // 2^10) so equilibration gives them non-unit ROW factors — without that the
+        // scaled and unscaled rays coincide on exactly the rows the certificate
+        // uses and the coupling under test is invisible. A third, harmless row adds
+        // the 1e8 entry that pushes the dynamic range past `SCALE_TRIGGER` (1e6).
+        let k0 = 2f64.powi(-10);
+        let k1 = 2f64.powi(10);
+        let a = [
+            k0, k0, 0.0, -k0, 0.0, 0.0, // x0 + x1 - s0 = 1.5  (x0 + x1 >= 1.5)
+            k1, k1, 0.0, 0.0, k1, 0.0, // x0 + x1 + s1 = 0.5  (x0 + x1 <= 0.5)
+            0.0, 0.0, 1e8, 0.0, 0.0, 1.0, // 1e8·x2 + s2 = 1e8    (feasible; sets the range)
+        ];
+        let b = [1.5 * k0, 0.5 * k1, 1e8];
+        let c = [0.0; 6];
+        let l = [0.0; 6];
+        let u = [1.0, 1.0, 1.0, INF, INF, INF];
+        assert!(
+            Scaling::from_sparse(&SparseCols::from_dense(&a, 3, 6), 3, 6).is_some(),
+            "fixture must actually trigger equilibration or the scaled path is untested"
+        );
+        let lp = LpView {
+            a: &a,
+            m: 3,
+            n: 6,
+            c: &c,
+            l: &l,
+            u: &u,
+        };
+        let o = MilpOptions {
+            n_struct: 3,
+            integer_cols: vec![0, 1, 2],
+            max_nodes: 5_000,
+            time_limit_s: None,
+            gap_tol: 1e-9,
+            root_cuts: 0,
+            cut_rounds: 1,
+            gmi_cuts: false,
+            cut_select: false,
+            node_cuts: false,
+            max_pool_cuts: 0,
+            heuristics: false,
+            presolve: false,
+            node_propagation: false,
+            strong_branch: false,
+            reduced_cost_fixing: true,
+            sb_max_cands: 0,
+            sb_node_budget: 0,
+            initial_incumbent: None,
+            simplex: SimplexOptions::default(),
+        };
+        let r = solve_milp(&lp, &b, 0.0, &o);
+        assert_eq!(
+            r.status,
+            MilpStatus::Infeasible,
+            "status (nodes {})",
+            r.nodes
+        );
+        assert_eq!(
+            r.nodes, 1,
+            "the ROOT ray must refute the model outright; branching at all means the \
+             scaled certificate was checked in the wrong coordinates"
         );
     }
 

--- a/crates/discopt-core/src/profile.rs
+++ b/crates/discopt-core/src/profile.rs
@@ -96,6 +96,12 @@ timed_phases!(
     // LP basis changes by one column per pivot); `LuNumeric` is `SparseLu::factor`
     // (the actual elimination). "Refactorization is 59.5% of wall" does not say
     // which half, and the two have completely different fixes.
+    // #1066: reduced-cost (objective) fixing at a node. It runs *outside* the
+    // `NodeLpSolve` timer, so a per-node cost hidden here reads as "unaccounted"
+    // wall in every previous phase split. Measured because the pass used to
+    // rebuild the node basis' sparse LU from scratch purely to recover duals the
+    // solve had already returned.
+    RedCostFix,
     LuSymbolic,
     LuNumeric,
 );
@@ -147,6 +153,15 @@ counters!(
     // — numerical breakdown / iteration cap on a *valid* warm start, i.e. the
     // "engine swap" the framework-LP-error-handling policy of #376 would try to
     // pre-empt by escalating in place). The ratio is the escalation headroom.
+    // #1066 reduced-cost fixing: how the node duals `y = B⁻ᵀc_B` were obtained.
+    // `RcFixDualReuse` = taken from the LP solve's own certificate (the basis was
+    // already factorized to produce it); `RcFixRefactor` = the fallback that
+    // rebuilds the sparse LU and btrans, taken only when the solve exported no
+    // usable dual (btran failure) or the opt-out env forces it. The pair is the
+    // audit that the reuse is actually happening (CLAUDE.md §6) — without it a
+    // silently-always-refactoring path reads exactly like a working one.
+    RcFixDualReuse,
+    RcFixRefactor,
     DualWarmSolves,
     DualColdFallbacks,
     // Warm dual-simplex stall-guard trips (discopt F2): a warm re-solve that hit

--- a/docs/dev/performance-plan.md
+++ b/docs/dev/performance-plan.md
@@ -3731,3 +3731,143 @@ or the per-node effort limit is itself bound-changing and would invalidate the
 measurement for whoever tunes the cut stage next: the lever to test first is
 per-node NLP iteration effort under appended GMI/c-MIR rows, **not** the cut
 count.
+
+> **Falsified (2026-08-20, issue #1066 — "the throttled MILP default cut budget
+> is what leaves the convex rsyn/syn/squfl class uncertified").** After #1102
+> made the root cut loop warm dual re-optimize each round instead of cold-solving
+> the augmented LP, the Python-facing default (`root_cuts=16, cut_rounds=1,
+> cut_select=False`, set in the three pyo3 signatures at
+> `crates/discopt-python/src/lp_bindings.rs:1009/1116/1238`) looked like a
+> throttle held on for a cost that no longer exists. Entry experiment before any
+> implementation, per Dev-Philosophy #4: `/tmp/mono/ab_cutbudget.py`, 16 instances
+> drawn by *family prefix* (`rsyn`, `syn`, `clay`, `batchs`, `fac`) filtered to
+> those with a `minlplib.solu` oracle and evenly strided — never by naming
+> instances (#2) — arms interleaved per instance (#9), arm B injecting
+> `root_cuts=500, cut_rounds=15, cut_select=True` by wrapping the Rust entry point
+> so nothing but the four cut arguments differs. **Kill criterion, stated in the
+> script docstring before the run:** arm B must certify *strictly more* instances
+> than arm A with no soundness or certification regression.
+>
+> **Result: `SOLVED_OPTIMAL A=5 B=5 of 16`, `CHECKS_EXECUTED 72`, `VIOLATIONS 0`.**
+> Load gate (#9): the first attempt was **discarded** at load 73 on a 14-core box
+> — an unrelated `cargo test --workspace --release` held ~10 cores and starved the
+> probe to 26% CPU — and re-run behind a load gate; the scored run sampled
+> load1 every 60 s across its own execution: `n=23 min=3.90 median=9.59 max=12.25`.
+>
+> The budget **does** work as a cut mechanism, and that is exactly what makes the
+> negative result informative. Over the 9 instances with a nontrivial root gap,
+> arm B closes a **median 23.7%** of arm A's root gap (max 36.3% on
+> `rsyn0820m02m`, 33.7% on `rsyn0815m02m`). It is not enough to matter, because
+> the gaps it is closing are enormous:
+>
+> | instance | root gap, arm A | root gap, arm B | closed | nodes in 60 s |
+> |---|---|---|---|---|
+> | rsyn0805m02m | 57.1% | 44.7% | 21.6% | 3 |
+> | rsyn0810m02m | 165.7% | 136.7% | 17.5% | 7 |
+> | rsyn0815m02m | 147.4% | 97.7% | 33.7% | 15 |
+> | rsyn0820m02m | 338.4% | 215.5% | 36.3% | 3 |
+> | rsyn0830m02m | 399.8% | 304.5% | 23.8% | 3 |
+> | rsyn0840m02m | 516.2% | 394.0% | 23.7% | 3 |
+> | syn30m02m | 126.9% | 95.7% | 24.6% | 31 |
+> | syn40m02m | 312.7% | 312.7% | 0.0% | 15 |
+>
+> Arm B is also **not** uniformly sound-and-neutral elsewhere: it lost
+> `clay0205hfsg`'s incumbent outright (`feasible` obj 24140 → `time_limit` obj
+> `nan`, on *more* nodes: 337 vs 305), returned a `nan` dual bound on `faclay35`
+> where arm A returned a finite one, and cost 21x wall on the easy `fac1`
+> (0.1 s / 0 nodes → 2.1 s / 7 nodes) and 5.7x on `syn15m02m`. Cert-clean but
+> neither broadly helpful nor free — the `DISCOPT_CUT_INHERIT` disposition
+> exactly (Dev-Philosophy #5: sound ≠ helpful). **The default is unchanged.**
+>
+> **Re-scope — the measurement points somewhere else entirely.** The column that
+> matters in the table above is the last one. The rsyn family explores **3 nodes
+> in 60 seconds**: 0.05 nodes/s, i.e. ~20 s *per node*, and `faclay35` manages
+> 1 node in 62 s (0.02 nodes/s). No root cut of any strength closes a 394% gap
+> from three nodes; SCIP and BARON solve these same instances in 0.2–48 s. The
+> binding constraint on the #1066 class is **per-node cost on the convex-MINLP
+> route**, not cut strength, and any further work on root cut budgets for this
+> class is premature until node throughput is within an order of magnitude of the
+> reference solvers. Measured throughput on the 11 time-limited rows for whoever
+> picks this up: 0.02–0.24 nodes/s on rsyn/faclay, 0.25–0.51 on syn30/40m02m,
+> 1.77 on batchs101006m, 5.05 on clay0205hfsg.
+
+### #1066 — the per-node cost was a duplicated LU factorization (2026-08-20)
+
+Following the re-scope above ("the binding constraint on the #1066 class is
+per-node cost"), the hypothesis was that the convex-MINLP route pays a redundant
+basis factorization per node. Stated before the run: the entry experiment is a
+`DISCOPT_PROFILE` counter split of one 60 s solve of `rsyn0820m02m`; the kill
+criterion is that the LU-factorization count per warm dual solve comes out at or
+below 1.0, which would mean nothing is duplicated and the cost is intrinsic.
+
+It did not. The counters read **2.15–2.20 sparse LU factorizations per warm dual
+solve** across three reps — one full refactorization per node beyond the one the
+warm dual start already pays. The extra one was `reduced_cost_fix`
+(`bnb/milp_driver.rs`): it rebuilt the node basis' sparse LU from scratch and
+btran'd it to recover `y = B⁻ᵀc_B`, a vector **the LP solve had already computed
+from its own final factorization** and exported as `LpSolve::dual` (both the warm
+dual and the cold primal fill it on `Optimal`). A new `Phase::RedCostFix` timer —
+the pass runs *outside* `NodeLpSolve`, which is why every earlier phase split
+booked it as unaccounted wall — priced it directly.
+
+#### Retraction: the first cut of this change broke the node Farkas fathom
+
+The first implementation unscaled `sol.dual` **in place** right after the node
+solve, on the reasoning that reduced-cost fixing was "the only consumer below".
+It is not. The `LpStatus::Infeasible` arm verifies the node's Farkas ray against
+the *scaled* batch CSC (`ctx.csc`, `ctx.sb`, scaled node bounds), so an unscaled
+ray no longer matches the data it is checked against: every verification failed
+and provably empty nodes stopped being fathomed. Sound — the arm's failure path
+returns a non-pruning `-inf` bound, so no optimum can be cut — but ruinous, and
+it wedged a `pytest -m smoke` run for >20 minutes inside a single MILP solve.
+
+The numbers first recorded here (2.17/2.15 LU per warm solve, +71% throughput)
+were measured on that broken cut and are **withdrawn**; the table below replaces
+them. The A/B gate did not catch it because both arms carried the in-place
+unscale — `DISCOPT_MILP_RC_FIX_REFACTOR` only selects the dual *source*, so a
+defect in code common to both arms is invisible to it. Lesson for the next
+differential flag: an env-var A/B tests the branch, never the code the branch
+shares with its control.
+
+The shipped fix leaves `sol.dual` in solve-space and unscales a private copy at
+the reduced-cost-fixing call site. `rc_fix_dual_unscale_does_not_break_the_node_farkas_fathom`
+pins it: an LP-infeasible model with non-unit row factors that the root ray must
+refute in one node — 3 nodes with the in-place unscale restored, 1 without.
+
+#### Measurement (corrected)
+
+Interleaved A/B, same binary, three reps, `DISCOPT_MILP_RC_FIX_REFACTOR=1`
+(legacy) vs default (reuse), `rsyn0820m02m`, 60 s, thread-summed phase times.
+Load average 9.9 before / 13.0 after — elevated by an unrelated process on the
+box, which is what the `pA2` outlier is:
+
+| metric | A r1 | A r2 | A r3 | B r1 | B r2 | B r3 |
+|---|---|---|---|---|---|---|
+| `RedCostFix` ms | 103,246 | 79,893 | 105,083 | **339** | **338** | **328** |
+| node LPs (`NodeLpSolve`) | 34,239 | 18,990 | 38,335 | 59,433 | 61,266 | 58,559 |
+| `DualWarmSolves` | 37,668 | 22,499 | 41,912 | 64,241 | 66,376 | 64,019 |
+| `LuSparseFactorizations` | 81,368 | 49,551 | 89,912 | 71,373 | 73,525 | 71,167 |
+| LU per warm solve | 2.16 | 2.20 | 2.15 | **1.111** | **1.108** | **1.112** |
+| wall (s) | 60.32 | 60.50 | 60.20 | 60.31 | 60.21 | 60.23 |
+| objective | −39.531007606231725 in all six runs | | | | | |
+| MINLP nodes | 3 in all six runs | | | | | |
+
+Reduced-cost fixing went from **96.1 s of mean thread time to 335 ms** (~290x).
+Node-LP throughput rose from a median 34.2k to 59.4k in the same ~60.3 s wall,
+**+74% on medians** (+96% on means; arm A's spread is 10.2k against arm B's 1.4k,
+so the median is the number to quote). The LU-per-warm-solve ratio is the robust
+statistic here — it is a within-run ratio, immune to the load that moved arm A's
+absolute counts, and it drops 2.15–2.20 → 1.108–1.112.
+
+Wall is pinned at the limit on this instance either way, so throughput — not wall
+— is the signal; scoring time-limited and certified instances together is how a
+panel like this reads as "no change".
+
+Bound-neutrality gate (`python/tests/data/minlplib_nl`, 66 instances, 20 s each,
+scored only where BOTH arms certify): `CERTIFIED_BOTH 48`, `CHECKS_EXECUTED 96`,
+`DRIFT 0` — every certified objective within 1e-9 relative and every node count
+exactly equal.
+
+Disposition: bound-neutral (§5 regime 1), default-on, legacy path retained as the
+fallback for an empty `dual` and reachable via `DISCOPT_MILP_RC_FIX_REFACTOR=1`
+for the differential test.


### PR DESCRIPTION
## What

`reduced_cost_fix` (`bnb/milp_driver.rs`) rebuilt the node basis' sparse LU from
scratch and btran'd it to recover `y = B^-T c_B` -- a vector the LP solve had
already computed from its own final factorization and exported as
`LpSolve::dual` (both the warm dual and the cold primal fill it on `Optimal`).
One redundant full sparse factorization per node, on every MILP node that runs
reduced-cost fixing.

This takes the exported duals when they are present and finite. The
from-scratch path is kept, not deleted: it is the fallback when `dual` is empty
(a failed btran leaves it so) and is reachable via
`DISCOPT_MILP_RC_FIX_REFACTOR=1` so the two dual sources can be differentially
tested against each other.

### The scaling coupling (worth reading before reviewing)

The duals come back in the **scaled** solve space. The `LpStatus::Infeasible`
arm right below verifies the node's Farkas ray against the *scaled* batch CSC
(`ctx.csc`, `ctx.sb`, scaled node bounds), so `sol.dual` must stay in solve-space
coordinates; reduced-cost fixing, which reads the unscaled working matrix,
unscales a private copy at its own call site.

The first cut of this change unscaled `sol.dual` in place instead. Every ray
verification then failed, provably empty nodes stopped being fathomed, and a
`pytest -m smoke` run wedged for >20 minutes inside a single MILP solve. It was
sound -- the arm's failure path returns a non-pruning `-inf` bound, so no optimum
can be cut -- but it is exactly the kind of silent slowdown that is hard to see.
`rc_fix_dual_unscale_does_not_break_the_node_farkas_fathom` pins it: 1 node with
the fix, 3 without (verified by restoring the in-place unscale).

Note the A/B env flag could not have caught this: `DISCOPT_MILP_RC_FIX_REFACTOR`
selects the dual *source*, and both arms carried the in-place unscale, so a
defect in the shared code was invisible to the differential gate.

## Also in this PR

- `Phase::RedCostFix`. The pass runs *outside* the `NodeLpSolve` timer, which is
  why every earlier phase split booked this cost as unaccounted wall.
- `Ctr::RcFixDualReuse` / `Ctr::RcFixRefactor` -- which branch actually ran, so
  "the reuse silently never fires" is not indistinguishable from a working
  optimization (CLAUDE.md §6).

## Verification

**Correctness (CLAUDE.md §5, bound-neutral regime).** Bound-neutrality gate over
`python/tests/data/minlplib_nl` (66 instances, 20 s each), default vs
`DISCOPT_MILP_RC_FIX_REFACTOR=1`, scored only where BOTH arms certify (a
timed-out instance has no certificate to compare):

```
CERTIFIED_BOTH 48
CHECKS_EXECUTED 96
DRIFT 0
```

Every certified objective within 1e-9 relative and every node count exactly
equal. Kill criterion was stated before the run: any certified objective moving
beyond 1e-9 relative, or any node-count difference, kills the change.

**Suites.**

| suite | result |
|---|---|
| `cargo test -p discopt-core --release` | 638 passed, 0 failed |
| `pytest -m smoke` | 1104 passed, 1 skipped, 9138 deselected, 2 xpassed (137.92s) |
| `pytest -m slow python/tests/test_adversarial_recent_fixes.py` | 19 passed (156.80s) |
| `cargo fmt -p discopt-core -- --check` | clean |

The full cargo suite was run three times to check the new tests are not flaky
(638/638 each time).

**Performance.** Interleaved A/B, same binary, three reps,
`DISCOPT_MILP_RC_FIX_REFACTOR=1` (legacy) vs default (reuse), `rsyn0820m02m`,
60 s, thread-summed phase times. Load average 9.9 before / 13.0 after -- elevated
by an unrelated process on the box, which is what the `A r2` outlier is:

| metric | A r1 | A r2 | A r3 | B r1 | B r2 | B r3 |
|---|---|---|---|---|---|---|
| `RedCostFix` ms | 103,246 | 79,893 | 105,083 | **339** | **338** | **328** |
| node LPs (`NodeLpSolve`) | 34,239 | 18,990 | 38,335 | 59,433 | 61,266 | 58,559 |
| `DualWarmSolves` | 37,668 | 22,499 | 41,912 | 64,241 | 66,376 | 64,019 |
| `LuSparseFactorizations` | 81,368 | 49,551 | 89,912 | 71,373 | 73,525 | 71,167 |
| LU per warm solve | 2.16 | 2.20 | 2.15 | **1.111** | **1.108** | **1.112** |
| wall (s) | 60.32 | 60.50 | 60.20 | 60.31 | 60.21 | 60.23 |

Objective was `-39.531007606231725` and the MINLP node count was 3 in all six
runs. Reduced-cost fixing: **96.1 s mean thread time to 335 ms (~290x)**.
Node-LP throughput: median **34.2k to 59.4k (+74%)** in the same ~60.3 s wall
(+96% on means; arm A's spread is 10.2k against arm B's 1.4k, so the median is
the number to quote). The LU-per-warm-solve ratio is the robust statistic --
within-run, immune to the load that moved arm A's absolute counts.

Wall is pinned at the time limit on this instance in both arms, so throughput,
not wall, is the signal.

## Scope

This is a per-node-cost fix on the MILP master. It does **not** on its own
certify the #1066 instance set -- `rsyn0820m02m` still returns `feasible` at 3
MINLP nodes after 60 s -- so `Contributes to #1066`, which stays open.

`docs/dev/performance-plan.md` carries the full record, including a written
retraction of the numbers first recorded there from the broken cut (CLAUDE.md
§11).
