### PR TITLE
fix(rust): silence clippy::drain_collect in tree_manager (unblocks Rust CI)

### DIFF
--- a/crates/discopt-core/src/bnb/tree_manager.rs
+++ b/crates/discopt-core/src/bnb/tree_manager.rs
@@ -491,7 +491,7 @@ impl TreeManager {
     pub fn process_evaluated(&mut self) -> ProcessingStats {
         let mut stats = ProcessingStats::default();
 
-        let pending: Vec<PendingResult> = self.pending_results.drain(..).collect();
+        let pending: Vec<PendingResult> = std::mem::take(&mut self.pending_results);
 
         for result in &pending {
             let node_lb = self.pool.get(result.node_id).local_lower_bound;


### PR DESCRIPTION
A clippy roll-forward (rust-1.98.0) started firing `clippy::drain_collect` on `TreeManager::process_evaluated`, which breaks `cargo clippy -p discopt-core -- -D warnings` — the `Rust` CI job — on every branch, including ones that touch no Rust at all (found on #1106).

The line is unchanged since #1060 and `main` was green on it as recently as `6b63c4f4` (run 32393041965). Only the lint set moved.

`std::mem::take(&mut self.pending_results)` is the lint's own suggestion and is what the code means — take the whole vector, leave an empty one behind — and it skips the extra allocation `drain(..).collect()` makes. Behavior is identical: both leave `self.pending_results` empty and hand the caller every element in order.

**Verified locally:**
- `cargo clippy -p discopt-core -- -D warnings` → clean
- `cargo test -p discopt-core` → **646 passed, 0 failed** (639 lib + 7 across the other targets)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017PQaiDVuY5Rs3tga98tnNo
