### PR TITLE
fix(oa): #1105 shared deadline for every MIP-NLP subsolve; honest no-incumbent result

### DIFF
--- a/python/discopt/modeling/core.py
+++ b/python/discopt/modeling/core.py
@@ -4853,7 +4853,15 @@ class Model:
         # in ``solver.py`` so the two cannot drift; spelling it inline as ``tol=1e-3``
         # loosened only the absolute leg and made the screen scale-blind on
         # large-magnitude rows (#1061).
-        if _verify_snap is not None and result.x is not None:
+        # ``result.x`` is truth-tested, not ``is not None``-tested: a solver that
+        # reports "no incumbent" as an EMPTY DICT rather than ``None`` (every
+        # no-incumbent exit of the MIP-NLP/OA route did, #1105) sails past an
+        # ``is not None`` check and reaches the ``result.x[_n]`` lookup below,
+        # which raises ``KeyError: 'x0'``. That lands in the ``except`` arm, so
+        # the user is told the incumbent is "UNSCREENED" for a solve that has no
+        # incumbent at all -- a soundness warning fired on a result where there
+        # was nothing to screen. Screening runs only when an incumbent exists.
+        if _verify_snap is not None and result.x:
             try:
                 import numpy as _np
 
@@ -4921,7 +4929,7 @@ class Model:
                     _exp_exc,
                 )
 
-        if validate and result.x is not None:
+        if validate and result.x:  # same no-incumbent guard as above (#1105)
             try:
                 from discopt.validation.examiner import examine
 

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -7374,7 +7374,11 @@ def solve_model(
         if (
             _mip_nlp_result is not None
             and model is _pre_route_model
-            and _routed_x is not None
+            # Truth-tested, not ``is not None``: an empty dict is a no-incumbent
+            # result, and recovering duals "at the incumbent" of a solve that has
+            # none is meaningless -- it only raised a KeyError into the debug-level
+            # ``except`` below, so the miss was invisible (#1105).
+            and _routed_x
             and getattr(_mip_nlp_result, "constraint_duals", None) is None
         ):
             try:

--- a/python/discopt/solvers/gdpopt_loa.py
+++ b/python/discopt/solvers/gdpopt_loa.py
@@ -365,7 +365,7 @@ def solve_gdpopt_loa(
             objective=None,
             bound=bound,
             gap=None,
-            x={},
+            x=None,  # no incumbent -- see SolveResult.x's contract (#1105)
             wall_time=wall_time,
             gap_certified=False,
         )
@@ -379,7 +379,7 @@ def solve_gdpopt_loa(
             objective=None,
             bound=bound,
             gap=None,
-            x={},
+            x=None,  # no incumbent -- see SolveResult.x's contract (#1105)
             wall_time=wall_time,
         )
 
@@ -391,7 +391,7 @@ def solve_gdpopt_loa(
         objective=None,
         bound=bound,
         gap=None,
-        x={},
+        x=None,  # no incumbent -- see SolveResult.x's contract (#1105)
         wall_time=wall_time,
         gap_certified=False,
     )

--- a/python/discopt/solvers/oa.py
+++ b/python/discopt/solvers/oa.py
@@ -1369,6 +1369,34 @@ def _is_primal_feasible(evaluator, x, tol: float = 1e-4) -> bool:
         return False
 
 
+#: Smallest wall budget handed to a subsolve. A budget of zero (or a negative
+#: one, once the deadline has already passed) is not "run instantly" to POUNCE
+#: -- it is an option value the backend may reject, which silently restores the
+#: UNBOUNDED behaviour this floor exists to prevent. Call sites that can skip
+#: the subsolve entirely check the deadline themselves; this floor only keeps a
+#: subsolve that *must* run from being handed a degenerate limit.
+_NLP_WALL_FLOOR_S = 0.1
+
+
+def _time_left(t_start: float, time_limit: float) -> float:
+    """Unfloored seconds left before ``t_start + time_limit`` (negative once past)."""
+    return float(time_limit) - (time.perf_counter() - float(t_start))
+
+
+def _remaining_wall(t_start: float, time_limit: float) -> float:
+    """Seconds left before ``t_start + time_limit``, floored at ``_NLP_WALL_FLOOR_S``.
+
+    The single source of the MIP-NLP deadline contract (#1105): every subsolve
+    launched inside a time-limited MIP-NLP region takes its wall budget from
+    here, so ``time_limit`` covers the whole run rather than each phase
+    separately. Before this existed the fixed-NLP, feasibility-restoration and
+    initialization NLPs ran with no budget at all -- on ``kondili_recipe_pr46``
+    a single feasibility subproblem launched at t=22 s ran 69.85 s against a
+    60 s limit, and the solve returned at 92.4 s (1.54x).
+    """
+    return max(_time_left(t_start, time_limit), _NLP_WALL_FLOOR_S)
+
+
 def _solve_nlp_attempt(
     evaluator,
     lb,
@@ -1376,8 +1404,17 @@ def _solve_nlp_attempt(
     nlp_solver: str,
     max_iter: int = 200,
     x0=None,
+    max_wall_time: Optional[float] = None,
 ) -> _NLPAttempt:
-    """Solve an NLP with given bounds, retaining solver multipliers."""
+    """Solve an NLP with given bounds, retaining solver multipliers.
+
+    ``max_wall_time`` is the subsolve's share of the caller's deadline, in
+    seconds. Measured on POUNCE 0.10 (``scratchpad/issue1105/probe_maxwall.py``,
+    400-var nonconvex NLP): unbounded 25.72 s, ``max_wall_time=0.5`` -> 0.517 s,
+    ``max_wall_time=2.0`` -> 2.073 s, both returning ``TIME_LIMIT``. Leaving it
+    ``None`` keeps the historical unbounded behaviour for callers with no
+    deadline of their own.
+    """
     if x0 is None:
         x0 = _default_nlp_start(lb, ub)
     else:
@@ -1400,6 +1437,8 @@ def _solve_nlp_attempt(
         opts = pounce_option_defaults()
         opts.update(pounce_incumbent_options())
         opts.update({"max_iter": max_iter})
+        if max_wall_time is not None:
+            opts["max_wall_time"] = max(float(max_wall_time), _NLP_WALL_FLOOR_S)
         result = solve_nlp(evaluator, x0, options=opts)
 
         from discopt.solvers import SolveStatus
@@ -1412,10 +1451,19 @@ def _solve_nlp_attempt(
                 status=result.status,
             )
 
-        # Accept iteration-limited results if the solution is primal feasible.
-        # The IPM may not certify dual convergence (code 4: stalled) yet still
-        # find a valid primal point, which is sufficient for OA linearization cuts.
-        if result.status == SolveStatus.ITERATION_LIMIT and result.x is not None:
+        # Accept iteration- and time-limited results if the solution is primal
+        # feasible. The IPM may not certify dual convergence (code 4: stalled)
+        # yet still find a valid primal point, which is sufficient for OA
+        # linearization cuts. ``TIME_LIMIT`` joined this set with #1105: once a
+        # subsolve carries a wall budget, stopping on the clock is the ordinary
+        # outcome, and dropping a feasible point purely because the clock (not
+        # the iteration counter) stopped it would lose incumbents the unbounded
+        # code path used to find. The point is screened by
+        # ``_is_primal_feasible`` either way, so nothing infeasible is admitted.
+        if (
+            result.status in (SolveStatus.ITERATION_LIMIT, SolveStatus.TIME_LIMIT)
+            and result.x is not None
+        ):
             if _is_primal_feasible(evaluator, result.x):
                 return _NLPAttempt(
                     x=result.x,
@@ -1430,9 +1478,19 @@ def _solve_nlp_attempt(
     return _NLPAttempt(x=None, objective=None, multipliers=None)
 
 
-def _solve_nlp(evaluator, lb, ub, nlp_solver: str, max_iter: int = 200, x0=None):
+def _solve_nlp(
+    evaluator,
+    lb,
+    ub,
+    nlp_solver: str,
+    max_iter: int = 200,
+    x0=None,
+    max_wall_time: Optional[float] = None,
+):
     """Solve an NLP with given bounds. Returns (x, obj) or (None, None)."""
-    attempt = _solve_nlp_attempt(evaluator, lb, ub, nlp_solver, max_iter=max_iter, x0=x0)
+    attempt = _solve_nlp_attempt(
+        evaluator, lb, ub, nlp_solver, max_iter=max_iter, x0=x0, max_wall_time=max_wall_time
+    )
     return attempt.x, attempt.objective
 
 
@@ -1457,9 +1515,12 @@ def _solve_nlp_relaxation(
     nlp_solver: str,
     initial_point=None,
     return_attempt: bool = False,
+    max_wall_time: Optional[float] = None,
 ):
     """Solve the continuous NLP relaxation (all integers relaxed)."""
-    attempt = _solve_nlp_attempt(evaluator, lb, ub, nlp_solver, x0=initial_point)
+    attempt = _solve_nlp_attempt(
+        evaluator, lb, ub, nlp_solver, x0=initial_point, max_wall_time=max_wall_time
+    )
     return _maybe_return_nlp_attempt(attempt, return_attempt)
 
 
@@ -1472,6 +1533,7 @@ def _solve_nlp_subproblem(
     nlp_solver,
     initial_point=None,
     return_attempt: bool = False,
+    max_wall_time: Optional[float] = None,
 ):
     """Fix integers at master values and solve NLP subproblem."""
     sub_lb = lb.copy()
@@ -1482,8 +1544,18 @@ def _solve_nlp_subproblem(
         sub_ub[idx] = val
 
     proxy = _BoundsProxy(evaluator, sub_lb, sub_ub)
-    attempt = _solve_nlp_attempt(proxy, sub_lb, sub_ub, nlp_solver, x0=initial_point)
+    attempt = _solve_nlp_attempt(
+        proxy, sub_lb, sub_ub, nlp_solver, x0=initial_point, max_wall_time=max_wall_time
+    )
     return _maybe_return_nlp_attempt(attempt, return_attempt)
+
+
+#: Optional ``_solve_nlp_subproblem`` keywords, in the order they are dropped
+#: when the bound implementation does not accept them (a stub or an older
+#: signature). Richest first: losing the wall budget only costs the deadline
+#: contract, losing ``return_attempt`` costs the status, losing
+#: ``initial_point`` costs the warm start.
+_FIXED_NLP_OPTIONAL_KWARGS = ("max_wall_time", "return_attempt", "initial_point")
 
 
 def _solve_fixed_nlp_subproblem_attempt(
@@ -1495,45 +1567,29 @@ def _solve_fixed_nlp_subproblem_attempt(
     nlp_solver,
     *,
     initial_point=None,
+    max_wall_time: Optional[float] = None,
 ) -> _NLPAttempt:
-    """Call the fixed-NLP helper and retain status when the implementation supports it."""
-    try:
-        result = _solve_nlp_subproblem(
-            evaluator,
-            lb,
-            ub,
-            int_indices,
-            x_master,
-            nlp_solver,
-            initial_point=initial_point,
-            return_attempt=True,
-        )
-    except TypeError as exc:
-        message = str(exc)
-        if "return_attempt" not in message and "initial_point" not in message:
-            raise
+    """Call the fixed-NLP helper and retain status when the implementation supports it.
+
+    Degrades one keyword at a time rather than all-or-nothing: a
+    ``_solve_nlp_subproblem`` that predates any of these keywords still runs,
+    and a ``TypeError`` that does not name one of the *remaining* optional
+    keywords is a real error and propagates.
+    """
+    args = (evaluator, lb, ub, int_indices, x_master, nlp_solver)
+    optional: dict[str, Any] = {"initial_point": initial_point, "return_attempt": True}
+    if max_wall_time is not None:
+        optional["max_wall_time"] = float(max_wall_time)
+    for dropped in range(len(_FIXED_NLP_OPTIONAL_KWARGS) + 1):
+        skip = _FIXED_NLP_OPTIONAL_KWARGS[:dropped]
+        kwargs = {name: value for name, value in optional.items() if name not in skip}
         try:
-            result = _solve_nlp_subproblem(
-                evaluator,
-                lb,
-                ub,
-                int_indices,
-                x_master,
-                nlp_solver,
-                initial_point=initial_point,
-            )
-        except TypeError as fallback_exc:
-            fallback_message = str(fallback_exc)
-            if "initial_point" not in fallback_message:
+            result = _solve_nlp_subproblem(*args, **kwargs)
+            break
+        except TypeError as exc:
+            remaining = _FIXED_NLP_OPTIONAL_KWARGS[dropped:]
+            if not any(name in str(exc) for name in remaining):
                 raise
-            result = _solve_nlp_subproblem(
-                evaluator,
-                lb,
-                ub,
-                int_indices,
-                x_master,
-                nlp_solver,
-            )
     return _coerce_nlp_attempt(result)
 
 
@@ -1764,6 +1820,7 @@ def _solve_feasibility_subproblem(
     x_master,
     nlp_solver,
     feasibility_norm,
+    max_wall_time: Optional[float] = None,
 ):
     """Solve feasibility problem with fixed integers.
 
@@ -1785,7 +1842,9 @@ def _solve_feasibility_subproblem(
 
     try:
         proxy = _FeasibilityEvaluator(evaluator, sub_lb, sub_ub, feasibility_norm)
-        x_feas, _obj_feas = _solve_nlp(proxy, sub_lb, sub_ub, nlp_solver, x0=x0)
+        x_feas, _obj_feas = _solve_nlp(
+            proxy, sub_lb, sub_ub, nlp_solver, x0=x0, max_wall_time=max_wall_time
+        )
         if x_feas is not None:
             candidate = np.clip(np.asarray(x_feas, dtype=np.float64), sub_lb, sub_ub)
             candidate_merit = _constraint_violation_merit(evaluator, candidate, feasibility_norm)
@@ -2014,6 +2073,7 @@ def _run_feasibility_pump(
         decomp.ub,
         nlp_solver,
         initial_point=initial_point,
+        max_wall_time=_remaining_wall(t_start, time_limit),
     )
     if x_relax is None:
         current = _default_nlp_start(decomp.lb, decomp.ub)
@@ -2089,6 +2149,7 @@ def _run_feasibility_pump(
             projected,
             nlp_solver,
             initial_point=projected,
+            max_wall_time=_remaining_wall(t_start, time_limit),
         )
         iterations = iteration + 1
         if x_nlp is not None:
@@ -2105,6 +2166,7 @@ def _run_feasibility_pump(
             projected,
             nlp_solver,
             feasibility_norm,
+            max_wall_time=_remaining_wall(t_start, time_limit),
         )
         if x_feas is not None:
             current = x_feas
@@ -3868,6 +3930,7 @@ def solve_feasibility_pump(
             decomp.ub,
             nlp_solver,
             initial_point=initial_point,
+            max_wall_time=_remaining_wall(t_start, time_limit),
         )
         wall_time = time.perf_counter() - t_start
         if x_sol is not None:
@@ -3885,7 +3948,7 @@ def solve_feasibility_pump(
             objective=None,
             bound=None,
             gap=None,
-            x={},
+            x=None,  # no incumbent -- see SolveResult.x's contract (#1105)
             wall_time=wall_time,
             gap_certified=False,
         )
@@ -3922,7 +3985,7 @@ def solve_feasibility_pump(
         objective=None,
         bound=None,
         gap=None,
-        x={},
+        x=None,  # no incumbent -- see SolveResult.x's contract (#1105)
         wall_time=wall_time,
         mip_count=fp.mip_count,
         gap_certified=False,
@@ -4193,6 +4256,7 @@ def solve_lp_nlp_bb(
             decomp.ub,
             nlp_solver,
             initial_point=initial_point,
+            max_wall_time=_remaining_wall(t_start, time_limit),
         )
         wall_time = time.perf_counter() - t_start
         if x_sol is not None:
@@ -4210,7 +4274,7 @@ def solve_lp_nlp_bb(
             objective=None,
             bound=None,
             gap=None,
-            x={},
+            x=None,  # no incumbent -- see SolveResult.x's contract (#1105)
             wall_time=wall_time,
             mip_count=0,
         )
@@ -4258,6 +4322,7 @@ def solve_lp_nlp_bb(
             decomp.ub,
             nlp_solver,
             initial_point=initial_point,
+            max_wall_time=_remaining_wall(t_start, time_limit),
         )
         if x_relax is not None:
             if obj_relax is not None:
@@ -4308,6 +4373,7 @@ def solve_lp_nlp_bb(
             x_seed,
             nlp_solver,
             initial_point=x_seed,
+            max_wall_time=_remaining_wall(t_start, time_limit),
         )
         add_oa_cuts_at(x_init if x_init is not None else x_seed)
         if x_init is not None and obj_init is not None:
@@ -4401,6 +4467,7 @@ def solve_lp_nlp_bb(
             x_master,
             nlp_solver,
             initial_point=x_master,
+            max_wall_time=_remaining_wall(t_start, time_limit),
         )
         if x_nlp is not None:
             fixed_nlp_status = "feasible"
@@ -4423,6 +4490,7 @@ def solve_lp_nlp_bb(
                     x_master,
                     nlp_solver,
                     feasibility_norm,
+                    max_wall_time=_remaining_wall(t_start, time_limit),
                 )
                 if x_feas is not None:
                     _add_feasibility_cuts(
@@ -4651,7 +4719,7 @@ def solve_lp_nlp_bb(
         objective=None,
         bound=(obj_sign * bound if bound is not None else None),
         gap=None,
-        x={},
+        x=None,  # no incumbent -- see SolveResult.x's contract (#1105)
         wall_time=wall_time,
         node_count=master_result.node_count,
         mip_count=1,
@@ -6163,6 +6231,7 @@ def solve_oa(
             decomp.ub,
             nlp_solver,
             initial_point=initial_point,
+            max_wall_time=_remaining_wall(t_start, time_limit),
         )
         wall_time = time.perf_counter() - t_start
         if x_sol is not None:
@@ -6183,7 +6252,7 @@ def solve_oa(
             objective=None,
             bound=None,
             gap=None,
-            x={},
+            x=None,  # no incumbent -- see SolveResult.x's contract (#1105)
             wall_time=wall_time,
             mip_nlp_trace=_build_mip_nlp_trace("continuous_nlp_infeasible"),
         )
@@ -6217,6 +6286,7 @@ def solve_oa(
                 nlp_solver,
                 initial_point=initial_point,
                 return_attempt=True,
+                max_wall_time=_remaining_wall(t_start, time_limit),
             )
             x_relax, obj_relax = relax_attempt.x, relax_attempt.objective
         else:
@@ -6226,6 +6296,7 @@ def solve_oa(
                 decomp.ub,
                 nlp_solver,
                 initial_point=initial_point,
+                max_wall_time=_remaining_wall(t_start, time_limit),
             )
 
         if x_relax is not None:
@@ -6352,6 +6423,7 @@ def solve_oa(
                     nlp_solver,
                     initial_point=x_seed,
                     return_attempt=True,
+                    max_wall_time=_remaining_wall(t_start, time_limit),
                 )
                 x_init, obj_init = init_attempt.x, init_attempt.objective
             else:
@@ -6364,6 +6436,7 @@ def solve_oa(
                     x_seed,
                     nlp_solver,
                     initial_point=x_seed,
+                    max_wall_time=_remaining_wall(t_start, time_limit),
                 )
             x_cut = x_init if x_init is not None else x_seed
             _add_oa_cuts(
@@ -7266,6 +7339,7 @@ def solve_oa(
                 x_master,
                 nlp_solver,
                 initial_point=warm_start,
+                max_wall_time=_remaining_wall(t_start, time_limit),
             )
             x_nlp, obj_nlp = nlp_attempt.x, nlp_attempt.objective
             nlp_status_name = _fixed_nlp_status_name(nlp_attempt)
@@ -7307,7 +7381,26 @@ def solve_oa(
                     decomp.int_indices,
                     x_master,
                 )
-                if feasibility_cuts:
+                # The fixed NLP may have consumed the rest of the budget on its
+                # way to failing, so re-check the deadline here rather than
+                # relying on the per-candidate check above: restoration is a
+                # SECOND full NLP solve, and running it past the deadline is
+                # exactly the #1105 overrun (69.85 s of a 60 s limit, launched
+                # with 38 s left). Its only product is cuts for a NEXT iteration
+                # that the deadline has already ruled out, so skipping it costs
+                # nothing.
+                restoration_time_left = _time_left(t_start, time_limit)
+                if feasibility_cuts and restoration_time_left <= _NLP_WALL_FLOOR_S:
+                    logger.info(
+                        "OA: skipping feasibility restoration at iteration %d; "
+                        "%.3f s left of the %.3f s limit",
+                        iteration,
+                        restoration_time_left,
+                        time_limit,
+                    )
+                    termination_reason = "time_limit"
+                    stop_after_master_pool = True
+                elif feasibility_cuts:
                     feasibility_subproblem_count += 1
                     x_feas = _solve_feasibility_subproblem(
                         evaluator,
@@ -7317,6 +7410,7 @@ def solve_oa(
                         x_master,
                         nlp_solver,
                         feasibility_norm,
+                        max_wall_time=_remaining_wall(t_start, time_limit),
                     )
                     if x_feas is not None:
                         _add_feasibility_cuts(
@@ -7535,6 +7629,19 @@ def solve_oa(
     has_unresolved = len(unresolved_int_configs) > 0
     if has_unresolved:
         reported_gap = None
+        # #1105: ``bound`` and the trace must not contradict each other. The
+        # trace publishes ``master_bound_valid``/``bound_validity`` computed as
+        # ``final_lb is not None and not has_unresolved and not inverted`` --
+        # so an unresolved configuration made the trace say
+        # ``master_bound_valid=false, bound_validity="uncertified"`` while the
+        # ``bound`` field still handed the caller the master number (reported
+        # on ``kondili_recipe_pr46`` as ``bound=0.0`` beside exactly those two
+        # trace fields). A consumer has no way to know which of the two to
+        # believe, and the general ``bound`` field is the one read as a dual
+        # certificate. Suppress it here and keep the number in the trace's
+        # ``final_lb``, which is where a diagnostic belongs. This only ever
+        # reports *less*, so it cannot manufacture a certificate.
+        bound = None
 
     if incumbent is not None and incumbent_obj is not None:
         status = "optimal" if _certified_gap_converged() and not has_unresolved else "feasible"
@@ -7564,23 +7671,6 @@ def solve_oa(
             gap_certified=(status == "optimal"),
         )
 
-    if has_unresolved:
-        # No feasible incumbent AND unresolved configurations: we cannot certify
-        # infeasibility (a merely-diverged subproblem is not a proof). Report an
-        # uncertified, inconclusive status instead of a false "infeasible".
-        return SolveResult(
-            status="unknown",
-            objective=None,
-            bound=(_obj_sign * bound if bound is not None else None),
-            gap=None,
-            x={},
-            wall_time=wall_time,
-            mip_count=mip_count,
-            subnlp_calls=nlp_subproblem_count,
-            mip_nlp_trace=_build_mip_nlp_trace(final_reason),
-            gap_certified=False,
-        )
-
     # No incumbent was found. A no-incumbent terminal state is only a *proof* of
     # infeasibility when the master MILP — a valid relaxation of the integer
     # feasible set carrying globally-valid OA and (rigorous) no-good cuts — was
@@ -7595,27 +7685,37 @@ def solve_oa(
     # (CLAUDE.md §1) — a solver that merely ran out of budget must never claim the
     # model is infeasible. Report "unknown" there, exactly as the C-35
     # unresolved-config path above does.
+    #
+    # C-35: if any integer configuration was left unresolved by a non-rigorous
+    # NLP failure we deliberately did NOT exclude it, so infeasibility is not
+    # proved either -- ``has_unresolved`` vetoes the "infeasible" arm as well.
     _PROVEN_INFEASIBLE_REASONS = {"master_infeasible", "master_infeasible_unrepaired"}
-    if final_reason in _PROVEN_INFEASIBLE_REASONS:
-        return SolveResult(
-            status="infeasible",
-            objective=None,
-            bound=(_obj_sign * bound if bound is not None else None),
-            gap=None,
-            x={},
-            wall_time=wall_time,
-            mip_count=mip_count,
-            subnlp_calls=nlp_subproblem_count,
-            mip_nlp_trace=_build_mip_nlp_trace(final_reason),
-            gap_certified=False,
-        )
+    # #1105: "unknown" is right for an exit whose cause we cannot name, but a
+    # solve that simply ran out of its wall-clock or iteration budget has a
+    # perfectly nameable cause, and it is the one fact the caller needs to
+    # decide whether to retry with a larger budget. Both spellings are in the
+    # ``SolveResult.status`` vocabulary and are what the B&B route already
+    # returns for the same exits, so reporting them here also makes the two
+    # routes comparable. Neither claims anything about feasibility.
+    _LIMIT_REASON_STATUS = {"time_limit": "time_limit", "iteration_limit": "iteration_limit"}
+    if final_reason in _PROVEN_INFEASIBLE_REASONS and not has_unresolved:
+        status = "infeasible"
+    else:
+        status = _LIMIT_REASON_STATUS.get(final_reason or "", "unknown")
 
+    # ``x=None``, not ``x={}``: ``SolveResult.x`` is documented as "None if no
+    # feasible solution found", and an empty dict is truthy-checked as an
+    # *existing* incumbent by every downstream consumer. ``Model.solve``'s
+    # false-primal screen indexed ``result.x["x0"]`` and raised ``KeyError``,
+    # which it then swallowed and warned that an "incumbent" was unscreened
+    # even though ``objective`` was None; the #1059 dual-recovery block reads
+    # the same dict and silently recovered nothing. (#1105)
     return SolveResult(
-        status="unknown",
+        status=status,
         objective=None,
         bound=(_obj_sign * bound if bound is not None else None),
         gap=None,
-        x={},
+        x=None,
         wall_time=wall_time,
         mip_count=mip_count,
         subnlp_calls=nlp_subproblem_count,

--- a/python/tests/test_mip_nlp.py
+++ b/python/tests/test_mip_nlp.py
@@ -982,7 +982,14 @@ def test_mip_nlp_shot_convex_bounding_skips_nonrigorous_no_good_cuts(monkeypatch
     assert trace["final_lb"] == pytest.approx(0.0)
     assert trace["heuristic_lb"] == pytest.approx(0.0)
     assert result.status == "feasible"
-    assert result.bound == pytest.approx(0.0)
+    # #1105: the general ``bound`` field no longer contradicts the validity
+    # signal published beside it. With an unresolved integer configuration the
+    # trace says ``bound_validity="uncertified"`` / ``master_bound_valid=False``,
+    # so ``bound`` is withheld and the master number stays available as the
+    # diagnostic ``trace["final_lb"]``/``["heuristic_lb"]`` asserted above. This
+    # test previously pinned the contradiction (``bound=0.0`` beside
+    # ``bound_validity="uncertified"``) that #1105 was filed about.
+    assert result.bound is None
     assert result.gap is None
     assert result.gap_certified is False
     assert result.objective == pytest.approx(1.0)
@@ -2703,6 +2710,7 @@ def test_lp_nlp_bb_lazy_callback_solves_fixed_integer_nlp(monkeypatch):
         _nlp_solver,
         initial_point=None,
         return_attempt=False,
+        max_wall_time=None,
     ):
         assert initial_point is not None
         calls["subproblem"] += 1
@@ -2790,6 +2798,7 @@ def test_lp_nlp_bb_shot_callback_trace_records_node_and_incumbent_cuts(monkeypat
         _nlp_solver,
         initial_point=None,
         return_attempt=False,
+        max_wall_time=None,
     ):
         assert initial_point is not None
         calls["subproblem"] += 1
@@ -3017,6 +3026,7 @@ def test_lp_nlp_bb_linear_objective_constant_offsets_certified_bound(monkeypatch
         _nlp_solver,
         initial_point=None,
         return_attempt=False,
+        max_wall_time=None,
     ):
         return np.asarray(x_master, dtype=np.float64), 100.0
 
@@ -3400,6 +3410,7 @@ def test_oa_solution_pool_processes_multiple_master_candidates(monkeypatch):
         _nlp_solver,
         initial_point=None,
         return_attempt=False,
+        max_wall_time=None,
     ):
         del initial_point
         x = np.asarray(x_master, dtype=float).copy()
@@ -3474,6 +3485,7 @@ def test_mip_nlp_shot_solution_pool_strategy_uses_candidate_pool(monkeypatch):
         _nlp_solver,
         initial_point=None,
         return_attempt=False,
+        max_wall_time=None,
     ):
         del initial_point
         x = np.asarray(x_master, dtype=float).copy()
@@ -4427,6 +4439,7 @@ def test_oa_derivative_regularization_requires_duals_from_initial_incumbent(monk
         nlp_solver,
         initial_point=None,
         return_attempt=False,
+        max_wall_time=None,
     ):
         attempt = oa_module._NLPAttempt(
             x=np.array([0.0], dtype=float),
@@ -4572,7 +4585,9 @@ def test_oa_regularization_seeds_nlp_without_replacing_master_assignment(monkeyp
     regularized_point = np.array([1.25, 1.0, 0.0, 2.0], dtype=float)
     subproblem_calls = []
 
-    def fake_solve_nlp_relaxation(evaluator, lb, ub, nlp_solver, initial_point=None):
+    def fake_solve_nlp_relaxation(
+        evaluator, lb, ub, nlp_solver, initial_point=None, max_wall_time=None
+    ):
         return relaxation_point, 4.0
 
     def fake_add_oa_cuts(*args, **kwargs):
@@ -4592,6 +4607,7 @@ def test_oa_regularization_seeds_nlp_without_replacing_master_assignment(monkeyp
         x_master,
         nlp_solver,
         initial_point=None,
+        max_wall_time=None,
     ):
         subproblem_calls.append(
             (
@@ -4637,6 +4653,7 @@ def test_oa_derivative_regularization_seeds_nlp_from_regularized_point(monkeypat
         nlp_solver,
         initial_point=None,
         return_attempt=False,
+        max_wall_time=None,
     ):
         attempt = oa_module._NLPAttempt(
             x=relaxation_point,
@@ -4666,6 +4683,7 @@ def test_oa_derivative_regularization_seeds_nlp_from_regularized_point(monkeypat
         nlp_solver,
         initial_point=None,
         return_attempt=False,
+        max_wall_time=None,
     ):
         subproblem_calls.append(
             (
@@ -4712,7 +4730,9 @@ def test_oa_rnlp_initialization_adds_cuts_at_relaxation_point(monkeypatch):
     relaxation_point = np.array([0.25, 0.5, 0.5, 1.5], dtype=float)
     cut_points = []
 
-    def fake_solve_nlp_relaxation(evaluator, lb, ub, nlp_solver, initial_point=None):
+    def fake_solve_nlp_relaxation(
+        evaluator, lb, ub, nlp_solver, initial_point=None, max_wall_time=None
+    ):
         assert np.asarray(initial_point, dtype=float).tolist() == pytest.approx(
             [1.25, 1.0, 0.0, 2.0]
         )
@@ -4732,10 +4752,11 @@ def test_oa_rnlp_initialization_adds_cuts_at_relaxation_point(monkeypatch):
     )
 
     # max_iterations=0 exits before any master solve or incumbent: the search is
-    # INCONCLUSIVE (iteration limit), not a proof of infeasibility -> "unknown",
-    # not the (false) "infeasible" this used to report. The rNLP cut-injection
-    # under test is unaffected.
-    assert result.status == "unknown"
+    # INCONCLUSIVE, not a proof of infeasibility -> never "infeasible". #1105
+    # narrowed the inconclusive status from a blanket "unknown" to the named
+    # limit that stopped the loop, which is equally non-committal about
+    # feasibility. The rNLP cut-injection under test is unaffected.
+    assert result.status == "iteration_limit"
     assert cut_points[0].tolist() == pytest.approx(relaxation_point.tolist())
 
 
@@ -4792,7 +4813,9 @@ def test_oa_no_discrete_relaxation_uses_initial_point(monkeypatch):
 
     initial_point = np.array([3.0], dtype=float)
 
-    def fake_solve_nlp_relaxation(evaluator, lb, ub, nlp_solver, initial_point=None):
+    def fake_solve_nlp_relaxation(
+        evaluator, lb, ub, nlp_solver, initial_point=None, max_wall_time=None
+    ):
         assert np.asarray(initial_point, dtype=float).tolist() == pytest.approx([3.0])
         return np.asarray(initial_point, dtype=float), 1.0
 
@@ -4829,6 +4852,7 @@ def test_oa_fixed_integer_initializers_seed_first_nlp(monkeypatch, strategy, sta
         x_master,
         nlp_solver,
         initial_point=None,
+        max_wall_time=None,
     ):
         fixed_points.append(np.asarray(x_master, dtype=float).copy())
         assert np.asarray(initial_point, dtype=float).tolist() == pytest.approx(expected_fixed)

--- a/python/tests/test_oa.py
+++ b/python/tests/test_oa.py
@@ -876,10 +876,11 @@ class TestOARobustnessOptions:
 
         # max_iterations=1 exhausts the iteration budget with no incumbent (the
         # monkeypatched master never turns infeasible), so the search is
-        # INCONCLUSIVE, not a proof of infeasibility -> "unknown", not the
-        # (false) "infeasible" this used to report. The no-good-cut mechanism
-        # under test is unaffected.
-        assert result.status == "unknown"
+        # INCONCLUSIVE, not a proof of infeasibility -> never "infeasible". #1105
+        # narrowed the inconclusive status from a blanket "unknown" to the named
+        # limit that actually stopped the loop; it is equally non-committal about
+        # feasibility. The no-good-cut mechanism under test is unaffected.
+        assert result.status == "iteration_limit"
         assert len(no_good_calls) == expected_calls
 
     def test_multitree_no_good_cut_skips_mixed_integer_model(
@@ -932,9 +933,10 @@ class TestOARobustnessOptions:
             cycling_check=False,
         )
 
-        # Iteration budget exhausted with no incumbent -> inconclusive "unknown"
-        # (not a false "infeasible"); the mechanism under test is unaffected.
-        assert result.status == "unknown"
+        # Iteration budget exhausted with no incumbent -> inconclusive
+        # "iteration_limit" (not a false "infeasible", #1105); the mechanism
+        # under test is unaffected.
+        assert result.status == "iteration_limit"
         assert no_good_calls == []
 
     def test_multitree_no_good_cut_uses_integer_binary_expansion_when_enabled(
@@ -990,9 +992,10 @@ class TestOARobustnessOptions:
             cycling_check=False,
         )
 
-        # Iteration budget exhausted with no incumbent -> inconclusive "unknown"
-        # (not a false "infeasible"); the mechanism under test is unaffected.
-        assert result.status == "unknown"
+        # Iteration budget exhausted with no incumbent -> inconclusive
+        # "iteration_limit" (not a false "infeasible", #1105); the mechanism
+        # under test is unaffected.
+        assert result.status == "iteration_limit"
         assert len(no_good_expansions) == 1
         assert no_good_expansions[0] is not None
         assert no_good_expansions[0].bit_count == 2
@@ -1287,3 +1290,200 @@ def test_integer_to_binary_no_good_cuts_preserve_general_integer_optimum():
     assert result.gap == pytest.approx(0.0, abs=1e-9)
     assert result.x["z"] == pytest.approx(2.0, abs=INTEGRALITY_TOL)
     assert result.mip_nlp_trace["summary"]["cut_source_counts"]["integer"] >= 1
+
+
+class TestOADeadlineAndNoIncumbentContract:
+    """#1105: ``time_limit`` must bound the whole solve, and a no-incumbent exit
+    must report ``x=None`` with a status and a bound that match its own trace.
+
+    Reported against ``kondili_recipe_pr46`` (3048 cols / 3536 rows): a 60 s
+    limit returned after 133.4 s with ``status="unknown"``, ``x={}`` and
+    ``bound=0.0`` beside ``bound_validity="uncertified"``. Reproduced locally at
+    92.4 s, of which a *single* feasibility-restoration NLP -- launched with 38 s
+    of budget left -- ran 69.85 s, because no NLP subsolve in this module carried
+    a wall budget at all.
+    """
+
+    def test_every_nlp_subsolve_carries_a_share_of_the_deadline(self, monkeypatch):
+        """No NLP may be launched unbudgeted while a ``time_limit`` is in force."""
+        import discopt.solvers.oa as oa_module
+
+        m = _mindtpy_simple_minlp()
+
+        real_attempt = oa_module._solve_nlp_attempt
+        budgets: list[object] = []
+
+        def spy(*args, **kwargs):
+            budgets.append(kwargs.get("max_wall_time"))
+            return real_attempt(*args, **kwargs)
+
+        monkeypatch.setattr(oa_module, "_solve_nlp_attempt", spy)
+
+        time_limit = 30.0
+        oa_module.solve_oa(m, time_limit=time_limit, max_iterations=5)
+
+        # CLAUDE.md §6: the probe must prove it fired. An empty ``budgets`` list
+        # would otherwise pass every assertion below vacuously.
+        assert budgets, "PROBE FIRED NOTHING: solve_oa launched no NLP subsolve"
+        unbudgeted = [i for i, b in enumerate(budgets) if b is None]
+        assert not unbudgeted, (
+            f"{len(unbudgeted)} of {len(budgets)} NLP subsolves were launched with no "
+            f"wall budget (call indices {unbudgeted}); each can outlive the whole "
+            "time_limit on its own"
+        )
+        for budget in budgets:
+            assert isinstance(budget, float)
+            assert 0.0 < budget <= time_limit, budget
+        print(f"PROBE OK: {len(budgets)} budgeted NLP subsolves")
+
+    def test_expired_deadline_skips_feasibility_restoration(self, monkeypatch):
+        """The step that overran in #1105 must not start past the deadline.
+
+        The fixed NLP can consume the rest of the budget on its way to failing,
+        so the deadline is re-checked between it and feasibility restoration --
+        the exact overrun reported (69.85 s of a 60 s limit, launched with 38 s
+        left).
+        """
+        import time as _time
+
+        import discopt.solvers.oa as oa_module
+        from discopt.solvers import MILPResult, SolveStatus
+
+        m = dm.Model("deadline_restoration")
+        y = m.binary("y")
+        x = m.continuous("x", lb=0, ub=2)
+        m.minimize(y + x)
+        m.subject_to(x**2 + y >= 1)
+
+        time_limit = 0.5
+        feasibility_calls: list[tuple] = []
+
+        monkeypatch.setattr(
+            oa_module,
+            "_solve_nlp_relaxation",
+            # Fractional in y, so OA cannot accept the relaxation outright.
+            lambda *args, **kwargs: (np.array([0.5, 1.0]), 1.5),
+        )
+        monkeypatch.setattr(oa_module, "_add_oa_cuts", lambda *args, **kwargs: None)
+        monkeypatch.setattr(
+            oa_module,
+            "_solve_master_milp",
+            lambda *args, **kwargs: MILPResult(
+                status=SolveStatus.OPTIMAL,
+                # (y, x) = (0, 0) violates x**2 + y >= 1, so the master point is
+                # never itself an incumbent -- the fixed NLP below is the only
+                # route to one, and it fails.
+                x=np.array([0.0, 0.0]),
+                objective=0.0,
+                bound=0.0,
+            ),
+        )
+
+        def _slow_failing_fixed_nlp(*args, **kwargs):
+            """Stands in for a fixed NLP that eats the remaining budget, then fails."""
+            _time.sleep(time_limit * 2.0)
+            return (None, None)
+
+        monkeypatch.setattr(oa_module, "_solve_nlp_subproblem", _slow_failing_fixed_nlp)
+        monkeypatch.setattr(
+            oa_module,
+            "_solve_feasibility_subproblem",
+            lambda *args, **kwargs: feasibility_calls.append(args),
+        )
+
+        result = oa_module.solve_oa(
+            m,
+            time_limit=time_limit,
+            max_iterations=50,
+            feasibility_cuts=True,
+            cycling_check=False,
+        )
+
+        assert feasibility_calls == [], (
+            "feasibility restoration was started after the deadline had already "
+            "expired; that subproblem is unbounded in wall time and is what "
+            "drove the #1105 overrun"
+        )
+        trace = result.mip_nlp_trace
+        assert trace is not None
+        assert trace["termination_reason"] == "time_limit"
+        # Expectation 2 of the issue: name the limit, and report no incumbent.
+        assert result.status == "time_limit"
+        assert result.objective is None
+        assert result.x is None, (
+            "a no-incumbent exit must return x=None, not an empty dict that every "
+            "downstream consumer truth-tests as an existing incumbent"
+        )
+
+    def test_no_incumbent_result_never_contradicts_its_own_trace_bound(self, monkeypatch):
+        """``bound`` must not carry a number the trace calls uncertified.
+
+        The reporter saw ``bound=0.0`` beside ``master_bound_valid=false`` and
+        ``bound_validity="uncertified"`` and had no way to know which to trust.
+        The number stays available as ``trace["final_lb"]``.
+        """
+        import discopt.solvers.oa as oa_module
+        from discopt.solvers import MILPResult, SolveStatus
+
+        # Linear objective => decomp.master_bound_valid, so the master bound is
+        # promoted to certified_LB -- the same shape as the reported instance.
+        m = dm.Model("uncertified_bound")
+        y = m.binary("y")
+        x = m.continuous("x", lb=0, ub=2)
+        m.minimize(y + x)
+        m.subject_to(x**2 + y >= 1)
+
+        monkeypatch.setattr(
+            oa_module,
+            "_solve_nlp_relaxation",
+            # Fractional in y, so OA cannot accept the relaxation outright.
+            lambda *args, **kwargs: (np.array([0.5, 1.0]), 1.5),
+        )
+        monkeypatch.setattr(oa_module, "_add_oa_cuts", lambda *args, **kwargs: None)
+        monkeypatch.setattr(
+            oa_module,
+            "_solve_master_milp",
+            lambda *args, **kwargs: MILPResult(
+                status=SolveStatus.OPTIMAL,
+                # (y, x) = (0, 0) violates x**2 + y >= 1, so the master point is
+                # never itself an incumbent -- the fixed NLP below is the only
+                # route to one, and it fails.
+                x=np.array([0.0, 0.0]),
+                objective=0.0,
+                bound=0.0,
+            ),
+        )
+        # Fixed NLP fails NON-rigorously: the configuration is neither solved nor
+        # excluded, which is what downgrades certification (C-35).
+        monkeypatch.setattr(
+            oa_module,
+            "_solve_nlp_subproblem",
+            lambda *args, **kwargs: (None, None),
+        )
+        monkeypatch.setattr(
+            oa_module,
+            "_fixed_subproblem_rigorously_infeasible",
+            lambda *args, **kwargs: False,
+        )
+
+        result = oa_module.solve_oa(
+            m,
+            time_limit=30.0,
+            max_iterations=3,
+            feasibility_cuts=False,
+            cycling_check=False,
+        )
+
+        trace = result.mip_nlp_trace
+        assert trace is not None
+        assert trace["summary"]["unresolved_integer_config_count"] >= 1
+        assert trace["master_bound_valid"] is False
+        assert trace["bound_validity"] == "uncertified"
+        # The master number is still there as a diagnostic...
+        assert trace["final_lb"] == pytest.approx(0.0)
+        # ...but the general ``bound`` field, which callers read as a dual
+        # certificate, no longer contradicts the validity signal beside it.
+        assert result.bound is None
+        assert result.gap is None
+        assert result.gap_certified is False
+        assert result.x is None


### PR DESCRIPTION
## Problem

Issue #1105 (@bernalde): on a 3,048-column / 3,536-row nonconvex MINLP, the documented MIP-NLP/OA configuration with a Gurobi master ignores `time_limit=60.0`. It returns after 133 s with `status="unknown"`, `x={}`, and `bound=0.0` published beside `bound_validity="uncertified"` / `master_bound_valid=false`. The empty dict is truth-tested as an incumbent, so `Model.solve`'s false-primal guard raises `KeyError: 'x0'`, is skipped, and then warns that the "incumbent" is UNSCREENED — on a solve that has no incumbent at all.

## Root cause (measured)

Not the master MILP (already budgeted via `_master_time_budget`) and not the cold-start defect of #1063. **No NLP subsolve in `oa.py` carried a wall budget at all** — only `max_iter=200`. On the reporter's instance a `_solve_feasibility_subproblem` launched at t≈22 s with 38 s of budget left ran **69.85 s**.

`max_wall_time` had to be verified empirically rather than assumed: the POUNCE backend passes options through `problem.add_option(...)` inside a `try/except` that **silently drops unknown options**. Probe: unbounded 25.72 s; `max_wall_time=0.5` → 0.517 s; `max_wall_time=2.0` → 2.073 s; both terminate `TIME_LIMIT`.

## Changes

`python/discopt/solvers/oa.py`
- `_time_left()` / `_remaining_wall()` (floored at `_NLP_WALL_FLOOR_S = 0.1`) are the single source of the deadline contract. A budget of ≤0 is not "run instantly" to POUNCE — it is a value the backend may reject, which silently restores the unbounded behavior; call sites that can skip a subsolve check the deadline themselves.
- **All 17 NLP call sites** now carry `max_wall_time` (16 direct, 1 forwarded inside `_solve_feasibility_subproblem`). `_solve_nlp`, `_solve_nlp_relaxation`, `_solve_nlp_subproblem`, `_solve_feasibility_subproblem`, `_solve_nlp_attempt` all thread the option.
- `SolveStatus.TIME_LIMIT` joins `ITERATION_LIMIT` as an acceptable subsolve outcome — still gated on `_is_primal_feasible`, so a truncated subsolve can contribute a point only if that point is actually feasible.
- Feasibility restoration is skipped, with a log line, when the deadline has already expired.
- The three no-incumbent returns collapse into one that maps the termination reason to a named status (`time_limit` / `iteration_limit`, or `infeasible` when the reason is a proven master infeasibility and nothing is unresolved). Genuine user-termination still returns `unknown`.
- When `unresolved_int_configs` is non-empty, the general `bound` field is suppressed to `None` instead of contradicting the validity signal published next to it; the number remains in `trace["final_lb"]`. This only ever reports *less*, so it cannot manufacture a certificate.
- 8 no-incumbent `x={}` → `x=None`.

`python/discopt/solvers/gdpopt_loa.py` — same 3 no-incumbent sites, `x={}` → `x=None`.

`python/discopt/modeling/core.py` — the false-primal screen and the validation pass truth-test `result.x` rather than `is not None`, so a no-incumbent result is never screened.

`python/discopt/solver.py` — the #1059 dual-recovery path truth-tests `_routed_x`; recovering duals "at the incumbent" of a solve that has none only ever raised a `KeyError` into a debug-level `except`, so the miss was invisible.

## Measurement

`kondili_recipe_pr46.nl`, `time_limit=60.0`, `gap_tolerance=0.0`, `heuristic_nonconvex=False`, 3 **interleaved** reps (CLAUDE.md §9), load avg 6–18 throughout, each arm asserting `discopt.__file__` **and** presence/absence of a version marker before solving (§8):

| arm | elapsed (s) | ratio to limit | status | x | bound |
|---|---|---|---|---|---|
| baseline (`main` @ 6b63c4f4) | 98.49 ± 1.50 | 1.64 | `unknown` | `{}` | `0.0` (beside `uncertified`) |
| fixed | 62.37 ± 1.12 | 1.04 | `time_limit` | `None` | `None` |

Raw: baseline 97.81 / 97.46 / 100.21; fixed 61.78 / 61.66 / 63.66. Harness: `scratchpad/issue1105/repro_ab.py`, `run_ab.sh`.

All four expectations in the issue are met: (1) the limit now covers the whole `Model.solve` with a 2.4 s cleanup allowance; (2) `status="time_limit"`, `objective=None`, `x=None`; (3) no verification or solution mapping runs without an incumbent; (4) no uncertified number reaches the general `bound` field.

## Tests

New `TestOADeadlineAndNoIncumbentContract` in `python/tests/test_oa.py`:
- `test_every_nlp_subsolve_carries_a_share_of_the_deadline` — spies on `_solve_nlp_attempt`, asserts every budget is non-`None` and in `(0, time_limit]`, and **fails loudly if the probe observed nothing** (§6: it prints an executed-comparison count).
- `test_expired_deadline_skips_feasibility_restoration` — a stub subproblem that sleeps past the limit; asserts restoration is never called and the result is `time_limit` / `objective=None` / `x=None`.
- `test_no_incumbent_result_never_contradicts_its_own_trace_bound` — asserts `result.bound is None` while `trace["final_lb"] ≈ 0.0` and `bound_validity == "uncertified"`.

Six pre-existing assertions pinned the old semantics and were updated with comments: four `status == "unknown"` → the named limit; `test_mip_nlp_shot_convex_bounding_skips_nonrigorous_no_good_cuts`'s `bound == 0.0` → `bound is None` (that test had pinned the exact contradiction #1105 was filed about). Thirteen test doubles gained `max_wall_time=None` in their signatures — the doubles were fixed, not the production call sites.

**Run:**
- `pytest -m smoke` → **1102 passed**, 1 skipped, 2 xpassed, **2 failed**
- `pytest -m slow python/tests/test_adversarial_recent_fixes.py` → **19 passed**
- `test_oa.py` + `test_mip_nlp.py` + `test_1060_native_single_tree.py` + `test_issue_1060_highs_master.py` + `test_oa_internals_units.py` → **289 passed**, 13 deselected
- `ruff check python/` / `ruff format --check python/` / `mypy` → clean
- No Rust touched, so `cargo test -p discopt-core` was not required.

**The two smoke failures are pre-existing and not caused by this branch** — `test_amp.py::test_unsafe_tan_objective_still_falls_back` and `test_monomial_straddle_kernel.py::test_regenerated_monomial_envelope_never_cuts_a_point_in_its_box` fail identically when run in the main tree at `6b63c4f4`. Cause is a stale `_rust` extension in the ambient environment (the monomial-straddle fix `b0d62687` is a Rust change and the installed `.so` predates it).

## Relation to #1104

Same *class* of defect ("`time_limit=T` does not bound the whole `Model.solve`"), different path and different cause. #1104 is a pre-B&B `O(vars x body^2)` blowup in `find_functionally_dependent_names` that runs before the limit is armed; this is unbudgeted NLP subsolves inside the OA loop. Neither fix helps the other, and this PR leaves #1104 open.

Closes #1105

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017PQaiDVuY5Rs3tga98tnNo
