### PR TITLE
fix(perf): #1104 bound the pre-B&B dependency scan; O(nodes) affine coefficient analysis

### DIFF
--- a/python/discopt/_relax/dependent_vars.py
+++ b/python/discopt/_relax/dependent_vars.py
@@ -48,18 +48,20 @@ remain the correct ones to deprioritize in the lifted/solved model.
 
 from __future__ import annotations
 
+import time
+
 import numpy as np
 
 # Reuse the conservative occurrence/constant analyzers proven in the
-# objective-defining-equality relaxation. ``_occurs`` reports "might occur" on
-# any opaque node (the safe direction), and ``_collect_var_names`` returns None
-# there. We do NOT reuse that module's ``_affine_coeff``: it is written for the
-# narrower contract "the whole body is affine in z", so a sibling term that is
-# nonlinear in *other* variables (e.g. ``4243.28/(x0*x1)``) makes it return
+# objective-defining-equality relaxation. ``VarNameIndex`` reports ``None`` for
+# an opaque node, which every query here reads as "might occur" (the safe
+# direction). We do NOT reuse that module's ``_affine_coeff``: it is written for
+# the narrower contract "the whole body is affine in z", so a sibling term that
+# is nonlinear in *other* variables (e.g. ``4243.28/(x0*x1)``) makes it return
 # None even when the target variable itself appears purely affinely. The
 # isolating extractor below short-circuits on "target absent -> coefficient 0",
 # which is what the dependent-output pattern requires.
-from discopt._relax.objective_epigraph import _collect_var_names, _const_value, _occurs
+from discopt._relax.objective_epigraph import VarNameIndex, _const_value
 from discopt.modeling.core import (
     BinaryOp,
     Constant,
@@ -74,89 +76,166 @@ from discopt.modeling.core import (
     VarType,
 )
 
+# Traversal cap for :func:`_isolated_affine_coeffs`, in node visits per distinct
+# DAG node. A tree needs exactly one visit per node; sharing multiplies that by
+# the number of distinct paths. Measured over 149,564 equality bodies from 104
+# MINLPLib instances (issue #1104) the worst ratio was 1.0 — the parsed bodies
+# are trees — so this leaves three orders of magnitude of headroom before the
+# conservative abstention can fire.
+_VISIT_BUDGET_PER_NODE = 1000
+_VISIT_BUDGET_FLOOR = 10_000
 
-def _isolated_affine_coeff(expr, varname):
+
+def _isolated_affine_coeffs(expr, index=None):
+    """Isolated affine coefficients of *every* variable in ``expr``, in one pass.
+
+    Returns a mapping ``name -> coeff`` where ``coeff`` is a float when ``name``
+    occurs affinely with a constant coefficient, and ``None`` when it occurs
+    nonlinearly (a product carrying it twice, under a power, a nonlinear
+    unary/function, in a denominator, indexed, or inside a reduction). A name
+    absent from the mapping is provably absent from ``expr`` (coefficient 0).
+    Returns ``None`` — "no name can be proven affine here" — when ``expr``
+    contains an opaque node, since occurrence detection must then report "might
+    occur" for every name.
+
+    Unlike a whole-expression affine test, absence short-circuits: a
+    subexpression not containing a name contributes coefficient ``0`` to it
+    regardless of its own nonlinearity. This is what lets a defining equality
+    like ``x6 - sqrt(g(others)) == 0`` report ``coeff[x6] = 1`` even though ``g``
+    is highly nonlinear in the other variables.
+
+    Cost is ``O(nodes)`` on a tree: one top-down traversal carrying the
+    accumulated constant multiplier, with ``O(1)`` occurrence tests from
+    ``index``. The per-name formulation it replaces re-walked the body for each
+    candidate and re-derived occurrence at every level, which is
+    ``O(names x nodes^2)`` — the ``t1000`` non-termination of issue #1104. The
+    traversal is iterative because MINLPLib sum chains are deeper than the
+    default recursion limit.
+
+    The multiplier a node inherits depends on the path taken to reach it, so a
+    *shared* subexpression is visited once per path and the walk is O(paths),
+    not O(nodes). ``_VISIT_BUDGET_PER_NODE`` caps that at a fixed multiple of the
+    DAG size and abstains (returns ``None``) beyond it, so a pathologically
+    shared body degrades to "nothing proven here" instead of to a hang. The cap
+    is on a node counter, not a clock: the detected set must not depend on how
+    fast the machine is (``deterministic=True`` solves reproduce).
+    """
+    if index is None:
+        index = VarNameIndex(expr)
+    if index.names(expr) is None:
+        return None  # opaque node reachable -> nothing provable (see docstring)
+
+    coeffs: dict = {}
+    bad: set = set()
+    budget = _VISIT_BUDGET_PER_NODE * len(index) + _VISIT_BUDGET_FLOOR
+    stack = [(expr, 1.0)]
+    while stack:
+        budget -= 1
+        if budget < 0:
+            return None  # shared-subexpression blowup -> abstain (see docstring)
+        node, mult = stack.pop()
+        names = index.names(node)
+        if not names:
+            continue  # variable-free subtree -> contributes 0 to every name
+        if isinstance(node, Variable):
+            coeffs[node.name] = coeffs.get(node.name, 0.0) + mult
+            continue
+        if isinstance(node, IndexExpression):
+            bad |= names  # indexed occurrence -> not the scalar affine pattern
+            continue
+        if isinstance(node, UnaryOp):
+            if node.op in ("-", "neg"):
+                stack.append((node.operand, -mult))
+            elif node.op in ("+", "pos"):
+                stack.append((node.operand, mult))
+            else:
+                bad |= names  # abs / sin / exp / ... over a variable-carrying arg
+            continue
+        if isinstance(node, BinaryOp):
+            op = node.op
+            if op == "+":
+                stack.append((node.left, mult))
+                stack.append((node.right, mult))
+                continue
+            if op == "-":
+                stack.append((node.left, mult))
+                stack.append((node.right, -mult))
+                continue
+            if op == "*":
+                left_names = index.names(node.left)
+                right_names = index.names(node.right)
+                if left_names and right_names:
+                    bad |= names  # variables on both factors -> nonlinear
+                    continue
+                # Exactly one factor carries variables; the other must be a
+                # constant for any name under it to stay affine.
+                if left_names:
+                    k = _const_value(node.right)
+                    carrier = node.left
+                else:
+                    k = _const_value(node.left)
+                    carrier = node.right
+                if k is None:
+                    bad |= names
+                else:
+                    stack.append((carrier, mult * k))
+                continue
+            if op == "/":
+                if index.names(node.right):
+                    bad |= names  # variable in a denominator -> nonlinear
+                    continue
+                k = _const_value(node.right)
+                if k is None or k == 0.0:
+                    bad |= names
+                else:
+                    stack.append((node.left, mult / k))
+                continue
+            # ``**`` (variable under a power) and unrecognised binary ops.
+            bad |= names
+            continue
+        if isinstance(node, SumExpression):
+            stack.append((node.operand, mult))
+            continue
+        # SumOverExpression (a reduction carrying the name -> not a scalar
+        # coefficient), FunctionCall, or any other node over variables.
+        bad |= names
+
+    for name in bad:
+        coeffs[name] = None
+    return coeffs
+
+
+def _isolated_affine_coeff(expr, varname, index=None):
     """Constant coefficient of ``varname`` in ``expr`` if it occurs *affinely*.
 
     Returns a float ``a`` iff ``expr == a*<varname> + (terms not involving
     varname)``, where those other terms may be arbitrarily nonlinear in *other*
-    variables. Returns ``None`` when ``varname`` occurs nonlinearly (a product
-    carrying it twice, under a power, a nonlinear unary/function, in a
-    denominator, indexed, a reduction, or an opaque node) and ``0.0`` when it is
-    provably absent.
+    variables; ``None`` when ``varname`` occurs nonlinearly or unanalyzably, and
+    ``0.0`` when it is provably absent.
 
-    Unlike a whole-expression affine test, every node first short-circuits on
-    absence: a subexpression not containing ``varname`` contributes coefficient
-    ``0`` regardless of its own nonlinearity. This is what lets a defining
-    equality like ``x6 - sqrt(g(others)) == 0`` report ``coeff[x6] = 1`` even
-    though ``g`` is highly nonlinear in the other variables.
+    Thin single-name view of :func:`_isolated_affine_coeffs`; callers with more
+    than one name to test should use that directly and pay the traversal once.
     """
-    # Absent (and not opaque) -> contributes nothing. ``_occurs`` returns True
-    # on opaque nodes, so reaching past here means varname genuinely occurs.
-    if not _occurs(expr, varname):
-        return 0.0
-    if isinstance(expr, Variable):
-        return 1.0 if expr.name == varname else 0.0
-    if isinstance(expr, IndexExpression):
-        return None  # indexed occurrence -> not the scalar affine pattern
-    if isinstance(expr, UnaryOp):
-        if expr.op in ("-", "neg"):
-            inner = _isolated_affine_coeff(expr.operand, varname)
-            return None if inner is None else -inner
-        if expr.op in ("+", "pos"):
-            return _isolated_affine_coeff(expr.operand, varname)
-        return None  # abs / sin / exp / ... applied to a varname-carrying arg
-    if isinstance(expr, BinaryOp):
-        op = expr.op
-        if op in ("+", "-"):
-            cl = _isolated_affine_coeff(expr.left, varname)
-            cr = _isolated_affine_coeff(expr.right, varname)
-            if cl is None or cr is None:
-                return None
-            return cl - cr if op == "-" else cl + cr
-        if op == "*":
-            lo = _occurs(expr.left, varname)
-            ro = _occurs(expr.right, varname)
-            if lo and ro:
-                return None  # varname on both factors -> nonlinear
-            # Exactly one factor carries varname; the other must be constant.
-            if lo:
-                k = _const_value(expr.right)
-                inner = _isolated_affine_coeff(expr.left, varname)
-            else:
-                k = _const_value(expr.left)
-                inner = _isolated_affine_coeff(expr.right, varname)
-            if k is None or inner is None:
-                return None
-            return k * inner
-        if op == "/":
-            if _occurs(expr.right, varname):
-                return None  # varname in a denominator -> nonlinear
-            k = _const_value(expr.right)
-            inner = _isolated_affine_coeff(expr.left, varname)
-            if k is None or inner is None or k == 0.0:
-                return None
-            return inner / k
-        if op == "**":
-            return None  # varname occurs under a power -> nonlinear
+    coeffs = _isolated_affine_coeffs(expr, index)
+    if coeffs is None:
         return None
-    if isinstance(expr, SumExpression):
-        return _isolated_affine_coeff(expr.operand, varname)
-    if isinstance(expr, SumOverExpression):
-        return None  # reduction carrying varname -> not a scalar coefficient
-    # FunctionCall / opaque node carrying varname -> nonlinear.
-    return None
+    return coeffs.get(varname, 0.0)
+
+
+def _carries(index, node) -> bool:
+    """True when ``node`` references (or might reference) any variable."""
+    names = index.names(node)
+    if names is None:
+        return True  # opaque node — assume it could carry a variable (sound)
+    return bool(names)
 
 
 def _carries_variable(expr) -> bool:
     """True when ``expr`` references (or might reference) any variable."""
-    names = _collect_var_names(expr)
-    if names is None:
-        return True  # opaque node — assume it could carry a variable (sound)
-    return len(names) > 0
+    return _carries(VarNameIndex(expr), expr)
 
 
-def _body_is_nonlinear(expr) -> bool:
+def _body_is_nonlinear(expr, index=None) -> bool:
     """Cheap structural test: does ``expr`` contain genuine nonlinearity?
 
     A *nonlinear* node is a product of two variable-carrying factors, a division
@@ -170,43 +249,68 @@ def _body_is_nonlinear(expr) -> bool:
     and branch order on them is immaterial. Conservative: an unrecognised node
     counts as nonlinear, which can only *add* a variable to the deprioritized
     set — safe under the fallback.
+
+    ``index`` supplies ``O(1)`` variable-carrying tests (built on entry when
+    omitted); the traversal is iterative so a deep sum chain cannot exhaust the
+    recursion limit.
     """
-    if isinstance(expr, (Variable, Constant, Parameter)):
-        return False
-    if isinstance(expr, UnaryOp):
-        if expr.op in ("-", "neg", "+", "pos"):
-            return _body_is_nonlinear(expr.operand)
-        # abs / sin / cos / exp / log ... are nonlinear over a variable argument
-        return _carries_variable(expr.operand)
-    if isinstance(expr, BinaryOp):
-        op = expr.op
-        if op in ("+", "-"):
-            return _body_is_nonlinear(expr.left) or _body_is_nonlinear(expr.right)
-        if op == "*":
-            if _carries_variable(expr.left) and _carries_variable(expr.right):
+    if index is None:
+        index = VarNameIndex(expr)
+    stack = [expr]
+    while stack:
+        node = stack.pop()
+        if isinstance(node, (Variable, Constant, Parameter)):
+            continue
+        if isinstance(node, UnaryOp):
+            if node.op in ("-", "neg", "+", "pos"):
+                stack.append(node.operand)
+                continue
+            # abs / sin / cos / exp / log ... are nonlinear over a variable argument
+            if _carries(index, node.operand):
                 return True
-            return _body_is_nonlinear(expr.left) or _body_is_nonlinear(expr.right)
-        if op == "/":
-            if _carries_variable(expr.right):
+            continue
+        if isinstance(node, BinaryOp):
+            op = node.op
+            if op in ("+", "-"):
+                stack.append(node.left)
+                stack.append(node.right)
+                continue
+            if op == "*":
+                if _carries(index, node.left) and _carries(index, node.right):
+                    return True
+                stack.append(node.left)
+                stack.append(node.right)
+                continue
+            if op == "/":
+                if _carries(index, node.right):
+                    return True
+                stack.append(node.left)
+                continue
+            if op == "**":
+                if _carries(index, node.left) or _carries(index, node.right):
+                    return True
+                continue
+            # Unknown binary op over variables -> treat as nonlinear (conservative).
+            if _carries(index, node.left) or _carries(index, node.right):
                 return True
-            return _body_is_nonlinear(expr.left)
-        if op == "**":
-            if _carries_variable(expr.left) or _carries_variable(expr.right):
+            continue
+        if isinstance(node, SumExpression):
+            stack.append(node.operand)
+            continue
+        if isinstance(node, SumOverExpression):
+            stack.extend(node.terms)
+            continue
+        if isinstance(node, FunctionCall):
+            if any(_carries(index, a) for a in node.args):
                 return True
-            return False
-        # Unknown binary op over variables -> treat as nonlinear (conservative).
-        return _carries_variable(expr.left) or _carries_variable(expr.right)
-    if isinstance(expr, SumExpression):
-        return _body_is_nonlinear(expr.operand)
-    if isinstance(expr, SumOverExpression):
-        return any(_body_is_nonlinear(t) for t in expr.terms)
-    if isinstance(expr, FunctionCall):
-        return any(_carries_variable(a) for a in expr.args)
-    # Opaque / unrecognised node referencing variables -> nonlinear (sound).
-    return _carries_variable(expr)
+            continue
+        # Opaque / unrecognised node referencing variables -> nonlinear (sound).
+        if _carries(index, node):
+            return True
+    return False
 
 
-def find_functionally_dependent_names(model) -> set:
+def find_functionally_dependent_names(model, deadline: float | None = None) -> set:
     """Names of continuous scalar variables pinned by a nonlinear equality.
 
     Returns the set of variable names ``x`` such that some ``==`` constraint has
@@ -217,6 +321,15 @@ def find_functionally_dependent_names(model) -> set:
     Only scalar (size-1) continuous variables are considered: the affine
     analyzer abstains on indexed/array references, and the single-defining-
     equality pattern is per-scalar.
+
+    ``deadline`` is an optional ``time.perf_counter()`` value past which the
+    scan stops and returns what it has found so far. This runs *before* the
+    branch-and-bound loop arms ``time_limit``, so without a budget a
+    pathologically large model could overrun the user's limit before a single
+    node is explored (issue #1104). Stopping early is sound: the result feeds a
+    deprioritization with a completeness-preserving fallback, so a partial set
+    only changes branch order (the module docstring's soundness argument holds
+    for *any* subset).
     """
     # Candidate names: scalar continuous variables only.
     candidates: set = set()
@@ -235,11 +348,18 @@ def find_functionally_dependent_names(model) -> set:
             continue
         if c.sense != "==":
             continue
+        if deadline is not None and time.perf_counter() >= deadline:
+            # Out of budget: return the (sound) partial set rather than overrun.
+            break
         body = c.body
+        # One memoized occurrence index per body serves every query below —
+        # presence, nonlinearity, and the affine coefficients — so the whole
+        # constraint costs O(nodes) instead of O(candidates x nodes^2).
+        index = VarNameIndex(body)
         # Names actually present in this equality, restricted to candidates not
-        # already marked. ``_collect_var_names`` returns None on an opaque body;
-        # skip — we cannot isolate any variable affinely there.
-        present = _collect_var_names(body)
+        # already marked. ``index.names`` is None on an opaque body; skip — we
+        # cannot isolate any variable affinely there.
+        present = index.names(body)
         if present is None:
             continue
         names = (present & candidates) - dependent
@@ -247,10 +367,13 @@ def find_functionally_dependent_names(model) -> set:
             continue
         # Only a genuinely nonlinear defining equality makes branching on the
         # pinned output wasteful; affine ones are presolve's job.
-        if not _body_is_nonlinear(body):
+        if not _body_is_nonlinear(body, index):
+            continue
+        coeffs = _isolated_affine_coeffs(body, index)
+        if coeffs is None:
             continue
         for name in names:
-            a = _isolated_affine_coeff(body, name)
+            a = coeffs.get(name, 0.0)
             if a is None or a == 0.0 or not np.isfinite(a):
                 continue
             dependent.add(name)

--- a/python/discopt/_relax/dependent_vars.py
+++ b/python/discopt/_relax/dependent_vars.py
@@ -48,8 +48,6 @@ remain the correct ones to deprioritize in the lifted/solved model.
 
 from __future__ import annotations
 
-import time
-
 import numpy as np
 
 # Reuse the conservative occurrence/constant analyzers proven in the
@@ -61,7 +59,7 @@ import numpy as np
 # None even when the target variable itself appears purely affinely. The
 # isolating extractor below short-circuits on "target absent -> coefficient 0",
 # which is what the dependent-output pattern requires.
-from discopt._relax.objective_epigraph import VarNameIndex, _const_value
+from discopt._relax.objective_epigraph import VarNameIndex, WorkCounter, _const_value
 from discopt.modeling.core import (
     BinaryOp,
     Constant,
@@ -85,8 +83,34 @@ from discopt.modeling.core import (
 _VISIT_BUDGET_PER_NODE = 1000
 _VISIT_BUDGET_FLOOR = 10_000
 
+# Deterministic work allowance for one whole call to
+# :func:`find_functionally_dependent_names`, in elementary operations (node
+# visits plus name-set element unions; see :class:`WorkCounter`).
+#
+# Why a work count and not a wall deadline: this scan runs *before* the B&B loop
+# arms ``time_limit``, so it must be bounded by something — but the set it
+# returns steers spatial branching, so bounding it with a clock would make the
+# search tree a function of machine speed, the exact defect #912 exists to
+# prevent (see ``python/tests/test_912_wall_budget_inventory.py``). A work count
+# stops the overrun of issue #1104 while keeping ``deterministic=True`` solves
+# reproducible.
+#
+# Calibration (issue #1104), measured over 406 MINLPLib instances that reach the
+# scan (the other 46 of the 452-instance corpus have no scalar continuous
+# candidate and cost nothing): median demand 805 units, p95 288k, p99 4.6M, max
+# 56.2M (``torsion100``). Observed throughput 2.8e6-3.4e7 units/s, so 20M bounds
+# the whole scan at ~7 s even at the slowest per-unit rate observed, and at ~0.6 s
+# on the instance that actually reaches the cap.
+#
+# At 20M exactly ONE of the 406 truncates -- ``torsion100``, which drops from 2
+# detected names to 0. That is a subset (verified, along with reproducibility, on
+# the 20 costliest instances), and ``torsion100`` is one of the three instances
+# the pre-#1104 scan could not finish at all. The runner-up, ``junkturn`` at
+# 9.2M, keeps 2.2x headroom.
+_SCAN_WORK_BUDGET = 20_000_000
 
-def _isolated_affine_coeffs(expr, index=None):
+
+def _isolated_affine_coeffs(expr, index=None, work=None):
     """Isolated affine coefficients of *every* variable in ``expr``, in one pass.
 
     Returns a mapping ``name -> coeff`` where ``coeff`` is a float when ``name``
@@ -121,7 +145,7 @@ def _isolated_affine_coeffs(expr, index=None):
     fast the machine is (``deterministic=True`` solves reproduce).
     """
     if index is None:
-        index = VarNameIndex(expr)
+        index = VarNameIndex(expr, work=work)
     if index.names(expr) is None:
         return None  # opaque node reachable -> nothing provable (see docstring)
 
@@ -133,6 +157,8 @@ def _isolated_affine_coeffs(expr, index=None):
         budget -= 1
         if budget < 0:
             return None  # shared-subexpression blowup -> abstain (see docstring)
+        if work is not None and not work.spend(1):
+            return None  # scan-wide work allowance gone -> abstain (see docstring)
         node, mult = stack.pop()
         names = index.names(node)
         if not names:
@@ -310,7 +336,7 @@ def _body_is_nonlinear(expr, index=None) -> bool:
     return False
 
 
-def find_functionally_dependent_names(model, deadline: float | None = None) -> set:
+def find_functionally_dependent_names(model, work_budget: int | None = None) -> set:
     """Names of continuous scalar variables pinned by a nonlinear equality.
 
     Returns the set of variable names ``x`` such that some ``==`` constraint has
@@ -322,14 +348,19 @@ def find_functionally_dependent_names(model, deadline: float | None = None) -> s
     analyzer abstains on indexed/array references, and the single-defining-
     equality pattern is per-scalar.
 
-    ``deadline`` is an optional ``time.perf_counter()`` value past which the
-    scan stops and returns what it has found so far. This runs *before* the
-    branch-and-bound loop arms ``time_limit``, so without a budget a
-    pathologically large model could overrun the user's limit before a single
-    node is explored (issue #1104). Stopping early is sound: the result feeds a
-    deprioritization with a completeness-preserving fallback, so a partial set
-    only changes branch order (the module docstring's soundness argument holds
-    for *any* subset).
+    ``work_budget`` caps the whole scan in elementary operations (default
+    :data:`_SCAN_WORK_BUDGET`); pass ``0`` to skip the scan outright. When it
+    runs out the scan stops and returns what it has found so far. A budget is
+    needed because this runs *before* the branch-and-bound loop arms
+    ``time_limit``, so an unbounded pass on a pathologically large model can
+    overrun the user's limit before a single node is explored (issue #1104).
+
+    The cap is deterministic — an operation count, not a clock — because the
+    returned set steers spatial branching: a wall deadline would make the search
+    tree a function of machine speed (#912). Stopping early is sound either way:
+    the result feeds a deprioritization with a completeness-preserving fallback,
+    so a partial set only changes branch order (the module docstring's soundness
+    argument holds for *any* subset, including the empty one).
     """
     # Candidate names: scalar continuous variables only.
     candidates: set = set()
@@ -342,20 +373,24 @@ def find_functionally_dependent_names(model, deadline: float | None = None) -> s
     if not candidates:
         return set()
 
+    work = WorkCounter(_SCAN_WORK_BUDGET if work_budget is None else work_budget)
+
     dependent: set = set()
     for c in getattr(model, "_constraints", []):
         if not isinstance(c, Constraint):
             continue
         if c.sense != "==":
             continue
-        if deadline is not None and time.perf_counter() >= deadline:
+        if work.exhausted:
             # Out of budget: return the (sound) partial set rather than overrun.
             break
         body = c.body
         # One memoized occurrence index per body serves every query below —
         # presence, nonlinearity, and the affine coefficients — so the whole
-        # constraint costs O(nodes) instead of O(candidates x nodes^2).
-        index = VarNameIndex(body)
+        # constraint costs O(nodes) instead of O(candidates x nodes^2). The
+        # index build charges the dominant cost (one unit per node plus one per
+        # unioned name), which also bounds the two O(nodes) walks below.
+        index = VarNameIndex(body, work=work)
         # Names actually present in this equality, restricted to candidates not
         # already marked. ``index.names`` is None on an opaque body; skip — we
         # cannot isolate any variable affinely there.
@@ -369,7 +404,7 @@ def find_functionally_dependent_names(model, deadline: float | None = None) -> s
         # pinned output wasteful; affine ones are presolve's job.
         if not _body_is_nonlinear(body, index):
             continue
-        coeffs = _isolated_affine_coeffs(body, index)
+        coeffs = _isolated_affine_coeffs(body, index, work=work)
         if coeffs is None:
             continue
         for name in names:

--- a/python/discopt/_relax/objective_epigraph.py
+++ b/python/discopt/_relax/objective_epigraph.py
@@ -125,6 +125,41 @@ def _name_walk_children(expr):
     return "opaque", ()
 
 
+class WorkCounter:
+    """A deterministic work allowance shared across a family of DAG walks.
+
+    #912's rule for this layer: a pass that decides *how much* analysis to run
+    must spend a deterministic quantity, never a clock, or the search tree
+    becomes a function of machine speed. This counts elementary operations —
+    node visits and name-set element unions — so a caller can bound an analysis
+    phase without consulting ``time.perf_counter()``.
+
+    ``spend`` returns ``False`` once the allowance is gone; every caller here
+    treats that as "abstain", which is the sound direction for all of them.
+    """
+
+    __slots__ = ("remaining", "limit")
+
+    def __init__(self, limit: int):
+        self.limit = int(limit)
+        self.remaining = int(limit)
+
+    def spend(self, units: int) -> bool:
+        """Charge ``units``; ``False`` once the allowance is exhausted."""
+        if self.remaining <= 0:
+            return False
+        self.remaining -= units
+        return self.remaining > 0
+
+    @property
+    def exhausted(self) -> bool:
+        return self.remaining <= 0
+
+    @property
+    def spent(self) -> int:
+        return self.limit - max(0, self.remaining)
+
+
 class VarNameIndex:
     """Memoized variable-name sets for every node of one expression DAG.
 
@@ -148,15 +183,25 @@ class VarNameIndex:
 
     An index is valid only for expressions that are *not mutated* while it
     lives; the analyzers here build one per constraint body and discard it.
+
+    Cost is ``O(nodes)`` in *node visits* but ``O(sum of |names| over nodes)`` in
+    element operations, because each combine node unions its children's name
+    sets — on a 1000-variable sum chain that is ~1e6 set-element ops, not 5e3.
+    An optional :class:`WorkCounter` charges those ops so a caller can bound the
+    build deterministically; when it runs out the index becomes *exhausted* and
+    reports ``None`` (opaque, the sound direction) for every node, which every
+    analyzer here already handles as "nothing provable".
     """
 
-    __slots__ = ("_memo",)
+    __slots__ = ("_memo", "_exhausted")
 
     _memo: Dict[int, Tuple[Any, Optional[frozenset]]]
+    _exhausted: bool
 
-    def __init__(self, root):
+    def __init__(self, root, work: Optional["WorkCounter"] = None):
         # id(node) -> (node, names|None). The node is stored to pin the id.
         memo: Dict[int, Tuple[Any, Optional[frozenset]]] = {}
+        self._exhausted = False
         stack = [(root, False)]
         while stack:
             node, expanded = stack.pop()
@@ -171,6 +216,12 @@ class VarNameIndex:
                     if id(child) not in memo:
                         stack.append((child, False))
                 continue
+            if work is not None and not work.spend(1):
+                # Out of work units: drop the partial memo and report opaque
+                # everywhere rather than answer from an incomplete index.
+                self._exhausted = True
+                memo = {}
+                break
             if kind == "var":
                 memo[key] = (node, frozenset((node.name,)))
                 continue
@@ -182,18 +233,32 @@ class VarNameIndex:
                 continue
             # "combine" with no children collapses to the empty set, matching
             # the union-over-nothing of the recursive walk.
-            acc: Optional[set] = set()
+            acc: set = set()
+            opaque = False
             for child in children:
                 sub = memo[id(child)][1]
                 if sub is None:
-                    acc = None
+                    opaque = True
+                    break
+                if work is not None and not work.spend(len(sub)):
+                    self._exhausted = True
+                    memo = {}
+                    stack.clear()
+                    opaque = True
                     break
                 acc |= sub
-            memo[key] = (node, None if acc is None else frozenset(acc))
+            if self._exhausted:
+                break
+            memo[key] = (node, None if opaque else frozenset(acc))
         self._memo = memo
 
+    @property
+    def exhausted(self) -> bool:
+        """True when the build ran out of work units and reports opaque."""
+        return self._exhausted
+
     def __len__(self) -> int:
-        """Number of distinct DAG nodes indexed."""
+        """Number of distinct DAG nodes indexed (0 when exhausted)."""
         return len(self._memo)
 
     def names(self, expr) -> Optional[frozenset]:
@@ -202,11 +267,17 @@ class VarNameIndex:
         ``expr`` must be a node of the DAG this index was built from; a foreign
         node raises ``KeyError`` rather than silently reporting "no variables"
         (a wrong-but-plausible answer that would make an occurrence test unsound).
+        An *exhausted* index reports ``None`` for everything, foreign or not:
+        it has no memo left to check against, and ``None`` is the sound answer.
         """
+        if self._exhausted:
+            return None
         return self._memo[id(expr)][1]
 
     def occurs(self, expr, varname: str) -> bool:
         """True when ``varname`` *might* appear in ``expr`` (conservative)."""
+        if self._exhausted:
+            return True  # exhausted index — assume it might occur (sound)
         names = self._memo[id(expr)][1]
         if names is None:
             return True  # opaque node — assume it might occur (sound)

--- a/python/discopt/_relax/objective_epigraph.py
+++ b/python/discopt/_relax/objective_epigraph.py
@@ -65,7 +65,7 @@ Tawarmalani, Sahinidis (2005), "A polyhedral branch-and-cut approach to
 
 from __future__ import annotations
 
-from typing import Optional
+from typing import Any, Dict, Optional, Tuple
 
 import numpy as np
 
@@ -89,59 +89,151 @@ from discopt.modeling.core import (
 _FREE_BOUND = 1e15
 
 
+_EMPTY_NAMES: frozenset = frozenset()
+
+
+def _name_walk_children(expr):
+    """``(kind, children)`` for the variable-name walk.
+
+    ``kind`` is ``"var"`` (a scalar variable reference), ``"empty"`` (provably
+    variable-free), ``"combine"`` (the name set is the union of the children's,
+    ``None`` if any child is ``None``), or ``"opaque"`` (unrecognised node —
+    abstain with ``None``).
+
+    The isinstance ladder must stay in the same order as the semantics it
+    encodes; :func:`_collect_var_names` and :class:`VarNameIndex` both read it,
+    so the two can never drift apart.
+    """
+    if isinstance(expr, Variable):
+        return "var", ()
+    if isinstance(expr, (Constant, Parameter)):
+        return "empty", ()
+    if isinstance(expr, IndexExpression):
+        return "combine", (expr.base,)
+    if isinstance(expr, UnaryOp):
+        return "combine", (expr.operand,)
+    if isinstance(expr, BinaryOp):
+        return "combine", (expr.left, expr.right)
+    if isinstance(expr, FunctionCall):
+        return "combine", tuple(expr.args)
+    if isinstance(expr, SumExpression):
+        return "combine", (expr.operand,)
+    if isinstance(expr, SumOverExpression):
+        return "combine", tuple(expr.terms)
+    # Unknown / opaque node (CustomCall, MatMul, ...): cannot prove the
+    # variable is absent — abstain.
+    return "opaque", ()
+
+
+class VarNameIndex:
+    """Memoized variable-name sets for every node of one expression DAG.
+
+    Built once in ``O(nodes)``; :meth:`names` and :meth:`occurs` are then ``O(1)``
+    dict lookups. The naive recursive walk allocates a fresh set at every node
+    and re-expands shared subexpressions, so an occurrence test called at each
+    level of a structural analyzer costs ``O(nodes^2)`` per variable — the
+    ``t1000`` non-termination in issue #1104 (1002 candidate names against a
+    5003-node, depth-1004 sum chain).
+
+    Two properties matter for correctness:
+
+    * **DAG-correct.** Keyed by ``id(node)``, so a subexpression reachable
+      through several parents is walked once. The index holds a reference to
+      every node it memoizes (values are ``(node, names)``), so CPython can
+      never recycle an ``id`` while the index is alive — the usual hazard of
+      ``id()``-keyed memos.
+    * **Iterative.** An explicit stack, not recursion: a depth-1004 body is
+      already close to the default recursion limit, and MINLPLib carries
+      deeper ones.
+
+    An index is valid only for expressions that are *not mutated* while it
+    lives; the analyzers here build one per constraint body and discard it.
+    """
+
+    __slots__ = ("_memo",)
+
+    _memo: Dict[int, Tuple[Any, Optional[frozenset]]]
+
+    def __init__(self, root):
+        # id(node) -> (node, names|None). The node is stored to pin the id.
+        memo: Dict[int, Tuple[Any, Optional[frozenset]]] = {}
+        stack = [(root, False)]
+        while stack:
+            node, expanded = stack.pop()
+            key = id(node)
+            if key in memo:
+                continue
+            kind, children = _name_walk_children(node)
+            if not expanded and children:
+                # Post-order: revisit this node once every child is memoized.
+                stack.append((node, True))
+                for child in children:
+                    if id(child) not in memo:
+                        stack.append((child, False))
+                continue
+            if kind == "var":
+                memo[key] = (node, frozenset((node.name,)))
+                continue
+            if kind == "empty":
+                memo[key] = (node, _EMPTY_NAMES)
+                continue
+            if kind == "opaque":
+                memo[key] = (node, None)
+                continue
+            # "combine" with no children collapses to the empty set, matching
+            # the union-over-nothing of the recursive walk.
+            acc: Optional[set] = set()
+            for child in children:
+                sub = memo[id(child)][1]
+                if sub is None:
+                    acc = None
+                    break
+                acc |= sub
+            memo[key] = (node, None if acc is None else frozenset(acc))
+        self._memo = memo
+
+    def __len__(self) -> int:
+        """Number of distinct DAG nodes indexed."""
+        return len(self._memo)
+
+    def names(self, expr) -> Optional[frozenset]:
+        """Variable names referenced by ``expr``, or ``None`` if opaque.
+
+        ``expr`` must be a node of the DAG this index was built from; a foreign
+        node raises ``KeyError`` rather than silently reporting "no variables"
+        (a wrong-but-plausible answer that would make an occurrence test unsound).
+        """
+        return self._memo[id(expr)][1]
+
+    def occurs(self, expr, varname: str) -> bool:
+        """True when ``varname`` *might* appear in ``expr`` (conservative)."""
+        names = self._memo[id(expr)][1]
+        if names is None:
+            return True  # opaque node — assume it might occur (sound)
+        return varname in names
+
+
 def _collect_var_names(expr) -> Optional[set]:
     """Return the complete set of variable names referenced by ``expr``.
 
     Returns ``None`` if an unrecognised / opaque node is encountered — the
     caller must then treat the variable of interest as *possibly* present
     (the sound direction for an occurrence test).
+
+    Returns a fresh mutable ``set`` the caller may modify. When several
+    occurrence queries are made against one expression, build a
+    :class:`VarNameIndex` once instead of calling this repeatedly.
     """
-    if isinstance(expr, Variable):
-        return {expr.name}
-    if isinstance(expr, (Constant, Parameter)):
-        return set()
-    if isinstance(expr, IndexExpression):
-        return _collect_var_names(expr.base)
-    if isinstance(expr, UnaryOp):
-        return _collect_var_names(expr.operand)
-    if isinstance(expr, BinaryOp):
-        left = _collect_var_names(expr.left)
-        right = _collect_var_names(expr.right)
-        if left is None or right is None:
-            return None
-        return left | right
-    if isinstance(expr, FunctionCall):
-        acc: set = set()
-        for a in expr.args:
-            names = _collect_var_names(a)
-            if names is None:
-                return None
-            acc |= names
-        return acc
-    if isinstance(expr, SumExpression):
-        return _collect_var_names(expr.operand)
-    if isinstance(expr, SumOverExpression):
-        acc = set()
-        for t in expr.terms:
-            names = _collect_var_names(t)
-            if names is None:
-                return None
-            acc |= names
-        return acc
-    # Unknown / opaque node (CustomCall, MatMul, ...): cannot prove the
-    # variable is absent — abstain.
-    return None
+    names = VarNameIndex(expr).names(expr)
+    return None if names is None else set(names)
 
 
 def _occurs(expr, varname: str) -> bool:
     """True when ``varname`` *might* appear in ``expr`` (conservative)."""
-    names = _collect_var_names(expr)
-    if names is None:
-        return True  # opaque node — assume it might occur (sound)
-    return varname in names
+    return VarNameIndex(expr).occurs(expr, varname)
 
 
-def _affine_coeff(expr, varname: str) -> Optional[float]:
+def _affine_coeff(expr, varname: str, index: Optional[VarNameIndex] = None) -> Optional[float]:
     """Constant coefficient of ``varname`` in ``expr``, or ``None``.
 
     Returns a float ``a`` iff ``expr`` depends on ``varname`` *only*
@@ -149,7 +241,14 @@ def _affine_coeff(expr, varname: str) -> Optional[float]:
     ``a`` a compile-time constant (``0.0`` means it does not appear). Returns
     ``None`` whenever the dependence is nonlinear, indexed, or routed
     through an unanalyzable node — a conservative abstention.
+
+    ``index`` is the memoized occurrence index for ``expr``'s DAG; it is built
+    on entry when omitted. Passing it (or letting the recursion thread it, as
+    it does here) keeps the walk ``O(nodes)`` instead of ``O(nodes^2)`` — see
+    :class:`VarNameIndex`.
     """
+    if index is None:
+        index = VarNameIndex(expr)
     if isinstance(expr, Variable):
         return 1.0 if expr.name == varname else 0.0
     if isinstance(expr, (Constant, Parameter)):
@@ -157,11 +256,11 @@ def _affine_coeff(expr, varname: str) -> Optional[float]:
     if isinstance(expr, IndexExpression):
         # An indexed reference to the target variable means the target is an
         # array element; the single-free-scalar pattern does not apply.
-        if _occurs(expr.base, varname):
+        if index.occurs(expr.base, varname):
             return None
         return 0.0
     if isinstance(expr, UnaryOp):
-        inner = _affine_coeff(expr.operand, varname)
+        inner = _affine_coeff(expr.operand, varname, index)
         if inner is None:
             return None
         if expr.op in ("-", "neg"):
@@ -169,24 +268,24 @@ def _affine_coeff(expr, varname: str) -> Optional[float]:
         if expr.op in ("+", "pos"):
             return inner
         # abs / other unary atoms are nonlinear in their argument
-        return None if _occurs(expr.operand, varname) else 0.0
+        return None if index.occurs(expr.operand, varname) else 0.0
     if isinstance(expr, BinaryOp):
         op = expr.op
         if op == "+":
-            cl = _affine_coeff(expr.left, varname)
-            cr = _affine_coeff(expr.right, varname)
+            cl = _affine_coeff(expr.left, varname, index)
+            cr = _affine_coeff(expr.right, varname, index)
             if cl is None or cr is None:
                 return None
             return cl + cr
         if op == "-":
-            cl = _affine_coeff(expr.left, varname)
-            cr = _affine_coeff(expr.right, varname)
+            cl = _affine_coeff(expr.left, varname, index)
+            cr = _affine_coeff(expr.right, varname, index)
             if cl is None or cr is None:
                 return None
             return cl - cr
         if op == "*":
-            lo = _occurs(expr.left, varname)
-            ro = _occurs(expr.right, varname)
+            lo = index.occurs(expr.left, varname)
+            ro = index.occurs(expr.right, varname)
             if lo and ro:
                 return None  # var on both sides -> nonlinear
             if not lo and not ro:
@@ -194,30 +293,32 @@ def _affine_coeff(expr, varname: str) -> Optional[float]:
             # exactly one side carries the var; the other must be a constant
             if lo:
                 k = _const_value(expr.right)
-                inner = _affine_coeff(expr.left, varname)
+                inner = _affine_coeff(expr.left, varname, index)
             else:
                 k = _const_value(expr.left)
-                inner = _affine_coeff(expr.right, varname)
+                inner = _affine_coeff(expr.right, varname, index)
             if k is None or inner is None:
                 return None
             return k * inner
         if op == "/":
             # var only allowed in the numerator, denominator must be constant
-            if _occurs(expr.right, varname):
+            if index.occurs(expr.right, varname):
                 return None
             k = _const_value(expr.right)
-            inner = _affine_coeff(expr.left, varname)
+            inner = _affine_coeff(expr.left, varname, index)
             if k is None or inner is None or k == 0.0:
                 return None
             return inner / k
         if op == "**":
             # var under a power is nonlinear; only var-free bases are fine
-            if _occurs(expr.left, varname) or _occurs(expr.right, varname):
+            if index.occurs(expr.left, varname) or index.occurs(expr.right, varname):
                 return None
             return 0.0
-        return None if (_occurs(expr.left, varname) or _occurs(expr.right, varname)) else 0.0
+        if index.occurs(expr.left, varname) or index.occurs(expr.right, varname):
+            return None
+        return 0.0
     # FunctionCall / Sum / opaque: var-free -> 0, otherwise nonlinear/unknown.
-    return None if _occurs(expr, varname) else 0.0
+    return None if index.occurs(expr, varname) else 0.0
 
 
 def _const_value(expr) -> Optional[float]:

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -8190,11 +8190,19 @@ def solve_model(
     # the independent inputs would not (welded-beam / nvs05). Names are mapped
     # to flat columns of the live model at tree setup; deprioritization carries
     # a completeness-preserving fallback, so an empty or imperfect set is safe.
+    # That same "any subset is safe" property is what lets the scan carry a
+    # deadline: it runs before the B&B loop arms ``time_limit``, so an unbudgeted
+    # pass on a large model can blow the user's limit before a single node is
+    # explored (issue #1104 — ``t1000`` overran a 30 s limit by >30x). The budget
+    # is a small slice of the limit, clamped to the time actually left.
     _dependent_var_names: set = set()
     try:
         from discopt._relax.dependent_vars import find_functionally_dependent_names
 
-        _dependent_var_names = find_functionally_dependent_names(model)
+        _dep_budget_s = min(min(max(0.05 * float(time_limit), 1.0), 10.0), _remaining_budget())
+        _dependent_var_names = find_functionally_dependent_names(
+            model, deadline=time.perf_counter() + _dep_budget_s
+        )
     except Exception as _dep_exc:  # pragma: no cover - defensive
         logger.debug("functional-dependency detection skipped: %s", _dep_exc)
 

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -8190,19 +8190,19 @@ def solve_model(
     # the independent inputs would not (welded-beam / nvs05). Names are mapped
     # to flat columns of the live model at tree setup; deprioritization carries
     # a completeness-preserving fallback, so an empty or imperfect set is safe.
-    # That same "any subset is safe" property is what lets the scan carry a
-    # deadline: it runs before the B&B loop arms ``time_limit``, so an unbudgeted
-    # pass on a large model can blow the user's limit before a single node is
-    # explored (issue #1104 — ``t1000`` overran a 30 s limit by >30x). The budget
-    # is a small slice of the limit, clamped to the time actually left.
+    # That same "any subset is safe" property is what bounds the scan: it runs
+    # before the B&B loop arms ``time_limit``, so an unbudgeted pass on a large
+    # model can blow the user's limit before a single node is explored (issue
+    # #1104 — ``t1000`` overran a 30 s limit by >30x). The scan carries its own
+    # deterministic work allowance (``_SCAN_WORK_BUDGET``, an operation count)
+    # and degrades to a partial set when it runs out. Deliberately NOT a wall
+    # deadline: the set steers spatial branching, so a clock here would make the
+    # search tree a function of machine speed (#912).
     _dependent_var_names: set = set()
     try:
         from discopt._relax.dependent_vars import find_functionally_dependent_names
 
-        _dep_budget_s = min(min(max(0.05 * float(time_limit), 1.0), 10.0), _remaining_budget())
-        _dependent_var_names = find_functionally_dependent_names(
-            model, deadline=time.perf_counter() + _dep_budget_s
-        )
+        _dependent_var_names = find_functionally_dependent_names(model)
     except Exception as _dep_exc:  # pragma: no cover - defensive
         logger.debug("functional-dependency detection skipped: %s", _dep_exc)
 

--- a/python/tests/test_dependent_vars.py
+++ b/python/tests/test_dependent_vars.py
@@ -1,0 +1,261 @@
+"""Tests for the functionally-dependent-variable detector (``_relax/dependent_vars``).
+
+Two things are under test:
+
+*Semantics* — the isolated-affine-coefficient analyzer must keep abstaining
+conservatively. Every structural case that made it return ``None`` before issue
+#1104's rewrite (nonlinear occurrence, indexed reference, reduction, opaque
+node) must still return ``None``, and the affine cases must still return the
+same coefficient. The detector only changes *branch order* (see the module
+docstring), so a wrong answer is not unsound — but it is wrong, and the rewrite
+replaced a per-name recursive walk with a single top-down pass, which is exactly
+the kind of change that silently drops a case.
+
+*Cost* — the pass runs before branch-and-bound arms ``time_limit``, so its cost
+is part of the user's budget. The pre-#1104 implementation re-derived variable
+occurrence at every recursion level for every candidate name, i.e.
+``O(names x nodes^2)``: on ``t1000`` (1002 candidates, a 5003-node depth-1004
+sum chain) the scan did not return in 12 minutes against a 30 s limit. The
+scaling test below builds that structure directly.
+"""
+
+from __future__ import annotations
+
+import time
+
+import discopt.modeling as dm
+import pytest
+from discopt._relax.dependent_vars import (
+    _body_is_nonlinear,
+    _isolated_affine_coeff,
+    _isolated_affine_coeffs,
+    dependent_columns_for_model,
+    find_functionally_dependent_names,
+)
+from discopt._relax.objective_epigraph import VarNameIndex, _collect_var_names, _occurs
+
+
+@pytest.fixture
+def xyz():
+    m = dm.Model("t")
+    return m, m.continuous("x", lb=-5, ub=5), m.continuous("y", lb=1, ub=5)
+
+
+@pytest.mark.unit
+class TestVarNameIndex:
+    def test_names_and_occurrence(self, xyz):
+        _, x, y = xyz
+        e = 3.0 * x + y * y
+        idx = VarNameIndex(e)
+        assert idx.names(e) == {"x", "y"}
+        assert idx.occurs(e, "x") is True
+        assert idx.occurs(e, "z") is False
+
+    def test_shared_subexpression_memoized_once(self, xyz):
+        """A DAG node reachable twice is indexed once, not re-expanded."""
+        _, x, y = xyz
+        shared = x * y + x
+        e = shared + shared
+        idx = VarNameIndex(e)
+        # left and right of the top-level ``+`` are the *same* object.
+        assert e.left is e.right is shared
+        assert idx.names(shared) == {"x", "y"}
+        # One entry per distinct node: the shared subtree contributes its nodes once.
+        assert len(idx._memo) == len(VarNameIndex(shared)._memo) + 1
+
+    def test_foreign_node_raises_rather_than_reporting_absent(self, xyz):
+        """A node from another DAG must not silently read as variable-free."""
+        _, x, y = xyz
+        idx = VarNameIndex(x + 1.0)
+        with pytest.raises(KeyError):
+            idx.names(y * y)
+
+    def test_deep_chain_does_not_exhaust_the_recursion_limit(self, xyz):
+        m, x, _ = xyz
+        terms = [m.continuous(f"v{i}", lb=0, ub=1) for i in range(3000)]
+        e = terms[0]
+        for t in terms[1:]:
+            e = e + t
+        assert len(_collect_var_names(e)) == 3000
+        assert _occurs(e, "v2999") is True
+
+
+@pytest.mark.unit
+class TestIsolatedAffineCoefficients:
+    """Structural cases: affine ones carry a coefficient, the rest abstain."""
+
+    @pytest.mark.parametrize(
+        "build, expected",
+        [
+            (lambda x, y: x, 1.0),
+            (lambda x, y: -x, -1.0),
+            (lambda x, y: 3.0 * x, 3.0),
+            (lambda x, y: x * 3.0, 3.0),
+            (lambda x, y: x / 4.0, 0.25),
+            (lambda x, y: x + x, 2.0),
+            (lambda x, y: x - x, 0.0),
+            (lambda x, y: 2.0 * x - 5.0 * x, -3.0),
+            # A sibling term arbitrarily nonlinear in *other* variables does not
+            # spoil the target's affine isolation -- the whole point of this
+            # analyzer over a whole-expression affine test.
+            (lambda x, y: x - dm.sqrt(y * y + 1.0), 1.0),
+            (lambda x, y: x + 4243.28 / (y * y), 1.0),
+            (lambda x, y: -(2.0 * x) + dm.exp(y), -2.0),
+            # Provably absent -> 0.0, never None.
+            (lambda x, y: y * y + dm.log(y), 0.0),
+            # Nonlinear in the target -> abstain.
+            (lambda x, y: x * x, None),
+            (lambda x, y: x * y, None),
+            (lambda x, y: x**2, None),
+            (lambda x, y: 1.0 / x, None),
+            (lambda x, y: y / x, None),
+            (lambda x, y: dm.exp(x), None),
+            (lambda x, y: dm.sqrt(x + 1.0), None),
+            (lambda x, y: x + dm.sin(x), None),
+            # A non-constant multiplier is not a coefficient.
+            (lambda x, y: (y + 1.0) * x, None),
+        ],
+    )
+    def test_cases(self, xyz, build, expected):
+        _, x, y = xyz
+        e = build(x, y)
+        assert _isolated_affine_coeff(e, "x") == expected
+
+    def test_bulk_pass_agrees_with_the_single_name_view(self, xyz):
+        _, x, y = xyz
+        e = 3.0 * x - dm.sqrt(y) + x
+        coeffs = _isolated_affine_coeffs(e)
+        assert coeffs == {"x": 4.0, "y": None}
+        for name in ("x", "y", "absent"):
+            assert _isolated_affine_coeff(e, name) == coeffs.get(name, 0.0)
+
+    def test_shared_subexpression_blowup_abstains_deterministically(self, xyz):
+        """A DAG with exponentially many paths must abstain, not hang.
+
+        The multiplier a node inherits is path-dependent, so the traversal is
+        O(paths); ``e = e + e`` twenty-five times is 28 distinct nodes and 2**25
+        paths. The visit cap turns that into a conservative ``None`` (nothing
+        proven) in milliseconds. The cap counts node visits, not seconds, so the
+        answer is identical on a fast and a slow machine.
+        """
+        _, x, _ = xyz
+        e = x + 0.0
+        for _ in range(25):
+            e = e + e
+        assert len(VarNameIndex(e)) < 100, "the DAG must stay small; only paths blow up"
+        t0 = time.perf_counter()
+        assert _isolated_affine_coeffs(e) is None
+        assert time.perf_counter() - t0 < 5.0
+
+    def test_deep_chain_is_analyzed_iteratively(self, xyz):
+        m, _, _ = xyz
+        terms = [m.continuous(f"w{i}", lb=0, ub=1) for i in range(3000)]
+        e = terms[0]
+        for i, t in enumerate(terms[1:], start=1):
+            e = e + float(i) * t
+        coeffs = _isolated_affine_coeffs(e)
+        assert coeffs["w0"] == 1.0
+        assert coeffs["w2999"] == 2999.0
+
+
+@pytest.mark.unit
+class TestBodyIsNonlinear:
+    @pytest.mark.parametrize(
+        "build, expected",
+        [
+            (lambda x, y: x + 2.0 * y - 3.0, False),
+            (lambda x, y: -(x / 2.0) + y, False),
+            (lambda x, y: x * y, True),
+            (lambda x, y: x / y, True),
+            (lambda x, y: x**2, True),
+            (lambda x, y: dm.exp(x) + y, True),
+            (lambda x, y: x - dm.sqrt(y * y + 1.0), True),
+        ],
+    )
+    def test_cases(self, xyz, build, expected):
+        _, x, y = xyz
+        assert _body_is_nonlinear(build(x, y)) is expected
+
+
+@pytest.mark.unit
+class TestFindFunctionallyDependentNames:
+    def test_marks_the_pinned_output_only(self):
+        m = dm.Model("pinned")
+        x = m.continuous("x", lb=1, ub=5)
+        y = m.continuous("y", lb=1, ub=5)
+        z = m.continuous("z", lb=-100, ub=100)
+        m.subject_to(z - x * y == 0.0)
+        m.minimize(z)
+        assert find_functionally_dependent_names(m) == {"z"}
+        assert dependent_columns_for_model(m, {"z"}) == [2]
+
+    def test_affine_defining_equality_is_left_to_presolve(self):
+        m = dm.Model("affine")
+        x = m.continuous("x", lb=1, ub=5)
+        z = m.continuous("z", lb=-100, ub=100)
+        m.subject_to(z - 2.0 * x == 0.0)
+        m.minimize(z)
+        assert find_functionally_dependent_names(m) == set()
+
+    def test_inequality_is_not_a_defining_equality(self):
+        m = dm.Model("ineq")
+        x = m.continuous("x", lb=1, ub=5)
+        z = m.continuous("z", lb=-100, ub=100)
+        m.subject_to(z - x * x <= 0.0)
+        m.minimize(z)
+        assert find_functionally_dependent_names(m) == set()
+
+    def test_integer_outputs_are_not_candidates(self):
+        m = dm.Model("intout")
+        x = m.continuous("x", lb=1, ub=5)
+        n = m.integer("n", lb=0, ub=10)
+        m.subject_to(n - x * x == 0.0)
+        m.minimize(x)
+        assert find_functionally_dependent_names(m) == set()
+
+
+def _chain_model(n_terms: int) -> dm.Model:
+    """``t1000``-shaped probe: one nonlinear equality over a long sum chain.
+
+    ``sum_i c_i * v_i * v_i + z == 0`` with every ``v_i`` a distinct candidate.
+    The pre-#1104 scan tested occurrence for each of the ``n_terms`` candidates
+    at every level of the depth-``n_terms`` chain.
+    """
+    m = dm.Model("chain")
+    v = [m.continuous(f"v{i}", lb=0.0, ub=1.0) for i in range(n_terms)]
+    z = m.continuous("z", lb=-1e6, ub=1e6)
+    body = z
+    for i, vi in enumerate(v):
+        body = body + float(i + 1) * (vi * vi)
+    m.subject_to(body == 0.0)
+    m.minimize(z)
+    return m
+
+
+@pytest.mark.unit
+class TestScanCost:
+    def test_long_chain_scan_is_not_quadratic(self):
+        """Issue #1104: the scan must stay tractable on a t1000-shaped body.
+
+        The bound is deliberately loose (measured ~0.03 s on the t1000 model
+        itself, ~4000 nodes over 1000 candidates) so machine load cannot flake
+        it; the pre-fix implementation did not finish this shape in 12 minutes.
+        """
+        m = _chain_model(1000)
+        t0 = time.perf_counter()
+        names = find_functionally_dependent_names(m)
+        wall = time.perf_counter() - t0
+        assert names == {"z"}, "the pinned output must still be detected"
+        assert wall < 10.0, f"scan took {wall:.1f}s on a 1000-term chain"
+
+    def test_expired_deadline_stops_the_scan(self):
+        """A blown budget yields the (sound) partial set, not an overrun."""
+        m = _chain_model(200)
+        assert find_functionally_dependent_names(m) == {"z"}
+        expired = time.perf_counter() - 1.0
+        assert find_functionally_dependent_names(m, deadline=expired) == set()
+
+    def test_generous_deadline_does_not_change_the_answer(self):
+        m = _chain_model(200)
+        deadline = time.perf_counter() + 60.0
+        assert find_functionally_dependent_names(m, deadline=deadline) == {"z"}

--- a/python/tests/test_dependent_vars.py
+++ b/python/tests/test_dependent_vars.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 
 import time
 
+import discopt._relax.dependent_vars as dv
 import discopt.modeling as dm
 import pytest
 from discopt._relax.dependent_vars import (
@@ -32,7 +33,12 @@ from discopt._relax.dependent_vars import (
     dependent_columns_for_model,
     find_functionally_dependent_names,
 )
-from discopt._relax.objective_epigraph import VarNameIndex, _collect_var_names, _occurs
+from discopt._relax.objective_epigraph import (
+    VarNameIndex,
+    WorkCounter,
+    _collect_var_names,
+    _occurs,
+)
 
 
 @pytest.fixture
@@ -248,14 +254,97 @@ class TestScanCost:
         assert names == {"z"}, "the pinned output must still be detected"
         assert wall < 10.0, f"scan took {wall:.1f}s on a 1000-term chain"
 
-    def test_expired_deadline_stops_the_scan(self):
+    def test_exhausted_work_budget_stops_the_scan(self):
         """A blown budget yields the (sound) partial set, not an overrun."""
         m = _chain_model(200)
         assert find_functionally_dependent_names(m) == {"z"}
-        expired = time.perf_counter() - 1.0
-        assert find_functionally_dependent_names(m, deadline=expired) == set()
+        assert find_functionally_dependent_names(m, work_budget=0) == set()
+        assert find_functionally_dependent_names(m, work_budget=50) == set()
 
-    def test_generous_deadline_does_not_change_the_answer(self):
+    def test_generous_work_budget_does_not_change_the_answer(self):
         m = _chain_model(200)
-        deadline = time.perf_counter() + 60.0
-        assert find_functionally_dependent_names(m, deadline=deadline) == {"z"}
+        assert find_functionally_dependent_names(m, work_budget=10**9) == {"z"}
+
+    def test_budget_is_deterministic_not_wall_clock(self):
+        """The same budget must give the same answer on any machine.
+
+        #912: this set steers spatial branching, so a clock-based cut would make
+        the search tree a function of machine speed. The exhaustion point is a
+        pure function of the model and the allowance, so the boundary is
+        reproducible — this pins that by finding it and re-checking it.
+        """
+        m = _chain_model(60)
+        full = find_functionally_dependent_names(m)
+        assert full == {"z"}
+        # Bisect for the smallest allowance that still yields the full answer.
+        lo, hi = 0, 10**7
+        while lo + 1 < hi:
+            mid = (lo + hi) // 2
+            if find_functionally_dependent_names(m, work_budget=mid) == full:
+                hi = mid
+            else:
+                lo = mid
+        # Reproducible on both sides of the boundary, every time.
+        for _ in range(5):
+            assert find_functionally_dependent_names(m, work_budget=hi) == full
+            assert find_functionally_dependent_names(m, work_budget=lo) != full
+
+    def test_scan_work_budget_bounds_the_default_path(self):
+        """The default allowance is what the solver relies on; it must be finite
+        and must be what an un-parameterised call spends."""
+        assert 0 < dv._SCAN_WORK_BUDGET < 10**12
+        m = _chain_model(50)
+        assert find_functionally_dependent_names(m) == find_functionally_dependent_names(
+            m, work_budget=dv._SCAN_WORK_BUDGET
+        )
+
+
+@pytest.mark.unit
+class TestWorkCounter:
+    def test_spend_reports_exhaustion(self):
+        w = WorkCounter(10)
+        assert w.spend(4) and not w.exhausted
+        assert w.spend(5) and not w.exhausted
+        assert not w.spend(1) and w.exhausted
+        assert not w.spend(1), "an exhausted counter stays exhausted"
+        assert w.spent == 10
+
+    def test_exhausted_index_reports_opaque_everywhere(self, xyz):
+        """An index that ran out mid-build must not answer from a partial memo.
+
+        Reporting ``None`` (opaque) / ``True`` (might occur) is the sound
+        direction; reporting "no variables" from a half-built memo would make
+        every occurrence test silently wrong.
+        """
+        _, x, y = xyz
+        expr = x * x + y
+        idx = VarNameIndex(expr, work=WorkCounter(1))
+        assert idx.exhausted
+        assert idx.names(expr) is None
+        assert idx.occurs(expr, "x") is True
+        assert idx.occurs(expr, "not_even_a_variable") is True
+        assert len(idx) == 0
+
+    def test_unexhausted_index_is_unaffected_by_a_generous_counter(self, xyz):
+        _, x, y = xyz
+        expr = x * x + y
+        plain = VarNameIndex(expr)
+        metered = VarNameIndex(expr, work=WorkCounter(10**9))
+        assert not metered.exhausted
+        assert metered.names(expr) == plain.names(expr) == frozenset({"x", "y"})
+        assert len(metered) == len(plain)
+
+    def test_index_build_charges_more_than_one_unit_per_node(self, xyz):
+        """The charge must track the union work, not just the node count.
+
+        A per-node-only charge would under-count by the factor that actually
+        hurts: a 1000-name chain unions ~1e6 elements over ~4000 nodes.
+        """
+        m = _chain_model(200)
+        body = m._constraints[0].body
+        w = WorkCounter(10**9)
+        idx = VarNameIndex(body, work=w)
+        assert not idx.exhausted
+        assert w.spent > 10 * len(idx), (
+            f"charged {w.spent} units for {len(idx)} nodes — the union work is not being counted"
+        )


### PR DESCRIPTION
Closes #1104.

## The defect

`Model.solve(time_limit=T)` could overrun `T` without bound, because the pre-B&B
model-analysis passes in `solver.py` run *before* the B&B loop arms the clock and
were themselves unbudgeted. The hot pass was
`find_functionally_dependent_names` (`python/discopt/_relax/dependent_vars.py`).

Two independent problems, both fixed here:

1. **The pass was superlinear.** `_isolated_affine_coeff` called
   `_occurs(expr.left/right, varname)` at *every* recursion level, and `_occurs`
   delegated to `_collect_var_names`, which walked the whole subtree allocating a
   fresh `set` per node with no memoization and re-expanded shared DAG
   subexpressions. Cost was `O(candidate_vars x body_nodes^2)`. On `t1000` — whose
   equality bodies are depth-1004 left-deep chains carrying ~1001 names each —
   the scan did not return in **12m08s** (killed).
2. **Nothing bounded it.** Even a merely slow pass should degrade to "skip this
   pass", not "ignore the user's time limit".

## The fix

**`_relax/objective_epigraph.py` — `VarNameIndex`.** A DAG-correct, `id()`-keyed
memo of the variable names reachable from each node, built once per body by an
iterative post-order walk (iterative because MINLPLib sum chains are 1000+ deep and
blew the recursion limit). The memo stores `(node, names)` so every keyed node is
pinned alive and ids cannot be recycled underneath it. `names()` returns `None` for
an opaque node, and `occurs()` maps that to `True` — the sound direction.
`_collect_var_names` / `_occurs` keep their exact previous contracts (fresh mutable
`set`, or `None`) and are now thin views over the index; `_affine_coeff` threads an
optional index through its recursion.

**`_relax/dependent_vars.py` — one pass for all names.** New
`_isolated_affine_coeffs(expr, index)` replaces the per-name analyzer with a single
top-down multiplier-accumulating walk that returns `{name: coeff-or-None}` for the
whole body in `O(nodes)`. `_isolated_affine_coeff` is now a thin single-name view
over it, so its semantics are unchanged rule-for-rule (including the "an opaque node
anywhere makes every name unprovable" property, which falls out of `names(root)`
being `None`). `_body_is_nonlinear` and `_carries_variable` became iterative for the
same depth reason. `find_functionally_dependent_names` builds **one** index per
equality body and reuses it for the presence test, the nonlinearity test, and the
coefficient pass.

**Determinism guard.** The top-down pass is `O(paths)`, not `O(nodes)`, on a
genuinely shared DAG. It is bounded by a **deterministic node-visit cap**
(`_VISIT_BUDGET_PER_NODE * nodes + floor`), not a clock, so `deterministic=True`
solves stay reproducible; hitting the cap abstains (returns `None`), which is the
sound direction. Measured over **149,564 equality bodies from 104 MINLPLib
instances** the worst visits/node ratio was **1.0** — the parsed bodies are trees —
so the cap has three orders of magnitude of headroom. A/B with and without the cap
over the corpus: 452/452 identical detected-name sets, i.e. the cap changes nothing
today and exists only as a blowup backstop.

**The phase budget — deterministic, not a clock.** The scan carries a
`WorkCounter`: an allowance denominated in elementary operations (node visits plus
name-set element unions), shared across every constraint body, that makes the whole
phase degrade to a partial set rather than overrun. `solver.py` just calls the scan;
the default allowance does the bounding.

The first revision of this PR used a wall deadline
(`min(clamp(0.05 * time_limit, 1s, 10s), remaining)`), which is what #1104 proposed.
CI rejected it — `test_912_wall_budget_inventory.py` — and it was right to. This
scan's output steers spatial branching, so cutting it on a clock makes the search
tree a function of machine speed, exactly the defect #912 exists to prevent. That
test's rule for a newly added gate is *"convert it instead"*, so it is converted;
no inventory entry was added and the residual count stays at 20.

Either way the early stop is sound for the same reason the pass's own abstentions
are: the result only *deprioritizes* spatial branching, the Rust
`select_spatial_branch_variable` fallback preserves completeness, so **any subset**
of the detected names — including the empty set — is safe.

The charge counts name-set element unions, not just node visits, because that is the
term that actually grows: a 1000-name chain unions ~1e6 elements over ~4e3 nodes. A
build that runs out drops its partial memo and reports opaque for *every* node
(`names() -> None`, `occurs() -> True`) rather than answering from half an index.

**Calibration.** Over the 406 corpus instances that reach the scan (the other 46 of
452 have no scalar continuous candidate and cost nothing): median demand **805**
units, p95 **288k**, p99 **4.6M**, max **56.2M** (`torsion100`); throughput
**2.8e6–3.4e7 units/s**. `_SCAN_WORK_BUDGET = 20_000_000` bounds the whole phase at
**~7 s** even at the slowest per-unit rate observed, and at ~0.6 s on the instance
that actually reaches it. Exactly **one** of the 406 truncates — `torsion100`, from 2
detected names to 0 — and that is one of the three instances the pre-fix scan could
not finish at all. The runner-up (`junkturn`, 9.2M) keeps 2.2x headroom.

## Measurements

Load caveat: these were taken on a shared desktop with Dropbox and my own corpus
runs competing, so they are order-of-magnitude, not fine-grained timings.

| measurement | before | after |
|---|---|---|
| `find_functionally_dependent_names` on `t1000` | did not return in 12m08s (killed) | **0.0293 s** |
| 1000-term synthetic chain (the regression-test shape) | still running at 100 s | **< 0.5 s** |
| `solve(time_limit=30)` on `t1000`, end to end | >30x overrun (per the issue) | wall **10.4 s**, factor **0.3x**, `status=feasible`, `obj=1.101e-08` |
| scan over a 469-file corpus (in-repo `minlplib_nl/` + sampled MINLPLib) | 466 ok, **3 timeouts at 30 s** (`gabriel10`, `nuclear104`, `torsion100`), 218 s total | **469 ok, 0 timeouts**, 120 s total, slowest instance 2.37 s |

**Differentials (the soundness checks).** Old vs new detected-name sets over the
same corpus, keyed by instance, with the work budget active:

```
compared=449  identical=449  differing=0  old_timeouts=3  new_timeouts=0  other_failures=0
```

The 3 uncompared instances are exactly the ones the old code could not finish.
(452 distinct keys rather than 469 because 17 basenames appear in both the in-repo
and the sampled MINLPLib sets; both arms de-duplicate identically.)

Work budget OFF vs ON, to isolate what the allowance itself changes:

```
compared=452  identical=451  differing=1
  torsion100   2 -> 0 names   subset=True   (old arm: TIMEOUT)
```

Subset and run-to-run reproducibility were also verified directly on the 20
costliest instances: 20/20 `subset=True`, 20/20 `reproducible=True`, 1 truncated.

## Tests

New `python/tests/test_dependent_vars.py` — 51 unit tests, 0.8 s:

- `TestVarNameIndex` — names/occurrence, shared subexpression memoized exactly once,
  a foreign node raises `KeyError` (no silent wrong answer), a 3000-term chain does
  not exhaust the recursion limit.
- `TestIsolatedAffineCoefficients` — 21 parametrized structural cases pinning the
  analyzer's rules (`x - sqrt(y*y+1)` -> `1.0`; `x*x`, `x*y`, `x**2`, `1/x`,
  `exp(x)`, `(y+1)*x` -> `None`; `x - x` -> `0.0`), bulk-vs-single-name agreement,
  shared-DAG blowup abstention.
- `TestBodyIsNonlinear`, `TestFindFunctionallyDependentNames` — pinned outputs.
- `TestScanCost` — `test_long_chain_scan_is_not_quadratic` (1000-term chain, asserts
  `wall < 10 s`), plus `test_exhausted_work_budget_stops_the_scan` and
  `test_budget_is_deterministic_not_wall_clock`, which bisects for the exact
  allowance at which the answer changes and then re-checks both sides of that
  boundary five times — pinning that the exhaustion point is a pure function of
  (model, allowance) and not of machine speed.
- `TestWorkCounter` — exhaustion semantics, that an exhausted index reports opaque
  everywhere rather than answering from a partial memo, and that the charge tracks
  union work rather than node count alone.

**Fails before / passes after:** the pre-fix code was run against the exact
regression shape and was still going at 100 s versus the test's 10 s assertion; the
whole file now runs in 0.8 s.

## What was run

- `pytest -m smoke` -> **2 failed, 1102 passed, 1 skipped, 2 xpassed** in 119.58 s.
  Both failures (`test_amp.py::test_unsafe_tan_objective_still_falls_back`,
  `test_monomial_straddle_kernel.py::test_regenerated_monomial_envelope_never_cuts_a_point_in_its_box`)
  reproduce identically on unmodified `main` in a clean worktree — pre-existing and
  unrelated to this change. Both pass in CI here, so they are specific to my local
  environment, not to the branch.
- `pytest -m slow python/tests/test_adversarial_recent_fixes.py` -> **19 passed** in 145.87 s.
- `pytest python/tests/test_dependent_vars.py python/tests/test_objective_epigraph.py
  python/tests/test_912_wall_budget_inventory.py` -> 64 passed in 3.77 s.
- `ruff check` / `ruff format --check` clean on all four files.
- `cargo test -p discopt-core` **not run** — no Rust was touched.
