### PR TITLE
perf(#1066): budget the convex-MINLP auto-route by progress, not by a clock

### DIFF
--- a/docs/dev/performance-plan.md
+++ b/docs/dev/performance-plan.md
@@ -3871,3 +3871,240 @@ exactly equal.
 Disposition: bound-neutral (§5 regime 1), default-on, legacy path retained as the
 fallback for an empty `dual` and reachable via `DISCOPT_MILP_RC_FIX_REFACTOR=1`
 for the differential test.
+
+## 22. #1066 route budget: the wall is blind, but capping the OA master is not the fix (2026-08-21)
+
+The #1066 reporter panel — 15 convex MINLPLib instances (`syn`/`rsyn`, `squfl`,
+`portfol_classical050_1`, `alan`) at default settings, `gap_tolerance=1e-4`,
+`time_limit=60` (600 s on two rows) — still returned **7/15 certified** on
+`main` after every linked work item (#1059–#1065) had merged. Two hypotheses
+were raised against those rows. One survived; the other is falsified here, and a
+claim published earlier in the same session is retracted with it.
+
+### 22.1 Confirmed: the fixed 50 % route budget cuts off routes that are converging
+
+`_CONVEX_ROUTE_BUDGET_FRACTION = 0.5` hands the #1059 auto-route half the
+caller's limit and reserves the rest for the spatial fallback. Attribution on
+`syn40m` (three arms, interleaved, load recorded):
+
+| arm | status | objective | wall |
+|---|---|---|---|
+| default (route gets 30 s) | feasible, uncertified | 58.210 | 61.7 s |
+| route budget = 1.0 | **optimal** | 67.71325583 | 32.9 s |
+| explicit `solver="mip-nlp"` | **optimal** | 67.71325583 | 42.3 s |
+
+Published optimum 67.713256. OA certifies this instance at 33–43 s; the wall
+lands at 30 s, so neither path certifies and the panel reports a 17 % gap.
+
+The justification recorded on the constant no longer holds either. It cites
+`alan` as a case where "the routed OA path burned the ENTIRE 180 s budget";
+`alan`'s OA arm now returns in **0.5 s** with `bound=None`, and the spatial path
+certifies 2.925 in 0.2 s / 13 nodes. The constant is defending against a failure
+that has since been fixed elsewhere, while causing a new one.
+
+Full 15 × 2 characterization (`t_oa`/`cert_oa` = explicit OA on the whole budget,
+`t_sp`/`cert_sp` = the spatial path with the route disabled):
+
+| instance | T | t_oa | cert_oa | t_sp | cert_sp |
+|---|---|---|---|---|---|
+| syn40m | 60 | 43.5 | **True** | 60.9 | False |
+| rsyn0820m | 60 | 60.9 | False | 63.9 | False |
+| rsyn0830m | 60 | 60.3 | False | 64.2 | False |
+| rsyn0840m | 60 | 60.6 | False | 62.2 | False |
+| rsyn0820m02m | 60 | 60.4 | False | 71.8 | False |
+| squfl025-040 | 60 | 60.2 | False | 60.6 | False |
+| portfol_classical050_1 | 60 | 60.4 | False | 63.0 | False |
+| alan | 60 | 0.5 | False | 0.2 | **True** |
+| rsyn0805m | 60 | 1.1 | **True** | 60.4 | False |
+| rsyn0810m | 60 | 1.3 | **True** | 63.1 | False |
+| rsyn0815m | 60 | 15.9 | **True** | 60.2 | False |
+| syn30m | 60 | 1.5 | **True** | 28.4 | **True** |
+| syn20m02m | 60 | 10.7 | **True** | 60.7 | False |
+| squfl020-150 | 600 | 602.0 | False | 609.7 | False |
+| squfl015-060 | 600 | 600.8 | False | 37.0 | **True** |
+
+**Handing the route the whole budget is not the fix.** Scored offline against
+these traces, `f = 1.0` gains `syn40m` and *loses* `squfl015-060`, where OA burns
+all 600 s uncertified and the spatial path certifies in 37.0 s — a wash on count
+and a loss on wall. The wall is blind in both directions, and both directions
+cost something.
+
+The discriminator is **progress, not gap level**. At the 50 % checkpoint
+`syn40m` sits at relative gap 0.147 but is moving fast (0.770 → 0.391 → 0.147),
+while `portfol_classical050_1` sits at 0.0045 and is *completely stalled* —
+identical bounds from iteration 30 through 33, 154 cuts per iteration buying
+nothing, final `bound=None`. A gap-*level* rule (θ = 0.2) extends `portfol` and
+costs it its dual bound; a progress rule does not. Scored over all 15 traces:
+
+| policy | certified | wall | rows with no dual bound |
+|---|---|---|---|
+| fixed f = 0.5 (shipping) | 7 | 1388.2 s | 0 |
+| fixed f = 0.75 | 8 | 1521.6 s | 0 |
+| fixed f = 1.0 | 7 | 1634.6 s | 1 |
+| gap-level f0 = 0.5, θ = 0.2 | 8 | 1372.1 s | 1 |
+| **progress-gated f0 = 0.5, δ = 0.25** | **8** | **1376.4 s** | **0** |
+
+Shipped as `DISCOPT_CONVEX_ROUTE_GUARD` / `_RouteProgressGuard`: the route gets
+the whole limit and an injected OA `termination_hook` that never fires before
+the old checkpoint and then hands back whatever the route has not earned.
+**Insufficient evidence is abandon, not continue** — on the four `rsyn` rows the
+OA loop completes two iterations in 60 s, offering one finite gap observation and
+no trend, and treating that as progress would leave the fallback nothing.
+
+### 22.2 FALSIFIED: capping the OA master to force more iterations
+
+**Hypothesis.** On `rsyn0820m`/`rsyn0830m`/`rsyn0840m`/`rsyn0820m02m` the OA loop
+completes only two iterations in 60 s because a single master MILP consumes
+almost the whole budget (`_MASTER_NO_INCUMBENT_BUDGET_FRAC = 0.9`, #1062). A
+truncated master still yields a valid dual bound for a relaxation of the MINLP,
+so capping it per call should buy many more cut rounds and a tighter bound.
+
+**Kill criterion** (stated before the run): *if capping the master leaves the
+dual bound no better, or costs the incumbent, on these rows, the hypothesis is
+dead.*
+
+**Result: both arms fired the kill criterion.** All four instances are
+MAXIMIZE, so the dual bound is an upper bound and *smaller is tighter*:
+
+| instance | optimum | arm | objective | dual bound | iterations |
+|---|---|---|---|---|---|
+| rsyn0840m | 325.55 | base | −11.413 | 759.439 | 2 |
+| | | cap 0.15 | −11.413 | 793.233 ✗ | 7 |
+| | | cap 0.30 | −11.413 | 669.653 ✓ | 4 |
+| rsyn0830m | 510.07 | base | **497.875** | 728.056 | 2 |
+| | | cap 0.15 | 296.403 ✗ | 849.534 ✗ | 7 |
+| | | cap 0.30 | 296.403 ✗ | 780.073 ✗ | 4 |
+| rsyn0820m02m | 1092.09 | base | −84.863 | 5136.400 | 2 |
+| | | cap 0.15 | −83.720 | 5406.735 ✗ | 7 |
+| | | cap 0.30 | −83.720 | 5152.472 ✗ | 4 |
+| rsyn0820m | 1150.30 | base | 1120.012 | **1184.479** | 2 |
+| | | cap 0.15 | 1120.012 | 1436.551 ✗ | 7 |
+| | | cap 0.30 | 1120.012 | 1426.337 ✗ | 4 |
+
+`CHECKS_EXECUTED 24`, all rows sound against `minlplib.solu`. The mechanism
+works — capping does produce 2 → 4 or 7 iterations — but **more rounds bought
+weaker cuts, not better bounds**: the bound is worse on 7 of 8 arm/instance
+pairs, and the single improvement (`rsyn0840m` at cap 0.30) is contradicted by
+cap 0.15 on the same instance, so it is not an effect. `rsyn0830m`'s incumbent
+regresses by 200 units under both caps. The master cap does not ship.
+
+The generalizable lesson: on these instances the OA master's *time* is not the
+scarce resource — the *strength of the cut set* is. A master truncated before it
+proves optimality returns a bound from a partially explored MILP tree, and
+iterating that faster compounds the weakness instead of amortizing it.
+
+### 22.3 Retraction
+
+Earlier in the same session I stated that OA performs "exactly one master MILP
+solve in the entire 60 s" on `rsyn0830m`/`rsyn0840m`/`rsyn0820m02m`. That was
+inferred from characterization traces that carried a single trace point, and it
+is **wrong**: the cleaner low-load `base` arm above measures **two** iterations
+and two master calls on all four `rsyn` rows. The substantive observation — that
+the OA loop barely iterates on this class — stands; the count does not.
+
+### 22.4 The guard needs OA to check in, or it arrives too late (2026-08-21)
+
+The first graduation panel for `DISCOPT_CONVEX_ROUTE_GUARD` (v1, log
+`scratchpad/issue1066/grad_panel_v1_stale.log`) was stopped after ten rows
+because those ten rows falsified the v1 design. Both arms of the same
+interleaved run, at `time_limit=60`, `gap_tolerance=1e-4`, load 8.1–9.9. Every
+instance here is a **maximization** model, so a higher objective is better and a
+*lower* dual bound is tighter:
+
+| instance | OFF obj | ON obj | OFF bound | ON bound | OFF wall | ON wall | guard |
+|---|---|---|---|---|---|---|---|
+| syn40m | 58.2096 | **67.7133 (cert)** | 68.2186 | 67.7133 | 61.6 | **33.5** | 4 calls, no fire |
+| rsyn0820m | 1130.1620 | 1120.0124 | 1420.8056 | 1184.4534 | 61.8 | 60.8 | 2 calls, no fire |
+| rsyn0830m | 497.8750 | 497.8750 | 766.8364 | 729.1202 | 64.4 | 70.6 | fired 54.61 |
+| rsyn0840m | 151.9691 | **−11.4133** | 814.2617 | 764.2488 | 61.0 | 64.9 | fired 55.13 |
+| rsyn0820m02m | −84.8635 | −84.8635 | 5257.0875 | 5091.9553 | 60.3 | 70.5 | fired 54.73 |
+
+The bound moved the right way on every row and `syn40m` gained its certificate,
+but `rsyn0840m` lost its incumbent outright and `rsyn0820m` lost 10 units. Under
+§5 bar 1 ("objective drift within tolerance") that is a failing panel, and the
+v1 flag would have stayed OFF.
+
+**Attribution.** The `fired` column is the mechanism. `_MASTER_NO_INCUMBENT_BUDGET_FRAC`
+gives the first master `0.9 × remaining`, so widening the route's budget from
+`0.5 × time_limit` to the whole limit also widened the first master from ~27 s to
+~54 s. The `termination_hook` only runs at the top of an OA iteration, so on the
+`rsyn` rows the guard's *second* call did not arrive until ~55 s of a 60 s limit.
+Abandoning there is worse than never having tried: the spatial fallback inherits
+~5 s instead of the 30 s the fixed split used to hand it, and never finds the
+incumbent it finds under OFF. The guard was not wrong about those rows — it was
+right and late.
+
+**Why the offline replay missed it.** `scratchpad/issue1066/guard_replay.py`
+scored the recorded OA gap traces for certificates and wall only. It never scored
+incumbent quality, so it was structurally blind to a policy that trades the
+fallback's incumbent for a tighter dual bound, and it scored all four `rsyn` rows
+"same". A replay can only falsify what it scores; this is §6 in a form that
+passes its own executed-assertion count.
+
+**The fix, and why it is not the falsified master cap.** `solve_oa` takes an
+optional `master_checkin_deadline` (seconds of elapsed OA time). `_master_time_budget`
+clamps a master solve so the loop returns to the top of an iteration by that
+deadline, and the clamp lifts once the deadline passes. The auto-route sets it to
+the guard's checkpoint. §22.2 falsified a *different* intervention: capping every
+master to a fraction of remaining, which forced more rounds of weaker cuts and cost
+`rsyn0830m` 200 units of objective. This truncates at most the one master that
+would cross the point where the caller has already said it will decide, and only
+while the route has shown no progress. It is refused without a `termination_hook`
+to read it, because a master truncation nobody acts on is exactly §22.2.
+
+**Entry experiment** (stated kill criterion: if `rsyn0840m`'s ON incumbent does
+not return to ≈151.97 while `syn40m` still certifies, the design is dead and the
+flag stays OFF). Interleaved, `CHECKS_EXECUTED 8`, `VIOLATIONS 0`,
+log `scratchpad/issue1066/entry_v2.log`:
+
+| instance | arm | status | objective | bound | wall | guard |
+|---|---|---|---|---|---|---|
+| syn40m | off | feasible | 58.2096 | 68.2186 | 61.7 | — |
+| syn40m | on | **optimal, certified** | 67.7133 | 67.7133 | 41.3 | 5 calls, no fire |
+| rsyn0840m | off | feasible | 151.9691 | 818.2426 | 62.7 | — |
+| rsyn0840m | on | feasible | **151.9691** | 802.0252 | 61.2 | fired **30.53** |
+
+The fire time moved from 55.1 s to 30.5 s, `rsyn0840m`'s incumbent is bit-identical
+to its OFF arm, and `syn40m` still certifies. `syn40m`'s masters never approach the
+checkpoint, so the clamp never binds there — which is the property that lets one
+mechanism serve both rows. Graduation is scored on the full v2 panel
+(`grad_panel_v2.json`), not on this experiment.
+
+### 22.5 `DISCOPT_CONVEX_ROUTE_GUARD` graduates default-on (2026-08-22)
+
+Panel: 79 instances -- the #1066 reporter's 15 at their reported limits (60 s,
+600 s on `squfl015-060` and `squfl020-150`) plus the 64 in-repo corpus instances
+at 20 s. Arms run back to back per instance so a load excursion hits both, each
+behind a `load1 <= 10` gate, every row scored against `minlplib.solu` in the
+model's own sense. Log `scratchpad/issue1066/grad_panel_v2.log`, data
+`grad_panel_v2.json`.
+
+| criterion | OFF | ON |
+|---|---|---|
+| certified | 55 / 79 | **56 / 79** |
+| total wall | 1817.3 s | **1799.5 s** |
+| certificates gained / lost | — | 1 / 0 |
+| incumbents better / worse | — | 1 / 0 |
+| dual bounds tighter / looser | — | 6 / 3 |
+
+**Bar 1, cert-clean: PASS.** 290 soundness checks executed, 0 violations. No
+incumbent beat its reference optimum, no dual bound crossed one, no
+`gap_certified=True` row regressed to uncertified, no row lost a dual bound it
+had, and the only objective that moved moved the right way (`syn40m`
+58.2096 -> 67.7133 on a maximization model). The three looser dual bounds
+(`casctanks` 6.3109 -> 6.2497, `rsyn0840m` 808.84 -> 820.55,
+`squfl020-150` 373.65 -> 353.18) are all on rows uncertified in **both** arms,
+and all remain on the valid side of their reference optimum.
+
+**Bar 2, net-positive: PASS,** though modestly: +1 certificate, −17.8 s total
+wall, 6 bounds tighter against 3 looser, nothing regressed. The certificate
+gained is `syn40m`, the row #1066 was opened about. The guard *fired* on 11
+instances spanning syn/rsyn/squfl/portfol/clay/cvxnonsep/tls, so the budget it
+reclaims is a class-wide effect and not a `syn40m` special case — on 10 of those
+11 it cut a dead route short without costing anything, which is the half of the
+mechanism that shows up in the wall column rather than the certificate column.
+
+Default flipped to on. `DISCOPT_CONVEX_ROUTE_GUARD=0` restores the fixed
+`_CONVEX_ROUTE_BUDGET_FRACTION` split, and that path stays tested
+(`python/tests/test_1066_route_progress_guard.py::TestGraduatedDefault`,
+`test_1059_route_fallback.py::test_auto_route_gets_a_fraction_of_the_limit`).

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -5219,8 +5219,22 @@ def _convex_minlp_auto_route(model: Model) -> tuple[Optional[str], str]:
     )
 
 
-#: Fraction of the caller's time limit the #1059 auto-route may spend before the
-#: fallback takes over. The §5 graduation panel measured the failure this bounds:
+#: Fraction of the caller's time limit at which the #1059 auto-route is judged.
+#: Under the #1066 guard (:class:`_RouteProgressGuard`) this is the *checkpoint*
+#: -- the route is untouched before it and must show progress after it. With
+#: ``DISCOPT_CONVEX_ROUTE_GUARD=0``, or for a routed method that carries no
+#: ``termination_hook``, it is the older hard wall it was introduced as.
+#:
+#: The paragraph below is the #1059 rationale, kept because it still explains
+#: why the route is judged at all. Its ``alan`` evidence has since expired:
+#: measured 2026-08-21, ``alan``'s OA arm returns in **0.5 s** with
+#: ``bound=None``, not after the whole budget. And its claim that the class the
+#: route exists for "certifies well inside" the split is what #1066 falsified --
+#: ``syn40m`` certifies at 43.5 s of 60, i.e. outside it, which is why the wall
+#: became a progress test rather than a bigger fraction.
+#:
+#: Original #1059 rationale -- the §5 graduation panel measured the failure this
+#: bounds:
 #: on ``alan`` (a 9-variable convex MIQP) the routed OA path burned the ENTIRE
 #: 180 s budget and returned an uncertified 3.000, where the default spatial path
 #: certifies 2.925 in 0.18 s -- reproducibly, 3/3 reps. Handing OA the whole
@@ -5235,6 +5249,232 @@ _CONVEX_ROUTE_BUDGET_FRACTION = 0.5
 #: routed (uncertified) result is returned as-is rather than being replaced by a
 #: fallback that is itself out of time.
 _CONVEX_ROUTE_FALLBACK_FLOOR_S = 1.0
+
+#: How much the routed solve's relative gap must shrink across one look-back
+#: window for the route to keep running past the checkpoint (#1066).
+_CONVEX_ROUTE_MIN_GAP_IMPROVEMENT = 0.25
+
+#: That look-back window, as a fraction of the checkpoint.
+_CONVEX_ROUTE_PROGRESS_WINDOW_FRACTION = 0.5
+
+
+def _convex_route_progress_guard_enabled() -> bool:
+    """Is the #1066 progress-gated route budget switched on?
+
+    Changing how much budget the route gets changes the bounds that come back,
+    so this is CLAUDE.md §5 regime 2. It graduated to default-on by the panel
+    below; ``DISCOPT_CONVEX_ROUTE_GUARD=0`` still restores the fixed
+    :data:`_CONVEX_ROUTE_BUDGET_FRACTION` split, and that path is kept intact
+    and tested. Read per call, not cached at import, so a test can flip it
+    without reloading the module.
+
+    Graduation panel (2026-08-22): 79 instances -- the #1066 reporter's 15 at
+    their reported limits, plus the 64 in-repo corpus instances at 20 s -- run
+    OFF/ON back to back per instance behind a load gate, scored against
+    ``minlplib.solu`` in each model's own sense
+    (``scratchpad/issue1066/grad_panel_v2.json``):
+
+    ==========================  =========  =========
+    criterion                   OFF        ON
+    ==========================  =========  =========
+    certified                   55 / 79    **56 / 79**
+    total wall                  1817.3 s   **1799.5 s**
+    certificates lost           --         0
+    incumbents worse            --         0
+    dual bounds tighter/looser  --         6 / 3
+    ==========================  =========  =========
+
+    290 soundness checks executed, 0 violations: no incumbent beat its reference
+    optimum, no dual bound crossed one, and no row lost a dual bound it had. The
+    certificate gained is ``syn40m``, the row #1066 was opened about; the guard
+    fired on 11 instances across the syn/rsyn/squfl/portfol/clay/cvxnonsep/tls
+    families, so what it buys is not confined to that row.
+    """
+    return os.environ.get("DISCOPT_CONVEX_ROUTE_GUARD", "1") != "0"
+
+
+class _RouteProgressGuard:
+    """Stop the #1059 auto-route once it stops making progress -- not on a clock.
+
+    :data:`_CONVEX_ROUTE_BUDGET_FRACTION` cuts the route off at a fixed half of
+    the budget no matter what it is doing. That wall is blind in both
+    directions, and both failures were measured on the #1066 reporter panel
+    (15 convex MINLPLib instances, default settings, 60 s; 600 s on two rows):
+
+    * It cuts off a route that is converging. ``syn40m``'s relative gap falls
+      0.770 -> 0.391 -> 0.147 and OA certifies the oracle optimum
+      67.713256 at **43.5 s** -- but the wall lands at 30 s, so the panel
+      reported ``feasible`` 58.210 and the fallback could not certify either.
+    * It lets a dead route run to the wall. ``portfol_classical050_1`` sits at
+      relative gap 0.0045 from iteration 30 through 33 -- identical bounds,
+      154 cuts per iteration buying nothing -- and still holds its budget for
+      the full 30 s. ``alan`` holds a gap of 1.0 flat.
+
+    So the discriminator is *progress*, not gap level, and not the clock. This
+    guard is a ``termination_hook``: it never fires before the checkpoint (so
+    behaviour up to it is exactly the fixed split's), and from the checkpoint
+    on it lets the route continue only while the route keeps *earning* the
+    budget -- the relative gap must have shrunk by
+    :data:`_CONVEX_ROUTE_MIN_GAP_IMPROVEMENT` across the trailing window.
+
+    **Insufficient evidence is abandon, not continue.** A route that has not
+    produced two finite dual bounds by the checkpoint has shown the router
+    nothing, and the fallback is the known-certifying path. This is not
+    hypothetical: on ``rsyn0830m``/``rsyn0840m``/``rsyn0820m02m``/``rsyn0820m``
+    at 60 s the OA loop completes exactly **two** iterations, so it offers one
+    finite gap observation and no trend at all. Treating that as progress would
+    hand the whole budget to a loop that cannot iterate and leave the fallback
+    nothing -- ``rsyn0840m`` would lose the 151.97 incumbent it reports today.
+
+    **Abandoning is not enough; it has to happen on time.** Those same two-iteration
+    ``rsyn`` rows are why this guard also needs :func:`~discopt.solvers.oa.solve_oa`'s
+    ``master_checkin_deadline``. A ``termination_hook`` only runs at the top of an OA
+    iteration, and OA's first master expands to fill the budget it is handed, so
+    simply widening the route from half the limit to all of it pushed the guard's
+    second call from ~30 s out to ~55 s of a 60 s limit. It still said abandon --
+    too late to leave the fallback its reserve, and ``rsyn0840m``'s incumbent
+    collapsed from 151.97 to -11.41 on a maximization model. The checkpoint is
+    therefore passed to OA as a soft master deadline as well as being the instant
+    this hook starts judging. See ``docs/dev/performance-plan.md`` §22.4.
+
+    Replaying this guard against every recorded trace on that panel
+    (``scratchpad/issue1066/charac.json``, 15 instances x 2 arms; the replay is
+    exact, because up to the instant the guard fires the run it judges *is* the
+    recorded full-budget run):
+
+    ======================  ==========  ==========
+    criterion               fixed 50%   guarded
+    ======================  ==========  ==========
+    certified               7 / 15      **8 / 15**
+    total wall              1388.2 s    **1376.4 s**
+    rows left with no dual bound     0  0
+    ======================  ==========  ==========
+
+    That replay scored certificates and wall only -- it never scored incumbent
+    quality, which is exactly why it missed the ``rsyn0840m`` collapse above and
+    why graduation is decided on a live A/B panel rather than on it. Handing the
+    route the whole budget unconditionally was measured too and is *worse*: it
+    loses ``squfl015-060``, where OA burns all 600 s uncertified and the fallback
+    certifies in 37.0 s.
+    """
+
+    def __init__(
+        self,
+        time_limit: float,
+        *,
+        check_fraction: Optional[float] = None,
+        min_improvement: Optional[float] = None,
+        window_fraction: Optional[float] = None,
+    ) -> None:
+        self.time_limit = float(time_limit)
+        limit = self.time_limit
+        fraction = (
+            _CONVEX_ROUTE_BUDGET_FRACTION if check_fraction is None else float(check_fraction)
+        )
+        # The same expression the fixed split used, so "never fires before the
+        # checkpoint" means "never fires before the old wall".
+        self.checkpoint = max(limit * fraction, min(limit, _CONVEX_ROUTE_FALLBACK_FLOOR_S))
+        self.window = self.checkpoint * (
+            _CONVEX_ROUTE_PROGRESS_WINDOW_FRACTION
+            if window_fraction is None
+            else float(window_fraction)
+        )
+        self.min_improvement = (
+            _CONVEX_ROUTE_MIN_GAP_IMPROVEMENT if min_improvement is None else float(min_improvement)
+        )
+        #: ``(elapsed, relative_gap)`` for every iteration that had a finite gap.
+        self.history: list[tuple[float, float]] = []
+        self.fired_at: Optional[float] = None
+        self.reason: Optional[str] = None
+        self.call_count = 0
+
+    def __call__(self, context: Mapping[str, Any]) -> bool:
+        # Deliberately unguarded: this hook reads a context this package builds,
+        # so a missing key is our bug and must surface (CLAUDE.md §7). The OA
+        # driver wraps a raising hook into a RuntimeError rather than losing it.
+        self.call_count += 1
+        elapsed = float(context["elapsed"])
+        gap = context["relative_gap"]
+        if (
+            gap is not None
+            and context["current_dual_bound"] is not None
+            and context["current_primal_bound"] is not None
+        ):
+            self.history.append((elapsed, float(gap)))
+        if elapsed < self.checkpoint:
+            return False
+        stop, reason = self._verdict(elapsed)
+        if stop:
+            self.fired_at = elapsed
+            self.reason = reason
+            logger.info(
+                "Convex MINLP route stopped at %.1fs of %.1fs (%s); "
+                "handing the remaining budget to the fallback",
+                elapsed,
+                self.time_limit,
+                reason,
+            )
+        return stop
+
+    def _verdict(self, now: float) -> tuple[bool, Optional[str]]:
+        """Has the route earned the rest of the budget as of ``now``?"""
+        if len(self.history) < 2:
+            return True, (
+                f"only {len(self.history)} finite dual-bound observation(s) by "
+                f"{now:.1f}s -- no trend to judge"
+            )
+        latest_gap = self.history[-1][1]
+        if latest_gap <= 0.0:
+            # Converged; the loop's own termination test owns this.
+            return False, None
+        cutoff = now - self.window
+        earlier = [gap for when, gap in self.history[:-1] if when >= cutoff]
+        if not earlier:
+            return True, f"no gap observation inside the trailing {self.window:.1f}s window"
+        reference = max(earlier)
+        if latest_gap <= (1.0 - self.min_improvement) * reference:
+            return False, None
+        return True, (
+            f"relative gap {latest_gap:.4g} vs {reference:.4g} over the trailing "
+            f"{self.window:.1f}s -- under the {self.min_improvement:.0%} improvement "
+            f"the route must show to keep the budget"
+        )
+
+
+def _route_progress_guard_options(
+    mip_nlp_options: Optional[Mapping[str, Any]],
+    *,
+    method_key: Any,
+    time_limit: float,
+) -> tuple[Optional[Mapping[str, Any]], Optional["_RouteProgressGuard"]]:
+    """Install the #1066 guard for an auto-routed solve, or decline to.
+
+    Returns ``(options, guard)``. A ``guard`` of ``None`` means the caller keeps
+    the fixed :data:`_CONVEX_ROUTE_BUDGET_FRACTION` split -- the guard declines
+    when it is switched off, when the routed method is not the one that carries
+    a ``termination_hook``, or when the caller supplied a termination hook of
+    their own (theirs wins; two hooks racing to stop the same loop is not a
+    contract worth having). The caller's mapping is never mutated.
+    """
+    if not _convex_route_progress_guard_enabled():
+        return mip_nlp_options, None
+    if method_key != "oa":
+        return mip_nlp_options, None
+    if mip_nlp_options is not None and mip_nlp_options.get("termination_hook") is not None:
+        return mip_nlp_options, None
+    guard = _RouteProgressGuard(time_limit)
+    options = dict(mip_nlp_options or {})
+    options["termination_hook"] = guard
+    # A hook that only runs at the top of an OA iteration cannot budget anything
+    # unless the loop actually gets back there. OA's first master expands to fill
+    # whatever budget it is handed (``_MASTER_NO_INCUMBENT_BUDGET_FRAC``), so
+    # widening the route from half the limit to all of it also widened the master
+    # -- on ``rsyn0840m`` the guard's second call arrived at 55.1s of a 60s limit
+    # and abandoning there left the fallback ~5s, which cost the row its incumbent
+    # (151.97 -> -11.41 on a maximization model). Telling OA when we intend to
+    # look restores the reserve without capping masters in general.
+    options["master_checkin_deadline"] = guard.checkpoint
+    return options, guard
 
 
 def _route_result_is_certified(result, gap_tolerance: float) -> bool:
@@ -7332,12 +7572,27 @@ def solve_model(
         # An EXPLICIT solver="mip-nlp" gets the whole budget: the caller chose the
         # algorithm and there is no fallback to reserve for. Only the auto-route
         # is budgeted.
+        #
+        # #1066: the auto-route is budgeted by PROGRESS where it can be. The
+        # guard gets the whole limit and gives back whatever it has not earned,
+        # which both lets a converging route finish (``syn40m`` certifies at
+        # 43.5 s of 60) and takes the budget off a stalled one before the old
+        # 50% wall would have (``portfol_classical050_1`` at 30.5 s). When the
+        # guard declines -- flag off, non-OA method, caller's own hook -- the
+        # fixed split stands exactly as before.
         _route_budget = time_limit
+        _route_guard: Optional[_RouteProgressGuard] = None
         if _auto_route_reason is not None:
-            _route_budget = max(
-                time_limit * _CONVEX_ROUTE_BUDGET_FRACTION,
-                min(time_limit, _CONVEX_ROUTE_FALLBACK_FLOOR_S),
+            mip_nlp_options, _route_guard = _route_progress_guard_options(
+                mip_nlp_options,
+                method_key=mip_nlp_method_key,
+                time_limit=time_limit,
             )
+            if _route_guard is None:
+                _route_budget = max(
+                    time_limit * _CONVEX_ROUTE_BUDGET_FRACTION,
+                    min(time_limit, _CONVEX_ROUTE_FALLBACK_FLOOR_S),
+                )
         _route_t0 = time.perf_counter()
         _mip_nlp_result = solve_mip_nlp(
             model,

--- a/python/discopt/solvers/mip_nlp.py
+++ b/python/discopt/solvers/mip_nlp.py
@@ -50,6 +50,7 @@ _OA_OPTION_KEYS = frozenset(
         "milp_solver",
         "solution_pool",
         "num_solution_iteration",
+        "master_checkin_deadline",
         *_EVENT_HOOK_OPTION_KEYS,
         *FP_OPTION_KEYS,
     }

--- a/python/discopt/solvers/oa.py
+++ b/python/discopt/solvers/oa.py
@@ -61,7 +61,12 @@ logger = logging.getLogger(__name__)
 _MASTER_NO_INCUMBENT_BUDGET_FRAC = 0.9
 
 
-def _master_time_budget(remaining: float, *, has_incumbent: bool) -> float:
+def _master_time_budget(
+    remaining: float,
+    *,
+    has_incumbent: bool,
+    checkin_remaining: Optional[float] = None,
+) -> float:
     """Time limit for one master MILP solve, reserving room for the fixed NLP.
 
     Once an incumbent exists OA has something to return, so the master may use
@@ -74,12 +79,28 @@ def _master_time_budget(remaining: float, *, has_incumbent: bool) -> float:
     which is the common case. Stopping the master early costs only master
     optimality, not soundness: a MILP master truncated at its time limit still
     yields a valid dual bound for a relaxation of the MINLP.
+
+    ``checkin_remaining`` is the caller's *soft* deadline: seconds from now by
+    which the OA loop must return control to the top of the iteration, where the
+    ``termination_hook`` runs. Without it a caller that budgets OA by progress
+    cannot act, because the budget it granted is exactly what the first master
+    expands to fill -- measured on ``rsyn0840m`` at a 60 s route budget, the
+    master ran to ~55 s and the hook's second call arrived too late to leave the
+    caller's fallback anything to work with (#1066). This is not the per-iteration
+    master cap falsified in ``docs/dev/performance-plan.md`` §22.2: that one
+    shrank *every* master to force more rounds and produced weaker bounds; this
+    truncates at most the one master that would cross the caller's deadline.
     """
-    if has_incumbent:
-        return remaining
-    if not math.isfinite(remaining) or remaining <= 0.0:
-        return remaining
-    return remaining * _MASTER_NO_INCUMBENT_BUDGET_FRAC
+    budget = remaining
+    if not has_incumbent and math.isfinite(remaining) and remaining > 0.0:
+        budget = remaining * _MASTER_NO_INCUMBENT_BUDGET_FRAC
+    if (
+        checkin_remaining is not None
+        and math.isfinite(checkin_remaining)
+        and checkin_remaining > 0.0
+    ):
+        budget = min(budget, float(checkin_remaining))
+    return budget
 
 
 _INIT_STRATEGIES = frozenset({"rNLP", "initial_binary", "max_binary", "fp"})
@@ -4957,6 +4978,7 @@ def solve_oa(
     external_hyperplane_hook: Any = None,
     external_dual_bound_hook: Any = None,
     termination_hook: Any = None,
+    master_checkin_deadline: Optional[float] = None,
     **kwargs,
 ) -> SolveResult:
     """Solve a MINLP via Outer Approximation.
@@ -5088,6 +5110,12 @@ def solve_oa(
         bound/incumbent data, and candidate points where relevant. Returned
         payloads are validated before they can add external fixed-NLP candidates,
         master cuts, dual-bound updates, or request user termination.
+    master_checkin_deadline : float, optional
+        Soft deadline, in seconds of elapsed OA time, by which the loop must
+        return to the top of an iteration so ``termination_hook`` can run. Only
+        the master MILP that would cross it is shortened, and only until the
+        deadline passes; after that the ordinary budget applies. Pointless
+        without ``termination_hook``, and validated as such.
 
     Returns
     -------
@@ -5132,6 +5160,18 @@ def solve_oa(
         external_dual_bound_hook,
     )
     termination_hook = _normalize_optional_hook("termination_hook", termination_hook)
+    if master_checkin_deadline is not None:
+        master_checkin_deadline = float(master_checkin_deadline)
+        if not math.isfinite(master_checkin_deadline) or master_checkin_deadline <= 0.0:
+            raise ValueError(
+                "master_checkin_deadline must be a finite positive number of seconds, "
+                f"got {master_checkin_deadline!r}"
+            )
+        if termination_hook is None:
+            raise ValueError(
+                "master_checkin_deadline only has an effect alongside termination_hook; "
+                "passing it without one shortens a master solve for no reader"
+            )
     heuristic_nonconvex = bool(heuristic_nonconvex)
     solution_pool = bool(solution_pool)
     shot_solution_pool_degraded_reason: Optional[str] = None
@@ -6844,7 +6884,11 @@ def solve_oa(
             decomp.obj_is_linear,
             master_bound_valid,
             time_limit=_master_time_budget(
-                time_limit - elapsed, has_incumbent=incumbent is not None
+                time_limit - elapsed,
+                has_incumbent=incumbent is not None,
+                checkin_remaining=(
+                    None if master_checkin_deadline is None else master_checkin_deadline - elapsed
+                ),
             ),
             gap_tolerance=gap_tolerance,
             add_slack=add_slack,

--- a/python/tests/test_1059_route_fallback.py
+++ b/python/tests/test_1059_route_fallback.py
@@ -31,6 +31,7 @@ from discopt.solver import (
 
 NL_DIR = Path(__file__).parent / "data" / "minlplib_nl"
 ROUTE_ENV = "DISCOPT_CONVEX_MINLP_ROUTE"
+GUARD_ENV = "DISCOPT_CONVEX_ROUTE_GUARD"
 
 pytest.importorskip("highspy", reason="the OA master needs a MILP backend")
 
@@ -270,7 +271,17 @@ class TestRouteBudget:
         return seen
 
     def test_auto_route_gets_a_fraction_of_the_limit(self, monkeypatch):
+        """The fixed split, pinned with ``DISCOPT_CONVEX_ROUTE_GUARD=0``.
+
+        #1066 replaced the fixed wall with a progress guard that hands the route
+        the whole limit and takes back what it does not earn. The fixed split is
+        still the fallback path -- for a non-OA method, for a caller with their
+        own termination hook, and for anyone who sets the opt-out -- so it keeps
+        a test. The guard's own budget wiring is tested in
+        ``test_1066_route_progress_guard.py``.
+        """
         monkeypatch.setenv(ROUTE_ENV, "1")
+        monkeypatch.setenv(GUARD_ENV, "0")
         seen = self._capture(monkeypatch)
         _load("gbd").solve(time_limit=20.0)
         assert seen, "solve_mip_nlp was never called -- the router did not fire"

--- a/python/tests/test_1066_route_progress_guard.py
+++ b/python/tests/test_1066_route_progress_guard.py
@@ -1,0 +1,426 @@
+"""#1066: the convex-MINLP auto-route is budgeted by *progress*, not by a clock.
+
+#1059 cut the auto-route off at a fixed half of the caller's limit so there was
+always a remainder to fall back with. That wall is blind in both directions, and
+the #1066 reporter panel (15 convex MINLPLib instances, default settings, 60 s;
+600 s on two rows) measured both failures:
+
+* it cuts off a route that is converging -- ``syn40m``'s relative gap falls
+  0.770 -> 0.391 -> 0.147 and OA certifies the oracle optimum 67.713256 at
+  43.5 s, but the wall lands at 30 s, so the panel reported ``feasible``
+  58.210 and neither path certified;
+* it lets a dead route hold the budget to the wall -- ``portfol_classical050_1``
+  sits at relative gap 0.0033823 from 49.4 s to 59.9 s, identical bounds, and
+  ``alan`` holds a gap of 1.0 flat for all 51 of its iterations.
+
+Every trace in these tests is real, copied from the measured run
+(``scratchpad/issue1066/charac.json``); the two extrapolated points are labelled
+where they appear. Replaying the guard over all 15 recorded traces: certified
+7 -> **8**, total wall 1388.2 s -> **1376.4 s**, no row left without a dual
+bound, nothing regressed.
+"""
+
+from pathlib import Path
+
+import pytest
+from discopt.modeling.core import Model, from_nl
+from discopt.solver import (
+    _CONVEX_ROUTE_BUDGET_FRACTION,
+    _CONVEX_ROUTE_MIN_GAP_IMPROVEMENT,
+    _convex_route_progress_guard_enabled,
+    _route_progress_guard_options,
+    _RouteProgressGuard,
+)
+from discopt.solvers.oa import _master_time_budget, solve_oa
+
+NL_DIR = Path(__file__).parent / "data" / "minlplib_nl"
+ROUTE_ENV = "DISCOPT_CONVEX_MINLP_ROUTE"
+GUARD_ENV = "DISCOPT_CONVEX_ROUTE_GUARD"
+
+pytest.importorskip("highspy", reason="the OA master needs a MILP backend")
+
+
+def _load(name: str) -> Model:
+    path = NL_DIR / f"{name}.nl"
+    assert path.exists(), f"missing corpus instance {path}"
+    m = from_nl(str(path))
+    m._convexity_time_budget = 10.0
+    return m
+
+
+def _ctx(elapsed, gap, *, bounded=True):
+    """One OA ``termination_hook`` context, shaped like the real one.
+
+    ``bounded=False`` is the OA driver's pre-dual-bound state: it reports
+    ``relative_gap=1.0`` with ``current_dual_bound=None``, a placeholder rather
+    than a measurement, and the guard has to tell the two apart.
+    """
+    return {
+        "elapsed": float(elapsed),
+        "relative_gap": gap,
+        "current_dual_bound": 0.0 if bounded else None,
+        "current_primal_bound": 1.0 if bounded else None,
+    }
+
+
+def _geometric(*, window_ratio, limit=60.0, step_s=1.0):
+    """A trace whose gap shrinks by ``window_ratio`` across each trailing window.
+
+    One point every ``step_s`` seconds out to ``limit``, decaying geometrically,
+    so the ratio between the newest gap and the oldest one still inside the
+    window is exactly ``window_ratio`` -- which is the quantity the guard tests.
+    """
+    window = limit * _CONVEX_ROUTE_BUDGET_FRACTION * 0.5
+    per_step = window_ratio ** (step_s / window)
+    points, gap, elapsed = [], 0.5, step_s
+    while elapsed <= limit:
+        points.append((elapsed, gap))
+        gap *= per_step
+        elapsed += step_s
+    return points
+
+
+def _replay(guard, points):
+    """Feed ``(elapsed, gap)`` points until the guard fires. Returns the time."""
+    for elapsed, gap in points:
+        if guard(_ctx(elapsed, gap)):
+            return elapsed
+    return None
+
+
+# The measured OA gap traces, ``(elapsed, relative_gap)``. ``None`` gaps are the
+# iterations that had no finite dual bound yet.
+SYN40M = [
+    (0.06, None),
+    (4.06, 0.7703621580824017),
+    (10.77, 0.39143864188149563),
+    (24.6, 0.14672035380698015),
+]
+RSYN0840M = [(0.14, None), (54.82, 1.014735195337869)]
+PORTFOL_TAIL = [
+    (30.5, 0.0033823455725941615),
+    (35.4, 0.0033823455725941615),
+    (44.1, 0.0033823455725941615),
+    (49.36, 0.0033823455725941615),
+    (54.41, 0.0033823455725941615),
+    (59.87, 0.0033823455725941615),
+]
+
+
+@pytest.mark.unit
+class TestGuardVerdicts:
+    """What the guard does with the traces that motivated it."""
+
+    def test_it_never_fires_before_the_checkpoint(self):
+        """Behaviour up to the old wall must be exactly the old wall's.
+
+        ``alan`` is the case: a gap pinned at 1.0 from the first iteration. The
+        guard has every reason to stop it and must not, because stopping before
+        the checkpoint would take budget the fixed split had already granted.
+        """
+        guard = _RouteProgressGuard(60.0)
+        flat = [(t / 10.0, 1.0) for t in range(1, 300)]  # 0.1s .. 29.9s
+        assert _replay(guard, flat) is None
+        assert guard.call_count == len(flat)
+        assert guard.fired_at is None
+
+    def test_a_converging_route_keeps_the_budget_past_the_old_wall(self):
+        """``syn40m``: the certificate the 30 s wall threw away.
+
+        The first four points are measured; OA's next iteration certified at
+        43.5 s. The 35 s point continues that trend (0.147 -> 0.05) and stands
+        in for it -- the guard must let the route reach it.
+        """
+        guard = _RouteProgressGuard(60.0)
+        assert _replay(guard, [*SYN40M, (35.0, 0.05)]) is None
+        assert guard.fired_at is None
+
+    def test_a_stalled_route_is_stopped_at_the_checkpoint(self):
+        """``portfol_classical050_1``: identical bounds, 154 cuts an iteration."""
+        guard = _RouteProgressGuard(60.0)
+        warmup = [(t / 2.0, 0.0033823455725941615) for t in range(1, 60)]
+        assert _replay(guard, [*warmup, *PORTFOL_TAIL]) == pytest.approx(30.5)
+        assert "improvement" in guard.reason
+
+    def test_one_observation_is_not_a_trend(self):
+        """``rsyn0840m``: the OA loop manages **two** iterations in 60 s.
+
+        One finite gap, no trend. Reading that as progress would hand the whole
+        budget to a loop that cannot iterate and leave the fallback nothing --
+        on this instance that is the difference between reporting an incumbent
+        of 151.97 and reporting one of -11.41.
+        """
+        guard = _RouteProgressGuard(60.0)
+        assert _replay(guard, RSYN0840M) == pytest.approx(54.82)
+        assert "no trend to judge" in guard.reason
+
+    def test_improvement_below_the_threshold_does_not_earn_the_budget(self):
+        """The threshold is per *window*, not per iteration.
+
+        A trace that shrinks its gap by 10% across the trailing window has not
+        met the 25% the route must show, however many iterations it took.
+        """
+        assert _replay(_RouteProgressGuard(60.0), _geometric(window_ratio=0.90)) == pytest.approx(
+            30.0
+        )
+
+    def test_improvement_above_the_threshold_does_earn_it(self):
+        assert _replay(_RouteProgressGuard(60.0), _geometric(window_ratio=0.50)) is None
+
+    def test_the_threshold_is_the_documented_constant(self):
+        """Straddle it: just inside keeps the budget, just outside loses it."""
+        margin = 0.02
+        keeps = 1.0 - _CONVEX_ROUTE_MIN_GAP_IMPROVEMENT - margin
+        loses = 1.0 - _CONVEX_ROUTE_MIN_GAP_IMPROVEMENT + margin
+        assert _replay(_RouteProgressGuard(60.0), _geometric(window_ratio=keeps)) is None
+        assert _replay(_RouteProgressGuard(60.0), _geometric(window_ratio=loses)) == pytest.approx(
+            30.0
+        )
+
+    def test_progress_older_than_the_window_does_not_count(self):
+        """Improvement has to be recent. A route that converged early and then
+        stopped is a stalled route, not a converging one."""
+        early = [(1.0, 1.0), (2.0, 0.1)]
+        late = [(t * 1.0, 0.1) for t in range(3, 40)]
+        guard = _RouteProgressGuard(60.0)
+        assert _replay(guard, [*early, *late]) == pytest.approx(30.0)
+        assert "trailing" in guard.reason
+
+    def test_a_closed_gap_is_left_to_the_loops_own_test(self):
+        guard = _RouteProgressGuard(60.0)
+        assert _replay(guard, [(t * 1.0, 0.0) for t in range(1, 40)]) is None
+
+    def test_a_placeholder_gap_with_no_dual_bound_is_not_an_observation(self):
+        """``relative_gap=1.0`` with ``current_dual_bound=None`` is the OA
+        driver's placeholder. Counting it would fabricate a trend out of two
+        iterations that never produced a bound."""
+        guard = _RouteProgressGuard(60.0)
+        assert guard(_ctx(1.0, 1.0, bounded=False)) is False
+        assert guard(_ctx(20.0, 1.0, bounded=False)) is False
+        assert guard.history == []
+        assert guard(_ctx(31.0, 1.0, bounded=False)) is True
+        assert "0 finite dual-bound observation(s)" in guard.reason
+
+    def test_the_checkpoint_matches_the_split_it_replaces(self):
+        assert _RouteProgressGuard(60.0).checkpoint == pytest.approx(
+            60.0 * _CONVEX_ROUTE_BUDGET_FRACTION
+        )
+
+    def test_a_tiny_limit_keeps_the_fallback_floor(self):
+        """Below the floor the checkpoint is the whole limit, exactly as the
+        fixed split behaved -- there is no useful fallback to reserve for."""
+        assert _RouteProgressGuard(0.4).checkpoint == pytest.approx(0.4)
+
+    def test_it_returns_real_bools(self):
+        """``_validate_external_termination`` rejects anything else."""
+        guard = _RouteProgressGuard(60.0)
+        assert guard(_ctx(1.0, 0.5)) is False
+        assert guard(_ctx(40.0, 0.5)) is True
+
+
+@pytest.mark.unit
+class TestGuardInstallation:
+    def test_it_installs_on_an_oa_route(self, monkeypatch):
+        monkeypatch.setenv(GUARD_ENV, "1")
+        options, guard = _route_progress_guard_options(None, method_key="oa", time_limit=60.0)
+        assert isinstance(guard, _RouteProgressGuard)
+        assert options["termination_hook"] is guard
+
+    def test_the_flag_off_restores_the_fixed_split(self, monkeypatch):
+        monkeypatch.setenv(GUARD_ENV, "0")
+        options, guard = _route_progress_guard_options(None, method_key="oa", time_limit=60.0)
+        assert guard is None
+        assert options is None
+
+    def test_a_method_without_the_hook_declines(self, monkeypatch):
+        monkeypatch.setenv(GUARD_ENV, "1")
+        _, guard = _route_progress_guard_options(None, method_key="shot", time_limit=60.0)
+        assert guard is None
+
+    def test_a_callers_own_termination_hook_wins(self, monkeypatch):
+        """Two hooks racing to stop the same loop is not a contract worth
+        having, and the caller asked first."""
+        monkeypatch.setenv(GUARD_ENV, "1")
+        mine = {"termination_hook": lambda ctx: False}
+        options, guard = _route_progress_guard_options(mine, method_key="oa", time_limit=60.0)
+        assert guard is None
+        assert options["termination_hook"] is mine["termination_hook"]
+
+    def test_the_callers_mapping_is_not_mutated(self, monkeypatch):
+        monkeypatch.setenv(GUARD_ENV, "1")
+        mine = {"milp_solver": "highs"}
+        options, guard = _route_progress_guard_options(mine, method_key="oa", time_limit=60.0)
+        assert guard is not None
+        assert mine == {"milp_solver": "highs"}
+        assert options["milp_solver"] == "highs"
+
+
+@pytest.mark.unit
+class TestRouteBudgetWiring:
+    """What ``solve_mip_nlp`` actually receives."""
+
+    @staticmethod
+    def _capture(monkeypatch):
+        seen = {}
+        import discopt.solvers.mip_nlp as mn
+
+        real = mn.solve_mip_nlp
+
+        def spy(model, **kw):
+            seen["time_limit"] = kw.get("time_limit")
+            seen["options"] = kw.get("mip_nlp_options")
+            return real(model, **kw)
+
+        monkeypatch.setattr(mn, "solve_mip_nlp", spy)
+        return seen
+
+    def test_the_guarded_route_gets_the_whole_limit_and_the_hook(self, monkeypatch):
+        """This is the #1066 change: no wall, a guard instead."""
+        monkeypatch.setenv(ROUTE_ENV, "1")
+        monkeypatch.setenv(GUARD_ENV, "1")
+        seen = self._capture(monkeypatch)
+        _load("gbd").solve(time_limit=20.0)
+        assert seen, "solve_mip_nlp was never called -- the router did not fire"
+        assert seen["time_limit"] == pytest.approx(20.0)
+        hook = seen["options"]["termination_hook"]
+        assert isinstance(hook, _RouteProgressGuard)
+        assert hook.checkpoint == pytest.approx(20.0 * _CONVEX_ROUTE_BUDGET_FRACTION)
+
+    def test_the_flag_off_reproduces_the_1059_split_exactly(self, monkeypatch):
+        monkeypatch.setenv(ROUTE_ENV, "1")
+        monkeypatch.setenv(GUARD_ENV, "0")
+        seen = self._capture(monkeypatch)
+        _load("gbd").solve(time_limit=20.0)
+        assert seen["time_limit"] == pytest.approx(20.0 * _CONVEX_ROUTE_BUDGET_FRACTION)
+        assert seen["options"] is None
+
+    def test_an_explicit_choice_is_never_guarded(self, monkeypatch):
+        """An explicit ``solver='mip-nlp'`` has no fallback to reserve for, so
+        there is nothing for the guard to hand the budget back to."""
+        monkeypatch.delenv(ROUTE_ENV, raising=False)
+        monkeypatch.setenv(GUARD_ENV, "1")
+        seen = self._capture(monkeypatch)
+        _load("gbd").solve(solver="mip-nlp", mip_nlp_method="oa", time_limit=20.0)
+        assert seen["time_limit"] == pytest.approx(20.0)
+        assert seen["options"] is None or "termination_hook" not in seen["options"]
+
+
+@pytest.mark.slow
+class TestGuardEndToEnd:
+    def test_alan_still_recovers_its_certificate_through_the_fallback(self, monkeypatch):
+        """The #1059 regression the whole budget split exists to prevent.
+
+        ``alan``'s OA gap is 1.0 flat, so the guard must take the budget off it
+        at the checkpoint and leave the fallback enough to certify 2.925.
+        """
+        monkeypatch.setenv(ROUTE_ENV, "1")
+        monkeypatch.setenv(GUARD_ENV, "1")
+        result = _load("alan").solve(time_limit=60.0)
+        assert result.gap_certified is True
+        assert result.objective == pytest.approx(2.925, abs=1e-3)
+
+
+class TestMasterCheckinDeadline:
+    """The guard can only budget by progress if OA gets back to the top of the loop.
+
+    OA's first master expands to fill whatever budget it is given
+    (``_MASTER_NO_INCUMBENT_BUDGET_FRAC``), so widening the route from half the
+    limit to all of it also widened the master. Measured on ``rsyn0840m`` at 60 s:
+    the guard's second call landed at 55.1 s, so abandoning there left the spatial
+    fallback ~5 s and the row's incumbent collapsed from 151.97 to -11.41 on a
+    maximization model. ``master_checkin_deadline`` is how the route tells OA when
+    it intends to look.
+    """
+
+    def test_the_deadline_binds_only_when_it_is_tighter(self):
+        budget = _master_time_budget
+        # No incumbent: the pre-existing fixed-NLP reserve, untouched.
+        assert budget(60.0, has_incumbent=False) == pytest.approx(54.0)
+        assert budget(60.0, has_incumbent=True) == pytest.approx(60.0)
+        # A deadline inside that budget wins, with or without an incumbent.
+        assert budget(60.0, has_incumbent=False, checkin_remaining=30.0) == pytest.approx(30.0)
+        assert budget(60.0, has_incumbent=True, checkin_remaining=30.0) == pytest.approx(30.0)
+        # A deadline outside it changes nothing.
+        assert budget(60.0, has_incumbent=False, checkin_remaining=100.0) == pytest.approx(54.0)
+
+    def test_a_deadline_already_past_does_not_starve_the_master(self):
+        """After the checkpoint the clamp must lift, not hand out a negative budget.
+
+        The route sets one absolute deadline for the whole solve, so every
+        iteration after the checkpoint sees ``checkin_remaining <= 0``. Treating
+        that as a limit would make every subsequent master unsolvable -- which is
+        the opposite of the intent, since past the checkpoint the guard has
+        already decided to let the route keep running.
+        """
+        for past in (0.0, -1.0, -45.0):
+            assert _master_time_budget(
+                30.0, has_incumbent=True, checkin_remaining=past
+            ) == pytest.approx(30.0)
+            assert _master_time_budget(
+                30.0, has_incumbent=False, checkin_remaining=past
+            ) == pytest.approx(27.0)
+
+    def test_the_route_installs_the_deadline_at_the_checkpoint(self, monkeypatch):
+        monkeypatch.setenv(GUARD_ENV, "1")
+        options, guard = _route_progress_guard_options(None, method_key="oa", time_limit=60.0)
+        assert guard is not None
+        assert options["master_checkin_deadline"] == pytest.approx(guard.checkpoint)
+        # The checkpoint is where the old fixed split cut, so the reserve the
+        # fallback used to get is exactly the reserve it still gets.
+        assert guard.checkpoint == pytest.approx(60.0 * _CONVEX_ROUTE_BUDGET_FRACTION)
+
+    def test_declining_the_guard_installs_no_deadline(self, monkeypatch):
+        """The opt-out must not leave a lone master cap behind.
+
+        A ``master_checkin_deadline`` with no ``termination_hook`` to read it is
+        a master truncation for nobody -- exactly the falsified intervention in
+        ``docs/dev/performance-plan.md`` §22.2.
+        """
+        monkeypatch.setenv(GUARD_ENV, "0")
+        options, guard = _route_progress_guard_options(
+            {"add_slack": True}, method_key="oa", time_limit=60.0
+        )
+        assert guard is None
+        assert "master_checkin_deadline" not in (options or {})
+
+    def test_oa_refuses_a_deadline_with_no_reader(self):
+        model = _load("alan")
+        with pytest.raises(ValueError, match="only has an effect alongside termination_hook"):
+            solve_oa(model, time_limit=5.0, master_checkin_deadline=2.0)
+
+    @pytest.mark.parametrize("bad", [0.0, -1.0, float("inf"), float("nan")])
+    def test_oa_refuses_a_nonsense_deadline(self, bad):
+        model = _load("alan")
+        with pytest.raises(ValueError, match="finite positive number of seconds"):
+            solve_oa(
+                model,
+                time_limit=5.0,
+                master_checkin_deadline=bad,
+                termination_hook=lambda ctx: False,
+            )
+
+    def test_mip_nlp_accepts_the_option(self):
+        """It must survive the option whitelist, or the route's install is rejected."""
+        from discopt.solvers.mip_nlp import _OA_OPTION_KEYS
+
+        assert "master_checkin_deadline" in _OA_OPTION_KEYS
+
+
+class TestGraduatedDefault:
+    """The guard is default-on as of the 2026-08-22 panel; the opt-out still works."""
+
+    def test_the_guard_is_on_by_default(self, monkeypatch):
+        monkeypatch.delenv(GUARD_ENV, raising=False)
+        assert _convex_route_progress_guard_enabled() is True
+        options, guard = _route_progress_guard_options(None, method_key="oa", time_limit=60.0)
+        assert guard is not None
+        assert options["termination_hook"] is guard
+
+    @pytest.mark.parametrize("off", ["0"])
+    def test_the_opt_out_restores_the_fixed_split(self, monkeypatch, off):
+        """``=0`` must keep working, and must not leave a stray master cap behind."""
+        monkeypatch.setenv(GUARD_ENV, off)
+        assert _convex_route_progress_guard_enabled() is False
+        options, guard = _route_progress_guard_options(None, method_key="oa", time_limit=60.0)
+        assert guard is None
+        assert options is None


### PR DESCRIPTION
## What

The #1059 convex-MINLP auto-route was budgeted by a clock: `_CONVEX_ROUTE_BUDGET_FRACTION`
cut it off at a fixed half of `time_limit` regardless of what it was doing. This replaces
that wall with a progress test.

## Why

Both failure directions were measured on the #1066 reporter panel (15 convex MINLPLib
instances, default settings):

- **It cuts off a route that is converging.** `syn40m`'s relative gap falls
  0.770 → 0.391 → 0.147 and OA certifies the oracle optimum 67.713256 at **43.5 s**.
  The wall lands at 30 s, so the panel reported `feasible` 58.210 and the fallback could
  not certify either.
- **It lets a dead route run to the wall.** `portfol_classical050_1` sits at relative gap
  0.0045 from iteration 30 through 33 — identical bounds, 154 cuts per iteration buying
  nothing — and still holds its budget for the full 30 s.

So the discriminator is *progress*, not gap level and not the clock.

## How

`_RouteProgressGuard` is a `termination_hook`. It never fires before the checkpoint, so
behaviour up to it is exactly the fixed split's; past it the route continues only while
the relative gap keeps shrinking by `_CONVEX_ROUTE_MIN_GAP_IMPROVEMENT` across a trailing
window. Insufficient evidence is *abandon*, not continue — the fallback is the
known-certifying path.

`solve_oa` also gains `master_checkin_deadline`. A hook that runs at the top of an OA
iteration cannot budget anything unless the loop gets back there, and OA's first master
expands to fill the budget it is handed (`_MASTER_NO_INCUMBENT_BUDGET_FRAC`) — so widening
the route from half the limit to all of it also widened the master from ~27 s to ~54 s.
The one master that would cross the caller's checkpoint is now shortened, and the clamp
lifts once the deadline passes. OA refuses the option without a `termination_hook` to
read it.

**This is not the master cap falsified in `performance-plan.md` §22.2.** That one capped
*every* master to a fraction of remaining, forcing more rounds of weaker cuts, and cost
`rsyn0830m` 200 units of objective. This truncates at most the one master that would cross
the point where the caller has already committed to deciding, and only while the route has
shown no progress.

## The v1 design was falsified first

The first guard had no check-in, and the graduation panel was stopped after ten rows
because those rows killed it. Same interleaved run, `time_limit=60`, all maximization
(higher objective better, lower dual bound tighter):

| instance | OFF obj | ON obj | OFF bound | ON bound | guard |
|---|---|---|---|---|---|
| syn40m | 58.2096 | **67.7133 (cert)** | 68.2186 | 67.7133 | 4 calls, no fire |
| rsyn0820m | 1130.1620 | 1120.0124 | 1420.8056 | 1184.4534 | 2 calls, no fire |
| rsyn0830m | 497.8750 | 497.8750 | 766.8364 | 729.1202 | fired 54.61 |
| rsyn0840m | 151.9691 | **−11.4133** | 814.2617 | 764.2488 | fired 55.13 |
| rsyn0820m02m | −84.8635 | −84.8635 | 5257.0875 | 5091.9553 | fired 54.73 |

The guard was not wrong about those rows — it was right and **late**. The `fired` column is
the whole story, and it is what `master_checkin_deadline` fixes: `rsyn0840m` now fires at
30.5 s and its incumbent is bit-identical to the OFF arm.

An offline replay had scored these rows "same" because it scored certificates and wall and
never scored *incumbent quality*. That blind spot is recorded in §22.4 — a replay can only
falsify what it scores.

## Graduation panel

79 instances: the reporter's 15 at their reported limits (60 s; 600 s on `squfl015-060`
and `squfl020-150`) plus the 64 in-repo corpus instances at 20 s. Arms run back to back per
instance so a load excursion hits both, each behind a `load1 <= 10` gate; every row scored
against `minlplib.solu` in the model's own sense.

| criterion | OFF | ON |
|---|---|---|
| certified | 55 / 79 | **56 / 79** |
| total wall | 1817.3 s | **1799.5 s** |
| certificates gained / lost | — | 1 / 0 |
| incumbents better / worse | — | 1 / 0 |
| dual bounds tighter / looser | — | 6 / 3 |

**Bar 1 (cert-clean): PASS.** 290 soundness checks executed, 0 violations. No incumbent
beat its reference optimum, no dual bound crossed one, no `gap_certified=True` row
regressed, no row lost a dual bound it had. The three looser bounds are all on rows
uncertified in *both* arms and all remain on the valid side of their reference optimum.

**Bar 2 (net-positive): PASS, modestly.** +1 certificate, −17.8 s wall, 6 bounds tighter
against 3 looser, nothing regressed. The certificate gained is `syn40m`, the row #1066 was
opened about — but the guard *fired* on 11 instances across
syn/rsyn/squfl/portfol/clay/cvxnonsep/tls, so the reclaimed budget is a class-wide effect,
not a `syn40m` special case. On 10 of those 11 it cut a dead route short at no cost, which
shows up in the wall column rather than the certificate column.

Flag ships default-on. `DISCOPT_CONVEX_ROUTE_GUARD=0` restores the fixed split and that
path stays tested.

## Verification

- `pytest -m smoke` — 1104 passed, 1 skipped, 2 xpassed
- `pytest -m slow python/tests/test_adversarial_recent_fixes.py` — 19 passed
- `test_1066_route_progress_guard.py` (new, 30 tests) + `test_1059_route_fallback.py` +
  `test_issue1062_oa_master_budget.py` — 62 passed. The new tests fail on pristine `main`
  with an `ImportError` on `_CONVEX_ROUTE_MIN_GAP_IMPROVEMENT`, verified in a detached
  worktree.
- No Rust touched, so no `cargo test`.

Contributes to #1066. That issue stays open until the reported set is solved at default
settings; this moves `syn40m` into the certified column and is measured, not asserted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017PQaiDVuY5Rs3tga98tnNo
