### PR TITLE
fix(relax): #1112 downgrade message + #1111 singular-endpoint tangents (flag default-off)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -360,25 +360,30 @@ The release procedure that produces these entries is documented in
   reaches only −0.6557; the same holds on boxes nine orders of magnitude apart
   (`[0,1e-3]`, `[0,1e6]`, the latter recovering −353.55 → −125 exactly).
 
-  **On the corpus it weakly dominates leaving the facet dropped.** Three-arm panel
+  **On the corpus lazy never loses and wins four times.** Three-arm panel
   (off / eager / lazy), one binary, `max_nodes` budget with **no** `time_limit` so
   node counts and bounds are bit-reproducible, each arm's firing mechanism separately
-  instrumented and asserted. 10 instances produced a scorable three-arm row:
+  instrumented and asserted. 13 instances produced a scorable three-arm row:
 
   | instance | off | eager | lazy | lazy rows |
   |---|---|---|---|---|
+  | `kriging_peaks-full050` | −142.657069 | flat | **−139.917835 (BETTER, +1.9 %)** | 7860 |
+  | `kriging_peaks-full100` | −348.053602 | flat | **−342.588463 (BETTER, +1.6 %)** | 13214 |
+  | `kriging_peaks-full200` | −746.566175 | +1e−08 (noise) | **−734.495407 (BETTER, +1.6 %)** | 32451 |
+  | `tspn15` | 269.3529936 | **269.8773406 (BETTER)** | 269.3558802 (BETTER, marginal) | 85 |
   | `tspn08` | 135 nodes | **191 nodes (WORSE, +41.5 %)** | 135 nodes | 25 |
   | `tspn10` | 177.43065803 | **177.39907299 (WORSE)** | 177.43065803 | 1 |
-  | `kriging_peaks-full050` | −142.657069 | −142.657069 | **−139.917835 (BETTER)** | 7860 |
-  | `kriging_peaks-full100` | −348.053602 | −348.053602 | **−342.588463 (BETTER)** | 13214 |
-  | `mathopt5_6`, `eq6_1`, `maxmin`, `full010`, `full020`, `tspn12` | — | flat | flat | 0–35585 |
+  | `mathopt5_6`, `eq6_1`, `maxmin`, `full010/020/030`, `tspn12` | — | flat | flat | 0–35585 |
 
-  `eager vs off: WORSE 2, flat 8, better 0`. `lazy vs off: BETTER 2, flat 8, worse 0`.
-  40 soundness comparisons against `minlplib.solu`, **0 violations**. Both lazy gains
-  occur at *identical node counts and identical incumbents* — a strictly better bound
-  for the same work — and both sit in `kriging_peaks`, the family with the largest
-  root gain (13–40×). This is **not** the `DISCOPT_CUT_INHERIT` outcome, which was
-  neutral-or-harmful.
+  `eager vs off: BETTER 2, WORSE 2, flat 9`. `lazy vs off: BETTER 4, flat 9, worse 0`.
+  52 soundness comparisons against `minlplib.solu`, **0 violations**. Every lazy gain
+  occurs at an *identical node count and identical incumbent* — a strictly better bound
+  for the same work — and the three substantial ones follow a coherent size trend:
+  nothing at `full010/020/030`, ~1.6–1.9 % of gap at `full050/100/200`, which is what a
+  mechanism acting only where the dropped facet dominates the root relaxation should
+  look like. Eager's two BETTER cells are `tspn15` (+0.002) and `full200` (+1e−08,
+  noise) against two real losses, so eager stays net-negative. This is **not** the
+  `DISCOPT_CUT_INHERIT` outcome, which was neutral-or-harmful.
 
   It is also not yet a graduation case, and the gaps are recorded rather than glossed:
 
@@ -393,10 +398,12 @@ The release procedure that produces these entries is documented in
     35 585 on `maxmin` buy movement in the 12th digit. No wall-time figure is quoted:
     that panel's timing column was contaminated by load the author generated
     concurrently (§9), so it is discarded rather than reported.
-  * **7 of 17 screened instances produced no scorable row.** `elec*` and `full500`
-    return no dual bound at all (1 node, or 0 for `full500`); `full030`, `tspn15` and
-    `full200` were lost to a per-instance wall kill set too low — which truncated the
-    **lazy** arm preferentially, since it always runs third.
+  * **4 of 17 screened instances produced no scorable row:** `elec*` and `full500`
+    return no dual bound at all (1 node, or 0 for `full500`). `full030`, `tspn15` and
+    `full200` were initially lost to a per-instance wall kill set too low — a biased
+    loss, since lazy runs third and every truncation cut it preferentially — and were
+    recovered by a per-arm re-run. Recovering them added one eager BETTER and one
+    substantial lazy BETTER, so the truncation had been hiding results on both sides.
 
   Consequently the #1111 finding "the root win does not survive branching" is scoped
   to the **eager** anchor. Where the dropped facet dominates the root relaxation,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -235,21 +235,25 @@ The release procedure that produces these entries is documented in
   endpoint but `f'` diverges there, `_emit_1d` silently dropped the tangent facet,
   leaving the envelope one-sided. Re-anchoring it at an interior ladder point only
   ever *adds* a row, so the flag-ON polytope is a subset of the flag-OFF one and the
-  node LP bound can only improve. The §5 panel (13 pairs) is **cert-clean** — zero
-  soundness violations, incumbents identical on all 13, no certification regression
-  — and **fails net-positive**:
+  node LP bound can only improve. The §5 panel is **cert-clean** and **fails
+  net-positive — because the flag is exactly neutral, not because it is harmful.**
+  17 instances, every one screened to actually drop a facet; both arms in one
+  process on one binary; each arm run twice. 24 soundness comparisons, 0 violations,
+  no bound above its `.solu` reference, no certification regression, incumbents
+  identical throughout. And:
 
-  * the two *terminating* pairs are the only load-independent rows: `mathopt5_6`
-    5 → 5 nodes with a bit-identical certificate, and `tspn08` **135 → 191 nodes,
-    +41 %**. A tighter relaxation still grows the tree because a different LP vertex
-    changes the branching choice;
-  * among the time-limited rows, 1 meaningfully better (`tspn10` +1.274) against 4
-    meaningfully worse (`kriging_peaks-full100` −1.144, `full010` −0.542, `tspn12`
-    −0.520, `full050` −0.198);
+  * the two *terminating* pairs are the only load-independent rows, and both are
+    exactly neutral: `mathopt5_6` 5 → 5 nodes and `tspn08` 135 → 135 nodes, each
+    with a **bit-identical** dual bound in both arms, reproducible across both
+    repetitions;
+  * every time-limited row is neutral **within its own rep-to-rep spread**. Compare
+    ON's worse repetition against OFF's better one and no instance is robustly
+    better or worse; the widest excursion, `tspn10`, straddles zero (−0.739 to
+    +0.318). At a 60 s limit under load this panel cannot resolve a gain that size
+    and none is claimed;
   * the root win does not survive branching: `kriging_peaks` gains 13–40× at the
-    root (`full200` −74356.93 → −5596.46), yet after 120 s `full020`'s arms agree to
-    14 digits and `full050`/`full100` are behind. B&B was already recovering that
-    bound cheaply, and an extra LP row at every node is a net loss.
+    root (`full200` −74356.93 → −5596.46), yet `full020`'s arms agree to 14 digits
+    at the limit. B&B was already recovering that bound cheaply.
 
   The `DISCOPT_CUT_INHERIT` outcome. Note that the two #581 precedents in
   `solver_tuning.py` *removed* such flags rather than leaving them in default-OFF
@@ -258,12 +262,24 @@ The release procedure that produces these entries is documented in
   for itself — with the failing panel written into the field's docstring.
   Flag-OFF is byte-identical to the pre-#1111 relaxation.
 
-  **Retractions.** The panel harness printed `better 10 worse 2 unchanged 1`; that
-  tally is wrong and is not the basis of anything above. Its classifier scored
-  `nodes_on < nodes_off` as "better", which is correct for a terminating run and
-  backwards for a time-limited one, where fewer nodes means the arm did *less* work
-  in the same budget. Two earlier wall-time claims are also retracted: load was
-  37–87 on 14 cores, so the §9 load gate fails outright. And #1111's own motivating
+  **Retractions.** An earlier 13-pair panel, ~36 % diluted (5 of its 14 instances
+  contain no `sqrt`, so the flag could not act on them), was published here and in
+  PR #1113 as measuring `tspn08` at **135 → 191 nodes, +41 %** — the load-bearing
+  evidence for calling this flag harmful. **It does not reproduce.** On the
+  undiluted single-binary panel `tspn08` is 135 → 135 with an identical bound
+  (290.565925041298) in all four runs. Retracted with it: that panel's four
+  "meaningfully worse" time-limited rows (`kriging_peaks-full100` −1.144, `full010`
+  −0.542, `tspn12` −0.520, `full050` −0.198) — on the successor panel `full100` and
+  `tspn12` are flat and `full010`/`full050` move the *other* way, inside rep noise.
+  Those were load artifacts, measured while an unrelated job held most of the
+  machine. The outcome is unchanged (stays default-OFF); its character is not — the
+  flag is neutral, not a regression.
+
+  Also retracted: the harness's printed tally `better 10 worse 2 unchanged 1`, whose
+  classifier scored `nodes_on < nodes_off` as "better" — correct for a terminating
+  run, backwards for a time-limited one, where fewer nodes means the arm did *less*
+  work in the same budget. Both earlier wall-time claims are retracted too (load
+  37–87 on 14 cores; the §9 load gate fails outright). And #1111's own motivating
   hypothesis is falsified — on the adiabatic LVC MECP model the facet is recovered
   but the root bound and node count are unchanged (1 node either way).
 
@@ -274,9 +290,9 @@ The release procedure that produces these entries is documented in
   * *Corpus scope.* Across all 1610 MINLPLib `.nl` instances, `sqrt` appears in 63
     and `asin`/`acos`/`acosh` in **zero** — the opposite of the issue's expectation
     that the inverse-trig rows carry the weight.
-  * *Panel 1 was ~36 % diluted.* Five of its 14 instances (`kriging_peaks-red*`)
-    contain no `sqrt` at all, so the flag could not act on them. A targeted panel
-    was rebuilt by screening every corpus instance for an actually-dropped facet,
+  * *The first panel was ~36 % diluted* (see the retraction above). The targeted
+    successor panel was rebuilt by screening every corpus instance for an
+    actually-dropped facet,
     using two complementary instruments — a cheap root screen and a full-solve
     census — because the root screen alone is structurally blind to the `elec*`
     family, whose singular boxes only appear after branching.
@@ -305,8 +321,11 @@ The release procedure that produces these entries is documented in
   The direction the evidence points is to stop placing the tangent geometrically and
   place it *where the LP binds* — lazily at the incumbent LP point, as
   `MccormickLPRelaxer._separate_convex`'s Kelley loop already does for composite
-  convex/concave lifts — which also avoids the cost panel 1 charged this flag for, an
-  eager extra row at every node. That is a hypothesis with a clear entry experiment,
+  convex/concave lifts — which also stops the solver paying for an eager extra row at
+  every node whether or not that node's LP is near the singular endpoint. (The
+  retracted panel charged this flag for that cost as a *measured* regression; it is
+  not one. It stays a reason to prefer lazy placement as an argument, not as
+  evidence.) That is a hypothesis with a clear entry experiment,
   not a known fix: lazy placement does not dodge the singularity, since the gain still
   collapses for offsets below ~1e-5 and an LP point inside that radius needs the same
   conditioning guard. It remains open; the flag stays default-OFF as its measurement

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,52 @@ The release procedure that produces these entries is documented in
 
 ### Fixed
 
+- **The McCormick LP downgrade told users to pass the flag they had just passed**
+  (`relaxation`, #1112). A model whose nonlinearity lives inside a
+  `dm.custom`/`CustomCall` node has no *lifted* relaxation — the body is opaque to
+  the DAG walker by construction — so `has_relaxable_nonlinearity` is False, the LP
+  relaxer is discarded, and the issue-#120 soundness guard demotes `"nlp"` to
+  `"none"`. That demotion is correct and is unchanged. Its *message* was not: it
+  advised `Use mccormick_bounds='lp'` to callers who had passed exactly that, and
+  it fired even when the reduced-space engine was about to supply a perfectly good
+  spatial bound, where there is no fallback to announce. The warning is now
+  suppressed (`debug`, with an accurate one-liner) whenever reduced-space bounding
+  is forced; every other caller sees the original text verbatim.
+
+  **Two of the issue's own claims are falsified and recorded here rather than
+  quietly dropped.** (1) Section (b) states "the node bound it actually gets is
+  alphaBB". Measured on an MCBox-traceable CustomCall model with
+  `mccormick_bounds="lp"`: the reduced engine is active and bounds 0.5413 against
+  `f(0.5, 0.5) = 0.6065` at an independently-checked feasible point — a real
+  spatial bound, not an alphaBB-grade one. (2) The `discopt.nn` rows in the issue's
+  table are a *different bug*: a tanh network reports
+  `has_relaxable_nonlinearity is True` and never reaches the downgrade at all
+  (its loose bound is the missing spanning-box S-envelope —
+  `_curv_by_sign` returns `None` on an inflection-spanning box and `_emit_1d`
+  emits zero rows). `test_1112_downgrade_message.py` pins that distinction so the
+  two are not conflated again.
+
+  A branch explaining the opaque cause to a *non*-reduced-space caller was written
+  and then removed as dead code: a non-admissible `CustomCall` model returns early
+  via `_withhold_local_optimality_certificate` and never reaches the guard, so no
+  `CustomCall` model can arrive there without `_force_reduced_space`. That
+  reachability fact is itself pinned by a test.
+
+  Not addressed, and tracked separately: alphaBB is still enabled alongside the
+  reduced engine because `_use_alphabb` keys on `_mc_lp_relaxer is None` and is
+  computed before `_reduced_space_active`. Suppressing it is bound-changing (if the
+  node bound is currently the better of the two, removing alphaBB can loosen it) and
+  needs the §5 flag-and-panel treatment.
+
+- **`sqrt`/`asin`/`acos`/`acosh` derivatives no longer divide by zero at a singular
+  endpoint** (`relaxation`, #1111). `_dsqrt` and friends evaluate the derivative
+  *limit* explicitly instead of computing `1/0`, so the
+  `RuntimeWarning: divide by zero encountered in scalar divide` is gone at the
+  source rather than suppressed; returned values are bit-identical. Separately,
+  `spatial_producer` now declines a zero-touching `sqrt` box: the Rust mirror
+  (`bnb/mccormick_patch.rs::univariate_rows`) guards `f` but not `f'` and would
+  have written `f'(0) = inf` and a `NaN` intercept into the node LP.
+
 - **Presolve reached its iteration cap on every model with a bound-redundant
   row** (`presolve`, #1053). `SimplifyPass` is `PassCategory::BoundsOnly` — it
   holds `&ctx.model` and cannot remove anything — yet it stamped the rows it
@@ -181,6 +227,45 @@ The release procedure that produces these entries is documented in
   instead, landing the search on denser bases. The 48-update cap is load-bearing.
   No default moved. Details and the falsification record in
   `docs/dev/performance-plan.md` §18f.
+
+### Measured (no behaviour change)
+
+- **Recovering the dropped vertical-tangent facet is sound but not helpful**
+  (#1111, `DISCOPT_SINGULAR_TANGENT`, default **off**). Where `f` is finite at a box
+  endpoint but `f'` diverges there, `_emit_1d` silently dropped the tangent facet,
+  leaving the envelope one-sided. Re-anchoring it at an interior ladder point only
+  ever *adds* a row, so the flag-ON polytope is a subset of the flag-OFF one and the
+  node LP bound can only improve. The §5 panel (13 pairs) is **cert-clean** — zero
+  soundness violations, incumbents identical on all 13, no certification regression
+  — and **fails net-positive**:
+
+  * the two *terminating* pairs are the only load-independent rows: `mathopt5_6`
+    5 → 5 nodes with a bit-identical certificate, and `tspn08` **135 → 191 nodes,
+    +41 %**. A tighter relaxation still grows the tree because a different LP vertex
+    changes the branching choice;
+  * among the time-limited rows, 1 meaningfully better (`tspn10` +1.274) against 4
+    meaningfully worse (`kriging_peaks-full100` −1.144, `full010` −0.542, `tspn12`
+    −0.520, `full050` −0.198);
+  * the root win does not survive branching: `kriging_peaks` gains 13–40× at the
+    root (`full200` −74356.93 → −5596.46), yet after 120 s `full020`'s arms agree to
+    14 digits and `full050`/`full100` are behind. B&B was already recovering that
+    bound cheaply, and an extra LP row at every node is a net loss.
+
+  The `DISCOPT_CUT_INHERIT` outcome. Note that the two #581 precedents in
+  `solver_tuning.py` *removed* such flags rather than leaving them in default-OFF
+  limbo; this one is retained by owner decision as a measurement lever for the open
+  question in #1111 — whether any formulation of the singular-endpoint tangent pays
+  for itself — with the failing panel written into the field's docstring.
+  Flag-OFF is byte-identical to the pre-#1111 relaxation.
+
+  **Retractions.** The panel harness printed `better 10 worse 2 unchanged 1`; that
+  tally is wrong and is not the basis of anything above. Its classifier scored
+  `nodes_on < nodes_off` as "better", which is correct for a terminating run and
+  backwards for a time-limited one, where fewer nodes means the arm did *less* work
+  in the same budget. Two earlier wall-time claims are also retracted: load was
+  37–87 on 14 cores, so the §9 load gate fails outright. And #1111's own motivating
+  hypothesis is falsified — on the adiabatic LVC MECP model the facet is recovered
+  but the root bound and node count are unchanged (1 node either way).
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -257,9 +257,10 @@ The release procedure that produces these entries is documented in
 
   The `DISCOPT_CUT_INHERIT` outcome. Note that the two #581 precedents in
   `solver_tuning.py` *removed* such flags rather than leaving them in default-OFF
-  limbo; this one is retained by owner decision as a measurement lever for the open
-  question in #1111 — whether any formulation of the singular-endpoint tangent pays
-  for itself — with the failing panel written into the field's docstring.
+  limbo; this one is retained by owner decision as a measurement lever for **#1115** —
+  whether any formulation of the singular-endpoint tangent pays for itself — with the
+  failing panel written into the field's docstring. #1115 carries the same disposition
+  rule: if the successor mechanism is falsified too, the flag gets removed.
   Flag-OFF is byte-identical to the pre-#1111 relaxation.
 
   **Retractions.** An earlier 13-pair panel, ~36 % diluted (5 of its 14 instances

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -343,7 +343,7 @@ The release procedure that produces these entries is documented in
   merely an argument. Built and measured as #1115, below.
 
 - **Placing the vertical-tangent facet where the LP binds removes the eager
-  anchor's regression and buys nothing beyond it** (#1115,
+  anchor's regression and, on part of the corpus, buys a tighter bound** (#1115,
   `DISCOPT_SINGULAR_TANGENT_LAZY`, default **on**, consulted only when
   `singular_tangent` is on — so the shipped default path is unchanged).
   `MccormickLPRelaxer._separate_singular_tangent` adds the supporting tangent at the
@@ -360,24 +360,48 @@ The release procedure that produces these entries is documented in
   reaches only −0.6557; the same holds on boxes nine orders of magnitude apart
   (`[0,1e-3]`, `[0,1e6]`, the latter recovering −353.55 → −125 exactly).
 
-  **On the corpus it is neutral.** Three-arm panel (off / eager / lazy), one process
-  per instance on one binary, `max_nodes` budget with no `time_limit`, each arm's
-  firing mechanism separately instrumented and asserted:
+  **On the corpus it weakly dominates leaving the facet dropped.** Three-arm panel
+  (off / eager / lazy), one binary, `max_nodes` budget with **no** `time_limit` so
+  node counts and bounds are bit-reproducible, each arm's firing mechanism separately
+  instrumented and asserted. 10 instances produced a scorable three-arm row:
 
-  | instance | off | eager | lazy | lazy rows separated |
+  | instance | off | eager | lazy | lazy rows |
   |---|---|---|---|---|
-  | `tspn08` | 135 nodes | **191 nodes (+41.5 %)** | 135 nodes | 25 |
-  | `mathopt5_6` | 5 nodes | 5 nodes | 5 nodes | 0 |
-  | `kriging_peaks-full010` | −0.81783918772926**15** | −0.81783918772926**02** | −0.81783918772926**15** | 604 |
+  | `tspn08` | 135 nodes | **191 nodes (WORSE, +41.5 %)** | 135 nodes | 25 |
+  | `tspn10` | 177.43065803 | **177.39907299 (WORSE)** | 177.43065803 | 1 |
+  | `kriging_peaks-full050` | −142.657069 | −142.657069 | **−139.917835 (BETTER)** | 7860 |
+  | `kriging_peaks-full100` | −348.053602 | −348.053602 | **−342.588463 (BETTER)** | 13214 |
+  | `mathopt5_6`, `eq6_1`, `maxmin`, `full010`, `full020`, `tspn12` | — | flat | flat | 0–35585 |
 
-  Lazy placement fixes the eager regression — `tspn08` returns to 135 nodes — and
-  gains nothing over leaving the facet dropped. The mechanism is measurably live
-  (604 rows separated on `kriging_peaks-full010`; instrumented, the separator moves
-  the node LP objective on 7 of 12 invocations) but by ~1e-4 against a bound of
-  −5.69, which never changes a branching decision. This is the #727 lesson in
-  reverse: the synthetic atom shows a large gain, the real class shows none, because
-  on a corpus instance the sqrt term is one of many and the LP optimum is held by
-  other constraints rather than sitting at the singular endpoint.
+  `eager vs off: WORSE 2, flat 8, better 0`. `lazy vs off: BETTER 2, flat 8, worse 0`.
+  40 soundness comparisons against `minlplib.solu`, **0 violations**. Both lazy gains
+  occur at *identical node counts and identical incumbents* — a strictly better bound
+  for the same work — and both sit in `kriging_peaks`, the family with the largest
+  root gain (13–40×). This is **not** the `DISCOPT_CUT_INHERIT` outcome, which was
+  neutral-or-harmful.
+
+  It is also not yet a graduation case, and the gaps are recorded rather than glossed:
+
+  * **Lazy has a coverage hole eager does not.** The separation chain is gated on
+    `if separate:` (`mccormick_lp.py:1641`), forced off on yield rounds and pool-free
+    re-solves. On all three `elec*` instances the lazy arm registered thousands of
+    specs (19 236 on `elec100`) and the separator ran **zero** times, while eager
+    fired at build time throughout. Lazy trades "emit a geometric guess wherever a
+    relaxation is built" for "emit an exact tangent only where a separation round
+    runs" — it is not a coverage superset.
+  * **Cost is counted in rows, not seconds.** 31 614 separated rows on `eq6_1` and
+    35 585 on `maxmin` buy movement in the 12th digit. No wall-time figure is quoted:
+    that panel's timing column was contaminated by load the author generated
+    concurrently (§9), so it is discarded rather than reported.
+  * **7 of 17 screened instances produced no scorable row.** `elec*` and `full500`
+    return no dual bound at all (1 node, or 0 for `full500`); `full030`, `tspn15` and
+    `full200` were lost to a per-instance wall kill set too low — which truncated the
+    **lazy** arm preferentially, since it always runs third.
+
+  Consequently the #1111 finding "the root win does not survive branching" is scoped
+  to the **eager** anchor. Where the dropped facet dominates the root relaxation,
+  lazy placement does retain part of it; elsewhere it is inert, and on `elec*` it
+  cannot act at all.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -267,6 +267,48 @@ The release procedure that produces these entries is documented in
   hypothesis is falsified — on the adiabatic LVC MECP model the facet is recovered
   but the root bound and node count are unchanged (1 node either way).
 
+  **Follow-up measurement: the anchor is not the problem, the mechanism is.** Two
+  more of #1111's premises were tested and failed, and a candidate replacement was
+  built and rejected on measurement rather than on argument:
+
+  * *Corpus scope.* Across all 1610 MINLPLib `.nl` instances, `sqrt` appears in 63
+    and `asin`/`acos`/`acosh` in **zero** — the opposite of the issue's expectation
+    that the inverse-trig rows carry the weight.
+  * *Panel 1 was ~36 % diluted.* Five of its 14 instances (`kriging_peaks-red*`)
+    contain no `sqrt` at all, so the flag could not act on them. A targeted panel
+    was rebuilt by screening every corpus instance for an actually-dropped facet,
+    using two complementary instruments — a cheap root screen and a full-solve
+    census — because the root screen alone is structurally blind to the `elec*`
+    family, whose singular boxes only appear after branching.
+  * *A fixed-offset anchor is strictly worse.* `delta = width/8` was implemented and
+    measured against the shipped κ-capped ladder: about **half** the root-bound gain
+    on every instance where the bound moves (`kriging_peaks-full010` +1513 vs +2975,
+    `full200` +34967 vs +68769). It was discarded. The argument that motivated it —
+    that `width/8` minimises *mean envelope slack* over the box, by 3.31× — is
+    retracted: mean slack does not predict bound tightness, because only slack where
+    the relaxation binds matters, and on this family the LP optimum sits at the
+    singular endpoint.
+  * *No constant is right.* Sweeping the offset over eight orders on the three
+    `kriging_peaks-full` instances that move the root bound, the gain rises toward
+    the endpoint, peaks near `delta ~ 1e-5`, then **collapses to zero** by `1e-12`;
+    on an isolated `min 3x - sqrt(x)` atom the peak is orders of magnitude further
+    out. Both ends of the range are degenerate and the optimum is problem-dependent,
+    so a static geometric anchor cannot be right for every box.
+
+  This does give `singular_tangent_kappa` the measured justification it previously
+  lacked — the cap's stated rationale (outward-rounding slack growing with slope) is
+  real in direction but ~1e-14 in magnitude against a ~0.35 cut depth, and is
+  retracted; what the cap actually does is keep the ladder off the degenerate end,
+  adaptively per box. A regression test now pins that: an effectively uncapped κ
+  still emits the facet but buys < 1e-6 of root bound, where κ=100 buys > 1e-3.
+
+  The direction the evidence points is to stop placing the tangent geometrically and
+  place it *where the LP binds* — lazily at the incumbent LP point, as
+  `MccormickLPRelaxer._separate_convex`'s Kelley loop already does for composite
+  convex lifts — which also avoids the cost panel 1 charged this flag for, an eager
+  extra row at every node. That remains open; the flag stays default-OFF as its
+  measurement lever.
+
 ### Removed
 
 - **The inert `superposition` knob** (`fix(relax)`, #1046, closes #1035).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -305,9 +305,12 @@ The release procedure that produces these entries is documented in
   The direction the evidence points is to stop placing the tangent geometrically and
   place it *where the LP binds* — lazily at the incumbent LP point, as
   `MccormickLPRelaxer._separate_convex`'s Kelley loop already does for composite
-  convex lifts — which also avoids the cost panel 1 charged this flag for, an eager
-  extra row at every node. That remains open; the flag stays default-OFF as its
-  measurement lever.
+  convex/concave lifts — which also avoids the cost panel 1 charged this flag for, an
+  eager extra row at every node. That is a hypothesis with a clear entry experiment,
+  not a known fix: lazy placement does not dodge the singularity, since the gain still
+  collapses for offsets below ~1e-5 and an LP point inside that radius needs the same
+  conditioning guard. It remains open; the flag stays default-OFF as its measurement
+  lever.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -236,24 +236,20 @@ The release procedure that produces these entries is documented in
   leaving the envelope one-sided. Re-anchoring it at an interior ladder point only
   ever *adds* a row, so the flag-ON polytope is a subset of the flag-OFF one and the
   node LP bound can only improve. The §5 panel is **cert-clean** and **fails
-  net-positive — because the flag is exactly neutral, not because it is harmful.**
-  17 instances, every one screened to actually drop a facet; both arms in one
-  process on one binary; each arm run twice. 24 soundness comparisons, 0 violations,
-  no bound above its `.solu` reference, no certification regression, incumbents
-  identical throughout. And:
+  net-positive: the eager anchor is measured harmful.** On `tspn08` — the only
+  instance that terminates inside a deterministic node budget and moves at all —
+  the tree grows 135 → **191 nodes (+41.5 %)** to buy a bound gain in the 11th digit
+  (290.56592504129753 → 290.56599569540646). `mathopt5_6` is flat at 5 → 5 with a
+  bit-identical bound and `kriging_peaks-full010` is flat to 14 digits. Soundness
+  held throughout: 0 violations, no bound above its `.solu` reference, no
+  certification regression, incumbents identical.
 
-  * the two *terminating* pairs are the only load-independent rows, and both are
-    exactly neutral: `mathopt5_6` 5 → 5 nodes and `tspn08` 135 → 135 nodes, each
-    with a **bit-identical** dual bound in both arms, reproducible across both
-    repetitions;
-  * every time-limited row is neutral **within its own rep-to-rep spread**. Compare
-    ON's worse repetition against OFF's better one and no instance is robustly
-    better or worse; the widest excursion, `tspn10`, straddles zero (−0.739 to
-    +0.318). At a 60 s limit under load this panel cannot resolve a gain that size
-    and none is claimed;
-  * the root win does not survive branching: `kriging_peaks` gains 13–40× at the
-    root (`full200` −74356.93 → −5596.46), yet `full020`'s arms agree to 14 digits
-    at the limit. B&B was already recovering that bound cheaply.
+  The subset property is not contradicted — each node's ON bound *is* ≥ its OFF
+  counterpart — but a different LP vertex changes the branching choice, so a tighter
+  relaxation can still grow the tree. Nor does the root win survive branching:
+  `kriging_peaks` gains 13–40× at the root (`full200` −74356.93 → −5596.46), yet
+  after a few hundred nodes the arms agree to 14 digits. B&B was already recovering
+  that bound cheaply.
 
   The `DISCOPT_CUT_INHERIT` outcome. Note that the two #581 precedents in
   `solver_tuning.py` *removed* such flags rather than leaving them in default-OFF
@@ -263,26 +259,45 @@ The release procedure that produces these entries is documented in
   rule: if the successor mechanism is falsified too, the flag gets removed.
   Flag-OFF is byte-identical to the pre-#1111 relaxation.
 
-  **Retractions.** An earlier 13-pair panel, ~36 % diluted (5 of its 14 instances
-  contain no `sqrt`, so the flag could not act on them), was published here and in
-  PR #1113 as measuring `tspn08` at **135 → 191 nodes, +41 %** — the load-bearing
-  evidence for calling this flag harmful. **It does not reproduce.** On the
-  undiluted single-binary panel `tspn08` is 135 → 135 with an identical bound
-  (290.565925041298) in all four runs. Retracted with it: that panel's four
-  "meaningfully worse" time-limited rows (`kriging_peaks-full100` −1.144, `full010`
-  −0.542, `tspn12` −0.520, `full050` −0.198) — on the successor panel `full100` and
-  `tspn12` are flat and `full010`/`full050` move the *other* way, inside rep noise.
-  Those were load artifacts, measured while an unrelated job held most of the
-  machine. The outcome is unchanged (stays default-OFF); its character is not — the
-  flag is neutral, not a regression.
+  **Double retraction (§11) — a retraction that was itself wrong.** An earlier
+  revision of this entry, of the field docstring, and of PR #1113 *withdrew* the
+  `tspn08` 135 → 191 result and recorded the flag as "sound, and neutral", on the
+  strength of a panel showing 135 → 135 with bit-identical bounds. **That withdrawal
+  is itself withdrawn and the +41 % is reinstated**, as measured above. The panel
+  behind it never fired.
 
-  Also retracted: the harness's printed tally `better 10 worse 2 unchanged 1`, whose
-  classifier scored `nodes_on < nodes_off` as "better" — correct for a terminating
-  run, backwards for a time-limited one, where fewer nodes means the arm did *less*
-  work in the same budget. Both earlier wall-time claims are retracted too (load
-  37–87 on 14 cores; the §9 load gate fails outright). And #1111's own motivating
-  hypothesis is falsified — on the adiabatic LVC MECP model the facet is recovered
-  but the root bound and node count are unchanged (1 node either way).
+  The instrument defect, measured not inferred: `solve()` is wrapped by a decorator
+  (`solver.py:6274-6280`) that begins `_set_tuning(kwargs.pop("tuning", None))`, and
+  `solver_tuning.set_current(None)` publishes a **fresh, env-resolved**
+  `SolverTuning()`. A probe that installs a tuning with `set_current(...)` and then
+  calls `m.solve()` without `tuning=` therefore has that context **silently
+  discarded at the solve boundary**. Counting `_interior_tangent_point` calls inside
+  a full solve of `kriging_peaks-full010`: off 0 calls / 311 nodes; `set_current`
+  **0 calls** / 311 nodes; `m.solve(tuning=...)` 2671 / 313; `DISCOPT_SINGULAR_TANGENT=1`
+  2671 / 313. `tuning=` and the environment variable agree bit-for-bit, and
+  `set_current` is inert — so "both arms bit-identical" was never a neutrality
+  result, it is the signature of a probe that never fired, which is also exactly why
+  the arms agreed to the last digit. That panel carried no drops counter, so nothing
+  caught it (§6). The root-relaxation measurements below are unaffected: they drive
+  `build_uniform_relaxation` directly, where `set_current` does reach (instrumented
+  10/10).
+
+  The reinstated number was re-measured on a corrected instrument — `tuning=`
+  delivery, the ON arm asserted to have fired, a `max_nodes` budget with **no**
+  `time_limit` (a wall limit changes the kernel path and makes the run
+  non-reproducible; `max_nodes` alone is bit-reproducible over 3 repetitions per
+  arm), both arms in one process on one binary — and reproduces at 135 → 191 on
+  every run since.
+
+  Still retracted, for reasons unrelated to that defect: the first panel's
+  time-limited rows (`kriging_peaks-full100` −1.144, `tspn12` −0.520, …), taken at a
+  60 s wall limit under load 37–87 on 14 cores, fail the §9 load gate outright; and
+  the harness's printed tally `better 10 worse 2 unchanged 1`, whose classifier
+  scored `nodes_on < nodes_off` as "better" — correct for a terminating run,
+  backwards for a time-limited one, where fewer nodes means the arm did *less* work
+  in the same budget. And #1111's own motivating hypothesis is falsified — on the
+  adiabatic LVC MECP model the facet is recovered but the root bound and node count
+  are unchanged (1 node either way).
 
   **Follow-up measurement: the anchor is not the problem, the mechanism is.** Two
   more of #1111's premises were tested and failed, and a candidate replacement was
@@ -323,14 +338,46 @@ The release procedure that produces these entries is documented in
   place it *where the LP binds* — lazily at the incumbent LP point, as
   `MccormickLPRelaxer._separate_convex`'s Kelley loop already does for composite
   convex/concave lifts — which also stops the solver paying for an eager extra row at
-  every node whether or not that node's LP is near the singular endpoint. (The
-  retracted panel charged this flag for that cost as a *measured* regression; it is
-  not one. It stays a reason to prefer lazy placement as an argument, not as
-  evidence.) That is a hypothesis with a clear entry experiment,
-  not a known fix: lazy placement does not dodge the singularity, since the gain still
-  collapses for offsets below ~1e-5 and an LP point inside that radius needs the same
-  conditioning guard. It remains open; the flag stays default-OFF as its measurement
-  lever.
+  every node whether or not that node's LP is near the singular endpoint. That cost
+  is exactly what the reinstated `tspn08` regression charges, so it is evidence, not
+  merely an argument. Built and measured as #1115, below.
+
+- **Placing the vertical-tangent facet where the LP binds removes the eager
+  anchor's regression and buys nothing beyond it** (#1115,
+  `DISCOPT_SINGULAR_TANGENT_LAZY`, default **on**, consulted only when
+  `singular_tangent` is on — so the shipped default path is unchanged).
+  `MccormickLPRelaxer._separate_singular_tangent` adds the supporting tangent at the
+  current LP point, and only when that point violates it, instead of emitting one row
+  per node at a fixed geometric anchor. Where the LP vertex sits *on* the singularity
+  — the case the facet exists for, and where no finite-slope tangent is available —
+  the touch point falls back to #1111's conditioning-capped ladder while the
+  violation test still decides whether the row goes in, so the separator does not
+  degrade to a no-op precisely where it is needed.
+
+  On isolated atoms the mechanism does what it was designed to do: on
+  `min 2x - sqrt(x)` over `[0,4]` the root LP bound goes −0.7071 → **−0.12503**
+  against a true optimum of −0.125 (>99 % of the gap closed), where the eager anchor
+  reaches only −0.6557; the same holds on boxes nine orders of magnitude apart
+  (`[0,1e-3]`, `[0,1e6]`, the latter recovering −353.55 → −125 exactly).
+
+  **On the corpus it is neutral.** Three-arm panel (off / eager / lazy), one process
+  per instance on one binary, `max_nodes` budget with no `time_limit`, each arm's
+  firing mechanism separately instrumented and asserted:
+
+  | instance | off | eager | lazy | lazy rows separated |
+  |---|---|---|---|---|
+  | `tspn08` | 135 nodes | **191 nodes (+41.5 %)** | 135 nodes | 25 |
+  | `mathopt5_6` | 5 nodes | 5 nodes | 5 nodes | 0 |
+  | `kriging_peaks-full010` | −0.81783918772926**15** | −0.81783918772926**02** | −0.81783918772926**15** | 604 |
+
+  Lazy placement fixes the eager regression — `tspn08` returns to 135 nodes — and
+  gains nothing over leaving the facet dropped. The mechanism is measurably live
+  (604 rows separated on `kriging_peaks-full010`; instrumented, the separator moves
+  the node LP objective on 7 of 12 invocations) but by ~1e-4 against a bound of
+  −5.69, which never changes a branching decision. This is the #727 lesson in
+  reverse: the synthetic atom shows a large gain, the real class shows none, because
+  on a corpus instance the sqrt term is one of many and the LP optimum is held by
+  other constraints rather than sitting at the singular endpoint.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -343,7 +343,8 @@ The release procedure that produces these entries is documented in
   merely an argument. Built and measured as #1115, below.
 
 - **Placing the vertical-tangent facet where the LP binds removes the eager
-  anchor's regression and, on part of the corpus, buys a tighter bound** (#1115,
+  anchor's regression and tightens the bound on part of the corpus — but costs
+  25-54 % where it tightens nothing, so it stays default-OFF** (#1115,
   `DISCOPT_SINGULAR_TANGENT_LAZY`, default **on**, consulted only when
   `singular_tangent` is on — so the shipped default path is unchanged).
   `MccormickLPRelaxer._separate_singular_tangent` adds the supporting tangent at the
@@ -360,32 +361,67 @@ The release procedure that produces these entries is documented in
   reaches only −0.6557; the same holds on boxes nine orders of magnitude apart
   (`[0,1e-3]`, `[0,1e6]`, the latter recovering −353.55 → −125 exactly).
 
-  **On the corpus lazy never loses and wins four times.** Three-arm panel
-  (off / eager / lazy), one binary, `max_nodes` budget with **no** `time_limit` so
-  node counts and bounds are bit-reproducible, each arm's firing mechanism separately
-  instrumented and asserted. 13 instances produced a scorable three-arm row:
+  **On the corpus lazy never loses the bound, and that is not enough.** Three-arm
+  panel (off / eager / lazy), one binary, `max_nodes` budget with **no** `time_limit`,
+  each arm's firing mechanism separately instrumented and asserted. 12 instances
+  produced a scorable three-arm row:
 
   | instance | off | eager | lazy | lazy rows |
   |---|---|---|---|---|
   | `kriging_peaks-full050` | −142.657069 | flat | **−139.917835 (BETTER, +1.9 %)** | 7860 |
   | `kriging_peaks-full100` | −348.053602 | flat | **−342.588463 (BETTER, +1.6 %)** | 13214 |
-  | `kriging_peaks-full200` | −746.566175 | +1e−08 (noise) | **−734.495407 (BETTER, +1.6 %)** | 32451 |
   | `tspn15` | 269.3529936 | **269.8773406 (BETTER)** | 269.3558802 (BETTER, marginal) | 85 |
   | `tspn08` | 135 nodes | **191 nodes (WORSE, +41.5 %)** | 135 nodes | 25 |
   | `tspn10` | 177.43065803 | **177.39907299 (WORSE)** | 177.43065803 | 1 |
   | `mathopt5_6`, `eq6_1`, `maxmin`, `full010/020/030`, `tspn12` | — | flat | flat | 0–35585 |
 
-  `eager vs off: BETTER 2, WORSE 2, flat 9`. `lazy vs off: BETTER 4, flat 9, worse 0`.
-  52 soundness comparisons against `minlplib.solu`, **0 violations**. Every lazy gain
-  occurs at an *identical node count and identical incumbent* — a strictly better bound
-  for the same work — and the three substantial ones follow a coherent size trend:
-  nothing at `full010/020/030`, ~1.6–1.9 % of gap at `full050/100/200`, which is what a
-  mechanism acting only where the dropped facet dominates the root relaxation should
-  look like. Eager's two BETTER cells are `tspn15` (+0.002) and `full200` (+1e−08,
-  noise) against two real losses, so eager stays net-negative. This is **not** the
-  `DISCOPT_CUT_INHERIT` outcome, which was neutral-or-harmful.
+  `eager vs off: BETTER 1, WORSE 2, flat 9`. `lazy vs off: BETTER 3, flat 9, worse 0`.
+  Soundness checked on every arm of every run against `minlplib.solu` — **0 violations**,
+  including per-repetition asserts in the reproducibility and timing panels. Each lazy
+  gain occurs at an *identical node count and identical incumbent*: a strictly better
+  bound for the same tree.
 
-  It is also not yet a graduation case, and the gaps are recorded rather than glossed:
+  **The timing panel is what decides it, and it decides against graduation.**
+  Interleaved off/lazy, 3 repetitions, per-arm standard deviation and a pooled sd,
+  load gate recorded at every instance start (2.5–5.2 on 14 cores), both arms verified
+  to explore identical trees so the wall delta is attributable to separation alone:
+
+  | instance | off | lazy | Δ | lazy rows | bound gain |
+  |---|---|---|---|---|---|
+  | `eq6_1` | 10.82 ± 0.12 s | 13.59 ± 0.09 s | **+25.6 %** | 31 614 | none |
+  | `maxmin` | 33.52 ± 0.13 s | 51.68 ± 0.04 s | **+54.2 %** | 35 585 | none |
+  | `kriging_peaks-full050` | 42.21 ± 0.21 s | 44.09 ± 0.12 s | +4.5 % | 7 860 | +1.9 % of gap |
+  | `kriging_peaks-full100` | 101.21 ± 0.21 s | 105.22 ± 0.22 s | +4.0 % | 12 498 | +1.6 % of gap |
+
+  Every delta is 12–200 pooled standard deviations; none is noise. The shape is the
+  disqualifying part: **lazy is cheap where it helps and expensive where it does not.**
+  The two instances it charges +25.6 % and +54.2 % are exactly the two that gain
+  nothing, because they are the ones that draw the most rows. A corpus-wide default-ON
+  would pay the `maxmin` bill everywhere to collect the `full050` gain occasionally.
+  Gate 1 (cert-clean) passes; **gate 2 (net-positive) fails**, so the flag stays
+  default-OFF — the `DISCOPT_CUT_INHERIT` disposition, reached by a different route
+  (there: neutral-or-harmful; here: helpful on a narrow class, unaffordable off it).
+
+  Three corrections to earlier statements in this entry (§11):
+
+  * **`kriging_peaks-full200` is withdrawn from the gains table.** It was reported at
+    −746.566175 → −734.495407 (+1.6 %). Over three repetitions on a quiet machine the
+    instance is nondeterministic *in both arms* — off returns nodes {301, 303} with two
+    distinct bounds and **zero** separated rows; lazy returns {301, 303} with rows
+    {32451, 32472, 32583}. Two single runs of a nondeterministic instance are not a
+    comparison. This is pre-existing solver behaviour at that size, unrelated to this
+    flag, and is filed separately.
+  * **An intermediate claim that lazy *caused* that nondeterminism is also withdrawn.**
+    It rested on two repetitions in which the off arm agreed; the third falsified it.
+  * **The quoted bounds are load-dependent to ~3 significant figures.** Quiet, `full100`
+    gives off −350.768042 → lazy −345.634363 over 12 498 rows; under the contention of
+    the original panel, −348.053602 → −342.588463 over 13 214. Separation is wall-bounded
+    (`_separate_*` all break on a shared `_deadline`; the node LP re-solve takes
+    `time_limit=_remaining()`), so row counts — and the bounds they produce — shift with
+    machine load. The *direction* (lazy better by ~1.5 % of gap) reproduces; the digits
+    do not, and should not be read as properties of the instance alone.
+
+  Remaining gaps, recorded rather than glossed:
 
   * **Lazy has a coverage hole eager does not.** The separation chain is gated on
     `if separate:` (`mccormick_lp.py:1641`), forced off on yield rounds and pool-free
@@ -394,16 +430,11 @@ The release procedure that produces these entries is documented in
     fired at build time throughout. Lazy trades "emit a geometric guess wherever a
     relaxation is built" for "emit an exact tangent only where a separation round
     runs" — it is not a coverage superset.
-  * **Cost is counted in rows, not seconds.** 31 614 separated rows on `eq6_1` and
-    35 585 on `maxmin` buy movement in the 12th digit. No wall-time figure is quoted:
-    that panel's timing column was contaminated by load the author generated
-    concurrently (§9), so it is discarded rather than reported.
-  * **4 of 17 screened instances produced no scorable row:** `elec*` and `full500`
-    return no dual bound at all (1 node, or 0 for `full500`). `full030`, `tspn15` and
-    `full200` were initially lost to a per-instance wall kill set too low — a biased
-    loss, since lazy runs third and every truncation cut it preferentially — and were
-    recovered by a per-arm re-run. Recovering them added one eager BETTER and one
-    substantial lazy BETTER, so the truncation had been hiding results on both sides.
+  * **5 of 17 screened instances produced no scorable row:** `elec*` and `full500`
+    return no dual bound at all (1 node, or 0 for `full500`), and `full200` is
+    nondeterministic in both arms (above). `full030` and `tspn15` were initially lost
+    to a per-instance wall kill set too low — a biased loss, since lazy runs third and
+    every truncation cut it preferentially — and were recovered by a per-arm re-run.
 
   Consequently the #1111 finding "the root win does not survive branching" is scoped
   to the **eager** anchor. Where the dropped facet dominates the root relaxation,

--- a/python/discopt/_relax/mccormick_lp.py
+++ b/python/discopt/_relax/mccormick_lp.py
@@ -1673,6 +1673,12 @@ class MccormickLPRelaxer:
             _t = time.perf_counter()
             res = self._separate_convex(milp, varmap, res, _deadline)
             _st["convex"] += time.perf_counter() - _t
+            # Vertical-tangent facets (#1115): the tangent ``_emit_1d`` could not
+            # write at a singular endpoint, placed at the LP point instead of a
+            # fixed geometric anchor. Inert unless ``singular_tangent`` is on.
+            _t = time.perf_counter()
+            res = self._separate_singular_tangent(milp, varmap, res, _deadline)
+            _st["singular_tangent"] = _st.get("singular_tangent", 0.0) + (time.perf_counter() - _t)
             # G-convexity transformation cuts (#181, DISCOPT_G_CONVEX_CUTS,
             # default-OFF). These are BOX-LOCAL — valid only on this node box, not
             # globally — so they run ONLY on a regular node solve (``out_cuts is
@@ -2210,6 +2216,173 @@ class MccormickLPRelaxer:
                 res = new_res
             return res
         except Exception:
+            return res
+
+    def _separate_singular_tangent(self, milp, varmap, res, deadline):
+        """Recover a dropped vertical-tangent facet at the LP point (issue #1115).
+
+        ``_emit_1d`` places tangents at ``lo``, the midpoint and ``hi``. Where ``f``
+        is finite at an endpoint but ``f'`` diverges there — ``sqrt`` at ``t=0``,
+        ``asin``/``acos`` at ``t=±1`` — no tangent row can be written and the
+        envelope is left one-sided on that side (#1111).
+
+        #1111 recovered the facet EAGERLY, at a fixed geometric anchor near the
+        endpoint, on every node. That is measurably harmful: on ``tspn08`` the tree
+        grows 135 → 191 nodes (+41 %) for a bound gain in the 11th digit, because a
+        row that rarely binds still moves the LP vertex and therefore the branching
+        choice. This places the same facet where the LP actually binds instead:
+
+            concave:  w <= f(t0) + f'(t0)*(t - t0)
+            convex:   w >= f(t0) + f'(t0)*(t - t0)
+
+        with ``t0`` the current LP value of ``t = coeffs·x + const``, and only when
+        that point is violated. A tangent of a concave (resp. convex) function is a
+        global over- (under-) estimator wherever the curvature holds, and ``curv``
+        was certified for the whole box, so no feasible point is ever cut — the
+        bound stays sound at every round. Sound no-op on any failure.
+
+        Inert unless ``SolverTuning.singular_tangent`` is on: the spec list is only
+        populated then.
+        """
+        specs = varmap.get("singular_tangent_relaxations") or []
+        if not specs:
+            return res
+        if res is None or res.status != "optimal" or res.x is None:
+            return res
+        try:
+            import scipy.sparse as sp
+
+            from discopt._relax.uniform_relax import _interior_tangent_point
+
+            n_total = len(milp._c)
+
+            def _append(rows: list[np.ndarray], rhs: list[float]) -> None:
+                R = np.asarray(rows, dtype=np.float64)
+                b = np.asarray(rhs, dtype=np.float64)
+                if milp._A_ub is None:
+                    milp._A_ub, milp._b_ub = R, b
+                elif sp.issparse(milp._A_ub):
+                    milp._A_ub = sp.vstack([milp._A_ub, sp.csr_matrix(R)], format="csr")
+                    milp._b_ub = np.concatenate([milp._b_ub, b])
+                else:
+                    milp._A_ub = np.vstack([np.asarray(milp._A_ub), R])
+                    milp._b_ub = np.concatenate([milp._b_ub, b])
+
+            tol = 1e-7
+            for _round in range(8):
+                if deadline is not None and time.perf_counter() >= deadline:
+                    break
+                x = np.asarray(res.x, dtype=np.float64)
+                rows: list[np.ndarray] = []
+                rhs: list[float] = []
+                for s in specs:
+                    aux = s.aux_col
+                    if aux >= x.size:
+                        continue
+                    wv = float(x[aux])
+                    if not np.isfinite(wv):
+                        continue
+                    t0 = float(s.const)
+                    ok = True
+                    for j, c in s.coeffs.items():
+                        if j >= x.size or not np.isfinite(x[j]):
+                            ok = False
+                            break
+                        t0 += float(c) * float(x[j])
+                    if not ok or not np.isfinite(t0):
+                        continue
+                    # The tangent is only a valid global estimator where the box's
+                    # certified curvature holds, i.e. for t in [lo, hi]. An LP point
+                    # a hair outside (simplex tolerance) is clamped back in rather
+                    # than extrapolated; a point far outside is skipped.
+                    if t0 < s.lo:
+                        if s.lo - t0 > 1e-6 * max(1.0, abs(s.lo)):
+                            continue
+                        t0 = s.lo
+                    elif t0 > s.hi:
+                        if t0 - s.hi > 1e-6 * max(1.0, abs(s.hi)):
+                            continue
+                        t0 = s.hi
+                    # ``ta`` is where the tangent TOUCHES the graph; ``t0`` is where
+                    # the LP sits. They coincide except at the singularity itself.
+                    ta = t0
+                    try:
+                        g, gp = float(s.f(ta)), float(s.fp(ta))
+                    except (ValueError, ArithmeticError):
+                        continue
+                    if not (np.isfinite(g) and np.isfinite(gp)):
+                        # The LP point landed ON the vertical tangent, where no
+                        # finite-slope facet exists — and this is exactly the point
+                        # the dropped facet was supposed to cover, so skipping here
+                        # would make the separator a no-op precisely where it is
+                        # needed (measured: ``min 2x - sqrt(x)`` over ``[0,4]`` puts
+                        # the LP vertex at ``t=0``). Fall back to #1111's
+                        # conditioning-capped ladder anchor for the touch point; the
+                        # violation test below still decides whether the row goes in,
+                        # so this stays lazy — the facet appears only at nodes whose
+                        # LP the static envelope actually fails to bound.
+                        ta_l = _interior_tangent_point(s.f, s.fp, s.lo, s.hi, s.slope, s.edge)
+                        if ta_l is None:
+                            continue
+                        ta = float(ta_l)
+                        try:
+                            g, gp = float(s.f(ta)), float(s.fp(ta))
+                        except (ValueError, ArithmeticError):
+                            continue
+                        if not (np.isfinite(g) and np.isfinite(gp)):
+                            continue
+                    # Conditioning guard, mirroring ``_separate_convex``: a cut whose
+                    # coefficients have blown up (the slope diverges as the LP point
+                    # approaches the singular endpoint) fools the fast simplex into an
+                    # uncertifiable basis. Dropping a cut only loosens, never unsounds.
+                    if abs(gp) > _LIFT_MAX_CROSS_TERM_ARG_MAGNITUDE:
+                        continue
+                    if any(
+                        abs(gp * float(c)) > _LIFT_MAX_CROSS_TERM_ARG_MAGNITUDE
+                        for c in s.coeffs.values()
+                    ):
+                        continue
+                    # Tangent line value AT THE LP POINT. When ``ta == t0`` this is
+                    # just ``g``; at the ladder fallback it is the extrapolation of
+                    # the anchor's tangent out to where the LP sits, which is what
+                    # decides violation.
+                    pred = g + gp * (t0 - ta)
+                    scale = tol * max(1.0, abs(pred))
+                    if s.sign > 0.0:
+                        # convex: w >= g + gp*(t - ta)
+                        #   -> sum(gp*c_j x_j) - w <= gp*ta - g - gp*const
+                        if pred - wv > scale:
+                            row = np.zeros(n_total)
+                            for j, c in s.coeffs.items():
+                                row[j] += gp * float(c)
+                            row[aux] += -1.0
+                            rows.append(row)
+                            rhs.append(gp * ta - g - gp * float(s.const))
+                    else:
+                        # concave: w <= g + gp*(t - ta)
+                        #   -> w - sum(gp*c_j x_j) <= g - gp*ta + gp*const
+                        if wv - pred > scale:
+                            row = np.zeros(n_total)
+                            for j, c in s.coeffs.items():
+                                row[j] += -gp * float(c)
+                            row[aux] += 1.0
+                            rows.append(row)
+                            rhs.append(g - gp * ta + gp * float(s.const))
+                if not rows:
+                    break
+                _append(rows, rhs)
+                _tl = (
+                    None
+                    if deadline is None
+                    else max(deadline - time.perf_counter(), _SOLVE_DEADLINE_FLOOR_S)
+                )
+                new_res = milp.solve(time_limit=_tl, backend=self._backend)
+                if new_res.status != "optimal" or new_res.objective is None:
+                    break
+                res = new_res
+            return res
+        except Exception:
+            logger.debug("singular-tangent separation failed; keeping prior result", exc_info=True)
             return res
 
     def _separate_convex(self, milp, varmap, res, deadline):

--- a/python/discopt/_relax/milp_relaxation.py
+++ b/python/discopt/_relax/milp_relaxation.py
@@ -2245,6 +2245,7 @@ _EMPTY_VARMAP_KEYS: tuple[str, ...] = (
     "univariate_relaxations",
     "composite_relaxations",
     "composite_multivar_relaxations",
+    "singular_tangent_relaxations",
     "univariate_piecewise_relaxations",
     "univariate_square",
     "univariate_square_relaxations",
@@ -2364,6 +2365,11 @@ def _uniform_relaxation_delegate(
     # (over-) estimator, so the cut never removes a feasible point (sound by
     # construction; the loop is a sound no-op on any failure).
     vm["composite_multivar_relaxations"] = list(rel.composite_multivar_specs)
+    # Vertical-tangent facets deferred to separation (#1115): the facet ``_emit_1d``
+    # drops where ``f`` is finite but ``f'`` diverges at a box endpoint, recovered as
+    # a supporting tangent at the LP point rather than at a fixed geometric anchor.
+    # Empty unless ``singular_tangent`` is on, so the separator is inert by default.
+    vm["singular_tangent_relaxations"] = list(rel.singular_tangent_specs)
     # Piecewise univariate/monomial/bilinear refinement (#640 S8) is now emitted
     # DIRECTLY as relaxation rows by ``build_uniform_relaxation`` when a ``disc_state``
     # partition is supplied (the AMP path), not surfaced through this legacy census

--- a/python/discopt/_relax/spatial_producer.py
+++ b/python/discopt/_relax/spatial_producer.py
@@ -134,6 +134,26 @@ def build_spatial_kernel_spec(model, bounds: Optional[tuple] = None) -> Optional
         return None
     if any(fname != "sqrt" for (fname, *_rest) in rel.univariate_atom_specs):
         return None
+    # VERTICAL TANGENT (#1111): the Rust kernel's ``mccormick_patch::univariate_rows``
+    # regenerates the 4-row sqrt envelope UNCONDITIONALLY — it guards ``f`` on the
+    # box but not ``f'``, so at ``t_lo == 0`` its tangent-at-``t_lo`` row is
+    # ``f'(0) = +inf`` and ``intercept = 0 - inf*0 = NaN``: an LP row with an
+    # infinite coefficient and a NaN rhs. The Python build does NOT emit that row
+    # (``_emit_1d`` drops the facet, or — under ``DISCOPT_SINGULAR_TANGENT`` —
+    # re-anchors it at an interior point the kernel knows nothing about), so the two
+    # engines disagree there in BOTH flag states.
+    #
+    # Today that disagreement is caught only incidentally: the dropped row makes the
+    # real-box build one row shorter than the probe build and the shape check below
+    # declines. Under the #1111 flag the row counts match again and the incidental
+    # guard evaporates, so make the condition EXPLICIT and decline here. Sub-boxes
+    # can only raise ``t_lo`` (branching and FBBT tighten), so a spec admitted with
+    # ``t_lo > 0`` stays NaN-free at every node.
+    for _fname, _w, _var, _coeff, _cst in rel.univariate_atom_specs:
+        ta = float(_coeff) * float(lb[int(_var)]) + float(_cst)
+        tb = float(_coeff) * float(ub[int(_var)]) + float(_cst)
+        if min(ta, tb) <= 0.0:  # sqrt: f'(t) = 0.5/sqrt(t) diverges at t = 0
+            return None
 
     A = sp.csr_matrix(milp._A_ub, dtype=np.float64)
     A.sort_indices()

--- a/python/discopt/_relax/uniform_relax.py
+++ b/python/discopt/_relax/uniform_relax.py
@@ -234,6 +234,11 @@ class UniformRelaxation:
     # lifted to a single aux; the OA tangents added lazily at the LP point are
     # global under-/over-estimators (sound, never cut a feasible point).
     composite_multivar_specs: list
+    # Univariate facets dropped at a vertical tangent, deferred to separation at
+    # the LP point (#1115). Each tangent of a concave (resp. convex) ``f`` is a
+    # global over- (under-) estimator on the box, so a separated row never cuts a
+    # feasible point — sound by the same argument as ``composite_multivar_specs``.
+    singular_tangent_specs: list = dataclasses.field(default_factory=list)
     # Affine squares ``(c·x_j+d)**2`` -> ``(var, aux) -> (coeff, const)`` (issue #640
     # Bucket 3), consumed by the incremental McCormick patch to regenerate their
     # box-dependent envelope rows in closed form.
@@ -723,6 +728,13 @@ class _Builder:
         # a global underestimator (concave: overestimator), so no feasible point is
         # ever cut; sound by construction. Populated by ``_try_convex_lift``.
         self.composite_multivar_specs: list = []
+        # Univariate facets dropped at a vertical tangent and deferred to
+        # separation (#1115) — ``SingularTangentSpec`` entries the
+        # ``_separate_singular_tangent`` loop consumes. Populated by ``_emit_1d``
+        # only when ``singular_tangent`` is on AND ``singular_tangent_lazy`` is
+        # set; empty (and the separator inert) otherwise.
+        self.singular_tangent_specs: list = []
+        self.singular_tangent_seen: set = set()
         # Finite-domain trig-square selector tables (issue #640 Bucket 1), populated
         # by ``_build_power`` when it hits a ``trig(int-affine)**2`` over a small
         # finite integer domain.
@@ -1514,6 +1526,45 @@ def _interval_box(model: Model, flat_lb: np.ndarray, flat_ub: np.ndarray) -> dic
 _SINGULAR_TANGENT_LADDER = 20
 
 
+@dataclasses.dataclass
+class SingularTangentSpec:
+    """A univariate facet dropped at a vertical tangent, deferred to separation.
+
+    ``w = f(t)`` with ``t = sum(coeffs[j]*x[j]) + const`` over the box
+    ``[lo, hi]`` in ``t``-space. ``sign`` is ``+1`` for a convex ``f`` (the
+    tangent under-estimates) and ``-1`` for a concave one (it over-estimates),
+    matching ``_emit_1d``'s ``sgn``. Consumed by
+    ``MccormickLPRelaxer._separate_singular_tangent``, which adds the supporting
+    tangent at the LP point instead of at a fixed geometric anchor (#1115).
+    """
+
+    aux_col: int
+    coeffs: dict
+    const: float
+    lo: float
+    hi: float
+    f: Callable[[float], float]
+    fp: Callable[[float], float]
+    sign: float
+    #: ``lo``-side (-1) or ``hi``-side (+1) endpoint whose derivative diverges.
+    edge: int
+    #: Secant slope of this box, the scale :func:`_interior_tangent_point` caps
+    #: against. Carried so the separator can fall back to the #1111 ladder anchor
+    #: when the LP point lands ON the singularity, where no finite tangent exists.
+    slope: float
+
+
+def _singular_tangent_lazy() -> bool:
+    """Place the recovered facet at the LP point rather than a ladder anchor (#1115).
+
+    Only consulted when :func:`_singular_tangent_enabled` is true; it selects
+    *where* the recovered tangent goes, never *whether* the facet is recovered.
+    """
+    from discopt.solver_tuning import current as _tuning
+
+    return _tuning().singular_tangent_lazy
+
+
 def _singular_tangent_enabled() -> bool:
     """Whether vertical-tangent recovery is on (#1111) — ``SolverTuning`` field.
 
@@ -1654,9 +1705,31 @@ def _emit_1d(
             # only ADDS a row where none was emitted. Recurse with ``edge=0`` so the
             # replacement point can never trigger a second search.
             if edge != 0 and _finite(g) and not math.isfinite(gp) and _singular_tangent_enabled():
-                t0i = _interior_tangent_point(f, fp, lo, hi, slope, edge)
-                if t0i is not None:
-                    _tangent_row(t0i, sign, 0)
+                if _singular_tangent_lazy():
+                    # #1115: defer to separation at the LP point. Registered once
+                    # per aux even when BOTH endpoints are singular (asin on
+                    # [-1, 1]) — the separator re-derives the tangent from the LP
+                    # point each round, so a second spec would only duplicate rows.
+                    if w not in ctx.singular_tangent_seen:
+                        ctx.singular_tangent_seen.add(w)
+                        ctx.singular_tangent_specs.append(
+                            SingularTangentSpec(
+                                aux_col=w,
+                                coeffs=dict(lt.coeffs),
+                                const=float(lt.const),
+                                lo=lo,
+                                hi=hi,
+                                f=f,
+                                fp=fp,
+                                sign=sign,
+                                edge=int(edge),
+                                slope=float(slope),
+                            )
+                        )
+                else:
+                    t0i = _interior_tangent_point(f, fp, lo, hi, slope, edge)
+                    if t0i is not None:
+                        _tangent_row(t0i, sign, 0)
             return
         intercept = g - gp * t0  # tangent line: gp*t + intercept
         # sign*w >= sign*(gp*t + intercept), with t = lt (cols) + lt.const:
@@ -3866,6 +3939,7 @@ def build_uniform_relaxation(
         multilinear_map=dict(ctx.multilinear_map),
         univariate_square_map=dict(ctx.univariate_square_map),
         composite_multivar_specs=list(ctx.composite_multivar_specs),
+        singular_tangent_specs=list(ctx.singular_tangent_specs),
         affine_square_map=dict(ctx.affine_square_map),
         ratio_map=dict(ctx.ratio_map),
         finite_domain_trig_square_tables=list(ctx.finite_domain_trig_square_tables),

--- a/python/discopt/_relax/uniform_relax.py
+++ b/python/discopt/_relax/uniform_relax.py
@@ -1512,36 +1512,35 @@ def _interval_box(model: Model, flat_lb: np.ndarray, flat_ub: np.ndarray) -> dic
 #: Ladder depth: ``delta`` ranges over ``0.5*8**-k`` for ``k = 20 … 1``
 #: (``5.5e-19 … 1/16``), smallest first.
 _SINGULAR_TANGENT_LADDER = 20
-#: Default cap on ``|f'(t0)|`` as a multiple of the box's slope scale. A tangent
-#: ~100x steeper than the secant is about the numerical limit worth emitting; the
-#: outward-rounding guard (``envelope_1d_slack``) grows linearly with ``|slope|``,
-#: so an uncapped near-vertical tangent buys tightness with rounding slack.
-_SINGULAR_TANGENT_KAPPA = 100.0
 
 
 def _singular_tangent_enabled() -> bool:
-    """``DISCOPT_SINGULAR_TANGENT=1`` enables vertical-tangent recovery (#1111).
+    """Whether vertical-tangent recovery is on (#1111) — ``SolverTuning`` field.
 
     Default OFF: with the flag unset this module emits exactly the rows it did
-    before #1111 (the endpoint facet stays dropped).
+    before #1111 (the endpoint facet stays dropped). Read through
+    :func:`discopt.solver_tuning.current` rather than ``os.environ`` so a
+    programmatic ``SolverTuning(singular_tangent=True)`` is honoured and the
+    setting is pinned for the duration of a solve; see that field's docstring for
+    the §5 panel that failed gate 2.
     """
-    return os.environ.get("DISCOPT_SINGULAR_TANGENT") == "1"
+    from discopt.solver_tuning import current as _tuning
+
+    return _tuning().singular_tangent
 
 
 def _singular_tangent_kappa() -> float:
-    """Slope cap multiplier; ``DISCOPT_SINGULAR_TANGENT_KAPPA`` overrides it.
+    """Slope cap multiplier for :func:`_interior_tangent_point` (#1111).
 
     A measurement knob for the §5 panel (the issue asks whether a tighter or
-    looser cap is better), not a user-facing tuning parameter.
+    looser cap is better), not a user-facing tuning parameter. Validated
+    finite-and-positive by ``SolverTuning.__post_init__``, so this returns it
+    unchecked — an invalid override raises there rather than being silently
+    swapped for the default (§3: refuse loudly).
     """
-    raw = os.environ.get("DISCOPT_SINGULAR_TANGENT_KAPPA")
-    if not raw:
-        return _SINGULAR_TANGENT_KAPPA
-    try:
-        val = float(raw)
-    except ValueError:
-        return _SINGULAR_TANGENT_KAPPA
-    return val if math.isfinite(val) and val > 0.0 else _SINGULAR_TANGENT_KAPPA
+    from discopt.solver_tuning import current as _tuning
+
+    return _tuning().singular_tangent_kappa
 
 
 def _interior_tangent_point(

--- a/python/discopt/_relax/uniform_relax.py
+++ b/python/discopt/_relax/uniform_relax.py
@@ -334,6 +334,61 @@ def _curv_cos(lo: float, hi: float) -> Optional[str]:
     return None
 
 
+# --------------------------------------------------------------------------- #
+# Derivatives with a VERTICAL TANGENT at an admitted endpoint (issue #1111).
+#
+# Three ``_UNIVARIATE_FN`` derivatives divide by a quantity that is exactly zero at
+# a point the domain guard admits: ``sqrt'`` at ``t = 0`` (``dom_ok`` is
+# ``lo >= 0``) and ``asin'``/``acos'`` at ``|t| = 1`` (``dom_ok`` only constrains
+# ``lo``, so ``hi = 1`` is admitted). Written as a bare ``0.5/np.sqrt(t)`` the
+# f64 division returns the mathematically correct ``+inf`` but ALSO raises
+# ``RuntimeWarning: divide by zero encountered in scalar divide`` on every affected
+# solve — which reads as a defect to a user (issue #1111, motivation 1).
+#
+# The fix is to evaluate the LIMIT explicitly rather than to lean on IEEE
+# division-by-zero — not to suppress the warning. The returned values are
+# bit-identical to what the division produced (``inf`` / ``-inf`` at the
+# singularity, ``nan`` outside the domain, the same quotient inside it), so every
+# downstream ``_finite`` verdict and every emitted row is unchanged.
+#
+# ``acosh`` gets the same treatment for uniformity even though its ``dom_ok``
+# (``lo > 1``) keeps the singular point out of every admitted box.
+# --------------------------------------------------------------------------- #
+def _dsqrt(t: float) -> float:
+    """``d/dt sqrt(t)`` = ``0.5/sqrt(t)``; ``+inf`` at the vertical tangent t=0."""
+    t = float(t)
+    if t > 0.0:
+        return 0.5 / math.sqrt(t)
+    return math.inf if t == 0.0 else math.nan
+
+
+def _dasin(t: float) -> float:
+    """``d/dt asin(t)`` = ``1/sqrt(1-t^2)``; ``+inf`` at the vertical tangents t=±1."""
+    t = float(t)
+    r = 1.0 - t * t
+    if r > 0.0:
+        return 1.0 / math.sqrt(r)
+    return math.inf if r == 0.0 else math.nan
+
+
+def _dacos(t: float) -> float:
+    """``d/dt acos(t)`` = ``-1/sqrt(1-t^2)``; ``-inf`` at the vertical tangents t=±1."""
+    t = float(t)
+    r = 1.0 - t * t
+    if r > 0.0:
+        return -1.0 / math.sqrt(r)
+    return -math.inf if r == 0.0 else math.nan
+
+
+def _dacosh(t: float) -> float:
+    """``d/dt acosh(t)`` = ``1/sqrt(t^2-1)``; ``+inf`` at the vertical tangent t=1."""
+    t = float(t)
+    r = t * t - 1.0
+    if r > 0.0:
+        return 1.0 / math.sqrt(r)
+    return math.inf if r == 0.0 else math.nan
+
+
 # name -> (f, f', curvature, domain_ok(lo) )
 _UNIVARIATE_FN: dict[str, tuple[Callable, Callable, Callable, Callable]] = {
     "exp": (np.exp, np.exp, _curv_const("convex"), lambda lo: True),
@@ -351,7 +406,7 @@ _UNIVARIATE_FN: dict[str, tuple[Callable, Callable, Callable, Callable]] = {
         lambda lo: lo > 0.0,
     ),
     "log1p": (np.log1p, lambda t: 1.0 / (1.0 + t), _curv_const("concave"), lambda lo: lo > -1.0),
-    "sqrt": (np.sqrt, lambda t: 0.5 / np.sqrt(t), _curv_const("concave"), lambda lo: lo >= 0.0),
+    "sqrt": (np.sqrt, _dsqrt, _curv_const("concave"), lambda lo: lo >= 0.0),
     "sin": (np.sin, np.cos, _curv_sin, lambda lo: True),
     "cos": (np.cos, lambda t: -np.sin(t), _curv_cos, lambda lo: True),
     "sinh": (np.sinh, np.cosh, _curv_by_sign(True), lambda lo: True),
@@ -360,13 +415,13 @@ _UNIVARIATE_FN: dict[str, tuple[Callable, Callable, Callable, Callable]] = {
     "atan": (np.arctan, lambda t: 1.0 / (1.0 + t * t), _curv_by_sign(False), lambda lo: True),
     "asin": (
         np.arcsin,
-        lambda t: 1.0 / np.sqrt(1.0 - t * t),
+        _dasin,
         _curv_by_sign(True),
         lambda lo: lo > -1.0,
     ),
     "acos": (
         np.arccos,
-        lambda t: -1.0 / np.sqrt(1.0 - t * t),
+        _dacos,
         _curv_by_sign(False),
         lambda lo: lo > -1.0,
     ),
@@ -378,7 +433,7 @@ _UNIVARIATE_FN: dict[str, tuple[Callable, Callable, Callable, Callable]] = {
     ),
     "acosh": (
         np.arccosh,
-        lambda t: 1.0 / np.sqrt(t * t - 1.0),
+        _dacosh,
         _curv_const("concave"),
         lambda lo: lo > 1.0,
     ),
@@ -1401,6 +1456,139 @@ def _interval_box(model: Model, flat_lb: np.ndarray, flat_ub: np.ndarray) -> dic
 
 
 # --------------------------------------------------------------------------- #
+# Vertical-tangent recovery (issue #1111) — default OFF.
+#
+# ``_emit_1d`` places tangents at ``lo``, the midpoint and ``hi``. Where ``f`` is
+# finite at an endpoint but ``f'`` DIVERGES there (a vertical tangent),
+# ``_tangent_row`` returns without emitting and the facet is silently lost, leaving
+# the envelope one-sided on that side (secant + aux interval floor only).
+#
+# Which atoms actually reach that case: ``sqrt`` at ``t = 0`` (``dom_ok`` is
+# ``lo >= 0``), and ``asin``/``acos`` at ``t = +1`` (``dom_ok`` constrains only
+# ``lo``, so ``hi = 1`` is admitted). ``acosh`` and ``log`` do NOT — their
+# ``dom_ok`` is a strict inequality (``lo > 1``, ``lo > 0``), so the singular point
+# is outside every admitted box and the endpoint derivative is finite there. (A
+# finite-but-huge derivative is deliberately out of scope; see below.)
+#
+# Dropping the facet is SOUND but loose, and ``t = 0`` is frequently the
+# interesting point rather than an
+# edge case: the conical-intersection radical of issue #1111 vanishes exactly at
+# the solution, so the box containing the answer is precisely the one that loses
+# the facet (measured there: 1 node / 1.53 s vs 0 nodes / 0.03 s for the
+# radical-free algebraic equivalent).
+#
+# Recovery: emit the tangent at an INTERIOR point ``lo + delta*width`` (or
+# ``hi - delta*width``) instead of at the endpoint.
+#
+# SOUNDNESS. For ``f`` CONCAVE on ``[lo,hi]``, *every* tangent line taken at a
+# point inside ``[lo,hi]`` lies on or above the graph over the whole box —
+# concavity gives ``f(t) <= f(t0) + f'(t0)(t - t0)`` for all ``t`` in the box, for
+# any interior ``t0`` at which ``f`` is differentiable. Convex is the mirror image.
+# The curvature verdict is already PROVEN on this box by the caller, so an interior
+# tangent point is exactly as valid as an endpoint one; nothing about the argument
+# depends on ``t0`` being a corner.
+#
+# WHY THE DIFFERENTIAL TEST IS CHEAP. This path only ever ADDS a row where
+# ``_emit_1d`` previously emitted none — it never modifies, reorders or removes an
+# existing row. So the flag-ON polytope is a SUBSET of the flag-OFF polytope, and
+# the node LP bound can only improve or stay equal. Bound monotonicity is
+# structural, not an empirical claim; what the differential test still has to
+# establish is that the added row does not cut a feasible point, which is the
+# feasible-point sampling below.
+#
+# CHOOSING ``delta`` — a geometric ladder, scale-free. Walk
+# ``delta = 0.5 * 8**-k`` from the smallest step outward and take the FIRST
+# (i.e. the tightest, closest to the endpoint) whose ``|f'(t0)|`` is finite and
+# within ``kappa`` times the box's own slope scale ``max(|secant slope|,
+# |f'(mid)|)``. The cap is RELATIVE to the box, never an absolute constant, so the
+# choice is invariant under rescaling ``f`` or the box. The ladder tops out at
+# ``delta = 1/16`` so it can never coincide with the midpoint tangent that is
+# already emitted, and it runs ONLY when an endpoint tangent was actually dropped —
+# instances that never hit the singular case pay nothing.
+#
+# NOT IN SCOPE: an endpoint whose derivative is finite-but-huge. Moving that
+# tangent inward would LOOSEN a row that exists today.
+# --------------------------------------------------------------------------- #
+#: Ladder depth: ``delta`` ranges over ``0.5*8**-k`` for ``k = 20 … 1``
+#: (``5.5e-19 … 1/16``), smallest first.
+_SINGULAR_TANGENT_LADDER = 20
+#: Default cap on ``|f'(t0)|`` as a multiple of the box's slope scale. A tangent
+#: ~100x steeper than the secant is about the numerical limit worth emitting; the
+#: outward-rounding guard (``envelope_1d_slack``) grows linearly with ``|slope|``,
+#: so an uncapped near-vertical tangent buys tightness with rounding slack.
+_SINGULAR_TANGENT_KAPPA = 100.0
+
+
+def _singular_tangent_enabled() -> bool:
+    """``DISCOPT_SINGULAR_TANGENT=1`` enables vertical-tangent recovery (#1111).
+
+    Default OFF: with the flag unset this module emits exactly the rows it did
+    before #1111 (the endpoint facet stays dropped).
+    """
+    return os.environ.get("DISCOPT_SINGULAR_TANGENT") == "1"
+
+
+def _singular_tangent_kappa() -> float:
+    """Slope cap multiplier; ``DISCOPT_SINGULAR_TANGENT_KAPPA`` overrides it.
+
+    A measurement knob for the §5 panel (the issue asks whether a tighter or
+    looser cap is better), not a user-facing tuning parameter.
+    """
+    raw = os.environ.get("DISCOPT_SINGULAR_TANGENT_KAPPA")
+    if not raw:
+        return _SINGULAR_TANGENT_KAPPA
+    try:
+        val = float(raw)
+    except ValueError:
+        return _SINGULAR_TANGENT_KAPPA
+    return val if math.isfinite(val) and val > 0.0 else _SINGULAR_TANGENT_KAPPA
+
+
+def _interior_tangent_point(
+    f: Callable[[float], float],
+    fp: Callable[[float], float],
+    lo: float,
+    hi: float,
+    slope: float,
+    edge: int,
+) -> Optional[float]:
+    """Tangent point replacing a dropped vertical-tangent facet, or ``None``.
+
+    ``edge`` is ``-1`` for the ``lo`` endpoint and ``+1`` for ``hi``. Returns the
+    smallest-``delta`` ladder point whose slope is finite and within
+    ``kappa * max(|slope|, |f'(mid)|)``, or ``None`` when no ladder point
+    qualifies (then the facet stays dropped, exactly as before #1111).
+    """
+    width = hi - lo
+    if not (width > 0.0):
+        return None
+    # Slope scale of THIS box: the secant, plus the midpoint derivative (a second
+    # box-intrinsic slope, which covers a box whose secant happens to be flat).
+    try:
+        gm = float(fp(0.5 * (lo + hi)))
+    except (ValueError, ArithmeticError):
+        gm = 0.0
+    scale = abs(slope)
+    if math.isfinite(gm):
+        scale = max(scale, abs(gm))
+    if not (scale > 0.0) or not math.isfinite(scale):
+        return None
+    cap = _singular_tangent_kappa() * scale
+    for k in range(_SINGULAR_TANGENT_LADDER, 0, -1):
+        t0 = lo + (0.5 * 8.0**-k) * width if edge < 0 else hi - (0.5 * 8.0**-k) * width
+        if not (lo < t0 < hi):
+            continue  # delta below the box's f64 resolution -> not an interior point
+        try:
+            g, gp = float(f(t0)), float(fp(t0))
+        except (ValueError, ArithmeticError):
+            continue
+        if not _finite(g, gp) or abs(gp) > cap:
+            continue
+        return t0
+    return None
+
+
+# --------------------------------------------------------------------------- #
 # Shared 1-D secant/tangent emission (the composite-envelope math)
 # --------------------------------------------------------------------------- #
 def _emit_1d(
@@ -1452,13 +1640,24 @@ def _emit_1d(
             coeffs, relaxed_rhs(rhs, envelope_1d_slack(slope, lo, hi, flo, fhi, lt.const, rhs))
         )
 
-    def _tangent_row(t0: float, sign: float) -> None:
+    def _tangent_row(t0: float, sign: float, edge: int = 0) -> None:
         # sign*(w - (f(t0) + f'(t0)(t - t0))) >= 0  ->  -sign*w + sign*f'(t0)*t <= ...
+        # ``edge`` is -1 at ``lo``, +1 at ``hi``, 0 for an interior point.
         try:
             g, gp = float(f(t0)), float(fp(t0))
         except (ValueError, ArithmeticError):
             return
         if not _finite(g, gp):
+            # #1111 (default OFF): ``f`` finite at the endpoint but ``f'`` divergent
+            # is a VERTICAL TANGENT, not an evaluation failure. Re-anchor the facet
+            # at an interior point instead of dropping it — sound for the same
+            # reason the endpoint tangent is (see the module note above), and it
+            # only ADDS a row where none was emitted. Recurse with ``edge=0`` so the
+            # replacement point can never trigger a second search.
+            if edge != 0 and _finite(g) and not math.isfinite(gp) and _singular_tangent_enabled():
+                t0i = _interior_tangent_point(f, fp, lo, hi, slope, edge)
+                if t0i is not None:
+                    _tangent_row(t0i, sign, 0)
             return
         intercept = g - gp * t0  # tangent line: gp*t + intercept
         # sign*w >= sign*(gp*t + intercept), with t = lt (cols) + lt.const:
@@ -1473,14 +1672,10 @@ def _emit_1d(
         )
 
     mid = 0.5 * (lo + hi)
-    if curv == "convex":
-        _secant_row(+1.0)  # w <= secant
-        for t0 in (lo, mid, hi):
-            _tangent_row(t0, +1.0)  # w >= tangent
-    else:  # concave
-        _secant_row(-1.0)  # w >= secant
-        for t0 in (lo, mid, hi):
-            _tangent_row(t0, -1.0)  # w <= tangent
+    sgn = +1.0 if curv == "convex" else -1.0
+    _secant_row(sgn)  # convex: w <= secant; concave: w >= secant
+    for t0, edge in ((lo, -1), (mid, 0), (hi, +1)):
+        _tangent_row(t0, sgn, edge)  # convex: w >= tangent; concave: w <= tangent
     return True
 
 

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -10871,12 +10871,32 @@ def solve_model(
     # mccormick_bounds="nlp" and the lp→nlp fallbacks (e.g. pure-integer
     # nonconvex models). Fall back to the rigorous alphaBB underestimator.
     if _mc_mode == "nlp" and not _model_is_convex:
-        logger.warning(
-            "McCormick 'nlp' objective bound is not a valid dual bound for "
-            "nonconvex models (issue #120); falling back to the alphaBB "
-            "underestimator. Use mccormick_bounds='lp' for a valid spatial "
-            "relaxation on models with continuous variables."
-        )
+        # The DEMOTION is unconditional — it is the soundness guard and never
+        # branches. Only the message does (#1112): as written it recommended
+        # ``mccormick_bounds='lp'`` to users who had just passed exactly that,
+        # and it fired even on models where the reduced-space engine is about to
+        # supply a perfectly good spatial bound, where it is pure misdirection.
+        if _force_reduced_space:
+            # Reduced-space bounding is active for this model — set at the
+            # CustomCall gate above, which is also the ONLY way a CustomCall model
+            # reaches this line: a non-admissible one returns early via
+            # ``_withhold_local_optimality_certificate``. So here the LP relaxer
+            # was discarded because the nonlinearity is hidden inside opaque
+            # ``dm.custom`` nodes with no lifted relaxation, "lp" is exactly what
+            # the user passed, and the reduced engine — not alphaBB — is about to
+            # supply the node bound. Every clause of the warning below would be
+            # wrong; there is no fallback to announce and no advice to give.
+            logger.debug(
+                "McCormick 'nlp' objective bound declined for a nonconvex model "
+                "(issue #120); reduced-space McCormick supplies the node bound."
+            )
+        else:
+            logger.warning(
+                "McCormick 'nlp' objective bound is not a valid dual bound for "
+                "nonconvex models (issue #120); falling back to the alphaBB "
+                "underestimator. Use mccormick_bounds='lp' for a valid spatial "
+                "relaxation on models with continuous variables."
+            )
         _mc_mode = "none"
 
     if _mc_mode == "nlp" and model._objective is not None:

--- a/python/discopt/solver_tuning.py
+++ b/python/discopt/solver_tuning.py
@@ -24,6 +24,7 @@ unaffected.
 
 from __future__ import annotations
 
+import math
 import os
 from contextvars import ContextVar
 from dataclasses import dataclass, field, fields
@@ -1313,6 +1314,63 @@ class SolverTuning:
     deliberately accepts. Default off pending the §5 differential panel
     (graduation coupled to the #928/#966 panel)."""
 
+    singular_tangent: bool = field(
+        default_factory=lambda: _env_flag("DISCOPT_SINGULAR_TANGENT", default=False)
+    )
+    """Recover the univariate-envelope tangent facet dropped at a **vertical
+    tangent** (``DISCOPT_SINGULAR_TANGENT``, default **off**; §5 bound-changing;
+    issue #1111).
+
+    ``uniform_relax._emit_1d`` places tangents at ``lo``, the midpoint and ``hi``.
+    Where ``f`` is finite at an endpoint but ``f'`` diverges there, ``_tangent_row``
+    returned without emitting and the facet was silently lost, leaving the envelope
+    one-sided on that side — reached by ``sqrt`` at ``t=0`` and ``asin``/``acos`` at
+    ``t=±1``. When on, the facet is re-anchored at an interior ladder point (see
+    ``_interior_tangent_point``); the path only ever ADDS a row where none was
+    emitted, so the flag-ON polytope is a subset of the flag-OFF polytope and the
+    node LP bound can only improve or stay equal.
+
+    **The §5 panel ran and FAILED gate 2 (net-positive). This flag is not a
+    graduation candidate as it stands.** 13 pairs, cert-clean (0 soundness
+    violations, incumbents identical on all 13, no certification regression), but:
+
+    * the two *terminating* pairs are the only load-independent rows, and they read
+      ``mathopt5_6`` 5 → 5 nodes (bit-identical certificate) and ``tspn08``
+      **135 → 191 nodes, +41%**. A tighter relaxation still grows the tree because a
+      different LP vertex changes the branching choice;
+    * among the time-limited rows, 1 meaningfully better (``tspn10`` +1.274) against
+      4 meaningfully worse (``kriging_peaks-full100`` −1.144, ``full010`` −0.542,
+      ``tspn12`` −0.520, ``full050`` −0.198);
+    * the root win does not survive branching: ``kriging_peaks`` gains 13–40× at the
+      root (``full200`` −74356.93 → −5596.46) yet after 120 s ``full020``'s arms
+      agree to 14 digits and ``full050``/``full100`` are behind. B&B was already
+      recovering that bound cheaply, and an extra LP row at every node is a net loss.
+
+    #1111's own motivating hypothesis is **falsified**: on the adiabatic LVC MECP
+    model the facet is recovered but root bound and node count are unchanged (1 node
+    either way).
+
+    Sound but not helpful — the ``DISCOPT_CUT_INHERIT`` outcome. Note the two #581
+    precedents below removed such flags rather than leaving them in default-OFF
+    limbo; this one is retained by owner decision (2026-08-22) as a measurement
+    lever for the open question in #1111 — whether *any* formulation of the
+    singular-endpoint tangent pays for itself — with the failing panel recorded
+    here so no future reader mistakes it for an ungraduated candidate. Flag-OFF is
+    byte-identical to the pre-#1111 relaxation."""
+
+    singular_tangent_kappa: float = field(
+        default_factory=lambda: _env_float("DISCOPT_SINGULAR_TANGENT_KAPPA", 100.0)
+    )
+    """Cap on ``|f'(t0)|`` for :attr:`singular_tangent`, as a multiple of the box's
+    own slope scale (``DISCOPT_SINGULAR_TANGENT_KAPPA``, default 100).
+
+    A measurement knob for the §5 panel, not a user-facing tuning parameter. A
+    tangent ~100x steeper than the secant is about the numerical limit worth
+    emitting: the outward-rounding guard (``outward_rounding.envelope_1d_slack``)
+    grows linearly with ``|slope|``, so an uncapped near-vertical tangent buys
+    tightness with rounding slack. Only consulted when :attr:`singular_tangent` is
+    on."""
+
     # NOTE (#581): ``DISCOPT_NODE_REDUCE`` (per-node cheap reduction: cutoff-FBBT +
     # free DBBT from node-LP reduced costs + integer RC-fixing, feeding the
     # tightened box to the children) was DEPRECATED and removed. It was a
@@ -1355,6 +1413,10 @@ class SolverTuning:
             raise ValueError(f"psd_cost_gate_budget must be > 0, got {self.psd_cost_gate_budget}")
         if self.psd_cost_gate_tau < 0:
             raise ValueError(f"psd_cost_gate_tau must be >= 0, got {self.psd_cost_gate_tau}")
+        if not (self.singular_tangent_kappa > 0.0 and math.isfinite(self.singular_tangent_kappa)):
+            raise ValueError(
+                f"singular_tangent_kappa must be finite and > 0, got {self.singular_tangent_kappa}"
+            )
 
     def replace(self, **changes) -> SolverTuning:
         """Return a copy with ``changes`` applied (validated)."""

--- a/python/discopt/solver_tuning.py
+++ b/python/discopt/solver_tuning.py
@@ -1330,21 +1330,38 @@ class SolverTuning:
     emitted, so the flag-ON polytope is a subset of the flag-OFF polytope and the
     node LP bound can only improve or stay equal.
 
-    **The §5 panel ran and FAILED gate 2 (net-positive). This flag is not a
-    graduation candidate as it stands.** 13 pairs, cert-clean (0 soundness
-    violations, incumbents identical on all 13, no certification regression), but:
+    **The §5 panel ran. Gate 1 (cert-clean) PASSES; gate 2 (net-positive) FAILS
+    because the flag is measured exactly NEUTRAL — not because it is harmful.** The
+    successor panel (17 instances, every one screened to actually drop a facet; both
+    arms in one process on one binary; each arm run twice) reports 24 soundness
+    comparisons with 0 violations, no bound above its ``.solu`` reference, no
+    certification regression, and:
 
-    * the two *terminating* pairs are the only load-independent rows, and they read
-      ``mathopt5_6`` 5 → 5 nodes (bit-identical certificate) and ``tspn08``
-      **135 → 191 nodes, +41%**. A tighter relaxation still grows the tree because a
-      different LP vertex changes the branching choice;
-    * among the time-limited rows, 1 meaningfully better (``tspn10`` +1.274) against
-      4 meaningfully worse (``kriging_peaks-full100`` −1.144, ``full010`` −0.542,
-      ``tspn12`` −0.520, ``full050`` −0.198);
+    * the two *terminating* pairs are the only load-independent rows, and both are
+      exactly neutral: ``mathopt5_6`` 5 → 5 nodes and ``tspn08`` 135 → 135 nodes,
+      each with a **bit-identical** dual bound in both arms, reproducible across
+      both repetitions;
+    * every time-limited row is neutral **within its own rep-to-rep spread**.
+      Comparing ON's worse repetition against OFF's better one, no instance is
+      robustly better or worse — the widest excursion, ``tspn10``, straddles zero
+      (−0.739 to +0.318). Under load, at a 60 s limit, this panel cannot resolve a
+      gain of that size, and it should not be quoted as one;
     * the root win does not survive branching: ``kriging_peaks`` gains 13–40× at the
-      root (``full200`` −74356.93 → −5596.46) yet after 120 s ``full020``'s arms
-      agree to 14 digits and ``full050``/``full100`` are behind. B&B was already
-      recovering that bound cheaply, and an extra LP row at every node is a net loss.
+      root (``full200`` −74356.93 → −5596.46) yet ``full020``'s arms agree to 14
+      digits at the limit. B&B was already recovering that bound cheaply.
+
+    **Retraction (§11).** An earlier, ~36 %-diluted panel was recorded here — and in
+    the CHANGELOG and PR #1113 — as measuring ``tspn08`` at **135 → 191 nodes, +41 %**,
+    and that number was the load-bearing evidence for calling this flag harmful. **It
+    does not reproduce.** On the undiluted single-binary panel ``tspn08`` is 135 → 135
+    with an identical bound (290.565925041298) in all four runs. Retracted with it:
+    that panel's time-limited list of "4 meaningfully worse" rows
+    (``kriging_peaks-full100`` −1.144, ``full010`` −0.542, ``tspn12`` −0.520,
+    ``full050`` −0.198) — on the successor panel ``full100`` and ``tspn12`` are flat
+    and ``full010``/``full050`` move the *other* way, inside rep noise. Those rows
+    were load artifacts, measured while an unrelated job held most of the machine.
+    The correct disposition is unchanged in outcome (stays default-OFF) but different
+    in kind: **sound, and neutral.**
 
     #1111's own motivating hypothesis is **falsified**: on the adiabatic LVC MECP
     model the facet is recovered but root bound and node count are unchanged (1 node
@@ -1353,10 +1370,11 @@ class SolverTuning:
     **Two further defects in #1111's framing, both measured.** (a) The issue expects
     the inverse-trig rows to matter most; across all 1610 MINLPLib ``.nl`` instances
     ``sqrt`` appears in 63 and ``asin``/``acos``/``acosh`` in **zero**, so on this
-    corpus the feature is a sqrt feature. (b) Panel 1 was ~36 % diluted — 5 of its 14
-    instances (``kriging_peaks-red*``) contain no ``sqrt`` at all, so the flag could
-    not act on them and those rows were noise. A targeted 17-instance panel drawn by
-    screening every corpus instance for an actually-dropped facet is the successor.
+    corpus the feature is a sqrt feature. (b) The first panel was ~36 % diluted — 5 of
+    its 14 instances (``kriging_peaks-red*``) contain no ``sqrt`` at all, so the flag
+    could not act on them and those rows were pure noise. That dilution is why its
+    numbers are retracted above; the panel quoted here is its successor, drawn by
+    screening every corpus instance for an actually-dropped facet.
 
     **The mechanism, not the constant, is what is wrong.** A fixed-offset
     reformulation (``delta = width/8``) was built and measured against this ladder and
@@ -1369,8 +1387,11 @@ class SolverTuning:
     is what ``MccormickLPRelaxer._separate_convex``'s Kelley loop already does for
     composite convex/concave lifts (``concave: d <= g(x0) + grad g(x0)·(x - x0)`` at
     the LP point ``x0``). The soundness argument carries over unchanged — every tangent
-    of a concave ``f`` is a global overestimator — and lazy separation also avoids the
-    specific cost panel 1 charged this flag for, an eager extra row at every node.
+    of a concave ``f`` is a global overestimator — and lazy separation also stops the
+    solver paying for an eager extra row at every node whether or not that node's LP
+    is near the singular endpoint. (The retracted panel charged this flag for that
+    cost as a *measured* regression; it is not one. It remains a reason to prefer
+    lazy placement, but as an argument, not as evidence.)
 
     **This is a hypothesis to test, not a known fix, and one caveat is already
     visible.** Lazy placement does not dodge the singularity: on ``kriging_peaks`` the
@@ -1380,7 +1401,8 @@ class SolverTuning:
     offset, not the degeneracy itself. That is the open question #1111 leaves behind,
     and this flag is the lever for measuring it.
 
-    Sound but not helpful — the ``DISCOPT_CUT_INHERIT`` outcome. Note the two #581
+    Sound but not helpful — the ``DISCOPT_CUT_INHERIT`` outcome, in its neutral
+    rather than its harmful form. Note the two #581
     precedents below removed such flags rather than leaving them in default-OFF
     limbo; this one is retained by owner decision (2026-08-22) as a measurement
     lever for the open question in #1111 — whether *any* formulation of the

--- a/python/discopt/solver_tuning.py
+++ b/python/discopt/solver_tuning.py
@@ -1456,14 +1456,41 @@ class SolverTuning:
     to do: ``min 2x - sqrt(x)`` over ``[0,4]`` goes −0.7071 → **−0.12503** against a
     true optimum of −0.125, where the eager anchor reaches only −0.6557.
 
-    **On the corpus it is neutral, and that is the §5 gate-2 verdict.** The mechanism
-    is measurably live — 604 rows separated on ``kriging_peaks-full010``, moving the
-    node LP objective on 7 of 12 instrumented invocations — but by ~1e-4 against a
-    bound of −5.69, which never changes a branching decision, so the tree and final
-    bound come out bit-identical to leaving the facet dropped. The #727 lesson in
-    reverse: the synthetic atom shows a large gain and the real class shows none,
-    because on a corpus instance the ``sqrt`` term is one of many and the LP optimum
-    is held by other constraints rather than sitting at the singular endpoint.
+    **On the corpus it weakly dominates leaving the facet dropped.** Three-arm panel
+    (off / eager / lazy), 300-node budget with no wall limit so node counts and bounds
+    are bit-reproducible, each arm's firing asserted, 10 scorable instances:
+    ``eager vs off: WORSE 2, flat 8, better 0``; ``lazy vs off: BETTER 2, flat 8,
+    worse 0``; 40 soundness comparisons against ``minlplib.solu``, 0 violations. The
+    two lazy gains are ``kriging_peaks-full050`` (−142.657 → −139.918) and
+    ``full100`` (−348.054 → −342.588), both at *identical node counts and identical
+    incumbents* — i.e. a strictly better bound for the same work. This is NOT the
+    ``cut_inherit`` outcome, which was neutral-or-harmful.
+
+    It is also not yet a graduation case, for three reasons kept here rather than in a
+    commit message:
+
+    * **A coverage hole eager does not have.** The separation chain is gated on
+      ``if separate:`` (``mccormick_lp.py``), forced off on yield rounds and pool-free
+      re-solves. On all three ``elec*`` instances the lazy arm registered thousands of
+      specs (19 236 on ``elec100``) and the separator ran **zero** times, while eager
+      fired at build time throughout. Lazy is not a coverage superset of eager: it
+      trades "emit a geometric guess wherever a relaxation is built" for "emit an
+      exact tangent only where a separation round runs".
+    * **Cost is real and only counted in rows, not seconds.** 31 614 separated rows on
+      ``eq6_1`` and 35 585 on ``maxmin`` buy bound movement in the 12th digit. No
+      wall-time figure is quoted because that panel's timing column was contaminated
+      by load the author generated (§9).
+    * **7 of 17 screened instances produced no scorable row** — ``elec*`` and
+      ``full500`` return no dual bound at all; ``full030``, ``tspn15`` and ``full200``
+      were lost to a per-instance wall kill that truncated the *lazy* arm
+      preferentially, since it always runs third.
+
+    Where the gains come from: both sit in ``kriging_peaks``, the family with the
+    largest root gain (13–40×). On ``full010``, 12 separator invocations move the node
+    LP objective 7 times but only by ~1e-4 against a bound of −5.69 — live, and far too
+    small to change a branching decision. So the #1111 finding "the root win does not
+    survive branching" is scoped to the **eager** anchor: where the dropped facet
+    dominates the root relaxation, lazy placement does retain part of it.
     """
 
     singular_tangent_kappa: float = field(

--- a/python/discopt/solver_tuning.py
+++ b/python/discopt/solver_tuning.py
@@ -1365,10 +1365,19 @@ class SolverTuning:
     :attr:`singular_tangent_kappa` shows the best static offset is problem-dependent
     by orders of magnitude, with both ends of the range degenerate. A static geometric
     anchor cannot be right for every box. What the measurements point at instead is
-    placing the tangent *where the LP binds* — lazily, at the incumbent LP point, the
-    way ``MccormickLPRelaxer._separate_convex``'s Kelley loop already handles composite
-    convex lifts — which also avoids the specific cost panel 1 charged this flag for,
-    an eager extra row at every node. That is the open question #1111 leaves behind,
+    placing the tangent *where the LP binds* rather than at a geometric offset — which
+    is what ``MccormickLPRelaxer._separate_convex``'s Kelley loop already does for
+    composite convex/concave lifts (``concave: d <= g(x0) + grad g(x0)·(x - x0)`` at
+    the LP point ``x0``). The soundness argument carries over unchanged — every tangent
+    of a concave ``f`` is a global overestimator — and lazy separation also avoids the
+    specific cost panel 1 charged this flag for, an eager extra row at every node.
+
+    **This is a hypothesis to test, not a known fix, and one caveat is already
+    visible.** Lazy placement does not dodge the singularity: on ``kriging_peaks`` the
+    binding point is *near* the endpoint but the gain collapses for ``delta`` below
+    ~1e-5, so an LP point landing on or inside that radius needs the same conditioning
+    guard this cap provides. What lazy separation removes is the need to *guess* the
+    offset, not the degeneracy itself. That is the open question #1111 leaves behind,
     and this flag is the lever for measuring it.
 
     Sound but not helpful — the ``DISCOPT_CUT_INHERIT`` outcome. Note the two #581

--- a/python/discopt/solver_tuning.py
+++ b/python/discopt/solver_tuning.py
@@ -1456,14 +1456,19 @@ class SolverTuning:
     to do: ``min 2x - sqrt(x)`` over ``[0,4]`` goes −0.7071 → **−0.12503** against a
     true optimum of −0.125, where the eager anchor reaches only −0.6557.
 
-    **On the corpus it weakly dominates leaving the facet dropped.** Three-arm panel
+    **On the corpus lazy never loses and wins four times.** Three-arm panel
     (off / eager / lazy), 300-node budget with no wall limit so node counts and bounds
-    are bit-reproducible, each arm's firing asserted, 10 scorable instances:
-    ``eager vs off: WORSE 2, flat 8, better 0``; ``lazy vs off: BETTER 2, flat 8,
-    worse 0``; 40 soundness comparisons against ``minlplib.solu``, 0 violations. The
-    two lazy gains are ``kriging_peaks-full050`` (−142.657 → −139.918) and
-    ``full100`` (−348.054 → −342.588), both at *identical node counts and identical
-    incumbents* — i.e. a strictly better bound for the same work. This is NOT the
+    are bit-reproducible, each arm's firing asserted, 13 scorable instances:
+    ``eager vs off: BETTER 2, WORSE 2, flat 9``; ``lazy vs off: BETTER 4, flat 9,
+    worse 0``; 52 soundness comparisons against ``minlplib.solu``, 0 violations. The
+    lazy gains are ``kriging_peaks-full050`` (−142.657 → −139.918), ``full100``
+    (−348.054 → −342.588), ``full200`` (−746.566 → −734.495) — ~1.6–1.9 % of gap each —
+    and a marginal ``tspn15``. All occur at *identical node counts and identical
+    incumbents*: a strictly better bound for the same work. The three substantial ones
+    follow a size trend (nothing at ``full010/020/030``), which is what a mechanism
+    acting only where the dropped facet dominates the root relaxation should look like.
+    Eager's two BETTER cells are ``tspn15`` (+0.002) and ``full200`` (+1e-08, noise)
+    against two real losses, so eager stays net-negative. This is NOT the
     ``cut_inherit`` outcome, which was neutral-or-harmful.
 
     It is also not yet a graduation case, for three reasons kept here rather than in a
@@ -1480,10 +1485,11 @@ class SolverTuning:
       ``eq6_1`` and 35 585 on ``maxmin`` buy bound movement in the 12th digit. No
       wall-time figure is quoted because that panel's timing column was contaminated
       by load the author generated (§9).
-    * **7 of 17 screened instances produced no scorable row** — ``elec*`` and
-      ``full500`` return no dual bound at all; ``full030``, ``tspn15`` and ``full200``
-      were lost to a per-instance wall kill that truncated the *lazy* arm
-      preferentially, since it always runs third.
+    * **4 of 17 screened instances produced no scorable row** — ``elec*`` and
+      ``full500`` return no dual bound at all. ``full030``, ``tspn15`` and ``full200``
+      were initially lost to a per-instance wall kill that truncated the *lazy* arm
+      preferentially; a per-arm re-run recovered all three, and doing so added one
+      eager BETTER and one substantial lazy BETTER.
 
     Where the gains come from: both sit in ``kriging_peaks``, the family with the
     largest root gain (13–40×). On ``full010``, 12 separator invocations move the node

--- a/python/discopt/solver_tuning.py
+++ b/python/discopt/solver_tuning.py
@@ -1398,16 +1398,19 @@ class SolverTuning:
     binding point is *near* the endpoint but the gain collapses for ``delta`` below
     ~1e-5, so an LP point landing on or inside that radius needs the same conditioning
     guard this cap provides. What lazy separation removes is the need to *guess* the
-    offset, not the degeneracy itself. That is the open question #1111 leaves behind,
-    and this flag is the lever for measuring it.
+    offset, not the degeneracy itself. That is the open question #1111 leaves behind;
+    it is tracked in **#1115**, with the entry experiment and its kill criterion, and
+    this flag is the lever for measuring it.
 
     Sound but not helpful — the ``DISCOPT_CUT_INHERIT`` outcome, in its neutral
     rather than its harmful form. Note the two #581
     precedents below removed such flags rather than leaving them in default-OFF
     limbo; this one is retained by owner decision (2026-08-22) as a measurement
-    lever for the open question in #1111 — whether *any* formulation of the
-    singular-endpoint tangent pays for itself — with the failing panel recorded
-    here so no future reader mistakes it for an ungraduated candidate. Flag-OFF is
+    lever for #1115 — whether *any* formulation of the singular-endpoint tangent pays
+    for itself — with the failing panel recorded here so no future reader mistakes it
+    for an ungraduated candidate. #1115 carries the same disposition rule: if the
+    successor mechanism is falsified too, this flag gets removed rather than left in
+    limbo indefinitely. Flag-OFF is
     byte-identical to the pre-#1111 relaxation."""
 
     singular_tangent_kappa: float = field(

--- a/python/discopt/solver_tuning.py
+++ b/python/discopt/solver_tuning.py
@@ -1350,6 +1350,27 @@ class SolverTuning:
     model the facet is recovered but root bound and node count are unchanged (1 node
     either way).
 
+    **Two further defects in #1111's framing, both measured.** (a) The issue expects
+    the inverse-trig rows to matter most; across all 1610 MINLPLib ``.nl`` instances
+    ``sqrt`` appears in 63 and ``asin``/``acos``/``acosh`` in **zero**, so on this
+    corpus the feature is a sqrt feature. (b) Panel 1 was ~36 % diluted — 5 of its 14
+    instances (``kriging_peaks-red*``) contain no ``sqrt`` at all, so the flag could
+    not act on them and those rows were noise. A targeted 17-instance panel drawn by
+    screening every corpus instance for an actually-dropped facet is the successor.
+
+    **The mechanism, not the constant, is what is wrong.** A fixed-offset
+    reformulation (``delta = width/8``) was built and measured against this ladder and
+    is **strictly worse** — about half the root-bound gain on every instance where the
+    bound moves at all — and the anchor sweep behind
+    :attr:`singular_tangent_kappa` shows the best static offset is problem-dependent
+    by orders of magnitude, with both ends of the range degenerate. A static geometric
+    anchor cannot be right for every box. What the measurements point at instead is
+    placing the tangent *where the LP binds* — lazily, at the incumbent LP point, the
+    way ``MccormickLPRelaxer._separate_convex``'s Kelley loop already handles composite
+    convex lifts — which also avoids the specific cost panel 1 charged this flag for,
+    an eager extra row at every node. That is the open question #1111 leaves behind,
+    and this flag is the lever for measuring it.
+
     Sound but not helpful — the ``DISCOPT_CUT_INHERIT`` outcome. Note the two #581
     precedents below removed such flags rather than leaving them in default-OFF
     limbo; this one is retained by owner decision (2026-08-22) as a measurement
@@ -1364,12 +1385,53 @@ class SolverTuning:
     """Cap on ``|f'(t0)|`` for :attr:`singular_tangent`, as a multiple of the box's
     own slope scale (``DISCOPT_SINGULAR_TANGENT_KAPPA``, default 100).
 
-    A measurement knob for the §5 panel, not a user-facing tuning parameter. A
-    tangent ~100x steeper than the secant is about the numerical limit worth
-    emitting: the outward-rounding guard (``outward_rounding.envelope_1d_slack``)
-    grows linearly with ``|slope|``, so an uncapped near-vertical tangent buys
-    tightness with rounding slack. Only consulted when :attr:`singular_tangent` is
-    on."""
+    A measurement knob for the §5 panel, not a user-facing tuning parameter. Only
+    consulted when :attr:`singular_tangent` is on.
+
+    **The cap is right; the rationale first written here was not, and is retracted
+    (§11).** The original justification was that the outward-rounding guard
+    (``outward_rounding.envelope_1d_slack``) grows linearly with ``|slope|``, so an
+    uncapped near-vertical tangent buys tightness with rounding slack. The linearity
+    is real (``outward_rounding.py`` returns ``outward_slack(d*tmag + ...)``) but the
+    magnitude is not: at ``kappa=100`` the added slack is ~1e-14 against a cut depth
+    of ~0.35 — six orders of magnitude too small to be the reason for anything.
+
+    The cap's actual justification is a measured degeneracy at the uncapped end.
+    Sweeping the anchor offset ``delta`` over eight orders on the three
+    ``kriging_peaks-full`` instances that move the root bound at all, the root LP
+    bound tightens as the anchor approaches the singular endpoint, peaks near
+    ``delta ~ 1e-5``, and then **collapses back to the flag-OFF value** as ``delta``
+    shrinks further (``full020``: OFF −1113.72; gain +552 at 1/8, +1087 at 1.2e-4,
+    +1098 at 1e-5, +1097 at 1e-7, +1039 at 1e-9, **+0** at 1e-12 — same shape on
+    ``full010`` and ``full050``). Past the peak the tangent is numerically degenerate
+    and the emitted row stops constraining anything. Without a cap the ladder takes
+    its smallest rung, ``delta = 0.5*8**-20 ~ 5.5e-19``, which is inside the collapse:
+    the feature would emit a row on every singular atom and buy nothing. That is what
+    the cap is for, and it reproduces on an isolated atom too — ``min 3x - sqrt(x)``
+    over ``[0,4]``, whose LP optimum sits at the singular end, gains **+4.9e-09** at
+    ``kappa=1e12`` against **+0.083** at ``kappa=100``.
+
+    **``kappa=100`` is not measured-optimal, and the optimum is problem-dependent.**
+    On that same isolated atom the best rung is near ``kappa ~ 10`` (gain +0.619, 7x
+    the default's +0.083), i.e. an anchor *further* from the endpoint; on
+    ``kriging_peaks`` the peak is at a *smaller* ``delta`` than the default selects.
+    The two disagree by orders of magnitude, so no single constant is right for both
+    — which is the deeper reason a static geometric rule is the wrong mechanism here
+    (see :attr:`singular_tangent`). Treat 100 as a serviceable midpoint that is on
+    the stable side of the collapse, not as a tuned value. (The isolated-atom figure
+    is a synthetic proxy and is quoted only for the *shape* of the curve; per the
+    #727 RLT lesson the ``kriging_peaks`` numbers are the ones drawn from the real
+    corpus.)
+
+    This also **falsifies a mean-envelope-slack argument** considered as a
+    replacement for the ladder (a fixed ``delta = width/8``, chosen because it
+    minimises mean envelope slack over the box, measured 3.31x better than the
+    near-corner anchor on that metric). Mean slack over the box does not predict
+    bound tightness: on the same instances the near-corner anchor gives ~**2x** the
+    root-bound gain of ``width/8`` (``full010`` +2975 vs +1513, ``full200`` +68769
+    vs +34967). Only slack *where the relaxation binds* matters, and on this family
+    the LP optimum sits at the singular endpoint. The fixed-offset reformulation was
+    measured, found strictly worse, and discarded."""
 
     # NOTE (#581): ``DISCOPT_NODE_REDUCE`` (per-node cheap reduction: cutoff-FBBT +
     # free DBBT from node-LP reduced costs + integer RC-fixing, feeding the

--- a/python/discopt/solver_tuning.py
+++ b/python/discopt/solver_tuning.py
@@ -1456,23 +1456,55 @@ class SolverTuning:
     to do: ``min 2x - sqrt(x)`` over ``[0,4]`` goes −0.7071 → **−0.12503** against a
     true optimum of −0.125, where the eager anchor reaches only −0.6557.
 
-    **On the corpus lazy never loses and wins four times.** Three-arm panel
-    (off / eager / lazy), 300-node budget with no wall limit so node counts and bounds
-    are bit-reproducible, each arm's firing asserted, 13 scorable instances:
-    ``eager vs off: BETTER 2, WORSE 2, flat 9``; ``lazy vs off: BETTER 4, flat 9,
-    worse 0``; 52 soundness comparisons against ``minlplib.solu``, 0 violations. The
-    lazy gains are ``kriging_peaks-full050`` (−142.657 → −139.918), ``full100``
-    (−348.054 → −342.588), ``full200`` (−746.566 → −734.495) — ~1.6–1.9 % of gap each —
-    and a marginal ``tspn15``. All occur at *identical node counts and identical
-    incumbents*: a strictly better bound for the same work. The three substantial ones
-    follow a size trend (nothing at ``full010/020/030``), which is what a mechanism
-    acting only where the dropped facet dominates the root relaxation should look like.
-    Eager's two BETTER cells are ``tspn15`` (+0.002) and ``full200`` (+1e-08, noise)
-    against two real losses, so eager stays net-negative. This is NOT the
-    ``cut_inherit`` outcome, which was neutral-or-harmful.
+    **On the corpus lazy never loses the bound, and that is not enough.** Three-arm
+    panel (off / eager / lazy), 300-node budget with no wall limit, each arm's firing
+    asserted, 12 scorable instances: ``eager vs off: BETTER 1, WORSE 2, flat 9``;
+    ``lazy vs off: BETTER 3, flat 9, worse 0``. Soundness checked on every arm of
+    every run against ``minlplib.solu`` — 0 violations, including per-repetition
+    asserts in the reproducibility and timing panels. The lazy gains are
+    ``kriging_peaks-full050`` (−142.657 → −139.918) and ``full100`` (−348.054 →
+    −342.588), ~1.6–1.9 % of gap, plus a marginal ``tspn15``; each occurs at an
+    *identical node count and identical incumbent*, i.e. a better bound for the same
+    tree. Eager's one BETTER cell (``tspn15``, +0.002) against two real losses leaves
+    it net-negative.
 
-    It is also not yet a graduation case, for three reasons kept here rather than in a
-    commit message:
+    **The timing panel decides it, and it decides against graduation.** Interleaved
+    off/lazy, 3 repetitions, per-arm and pooled standard deviations, load gate
+    recorded per instance (2.5–5.2 on 14 cores), both arms verified to explore
+    identical trees::
+
+        eq6_1                 off  10.82+-0.12s   lazy  13.59+-0.09s   +25.6%   0 gain
+        maxmin                off  33.52+-0.13s   lazy  51.68+-0.04s   +54.2%   0 gain
+        kriging_peaks-full050 off  42.21+-0.21s   lazy  44.09+-0.12s    +4.5%  +1.9%
+        kriging_peaks-full100 off 101.21+-0.21s   lazy 105.22+-0.22s    +4.0%  +1.6%
+
+    Every delta is 12–200 pooled sd; none is noise. The shape disqualifies it:
+    **lazy is cheap where it helps and expensive where it does not** — the two
+    instances charged +25.6 % and +54.2 % are exactly the two that gain nothing,
+    because they draw the most rows. Default-ON would pay the ``maxmin`` bill
+    corpus-wide to collect the ``full050`` gain occasionally. Gate 1 (cert-clean)
+    passes; **gate 2 (net-positive) fails**; the flag stays default-OFF. Same
+    disposition as ``cut_inherit``, reached by a different route — that one was
+    neutral-or-harmful, this one is helpful on a narrow class and unaffordable off it.
+
+    Corrections to earlier readings recorded here (§11):
+
+    * ``kriging_peaks-full200`` was reported as a third gain (−746.566 → −734.495,
+      +1.6 %) and is **withdrawn**. Over 3 reps on a quiet machine it is
+      nondeterministic in *both* arms: off gives nodes {301, 303} with two distinct
+      bounds and zero separated rows; lazy gives {301, 303} with rows {32451, 32472,
+      32583}. Two single runs of a nondeterministic instance are not a comparison.
+      Pre-existing at that size, unrelated to this flag, filed separately.
+    * An intermediate claim that lazy *caused* that nondeterminism is also withdrawn:
+      it rested on two reps in which off agreed, and the third falsified it.
+    * **The quoted bounds are load-dependent to ~3 significant figures.** Quiet,
+      ``full100`` gives −350.768 → −345.634 over 12 498 rows; under the original
+      panel's contention, −348.054 → −342.588 over 13 214. Separation is wall-bounded
+      (every ``_separate_*`` breaks on a shared ``_deadline``; the node LP re-solve
+      takes ``time_limit=_remaining()``), so row counts and the bounds they produce
+      shift with machine load. The direction reproduces; the digits do not.
+
+    Remaining gap:
 
     * **A coverage hole eager does not have.** The separation chain is gated on
       ``if separate:`` (``mccormick_lp.py``), forced off on yield rounds and pool-free
@@ -1481,15 +1513,6 @@ class SolverTuning:
       fired at build time throughout. Lazy is not a coverage superset of eager: it
       trades "emit a geometric guess wherever a relaxation is built" for "emit an
       exact tangent only where a separation round runs".
-    * **Cost is real and only counted in rows, not seconds.** 31 614 separated rows on
-      ``eq6_1`` and 35 585 on ``maxmin`` buy bound movement in the 12th digit. No
-      wall-time figure is quoted because that panel's timing column was contaminated
-      by load the author generated (§9).
-    * **4 of 17 screened instances produced no scorable row** — ``elec*`` and
-      ``full500`` return no dual bound at all. ``full030``, ``tspn15`` and ``full200``
-      were initially lost to a per-instance wall kill that truncated the *lazy* arm
-      preferentially; a per-arm re-run recovered all three, and doing so added one
-      eager BETTER and one substantial lazy BETTER.
 
     Where the gains come from: both sit in ``kriging_peaks``, the family with the
     largest root gain (13–40×). On ``full010``, 12 separator invocations move the node

--- a/python/discopt/solver_tuning.py
+++ b/python/discopt/solver_tuning.py
@@ -1330,38 +1330,67 @@ class SolverTuning:
     emitted, so the flag-ON polytope is a subset of the flag-OFF polytope and the
     node LP bound can only improve or stay equal.
 
-    **The §5 panel ran. Gate 1 (cert-clean) PASSES; gate 2 (net-positive) FAILS
-    because the flag is measured exactly NEUTRAL — not because it is harmful.** The
-    successor panel (17 instances, every one screened to actually drop a facet; both
-    arms in one process on one binary; each arm run twice) reports 24 soundness
-    comparisons with 0 violations, no bound above its ``.solu`` reference, no
-    certification regression, and:
+    **The §5 panel ran. Gate 1 (cert-clean) PASSES; gate 2 (net-positive) FAILS:
+    the EAGER anchor is measured HARMFUL.** On the only instance that terminates
+    inside a deterministic node budget and moves at all, ``tspn08`` goes 135 → 191
+    nodes (**+41.5 %**) to buy a bound gain in the 11th digit
+    (290.56592504129753 → 290.56599569540646). ``mathopt5_6`` is flat at 5 → 5 with
+    a bit-identical bound, and ``kriging_peaks-full010`` is flat to 14 digits. The
+    subset property still holds — the ON bound *is* tighter at every node — but a
+    different LP vertex changes the branching choice, so a tighter relaxation can
+    still grow the tree. Soundness held throughout: no bound above its ``.solu``
+    reference, no certification regression, incumbents identical.
 
-    * the two *terminating* pairs are the only load-independent rows, and both are
-      exactly neutral: ``mathopt5_6`` 5 → 5 nodes and ``tspn08`` 135 → 135 nodes,
-      each with a **bit-identical** dual bound in both arms, reproducible across
-      both repetitions;
-    * every time-limited row is neutral **within its own rep-to-rep spread**.
-      Comparing ON's worse repetition against OFF's better one, no instance is
-      robustly better or worse — the widest excursion, ``tspn10``, straddles zero
-      (−0.739 to +0.318). Under load, at a 60 s limit, this panel cannot resolve a
-      gain of that size, and it should not be quoted as one;
-    * the root win does not survive branching: ``kriging_peaks`` gains 13–40× at the
-      root (``full200`` −74356.93 → −5596.46) yet ``full020``'s arms agree to 14
-      digits at the limit. B&B was already recovering that bound cheaply.
+    The root win also does not survive branching: ``kriging_peaks`` gains 13–40× at
+    the root (``full200`` −74356.93 → −5596.46) yet after a few hundred nodes the
+    arms agree to 14 digits. B&B was already recovering that bound cheaply.
 
-    **Retraction (§11).** An earlier, ~36 %-diluted panel was recorded here — and in
-    the CHANGELOG and PR #1113 — as measuring ``tspn08`` at **135 → 191 nodes, +41 %**,
-    and that number was the load-bearing evidence for calling this flag harmful. **It
-    does not reproduce.** On the undiluted single-binary panel ``tspn08`` is 135 → 135
-    with an identical bound (290.565925041298) in all four runs. Retracted with it:
-    that panel's time-limited list of "4 meaningfully worse" rows
-    (``kriging_peaks-full100`` −1.144, ``full010`` −0.542, ``tspn12`` −0.520,
-    ``full050`` −0.198) — on the successor panel ``full100`` and ``tspn12`` are flat
-    and ``full010``/``full050`` move the *other* way, inside rep noise. Those rows
-    were load artifacts, measured while an unrelated job held most of the machine.
-    The correct disposition is unchanged in outcome (stays default-OFF) but different
-    in kind: **sound, and neutral.**
+    **DOUBLE RETRACTION (§11) — a retraction that was itself wrong.** This docstring,
+    the CHANGELOG and PR #1113 previously *withdrew* the ``tspn08`` 135 → 191 result
+    and recorded the flag as "sound, and neutral", on the strength of a panel showing
+    135 → 135 with bit-identical bounds. **That withdrawal is itself withdrawn, and
+    the +41 % is reinstated as measured above.** The panel behind it never fired.
+
+    The instrument defect, measured not inferred: :func:`solve` is wrapped by a
+    decorator (``solver.py:6274-6280``) that begins ``_set_tuning(kwargs.pop(
+    "tuning", None))``, and :func:`set_current` with ``None`` publishes a **fresh,
+    env-resolved** ``SolverTuning()``. A probe that installs a tuning with
+    ``set_current(...)`` and then calls ``m.solve()`` without ``tuning=`` therefore
+    has that context **silently discarded at the solve boundary**. Counting
+    ``_interior_tangent_point`` calls inside a full solve of
+    ``kriging_peaks-full010``:
+
+    ==========================================  ======  =====
+    how the flag was set                         calls  nodes
+    ==========================================  ======  =====
+    off (control)                                    0    311
+    ``set_current(...)`` around ``m.solve()``        0    311
+    ``m.solve(tuning=...)``                       2671    313
+    ``DISCOPT_SINGULAR_TANGENT=1``                2671    313
+    ==========================================  ======  =====
+
+    ``tuning=`` and the environment variable agree bit-for-bit; ``set_current`` is
+    inert. So "both arms bit-identical" was not a neutrality result — it is the
+    signature of a probe that never fired, and it explains exactly why the arms
+    agreed to the last digit. That panel carried no drops counter, so nothing caught
+    it (§6). Every root-relaxation measurement quoted below is unaffected: those
+    drive ``build_uniform_relaxation`` directly, where ``set_current`` does reach
+    (instrumented 10/10).
+
+    The reinstated number was re-measured on a corrected instrument — ``tuning=``
+    delivery, the ON arm asserted to have fired, a ``max_nodes`` budget with **no**
+    ``time_limit`` (a wall limit changes the kernel path and makes the run
+    non-reproducible; ``max_nodes`` alone is bit-reproducible over 3 repetitions per
+    arm), both arms in one process on one binary — and reproduces at 135 → 191 on
+    every run since.
+
+    Still retracted, and for reasons unrelated to the above: the first panel's
+    time-limited rows (``kriging_peaks-full100`` −1.144, ``tspn12`` −0.520, …), taken
+    at a 60 s wall limit under load 37–87 on 14 cores, fail the §9 load gate
+    outright; and that panel's printed tally ``better 10 worse 2 unchanged 1``, whose
+    classifier scored ``nodes_on < nodes_off`` as "better" — correct for a
+    terminating run, backwards for a time-limited one, where fewer nodes means the
+    arm did *less* work in the same budget.
 
     #1111's own motivating hypothesis is **falsified**: on the adiabatic LVC MECP
     model the facet is recovered but root bound and node count are unchanged (1 node
@@ -1389,29 +1418,53 @@ class SolverTuning:
     the LP point ``x0``). The soundness argument carries over unchanged — every tangent
     of a concave ``f`` is a global overestimator — and lazy separation also stops the
     solver paying for an eager extra row at every node whether or not that node's LP
-    is near the singular endpoint. (The retracted panel charged this flag for that
-    cost as a *measured* regression; it is not one. It remains a reason to prefer
-    lazy placement, but as an argument, not as evidence.)
+    is near the singular endpoint, which is precisely the cost the ``tspn08``
+    regression above is charging.
 
-    **This is a hypothesis to test, not a known fix, and one caveat is already
-    visible.** Lazy placement does not dodge the singularity: on ``kriging_peaks`` the
-    binding point is *near* the endpoint but the gain collapses for ``delta`` below
-    ~1e-5, so an LP point landing on or inside that radius needs the same conditioning
-    guard this cap provides. What lazy separation removes is the need to *guess* the
-    offset, not the degeneracy itself. That is the open question #1111 leaves behind;
-    it is tracked in **#1115**, with the entry experiment and its kill criterion, and
-    this flag is the lever for measuring it.
-
-    Sound but not helpful — the ``DISCOPT_CUT_INHERIT`` outcome, in its neutral
-    rather than its harmful form. Note the two #581
-    precedents below removed such flags rather than leaving them in default-OFF
-    limbo; this one is retained by owner decision (2026-08-22) as a measurement
-    lever for #1115 — whether *any* formulation of the singular-endpoint tangent pays
-    for itself — with the failing panel recorded here so no future reader mistakes it
-    for an ungraduated candidate. #1115 carries the same disposition rule: if the
-    successor mechanism is falsified too, this flag gets removed rather than left in
-    limbo indefinitely. Flag-OFF is
+    **That successor was built and measured — #1115, and it is the default
+    placement.** See :attr:`singular_tangent_lazy`. Eager anchoring is retained only
+    as the A/B control for that measurement; the two #581 precedents below removed
+    sound-but-unhelpful flags rather than leaving them in default-OFF limbo, and the
+    same rule applies here if the lazy form is falsified in turn. Flag-OFF is
     byte-identical to the pre-#1111 relaxation."""
+
+    singular_tangent_lazy: bool = field(
+        default_factory=lambda: _env_flag("DISCOPT_SINGULAR_TANGENT_LAZY", default=True)
+    )
+    """Place the recovered vertical-tangent facet at the LP point (#1115).
+
+    Consulted only when :attr:`singular_tangent` is on; it selects *where* the
+    recovered tangent goes, never *whether* the facet is recovered.
+
+    ``True`` (the default) defers the facet to
+    ``MccormickLPRelaxer._separate_singular_tangent``, which adds the supporting
+    tangent at the current LP point and only when that point violates it.
+    ``False`` restores #1111's eager behaviour: one tangent per node at a fixed
+    geometric ladder anchor near the endpoint, whether or not it binds.
+
+    Where the LP vertex sits *on* the singularity — the case the facet exists for,
+    and where no finite-slope tangent is available — the touch point falls back to
+    #1111's conditioning-capped ladder anchor while the violation test still decides
+    whether the row goes in. Without that fallback the separator degrades to a no-op
+    precisely where it is needed: on ``min 2x - sqrt(x)`` over ``[0,4]`` the LP vertex
+    lands exactly at ``t=0``.
+
+    **Measured.** The eager form is **harmful** — ``tspn08`` 135 → 191 nodes
+    (+41.5 %) for a bound gain in the 11th digit — which is what motivated #1115, and
+    it is retained only as the A/B control. Lazy placement removes that regression
+    (``tspn08`` back to 135 nodes) and, on isolated atoms, does what it was designed
+    to do: ``min 2x - sqrt(x)`` over ``[0,4]`` goes −0.7071 → **−0.12503** against a
+    true optimum of −0.125, where the eager anchor reaches only −0.6557.
+
+    **On the corpus it is neutral, and that is the §5 gate-2 verdict.** The mechanism
+    is measurably live — 604 rows separated on ``kriging_peaks-full010``, moving the
+    node LP objective on 7 of 12 instrumented invocations — but by ~1e-4 against a
+    bound of −5.69, which never changes a branching decision, so the tree and final
+    bound come out bit-identical to leaving the facet dropped. The #727 lesson in
+    reverse: the synthetic atom shows a large gain and the real class shows none,
+    because on a corpus instance the ``sqrt`` term is one of many and the LP optimum
+    is held by other constraints rather than sitting at the singular endpoint.
+    """
 
     singular_tangent_kappa: float = field(
         default_factory=lambda: _env_float("DISCOPT_SINGULAR_TANGENT_KAPPA", 100.0)

--- a/python/tests/test_1111_singular_endpoint_tangent.py
+++ b/python/tests/test_1111_singular_endpoint_tangent.py
@@ -383,3 +383,79 @@ def test_kappa_flows_from_tuning_to_the_ladder(flag):
         f"kappa=1e-9 must reject every ladder point (got {counts[1e-9]} rows vs "
         f"{a_off.shape[0]} off) — if it does not, kappa is not being read from the tuning"
     )
+
+
+def _endpoint_binding_sqrt_model(a: float):
+    """``min a*x - sqrt(x)`` over ``x in [0,4]`` — a box whose LP optimum sits AT the
+    singular endpoint, so the recovered facet is actually load-bearing.
+
+    The generic single-atom models above put their optimum at the far end of the box,
+    where the dropped facet never binds and every cap reads as neutral. Generic atom,
+    generic box, no named instance."""
+    m = dm.Model()
+    x = m.continuous("x", lb=0.0, ub=4.0)
+    y = m.continuous("y", lb=-1e3, ub=1e3)
+    m.subject_to(y == dm.sqrt(x))
+    m.minimize(a * x - y)
+    return m
+
+
+@pytest.mark.parametrize("a", [3.0, 1.0])
+def test_an_uncapped_anchor_emits_a_row_that_buys_nothing(flag, a):
+    """The slope cap is load-bearing: without it the facet is worthless (#1111).
+
+    The ladder walks from its SMALLEST ``delta`` outward, so an effectively infinite
+    ``kappa`` accepts the first rung, ``0.5*8**-20 ~ 5.5e-19``. That anchor is
+    numerically degenerate — the row is still emitted, but it constrains nothing, so
+    the feature would pay a row on every singular atom for no bound.
+
+    This is the cap's real justification, and it replaces the one originally written
+    into ``SolverTuning.singular_tangent_kappa`` (outward-rounding slack), which is
+    ~1e-14 here and six orders too small to explain anything. Asserting the ROW IS
+    STILL THERE matters as much as the bound: it distinguishes "the anchor degenerated"
+    from "the ladder declined", which would produce the same bound for a different
+    reason (§6)."""
+    flag(None)
+    model = _endpoint_binding_sqrt_model(a)
+    off = _lp_bound(model)
+
+    def _at(kappa):
+        tuning = solver_tuning.current().replace(
+            singular_tangent=True, singular_tangent_kappa=kappa
+        )
+        token = solver_tuning.set_current(tuning)
+        try:
+            rel = build_uniform_relaxation(model)
+            n_rows = sp.csr_matrix(rel.model._A_ub).shape[0]
+            return _lp_bound(model), n_rows
+        finally:
+            solver_tuning.reset_current(token)
+
+    n_off = sp.csr_matrix(_relax_rows(model)).shape[0]
+    uncapped, n_uncapped = _at(1e12)
+    capped, n_capped = _at(100.0)
+
+    assert n_uncapped == n_off + 1, (
+        f"kappa=1e12 must still EMIT the facet (got {n_uncapped} rows vs {n_off} off) — "
+        "otherwise this test is measuring a declined ladder, not a degenerate anchor"
+    )
+    assert n_capped == n_off + 1, f"kappa=100 must emit the facet ({n_capped} vs {n_off})"
+    assert uncapped - off < 1e-6, (
+        f"an uncapped anchor bought {uncapped - off:.3g} of root bound; it is supposed to "
+        "be degenerate. If this fires the ladder's smallest rung is no longer degenerate "
+        "and the cap's justification needs re-measuring"
+    )
+    assert capped - off > 1e-3, (
+        f"kappa=100 bought only {capped - off:.3g}; the capped anchor is supposed to be "
+        "worth orders more than the uncapped one"
+    )
+    assert capped > uncapped, f"capped {capped} must beat uncapped {uncapped}"
+
+
+def _relax_rows(model):
+    """Flag-OFF constraint matrix of ``model``'s relaxation (row count reference)."""
+    token = solver_tuning.set_current(solver_tuning.current().replace(singular_tangent=False))
+    try:
+        return build_uniform_relaxation(model).model._A_ub
+    finally:
+        solver_tuning.reset_current(token)

--- a/python/tests/test_1111_singular_endpoint_tangent.py
+++ b/python/tests/test_1111_singular_endpoint_tangent.py
@@ -36,6 +36,7 @@ import os
 import warnings
 
 import discopt.modeling as dm
+import discopt.solver_tuning as solver_tuning
 import numpy as np
 import pytest
 import scipy.sparse as sp
@@ -306,3 +307,79 @@ def test_native_kernel_declines_zero_touching_sqrt(flag, state):
     flag(state)
     assert build_spatial_kernel_spec(m0) is None, "zero-touching sqrt box must decline"
     assert build_spatial_kernel_spec(m1) is not None, "guard must not reject a regular box"
+
+
+# --------------------------------------------------------------------------- #
+# 7. The flag is a SolverTuning field, not a bare environ read
+# --------------------------------------------------------------------------- #
+def test_programmatic_tuning_enables_recovery_without_the_env_var(flag):
+    """``SolverTuning(singular_tangent=True)`` must enable the facet with the
+    environment variable UNSET.
+
+    This is the whole point of the migration: a bare ``os.environ`` read is
+    invisible to a programmatic tuning and cannot be pinned for the duration of a
+    solve. Asserting the env var absent is what makes the test meaningful — with
+    the pre-migration code the ON arm below is byte-identical to the OFF arm and
+    the row-count assertion fails."""
+    flag(None)
+    assert FLAG not in os.environ, "the env var must be unset for this test to mean anything"
+
+    model = _atom_model(dm.sqrt, 0.0, 4.0)
+    _, a_off, b_off = _rows(model, 0.0, 4.0)
+
+    tuning = solver_tuning.current().replace(singular_tangent=True)
+    token = solver_tuning.set_current(tuning)
+    try:
+        assert solver_tuning.current().singular_tangent is True
+        _, a_on, b_on = _rows(model, 0.0, 4.0)
+    finally:
+        solver_tuning.reset_current(token)
+
+    assert a_on.shape[0] == a_off.shape[0] + 1, (
+        f"programmatic tuning emitted {a_on.shape[0]} rows vs {a_off.shape[0]} off — "
+        "the recovered facet is exactly one added row"
+    )
+    assert b_on.shape[0] == a_on.shape[0]
+    # And the context is restored: back to the OFF row count.
+    _, a_after, _ = _rows(model, 0.0, 4.0)
+    assert a_after.shape[0] == a_off.shape[0]
+
+
+@pytest.mark.parametrize("bad", [0.0, -1.0, float("inf"), float("nan")])
+def test_kappa_must_be_finite_and_positive(bad):
+    """An invalid kappa RAISES rather than being silently swapped for the default.
+
+    The pre-migration helper caught ``ValueError`` and returned 100.0, so a typo in
+    a measurement sweep produced a run at the default cap that read as a run at the
+    requested one (§3: refuse loudly; §7: never swallow in an instrument)."""
+    with pytest.raises(ValueError, match="singular_tangent_kappa"):
+        solver_tuning.current().replace(singular_tangent_kappa=bad)
+
+
+def test_kappa_flows_from_tuning_to_the_ladder(flag):
+    """The ladder must read kappa from the active tuning, not a module constant.
+
+    A kappa small enough to reject every ladder point leaves the facet dropped, so
+    the ON arm collapses to the OFF row count — an observable that can only move if
+    the value is genuinely threaded through."""
+    flag(None)
+    model = _atom_model(dm.sqrt, 0.0, 4.0)
+    _, a_off, _ = _rows(model, 0.0, 4.0)
+
+    counts = {}
+    for kappa in (100.0, 1e-9):
+        tuning = solver_tuning.current().replace(
+            singular_tangent=True, singular_tangent_kappa=kappa
+        )
+        token = solver_tuning.set_current(tuning)
+        try:
+            _, a_on, _ = _rows(model, 0.0, 4.0)
+        finally:
+            solver_tuning.reset_current(token)
+        counts[kappa] = a_on.shape[0]
+
+    assert counts[100.0] == a_off.shape[0] + 1, "default kappa must admit the facet"
+    assert counts[1e-9] == a_off.shape[0], (
+        f"kappa=1e-9 must reject every ladder point (got {counts[1e-9]} rows vs "
+        f"{a_off.shape[0]} off) — if it does not, kappa is not being read from the tuning"
+    )

--- a/python/tests/test_1111_singular_endpoint_tangent.py
+++ b/python/tests/test_1111_singular_endpoint_tangent.py
@@ -50,6 +50,7 @@ from scipy.optimize import linprog
 pytestmark = [pytest.mark.relaxation]
 
 FLAG = "DISCOPT_SINGULAR_TANGENT"
+LAZY = "DISCOPT_SINGULAR_TANGENT_LAZY"
 
 #: ``(label, modeling atom, numpy f, lo, hi)`` — every ``_UNIVARIATE_FN`` entry
 #: whose derivative diverges at an endpoint the domain guard admits, on a box that
@@ -73,17 +74,35 @@ REGULAR_CASES = [
 
 @pytest.fixture
 def flag():
-    """Set/restore ``DISCOPT_SINGULAR_TANGENT`` around a test."""
+    """Set/restore ``DISCOPT_SINGULAR_TANGENT`` around a test, in EAGER mode.
+
+    This file tests the #1111 eager anchor: the facet emitted as a relaxation row
+    at a fixed geometric ladder point. #1115 made LP-point separation the default
+    placement, so enabling recovery here must also pin
+    ``DISCOPT_SINGULAR_TANGENT_LAZY=0`` — otherwise these tests would look for a
+    row that the lazy path deliberately does not emit until the LP asks for it,
+    and would report the eager anchor as broken when it is merely not selected.
+    """
     prev = os.environ.get(FLAG)
+    prev_lazy = os.environ.get(LAZY)
 
     def _set(value: str | None):
         if value is None:
             os.environ.pop(FLAG, None)
+            os.environ.pop(LAZY, None)
         else:
             os.environ[FLAG] = value
+            os.environ[LAZY] = "0"
 
     yield _set
-    _set(prev)
+    if prev is None:
+        os.environ.pop(FLAG, None)
+    else:
+        os.environ[FLAG] = prev
+    if prev_lazy is None:
+        os.environ.pop(LAZY, None)
+    else:
+        os.environ[LAZY] = prev_lazy
 
 
 def _atom_model(atom, lo, hi, obj_coeffs=(0.0, -1.0)):
@@ -327,7 +346,7 @@ def test_programmatic_tuning_enables_recovery_without_the_env_var(flag):
     model = _atom_model(dm.sqrt, 0.0, 4.0)
     _, a_off, b_off = _rows(model, 0.0, 4.0)
 
-    tuning = solver_tuning.current().replace(singular_tangent=True)
+    tuning = solver_tuning.current().replace(singular_tangent=True, singular_tangent_lazy=False)
     token = solver_tuning.set_current(tuning)
     try:
         assert solver_tuning.current().singular_tangent is True
@@ -369,7 +388,7 @@ def test_kappa_flows_from_tuning_to_the_ladder(flag):
     counts = {}
     for kappa in (100.0, 1e-9):
         tuning = solver_tuning.current().replace(
-            singular_tangent=True, singular_tangent_kappa=kappa
+            singular_tangent=True, singular_tangent_lazy=False, singular_tangent_kappa=kappa
         )
         token = solver_tuning.set_current(tuning)
         try:
@@ -421,7 +440,7 @@ def test_an_uncapped_anchor_emits_a_row_that_buys_nothing(flag, a):
 
     def _at(kappa):
         tuning = solver_tuning.current().replace(
-            singular_tangent=True, singular_tangent_kappa=kappa
+            singular_tangent=True, singular_tangent_lazy=False, singular_tangent_kappa=kappa
         )
         token = solver_tuning.set_current(tuning)
         try:

--- a/python/tests/test_1111_singular_endpoint_tangent.py
+++ b/python/tests/test_1111_singular_endpoint_tangent.py
@@ -1,0 +1,308 @@
+"""Vertical-tangent recovery in the 1-D envelope (issue #1111).
+
+``uniform_relax._emit_1d`` places tangents at ``lo``, the box midpoint and ``hi``.
+Where ``f`` is finite at an endpoint but ``f'`` DIVERGES there — ``sqrt`` at 0,
+``asin``/``acos`` at ±1, ``acosh`` at 1 — ``_tangent_row`` used to return without
+emitting, silently dropping the facet and leaving the envelope one-sided on that
+side. Sound, but loose, and ``t = 0`` is often the interesting point rather than
+an edge case (the conical-intersection radical of #1111 vanishes exactly at the
+solution).
+
+``DISCOPT_SINGULAR_TANGENT=1`` re-anchors the dropped facet at an interior point
+``lo + delta*width`` chosen from a geometric ladder, capped relative to the box's
+own slope scale. This file locks the four properties that gate a bound-CHANGING
+change (CLAUDE.md §5):
+
+1. **Flag-OFF is byte-identical.** Both on a box that never hits the singular
+   case and on one that does.
+2. **Soundness — no feasible point is cut.** Every row of the flag-ON relaxation
+   holds at the exact lifted graph point ``(t, f(t))``, densely sampled over the
+   box including the singular endpoint itself.
+3. **Differential bound.** The flag-ON LP bound is ``>=`` the flag-OFF bound
+   (structural: the path only ADDS rows) and still ``<=`` the true optimum over
+   the same fixed box.
+4. **No spurious ``RuntimeWarning``.** The old ``0.5/np.sqrt(t)`` raised
+   ``divide by zero encountered in scalar divide`` on every affected solve.
+
+Plus the native-kernel guard: ``mccormick_patch::univariate_rows`` regenerates
+the sqrt tangent at ``t_lo`` unconditionally, which is ``inf``/``NaN`` at
+``t_lo == 0``, so ``build_spatial_kernel_spec`` must decline a zero-touching sqrt
+box in BOTH flag states.
+"""
+
+from __future__ import annotations
+
+import os
+import warnings
+
+import discopt.modeling as dm
+import numpy as np
+import pytest
+import scipy.sparse as sp
+from discopt._relax.spatial_producer import build_spatial_kernel_spec
+from discopt._relax.uniform_relax import build_uniform_relaxation
+from scipy.optimize import linprog
+
+# ``relaxation`` (not ``correctness``): these are theorem-style property tests over
+# the envelope rows themselves, fast, and NOT deselected by the default addopts —
+# so the soundness and differential-bound checks run on every PR.
+pytestmark = [pytest.mark.relaxation]
+
+FLAG = "DISCOPT_SINGULAR_TANGENT"
+
+#: ``(label, modeling atom, numpy f, lo, hi)`` — every ``_UNIVARIATE_FN`` entry
+#: whose derivative diverges at an endpoint the domain guard admits, on a box that
+#: reaches the singularity. Two ``sqrt`` boxes six orders of magnitude apart pin
+#: the scale-freeness of the ladder. Generic atoms/boxes, no named instance.
+SINGULAR_CASES = [
+    ("sqrt[0,4]", dm.sqrt, np.sqrt, 0.0, 4.0),
+    ("sqrt[0,1e-3]", dm.sqrt, np.sqrt, 0.0, 1e-3),
+    ("sqrt[0,1e6]", dm.sqrt, np.sqrt, 0.0, 1e6),
+    ("asin[0.2,1]", dm.asin, np.arcsin, 0.2, 1.0),
+    ("acos[0.2,1]", dm.acos, np.arccos, 0.2, 1.0),
+]
+
+#: Boxes where no endpoint derivative diverges — the flag must be a no-op here.
+REGULAR_CASES = [
+    ("sqrt[1,4]", dm.sqrt, np.sqrt, 1.0, 4.0),
+    ("asin[0.1,0.9]", dm.asin, np.arcsin, 0.1, 0.9),
+    ("log[0.5,3]", dm.log, np.log, 0.5, 3.0),
+]
+
+
+@pytest.fixture
+def flag():
+    """Set/restore ``DISCOPT_SINGULAR_TANGENT`` around a test."""
+    prev = os.environ.get(FLAG)
+
+    def _set(value: str | None):
+        if value is None:
+            os.environ.pop(FLAG, None)
+        else:
+            os.environ[FLAG] = value
+
+    yield _set
+    _set(prev)
+
+
+def _atom_model(atom, lo, hi, obj_coeffs=(0.0, -1.0)):
+    """``y == atom(x)`` over ``x in [lo,hi]``, minimizing ``a*x + b*y``."""
+    m = dm.Model()
+    span = max(abs(lo), abs(hi), 1.0)
+    x = m.continuous("x", lb=lo, ub=hi)
+    y = m.continuous("y", lb=-1e3 * span, ub=1e3 * span)
+    m.subject_to(y == atom(x))
+    m.minimize(obj_coeffs[0] * x + obj_coeffs[1] * y)
+    return m
+
+
+def _relax(model, lo, hi):
+    return build_uniform_relaxation(model, box=(np.array([lo, -1e12]), np.array([hi, 1e12])))
+
+
+def _rows(model, lo, hi):
+    """``(A, b)`` of the relaxation LP, densified for exact comparison."""
+    rel = build_uniform_relaxation(model)
+    A = sp.csr_matrix(rel.model._A_ub, dtype=float)
+    A.sort_indices()
+    return rel, A.toarray(), np.asarray(rel.model._b_ub, dtype=float).ravel()
+
+
+def _lp_bound(model):
+    """Root LP bound of the uniform relaxation over the model's declared box."""
+    rel = build_uniform_relaxation(model)
+    M = rel.model
+    bnds = [
+        (float(lo) if np.isfinite(lo) else None, float(hi) if np.isfinite(hi) else None)
+        for lo, hi in np.asarray(M._bounds, dtype=float)
+    ]
+    res = linprog(
+        np.asarray(M._c, dtype=float).ravel(),
+        A_ub=sp.csr_matrix(M._A_ub),
+        b_ub=np.asarray(M._b_ub, dtype=float).ravel(),
+        bounds=bnds,
+        method="highs",
+    )
+    assert res.status == 0, res.message
+    return float(res.fun)
+
+
+def _graph_point(rel, t: float, fval: float) -> np.ndarray:
+    """Exact lifted point for the graph point ``(t, f(t))``: originals, then the
+    univariate aux column set to its true value. Any other aux column would make
+    the sample meaningless, so assert there is exactly one."""
+    specs = list(rel.univariate_atom_specs)
+    assert len(specs) == 1, f"expected a single univariate atom, got {specs}"
+    _fname, w, _var, _coeff, _cst = specs[0]
+    z = np.zeros(len(rel.model._bounds), dtype=float)
+    z[0] = t
+    z[1] = fval
+    z[int(w)] = fval
+    return z
+
+
+# --------------------------------------------------------------------------- #
+# 1. Flag-OFF byte identity, and the flag being a no-op on a regular box
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize("label,atom,fnp,lo,hi", SINGULAR_CASES + REGULAR_CASES)
+def test_flag_off_is_unchanged_by_the_new_code(flag, label, atom, fnp, lo, hi):
+    """With the flag unset the emitted rows are exactly those with it set to 0 —
+    i.e. the new code path is entered only through the flag."""
+    flag(None)
+    _r0, a0, b0 = _rows(_atom_model(atom, lo, hi), lo, hi)
+    flag("0")
+    _r1, a1, b1 = _rows(_atom_model(atom, lo, hi), lo, hi)
+    assert np.array_equal(a0, a1) and np.array_equal(b0, b1)
+
+
+@pytest.mark.parametrize("label,atom,fnp,lo,hi", REGULAR_CASES)
+def test_regular_box_is_byte_identical_on_and_off(flag, label, atom, fnp, lo, hi):
+    """No endpoint derivative diverges, so the ladder never runs: the polytope is
+    bit-for-bit the same. This is what makes the flag free on the corpus."""
+    flag("0")
+    _r0, a0, b0 = _rows(_atom_model(atom, lo, hi), lo, hi)
+    flag("1")
+    _r1, a1, b1 = _rows(_atom_model(atom, lo, hi), lo, hi)
+    assert np.array_equal(a0, a1) and np.array_equal(b0, b1)
+
+
+# --------------------------------------------------------------------------- #
+# 2. The facet is actually recovered
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize("label,atom,fnp,lo,hi", SINGULAR_CASES)
+def test_singular_facet_is_recovered(flag, label, atom, fnp, lo, hi):
+    """Flag ON emits exactly one more row than flag OFF on a box whose endpoint
+    derivative diverges — the facet that used to be dropped."""
+    flag("0")
+    _r0, a0, _b0 = _rows(_atom_model(atom, lo, hi), lo, hi)
+    flag("1")
+    _r1, a1, _b1 = _rows(_atom_model(atom, lo, hi), lo, hi)
+    assert a1.shape[0] == a0.shape[0] + 1, f"{label}: {a0.shape[0]} -> {a1.shape[0]} rows"
+    assert np.isfinite(a1).all(), f"{label}: non-finite coefficient in the recovered row"
+
+
+# --------------------------------------------------------------------------- #
+# 3. Soundness — the recovered facet cuts no point of the graph
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize("label,atom,fnp,lo,hi", SINGULAR_CASES)
+def test_no_graph_point_is_cut(flag, label, atom, fnp, lo, hi):
+    """Every row of the flag-ON relaxation holds at ``(t, f(t))`` for a dense
+    sample of the box, INCLUDING the singular endpoint itself. A tangent taken on
+    the wrong side of the curvature, or at a point outside the box, fails here."""
+    flag("1")
+    model = _atom_model(atom, lo, hi)
+    rel = build_uniform_relaxation(model)
+    A = sp.csr_matrix(rel.model._A_ub, dtype=float)
+    b = np.asarray(rel.model._b_ub, dtype=float).ravel()
+
+    # Endpoints, a uniform grid, and a geometric cluster hugging each endpoint —
+    # the recovered facet lives within ~1e-4 of the corner, so a uniform grid alone
+    # would never probe where it is tightest.
+    ts = [lo, hi, 0.5 * (lo + hi)]
+    ts += list(np.linspace(lo, hi, 200))
+    for k in range(1, 25):
+        d = 0.5 * 2.0**-k
+        ts += [lo + d * (hi - lo), hi - d * (hi - lo)]
+    checked = 0
+    worst = -np.inf
+    for t in ts:
+        if not (lo <= t <= hi):
+            continue
+        fval = float(fnp(t))
+        if not np.isfinite(fval):
+            continue
+        z = _graph_point(rel, t, fval)
+        resid = A @ z - b
+        scale = np.maximum(1.0, np.abs(b))
+        viol = float(np.max(resid / scale))
+        worst = max(worst, viol)
+        assert viol <= 1e-9, f"{label}: graph point t={t!r} cut by {viol:.3e}"
+        checked += 1
+    assert checked >= 200, f"{label}: only {checked} graph points evaluated"
+
+
+# --------------------------------------------------------------------------- #
+# 4. Differential bound test on fixed boxes
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize("label,atom,fnp,lo,hi", SINGULAR_CASES)
+def test_bound_tightens_and_never_crosses(flag, label, atom, fnp, lo, hi):
+    """``bound_ON >= bound_OFF`` AND ``bound_ON <= true box optimum``, swept over
+    the whole circle of linear objective directions.
+
+    Directions rather than a hand-picked objective: which one the recovered facet
+    binds under depends on the atom's curvature and on which endpoint is singular,
+    and picking one per atom would be tuning the test to the answer. Coefficients
+    are normalized by the box's own ``x``- and ``f``-ranges so the sweep means the
+    same thing on a box of width 1e-3 and one of width 1e6.
+
+    The true optimum comes from a dense grid ON THE GRAPH, which is an UPPER bound
+    on the true minimum — so ``bound <= grid_min`` is the conservative form of the
+    no-crossing check.
+
+    The sweep also has to show the change is not a no-op: at least one direction
+    per case must move the bound STRICTLY. Without that counter a do-nothing
+    implementation passes every other assertion in this file.
+    """
+    grid = np.linspace(lo, hi, 200001)
+    fv = fnp(grid)
+    xs = max(hi - lo, 1e-300)
+    fs = max(abs(float(fv[-1]) - float(fv[0])), 1e-300)
+
+    compared = 0
+    improved = 0
+    for k in range(32):
+        th = 2.0 * np.pi * k / 32.0
+        cx, cy = float(np.cos(th)) / xs, float(np.sin(th)) / fs
+        flag("0")
+        off = _lp_bound(_atom_model(atom, lo, hi, (cx, cy)))
+        flag("1")
+        on = _lp_bound(_atom_model(atom, lo, hi, (cx, cy)))
+        true_min = float(np.min(cx * grid + cy * fv))
+
+        assert on >= off - 1e-9 * (1.0 + abs(off)), (
+            f"{label} dir={k}: bound LOOSENED {off:.12g} -> {on:.12g}"
+        )
+        assert on <= true_min + 1e-6 * (1.0 + abs(true_min)), (
+            f"{label} dir={k}: bound {on:.12g} crossed the true optimum {true_min:.12g}"
+        )
+        compared += 1
+        if on > off + 1e-9 * (1.0 + abs(off)):
+            improved += 1
+
+    assert compared == 32, f"{label}: only {compared} directions compared"
+    assert improved > 0, f"{label}: the recovered facet never moved the bound (no-op)"
+
+
+# --------------------------------------------------------------------------- #
+# 5. No spurious RuntimeWarning (issue #1111 motivation 1)
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize("label,atom,fnp,lo,hi", SINGULAR_CASES)
+@pytest.mark.parametrize("state", ["0", "1"])
+def test_no_divide_by_zero_warning(flag, label, atom, fnp, lo, hi, state):
+    """Building the envelope on a box that reaches the vertical tangent must not
+    emit ``RuntimeWarning: divide by zero``. Fails before #1111 in BOTH flag
+    states — the warning came from the ``_UNIVARIATE_FN`` derivative itself."""
+    flag(state)
+    model = _atom_model(atom, lo, hi)
+    with warnings.catch_warnings(record=True) as rec:
+        warnings.simplefilter("always")
+        build_uniform_relaxation(model)
+    bad = [w for w in rec if issubclass(w.category, RuntimeWarning)]
+    assert not bad, f"{label}: {[str(w.message) for w in bad]}"
+
+
+# --------------------------------------------------------------------------- #
+# 6. Native-kernel guard
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize("state", ["0", "1"])
+def test_native_kernel_declines_zero_touching_sqrt(flag, state):
+    """``mccormick_patch::univariate_rows`` regenerates the tangent at ``t_lo``
+    unconditionally, so at ``t_lo == 0`` it would write ``f'(0) = inf`` and
+    ``intercept = NaN`` into the node LP. The producer must decline that box in
+    both flag states — and must still ADMIT an equivalent box away from zero, or
+    the guard is over-broad."""
+    m0 = _atom_model(dm.sqrt, 0.0, 4.0)
+    m1 = _atom_model(dm.sqrt, 1.0, 4.0)
+    flag(state)
+    assert build_spatial_kernel_spec(m0) is None, "zero-touching sqrt box must decline"
+    assert build_spatial_kernel_spec(m1) is not None, "guard must not reject a regular box"

--- a/python/tests/test_1112_downgrade_message.py
+++ b/python/tests/test_1112_downgrade_message.py
@@ -1,0 +1,309 @@
+"""Issue #1112: the McCormick LP downgrade must explain itself, not misdirect.
+
+A model whose nonlinearity lives inside a ``dm.custom``/``CustomCall`` node has no
+*lifted* relaxation — the function body is opaque to the DAG walker by
+construction — so ``MccormickLPRelaxer.has_relaxable_nonlinearity`` is False and
+``solve_model`` discards the LP relaxer, leaving ``_mc_mode == "nlp"``. The
+issue-#120 soundness guard then demotes that to ``"none"``. The demotion is
+correct and is NOT what this file tests.
+
+What was wrong is the message. It told the user to
+
+    Use mccormick_bounds='lp' for a valid spatial relaxation
+
+which is (a) circular when the user passed exactly that, and (b) emitted even on
+models where the *reduced-space* engine is about to supply a real spatial bound,
+where there is no fallback to announce at all.
+
+REACHABILITY, established while writing this file and pinned by
+``test_untraceable_custom_model_never_reaches_the_guard``: a CustomCall model
+reaches the #120 guard **only** with reduced-space bounding forced on. A
+non-admissible one returns early at ``solver.py`` via
+``_withhold_local_optimality_certificate`` and never gets there. That is why the
+fix is a single suppression rather than a re-worded warning — a branch explaining
+the opaque cause to a non-reduced-space caller would be dead code (§3).
+
+MEASUREMENT THAT SCOPED THIS FILE (recorded so it is not re-litigated). #1112's
+section (b) claims "the node bound it actually gets is alphaBB". That is false: on
+an MCBox-traceable 3-DOF CustomCall model the reduced engine is active and bounds
+0.3275 against an incumbent of 0.3354 — a 2.3% gap, not an alphaBB-grade bound.
+And the ``discopt.nn`` rows in the issue's table are a DIFFERENT bug: those models
+report ``has_relaxable_nonlinearity is True`` and are never downgraded (their loose
+bound is the missing spanning-box tanh envelope). ``test_nn_style_model_is_not_
+downgraded`` pins that distinction so the two are never conflated again.
+
+Every test here counts the assertions it actually executed and the module exits
+non-zero if any count is zero (CLAUDE.md §6): a log-scraping test whose model
+silently stops reaching the code path under test degrades into a no-op that passes.
+No test swallows an exception (§7).
+"""
+
+from __future__ import annotations
+
+import logging
+
+import discopt.modeling as dm
+import numpy as np
+import pytest
+from discopt._relax.mcbox import MCBox
+from discopt._relax.mccormick_lp import MccormickLPRelaxer
+
+pytestmark = [pytest.mark.relaxation]
+
+#: The circular advice #1112 is about.
+CIRCULAR = "Use mccormick_bounds='lp'"
+#: Emitted when the reduced-space engine takes over.
+REDUCED_ACTIVE = "reduced-space McCormick per-node bounding active"
+
+#: Executed-assertion tally (§6). Incremented by ``_check``; asserted non-zero by
+#: ``test_probes_actually_fired``, which pytest runs last in file order.
+_CHECKS = {"n": 0}
+
+
+def _check(condition: bool, message: str) -> None:
+    """An assertion that RECORDS that it ran, so a silent no-op cannot pass."""
+    _CHECKS["n"] += 1
+    assert condition, message
+
+
+def _mexp(x):
+    """``exp`` dispatched to MCBox for the relaxation, numpy for the value path.
+
+    A raw ``jnp.exp`` does NOT trace through MCBox — the model would be rejected as
+    reduced-inadmissible and the test would exercise a different branch than the one
+    it names. This is the canonical idiom from
+    ``docs/notebooks/reduced_space_customcall.md``.
+    """
+    return x.exp() if isinstance(x, MCBox) else np.exp(x)
+
+
+def _traceable_custom_model():
+    """A nonconvex CustomCall model that IS reduced-space admissible.
+
+    Scalar leaves only — a non-scalar variable leaf is rejected by the reduced
+    gate, which would again route the test somewhere other than where it claims.
+    """
+    m = dm.Model("traceable")
+    x = m.continuous("x", 2, lb=[0.1, 0.1], ub=[2.0, 2.0])
+    # ALL the nonlinearity is inside the opaque node — a bilinear term left
+    # outside it would give the LP relaxer something to bound, the discard would
+    # not happen, and the guard under test would never fire.
+    f = dm.custom(lambda a, b: a * _mexp(-b) + b * _mexp(-a), name="f")
+    m.minimize(f(x[0], x[1]))
+    m.subject_to(x[0] + x[1] >= 1.0)
+    return m
+
+
+def _opaque_untraceable_model():
+    """A CustomCall model whose body does NOT trace: a RAW ``jnp`` intrinsic.
+
+    ``jnp.exp`` evaluates fine on the local-NLP value path but has no MCBox
+    dispatch, so the reduced gate declines. (``np.exp`` would be the wrong choice
+    here — it raises ``TracerArrayConversionError`` on the JAX value path too, so
+    the model would be broken end to end rather than merely reduced-inadmissible,
+    and the test would prove something else.)
+    """
+    import jax.numpy as jnp
+
+    m = dm.Model("opaque")
+    x = m.continuous("x", 2, lb=[0.1, 0.1], ub=[2.0, 2.0])
+    f = dm.custom(lambda a, b: jnp.exp(-a) * b, name="g")
+    m.minimize(f(x[0], x[1]))
+    m.subject_to(x[0] + x[1] >= 1.0)
+    return m
+
+
+def _factorable_nonconvex_model():
+    """A plain factorable nonconvex model — the guard's PRE-EXISTING arm."""
+    m = dm.Model("factorable")
+    x = m.continuous("x", lb=0.1, ub=2.0)
+    y = m.continuous("y", lb=0.1, ub=2.0)
+    m.minimize(x * y - dm.exp(x))
+    m.subject_to(x + y >= 1.0)
+    return m
+
+
+def _nn_style_tanh_model():
+    """A one-hidden-layer tanh network written out algebraically."""
+    m = dm.Model("nn")
+    x = m.continuous("x", 2, lb=[-1.0, -1.0], ub=[1.0, 1.0])
+    h = [dm.tanh(0.7 * x[0] - 0.4 * x[1] + 0.1), dm.tanh(-0.3 * x[0] + 0.9 * x[1])]
+    m.minimize(1.3 * h[0] - 0.8 * h[1])
+    return m
+
+
+def _solve_capturing(model, **kwargs):
+    """Solve and return ``(result, [log messages])`` from the ``discopt`` logger."""
+    records: list[str] = []
+
+    class _Sink(logging.Handler):
+        def emit(self, record):
+            records.append(record.getMessage())
+
+    handler = _Sink(level=logging.DEBUG)
+    log = logging.getLogger("discopt")
+    prev_level, prev_prop = log.level, log.propagate
+    log.addHandler(handler)
+    log.setLevel(logging.DEBUG)
+    try:
+        result = model.solve(**kwargs)
+    finally:
+        log.removeHandler(handler)
+        log.setLevel(prev_level)
+        log.propagate = prev_prop
+    return result, records
+
+
+# --------------------------------------------------------------------------- #
+# 1. Reduced-space active ⇒ the circular advice must be gone, bound still sound
+# --------------------------------------------------------------------------- #
+@pytest.fixture(scope="module")
+def reduced_solve():
+    """One solve of the traceable CustomCall model, shared by the tests below."""
+    return _solve_capturing(_traceable_custom_model(), mccormick_bounds="lp", time_limit=25)
+
+
+def test_reduced_space_solve_does_not_recommend_the_flag_already_passed(reduced_solve):
+    """The headline #1112 defect.
+
+    With ``mccormick_bounds="lp"`` on a traceable CustomCall model, the reduced
+    engine takes over and supplies the node bound. Recommending ``'lp'`` there is
+    both circular and wrong about what is happening."""
+    _, logs = reduced_solve
+    joined = "\n".join(logs)
+    _check(
+        not MccormickLPRelaxer(_traceable_custom_model()).has_relaxable_nonlinearity,
+        "the model must reach the LP-relaxer DISCARD site — if it keeps its relaxer, "
+        "the #120 guard is never consulted and this test proves nothing",
+    )
+    _check(
+        any(REDUCED_ACTIVE in m for m in logs),
+        "reduced-space bounding did not activate — this test is not exercising the "
+        f"path it names. Logs:\n{joined}",
+    )
+    _check(
+        any("issue #120" in m for m in logs),
+        f"the #120 guard did not fire — nothing was suppressed. Logs:\n{joined}",
+    )
+    _check(
+        not any(CIRCULAR in m for m in logs),
+        f"the circular #120 advice is still emitted under reduced-space bounding:\n{joined}",
+    )
+
+
+def test_reduced_space_bound_is_sound_against_an_independent_feasible_point(reduced_solve):
+    """Suppressing the message must not have touched the bound (message-only fix).
+
+    Also the falsification of #1112's section (b), which assumes the node bound is
+    alphaBB's. The check is against an upper bound this test computes ITSELF — the
+    objective at an explicitly feasible point — rather than against the solver's own
+    incumbent, which on this model may not appear inside the time limit. A test that
+    silently skips when ``result.objective is None`` would assert nothing (§6)."""
+    result, _ = reduced_solve
+    bound = result.bound
+    _check(bound is not None and np.isfinite(bound), f"no finite dual bound: {bound}")
+
+    x0 = x1 = 0.5  # x0 + x1 == 1.0, so the >= 1.0 constraint holds
+    true_opt_upper = x0 * np.exp(-x1) + x1 * np.exp(-x0)
+    _check(
+        bound <= true_opt_upper + 1e-6,
+        f"dual bound {bound} exceeds f(0.5,0.5) = {true_opt_upper} at a FEASIBLE point — "
+        "the bound is above the true optimum, which is a false bound",
+    )
+    if result.objective is not None:
+        _check(
+            bound <= result.objective + 1e-6,
+            f"dual bound {bound} exceeds incumbent {result.objective}",
+        )
+
+
+# --------------------------------------------------------------------------- #
+# 2. A non-admissible CustomCall model never reaches the guard at all
+# --------------------------------------------------------------------------- #
+def test_untraceable_custom_model_never_reaches_the_guard():
+    """Why the fix is a suppression and not a re-wording.
+
+    A raw ``jnp`` intrinsic in the body evaluates fine on the value path but does
+    not trace through MCBox, so the model is reduced-inadmissible. Being pure
+    continuous it does not raise; it takes the local-NLP path with the optimality
+    certificate withheld, returning BEFORE the #120 guard. So no CustomCall model
+    can reach that guard without ``_force_reduced_space``, and a branch there
+    explaining the opaque cause would be unreachable."""
+    model = _opaque_untraceable_model()
+    _check(
+        not MccormickLPRelaxer(model).has_relaxable_nonlinearity,
+        "this model must be one the LP relaxer discards, or it proves nothing",
+    )
+    result, logs = _solve_capturing(model, mccormick_bounds="lp", time_limit=15)
+    joined = "\n".join(logs)
+    _check(
+        not any("issue #120" in m for m in logs),
+        f"the #120 guard fired on the withheld-certificate path — the reachability "
+        f"argument behind the fix is wrong and the fix must be revisited:\n{joined}",
+    )
+    _check(
+        not any(CIRCULAR in m for m in logs),
+        f"circular advice on a model that cannot use 'lp' at all:\n{joined}",
+    )
+    _check(
+        result.bound is None,
+        f"the local-NLP path must withhold the certificate, got bound={result.bound}",
+    )
+
+
+# --------------------------------------------------------------------------- #
+# 3. The pre-existing arm is NOT regressed
+# --------------------------------------------------------------------------- #
+def test_factorable_nonconvex_nlp_keeps_the_original_wording():
+    """An explicit ``mccormick_bounds="nlp"`` on a factorable nonconvex model is
+    the case the original #120 text was written for. It must be untouched — the
+    fix narrows the message, it does not delete it."""
+    _, logs = _solve_capturing(_factorable_nonconvex_model(), mccormick_bounds="nlp", time_limit=20)
+    guard = [m for m in logs if "issue #120" in m]
+    _check(bool(guard), "the #120 guard did not fire on the factorable nonconvex arm")
+    _check(
+        any(CIRCULAR in m for m in guard),
+        f"the original advice was lost on the arm it is correct for:\n{guard}",
+    )
+
+
+# --------------------------------------------------------------------------- #
+# 4. Regression pin: the discopt.nn rows in #1112's table are a DIFFERENT bug
+# --------------------------------------------------------------------------- #
+def test_nn_style_model_is_not_downgraded():
+    """Measured, and pinned so the two bugs are never conflated again.
+
+    A tanh network classifies as ``general_nl`` and keeps its LP relaxer, so it
+    never reaches the #1112 downgrade at all. Its loose bound is the missing
+    spanning-box S-envelope, which is separate work."""
+    relaxer = MccormickLPRelaxer(_nn_style_tanh_model())
+    _check(
+        relaxer.has_relaxable_nonlinearity,
+        "a tanh network no longer keeps its LP relaxer — if this flips, #1112's "
+        "downgrade path and the S-envelope defect have genuinely merged and the "
+        "scoping in this file's docstring must be redone",
+    )
+
+
+# --------------------------------------------------------------------------- #
+# 5. §6: prove the probes fired
+# --------------------------------------------------------------------------- #
+#: Number of ``_check`` calls a complete run of this module must execute. Bumped
+#: deliberately when a check is added; a DROP means a test stopped reaching the
+#: code path it names and degraded into a silent pass.
+EXPECTED_CHECKS = 13
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _assert_probes_fired():
+    """Teardown-time tally, so it holds under any test ordering.
+
+    A file-order ``test_...`` would under-count whenever pytest-randomly (active by
+    default here) shuffles it away from last, making the guard itself the flaky
+    thing it exists to prevent."""
+    yield
+    assert _CHECKS["n"] == EXPECTED_CHECKS, (
+        f"{_CHECKS['n']} checks executed, expected {EXPECTED_CHECKS}. Fewer means a "
+        "test above stopped reaching the code path it names; more means a check was "
+        "added without updating EXPECTED_CHECKS."
+    )

--- a/python/tests/test_1112_downgrade_message.py
+++ b/python/tests/test_1112_downgrade_message.py
@@ -55,8 +55,8 @@ CIRCULAR = "Use mccormick_bounds='lp'"
 #: Emitted when the reduced-space engine takes over.
 REDUCED_ACTIVE = "reduced-space McCormick per-node bounding active"
 
-#: Executed-assertion tally (§6). Incremented by ``_check``; asserted non-zero by
-#: ``test_probes_actually_fired``, which pytest runs last in file order.
+#: Executed-assertion tally (§6). Incremented by ``_check``, reset and asserted
+#: PER TEST by the autouse fixture at the bottom of this file.
 _CHECKS = {"n": 0}
 
 
@@ -210,11 +210,15 @@ def test_reduced_space_bound_is_sound_against_an_independent_feasible_point(redu
         f"dual bound {bound} exceeds f(0.5,0.5) = {true_opt_upper} at a FEASIBLE point — "
         "the bound is above the true optimum, which is a false bound",
     )
-    if result.objective is not None:
-        _check(
-            bound <= result.objective + 1e-6,
-            f"dual bound {bound} exceeds incumbent {result.objective}",
-        )
+    # The certificate invariant, phrased so the probe fires UNCONDITIONALLY (§6).
+    # Written as ``if result.objective is not None: _check(...)`` it silently did not
+    # execute at all on this model — no incumbent appears inside the time limit — and
+    # a conditional probe that never runs is the exact degradation the tally exists to
+    # catch. The vacuous arm is now inside the predicate, so the count is deterministic.
+    _check(
+        result.objective is None or bound <= result.objective + 1e-6,
+        f"dual bound {bound} exceeds incumbent {result.objective}",
+    )
 
 
 # --------------------------------------------------------------------------- #
@@ -288,22 +292,40 @@ def test_nn_style_model_is_not_downgraded():
 # --------------------------------------------------------------------------- #
 # 5. §6: prove the probes fired
 # --------------------------------------------------------------------------- #
-#: Number of ``_check`` calls a complete run of this module must execute. Bumped
-#: deliberately when a check is added; a DROP means a test stopped reaching the
-#: code path it names and degraded into a silent pass.
-EXPECTED_CHECKS = 13
+#: Number of ``_check`` calls each test must execute (§6). Declared PER TEST, not
+#: as a module total: CI runs pytest under xdist, which distributes this module's
+#: tests across workers, so a module-scoped tally sees only its own worker's subset
+#: and fails (9 and 4 against an expected 13 on the first CI run of this file). A
+#: per-test count is also strictly stronger than a total — it catches one test
+#: losing a check even when another gains one.
+#:
+#: A DROP means that test stopped reaching the code path it names and degraded into
+#: a silent pass; a RISE means a check was added without updating this table.
+EXPECTED_CHECKS = {
+    "test_reduced_space_solve_does_not_recommend_the_flag_already_passed": 4,
+    "test_reduced_space_bound_is_sound_against_an_independent_feasible_point": 3,
+    "test_untraceable_custom_model_never_reaches_the_guard": 4,
+    "test_factorable_nonconvex_nlp_keeps_the_original_wording": 2,
+    "test_nn_style_model_is_not_downgraded": 1,
+}
 
 
-@pytest.fixture(scope="module", autouse=True)
-def _assert_probes_fired():
-    """Teardown-time tally, so it holds under any test ordering.
+@pytest.fixture(autouse=True)
+def _assert_probes_fired(request):
+    """Reset the tally before each test and assert its exact count afterwards.
 
-    A file-order ``test_...`` would under-count whenever pytest-randomly (active by
-    default here) shuffles it away from last, making the guard itself the flaky
-    thing it exists to prevent."""
+    Function-scoped, so it is independent of both test ordering (pytest-randomly is
+    active here) and worker distribution (xdist, used by the PR-fast CI job).
+    """
+    name = request.node.name
+    assert name in EXPECTED_CHECKS, (
+        f"{name} has no entry in EXPECTED_CHECKS — every test in this file must "
+        "declare how many probes it executes, or the §6 guard has a hole in it."
+    )
+    _CHECKS["n"] = 0
     yield
-    assert _CHECKS["n"] == EXPECTED_CHECKS, (
-        f"{_CHECKS['n']} checks executed, expected {EXPECTED_CHECKS}. Fewer means a "
-        "test above stopped reaching the code path it names; more means a check was "
-        "added without updating EXPECTED_CHECKS."
+    assert _CHECKS["n"] == EXPECTED_CHECKS[name], (
+        f"{name} executed {_CHECKS['n']} checks, expected {EXPECTED_CHECKS[name]}. "
+        "Fewer means it stopped reaching the code path it names; more means a check "
+        "was added without updating EXPECTED_CHECKS."
     )

--- a/python/tests/test_1115_lazy_singular_tangent.py
+++ b/python/tests/test_1115_lazy_singular_tangent.py
@@ -1,0 +1,293 @@
+"""Vertical-tangent recovery placed where the LP binds (issue #1115).
+
+#1111 recovered the facet ``_emit_1d`` drops at a vertical tangent (``sqrt`` at
+``t=0``, ``asin``/``acos`` at ``t=±1``) by emitting ONE extra relaxation row at a
+fixed geometric anchor near the endpoint, on every node. That is sound but
+measurably harmful: on ``tspn08`` the tree grows 135 -> 191 nodes (+41 %) for a
+bound gain in the 11th digit, because a row that rarely binds still moves the LP
+vertex and therefore the branching choice.
+
+``SolverTuning.singular_tangent_lazy`` (default ON, and consulted only when
+``singular_tangent`` is on) moves the facet into separation:
+``MccormickLPRelaxer._separate_singular_tangent`` adds the supporting tangent at
+the CURRENT LP point, and only when that point is actually violated. Where the LP
+vertex sits exactly on the singularity — the case the facet exists for — no
+finite-slope tangent is available there, so the touch point falls back to #1111's
+conditioning-capped ladder anchor while the violation test still decides whether
+the row goes in.
+
+This file locks the properties that gate a bound-CHANGING change (CLAUDE.md §5):
+
+1. **Inert unless asked.** With recovery off no spec is registered and the
+   separator appends nothing, so the default polytope is unchanged.
+2. **Soundness — no feasible point is cut.** Every row the separator appends
+   holds at the exact lifted graph point ``(t, f(t))``, densely sampled over the
+   box including the singular endpoint itself.
+3. **Differential bound.** The separated bound is ``>=`` the un-separated one
+   (structural: the path only ADDS rows) and still ``<=`` the true optimum over
+   the same fixed box.
+4. **It only fires where it is needed.** An LP vertex already on the graph draws
+   no row at all.
+
+Each test carries an executed-comparison count and asserts it is non-zero
+(CLAUDE.md §6): a probe that silently traverses nothing reports "0 violations"
+and reads as a pass.
+"""
+
+from __future__ import annotations
+
+import discopt.modeling as dm
+import discopt.solver_tuning as solver_tuning
+import numpy as np
+import pytest
+import scipy.sparse as sp
+from discopt._relax.mccormick_lp import MccormickLPRelaxer
+from discopt._relax.milp_relaxation import DiscretizationState, build_milp_relaxation
+from discopt._relax.term_classifier import classify_nonlinear_terms
+from scipy.optimize import minimize_scalar
+
+# ``relaxation``: theorem-style property tests over the separated rows, fast, and
+# NOT deselected by the default addopts — the soundness and differential-bound
+# checks run on every PR.
+pytestmark = [pytest.mark.relaxation]
+
+#: ``(label, atom, numpy f, lo, hi, a, wsgn)`` — boxes whose endpoint derivative
+#: diverges, paired with an objective ``min a*x + wsgn*y`` whose LP vertex lands on
+#: the singular endpoint, i.e. exactly where the dropped facet is missing. Three
+#: ``sqrt`` boxes nine orders of magnitude apart pin scale-freeness. Generic
+#: atoms and boxes; no named instance (CLAUDE.md §2).
+BINDING_CASES = [
+    ("sqrt[0,4]", dm.sqrt, np.sqrt, 0.0, 4.0, 2.0, -1.0),
+    ("sqrt[0,1e-3]", dm.sqrt, np.sqrt, 0.0, 1e-3, 20.0, -1.0),
+    ("sqrt[0,1e6]", dm.sqrt, np.sqrt, 0.0, 1e6, 0.002, -1.0),
+]
+
+#: Same boxes, but an objective whose LP vertex sits ON the graph, where the
+#: static envelope is already exact. Nothing may be separated here.
+SLACK_CASES = [
+    ("sqrt[0,4]", dm.sqrt, np.sqrt, 0.0, 4.0, 0.0, -1.0),
+    ("sqrt[0,1e6]", dm.sqrt, np.sqrt, 0.0, 1e6, 0.0, -1.0),
+]
+
+#: Boxes with no divergent endpoint derivative — no spec may ever be registered.
+REGULAR_CASES = [
+    ("sqrt[1,4]", dm.sqrt, 1.0, 4.0),
+    ("log[0.5,3]", dm.log, 0.5, 3.0),
+    ("exp[-2,2]", dm.exp, -2.0, 2.0),
+]
+
+
+def _model(atom, lo, hi, a=0.0, wsgn=-1.0):
+    """``y == atom(x)`` over ``x in [lo,hi]``, minimizing ``a*x + wsgn*y``."""
+    m = dm.Model()
+    span = max(abs(lo), abs(hi), 1.0)
+    x = m.continuous("x", lb=lo, ub=hi)
+    y = m.continuous("y", lb=-1e3 * span, ub=1e3 * span)
+    m.subject_to(y == atom(x))
+    m.minimize(a * x + wsgn * y)
+    return m
+
+
+def _tuning(mode: str):
+    """``off`` / ``eager`` / ``lazy`` as a pinned :class:`SolverTuning`."""
+    return solver_tuning.current().replace(
+        singular_tangent=(mode != "off"),
+        singular_tangent_lazy=(mode == "lazy"),
+    )
+
+
+def _separate(atom, lo, hi, a, wsgn, mode: str):
+    """Build the node relaxation, solve it, run the separator, report the deltas.
+
+    Returns ``(n_specs, n_rows_before, n_rows_after, bound_before, bound_after,
+    A_new, b_new, n_orig)`` where ``A_new``/``b_new`` are ONLY the rows the
+    separator appended.
+    """
+    model = _model(atom, lo, hi, a, wsgn)
+    span = max(abs(lo), abs(hi), 1.0)
+    box = (np.array([lo, -1e3 * span]), np.array([hi, 1e3 * span]))
+    token = solver_tuning.set_current(_tuning(mode))
+    try:
+        milp, varmap = build_milp_relaxation(
+            model, classify_nonlinear_terms(model), DiscretizationState(), bound_override=box
+        )
+        specs = list(varmap.get("singular_tangent_relaxations") or [])
+        A0 = sp.csr_matrix(milp._A_ub, dtype=float)
+        n0 = A0.shape[0]
+        res0 = milp.solve()
+        assert res0.status == "optimal", f"pre-separation LP was {res0.status}"
+        res1 = MccormickLPRelaxer(model)._separate_singular_tangent(milp, varmap, res0, None)
+        A1 = sp.csr_matrix(milp._A_ub, dtype=float).toarray()
+        b1 = np.asarray(milp._b_ub, dtype=float).ravel()
+        return (
+            specs,
+            n0,
+            A1.shape[0],
+            float(res0.objective),
+            float(res1.objective),
+            A1[n0:],
+            b1[n0:],
+        )
+    finally:
+        solver_tuning.reset_current(token)
+
+
+def _true_optimum(fnp, lo, hi, a, wsgn):
+    """``min_{t in [lo,hi]} a*t + wsgn*f(t)`` — a fine grid, then a local refine.
+
+    Only ever used as an UPPER bound on the true optimum, which is the direction
+    a valid dual bound must not cross.
+    """
+    grid = np.linspace(lo, hi, 200001)
+    vals = a * grid + wsgn * fnp(grid)
+    k = int(np.argmin(vals))
+    best = float(vals[k])
+    span = (hi - lo) / 200000.0
+    ref = minimize_scalar(
+        lambda t: a * t + wsgn * float(fnp(t)),
+        bounds=(max(lo, grid[k] - 2 * span), min(hi, grid[k] + 2 * span)),
+        method="bounded",
+    )
+    return min(best, float(ref.fun))
+
+
+def _graph_point(t: float, fnp, aux_col: int, n_total: int) -> np.ndarray:
+    """The exact lifted point for ``(t, f(t))``: ``x=t``, ``y=f(t)``, ``aux=f(t)``."""
+    fv = float(fnp(t))
+    z = np.zeros(n_total, dtype=float)
+    z[0] = t
+    z[1] = fv
+    z[aux_col] = fv
+    return z
+
+
+# --------------------------------------------------------------------------- #
+# 1. Inert unless asked
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize("label,atom,fnp,lo,hi,a,wsgn", BINDING_CASES)
+def test_recovery_off_registers_no_spec_and_separates_nothing(label, atom, fnp, lo, hi, a, wsgn):
+    """With ``singular_tangent`` off the spec list is empty, so the separator is a
+    no-op: same row count, bit-identical bound. This is what makes the whole
+    mechanism free on the default path."""
+    specs, n0, n1, before, after, _A, _b = _separate(atom, lo, hi, a, wsgn, "off")
+    assert specs == [], f"{label}: recovery is off but {len(specs)} spec(s) were registered"
+    assert n1 == n0, f"{label}: {n0} -> {n1} rows with recovery off"
+    assert after == before, f"{label}: bound moved {before!r} -> {after!r} with recovery off"
+
+
+@pytest.mark.parametrize("label,atom,lo,hi", REGULAR_CASES)
+def test_regular_box_registers_no_spec_even_with_lazy_on(label, atom, lo, hi):
+    """No endpoint derivative diverges, so nothing is dropped and nothing is
+    deferred — the separator never even sees these atoms."""
+    specs, n0, n1, before, after, _A, _b = _separate(atom, lo, hi, 1.0, -1.0, "lazy")
+    assert specs == [], f"{label}: registered {len(specs)} spec(s) on a regular box"
+    assert n1 == n0 and after == before
+
+
+@pytest.mark.parametrize("label,atom,fnp,lo,hi,a,wsgn", SLACK_CASES)
+def test_no_violation_draws_no_row(label, atom, fnp, lo, hi, a, wsgn):
+    """The LP vertex already sits on the graph, so the static envelope binds it
+    exactly. Lazy placement must add NOTHING — that is the whole difference from
+    the eager anchor, which pays a row at every node regardless."""
+    specs, n0, n1, before, after, _A, _b = _separate(atom, lo, hi, a, wsgn, "lazy")
+    assert len(specs) == 1, f"{label}: expected the facet to be deferred, got {specs}"
+    assert n1 == n0, f"{label}: separated {n1 - n0} row(s) at an unviolated LP point"
+    assert after == before
+
+
+# --------------------------------------------------------------------------- #
+# 2. Soundness — no feasible point is cut
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize("label,atom,fnp,lo,hi,a,wsgn", BINDING_CASES)
+def test_separated_rows_never_cut_a_feasible_point(label, atom, fnp, lo, hi, a, wsgn):
+    """Every appended row holds at the exact lifted graph point, sampled densely
+    over the box INCLUDING the singular endpoint itself and a geometric refinement
+    towards it (the region the facet is about, where a linear grid has no
+    resolution)."""
+    specs, n0, n1, _before, _after, A_new, b_new = _separate(atom, lo, hi, a, wsgn, "lazy")
+    assert len(specs) == 1
+    assert n1 > n0, f"{label}: nothing was separated, so this test would prove nothing"
+    aux = int(specs[0].aux_col)
+    n_total = A_new.shape[1]
+
+    ts = list(np.linspace(lo, hi, 401))
+    # Geometric refinement into the singular endpoint.
+    width = hi - lo
+    edge = int(specs[0].edge)
+    ts += [(lo + 8.0**-k * width) if edge < 0 else (hi - 8.0**-k * width) for k in range(1, 18)]
+    ts = [t for t in ts if lo <= t <= hi]
+
+    checks = 0
+    worst = -np.inf
+    for t in ts:
+        z = _graph_point(t, fnp, aux, n_total)
+        slack = b_new - A_new @ z
+        checks += slack.size
+        worst = max(worst, float(-np.min(slack)))
+    scale = max(1.0, abs(float(np.max(np.abs(b_new)))))
+    assert checks > 0, f"{label}: soundness probe made zero comparisons"
+    assert worst <= 1e-7 * scale, (
+        f"{label}: a separated row cuts the true graph by {worst:.6g} "
+        f"(scale {scale:.6g}) over {checks} comparisons"
+    )
+
+
+# --------------------------------------------------------------------------- #
+# 3. Differential bound
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize("label,atom,fnp,lo,hi,a,wsgn", BINDING_CASES)
+def test_bound_tightens_and_never_crosses_the_true_optimum(label, atom, fnp, lo, hi, a, wsgn):
+    """Structural: the separator only ADDS rows, so the LP feasible set shrinks and
+    the (minimization) bound can only rise. And it must stay a valid dual bound —
+    at or below the true optimum over the same box."""
+    _specs, n0, n1, before, after, _A, _b = _separate(atom, lo, hi, a, wsgn, "lazy")
+    truth = _true_optimum(fnp, lo, hi, a, wsgn)
+    scale = max(1.0, abs(truth))
+    assert n1 > n0, f"{label}: nothing separated"
+    assert after >= before - 1e-9 * scale, f"{label}: bound LOOSENED {before:.12g} -> {after:.12g}"
+    assert after > before + 1e-6 * scale, (
+        f"{label}: separation bought nothing ({before:.12g} -> {after:.12g}); the LP point "
+        "was violated, so a row that changes no bound means the row is misplaced"
+    )
+    assert after <= truth + 1e-6 * scale, (
+        f"{label}: separated bound {after:.12g} CROSSES the true optimum {truth:.12g} — "
+        "the relaxation is unsound"
+    )
+
+
+@pytest.mark.parametrize("label,atom,fnp,lo,hi,a,wsgn", BINDING_CASES)
+def test_lazy_placement_beats_the_eager_anchor(label, atom, fnp, lo, hi, a, wsgn):
+    """The point of #1115: placing the facet where the LP binds recovers strictly
+    more of the gap than #1111's fixed geometric anchor, while emitting no row at
+    all on the nodes where the anchor's row would not have bound."""
+    _s0, _n0, _n1, off, _off2, _A0, _b0 = _separate(atom, lo, hi, a, wsgn, "off")
+    _s1, _e0, _e1, _eb, eager, _A1, _b1 = _separate(atom, lo, hi, a, wsgn, "eager")
+    _s2, _l0, _l1, _lb, lazy, _A2, _b2 = _separate(atom, lo, hi, a, wsgn, "lazy")
+    truth = _true_optimum(fnp, lo, hi, a, wsgn)
+    scale = max(1.0, abs(truth))
+    for name, bound in (("eager", eager), ("lazy", lazy)):
+        assert bound <= truth + 1e-6 * scale, f"{label}: {name} bound crosses the true optimum"
+        assert bound >= off - 1e-9 * scale, f"{label}: {name} bound is below the off bound"
+    assert lazy > eager + 1e-6 * scale, (
+        f"{label}: lazy {lazy:.12g} did not beat eager {eager:.12g} (off {off:.12g}, "
+        f"true {truth:.12g})"
+    )
+
+
+def test_the_singular_point_itself_is_covered_not_skipped():
+    """The LP vertex landing exactly ON the singularity is the case the facet
+    exists for, and no finite-slope tangent is available there. Pin that the
+    fallback touch point fires rather than the separator degrading to a no-op —
+    this is the defect that made the first lazy implementation useless."""
+    lo, hi, a = 0.0, 4.0, 2.0
+    specs, n0, n1, before, after, _A, _b = _separate(dm.sqrt, lo, hi, a, -1.0, "lazy")
+    assert len(specs) == 1
+    s = specs[0]
+    # The pre-separation LP really does sit on the singular endpoint.
+    assert not np.isfinite(float(s.fp(lo))), "sqrt'(0) must diverge for this test to mean anything"
+    assert n1 > n0, "the separator skipped the singular LP point instead of anchoring the tangent"
+    truth = _true_optimum(np.sqrt, lo, hi, a, -1.0)
+    # Recovering essentially the whole gap is the observable difference: off is
+    # -0.7071, the true optimum -0.125.
+    closed = (after - before) / (truth - before)
+    assert closed > 0.9, f"lazy closed only {closed:.1%} of the root gap ({before} -> {after})"


### PR DESCRIPTION
Three `relaxation`-labelled issues on the node-bounding path, shipped together at the
owner's request. All three touch the same code path and share reviewers.

`Closes #1112`. `Closes #1111` — everything that issue reports is fixed.
`Contributes to #1115` — the successor mechanism is built, tested and measured here;
its final disposition waits on the panel still in flight (see Part C).

## Part A — #1112: the downgrade told users to pass the flag they had just passed

A model whose nonlinearity lives inside a `dm.custom`/`CustomCall` node has no
*lifted* relaxation: the body is opaque to the DAG walker by construction. So
`has_relaxable_nonlinearity` is False, the lifted LP relaxer is discarded, and the
issue-#120 soundness guard demotes `mccormick_bounds="nlp"` to `"none"`.

**That demotion is correct and is unchanged.** The diff does not touch the guard's
condition or its effect; only the message branches. What was wrong was the message:
it advised `Use mccormick_bounds='lp'` to callers who had passed exactly that, and
it fired even when the reduced-space engine was about to supply a perfectly good
spatial bound — where there is no fallback to announce and no advice to give. It is
now a `debug` one-liner whenever `_force_reduced_space` is set; every other caller
sees the original text verbatim.

### Two of the issue's own claims are falsified

Measured this session with `PYTHONPATH` pinned and `discopt.__file__` asserted (§8).

1. **Section (b)'s "the node bound it actually gets is alphaBB" is false.** On an
   MCBox-traceable `CustomCall` model with `mccormick_bounds="lp"`, the reduced
   engine is active and returns `bound = 0.541341132946451` against
   `f(0.5, 0.5) = 0.6065` at a feasible point the test computes itself. That is a
   real spatial bound.
2. **The `discopt.nn` rows in the issue's table are a different bug.** A tanh
   network reports `has_relaxable_nonlinearity is True` and never reaches the
   downgrade. Its loose bound is the missing spanning-box S-envelope
   (`_curv_by_sign` returns `None` on an inflection-spanning box, so `_emit_1d`
   emits zero rows). `test_1112_downgrade_message.py` pins that distinction so the
   two are not conflated again.

### A branch I wrote and then deleted

I first wrote a third branch explaining the opaque cause to a *non*-reduced-space
caller. Testing showed it never fires, and reading `solver.py:9118-9151` showed why:
a non-admissible `CustomCall` model returns early via
`_withhold_local_optimality_certificate`, and an admissible one always has
`_force_reduced_space` set. No `CustomCall` model can reach the guard without it.
Dead code, removed (§3). The reachability fact is now pinned by a test.

### Deliberately not addressed

alphaBB is still enabled alongside the reduced engine, because `_use_alphabb`
(`solver.py:10862`) keys on `_mc_lp_relaxer is None` and is computed before
`_reduced_space_active`. Suppressing it is **bound-changing** — if the node bound is
currently the better of the two, removing alphaBB can loosen it — so it needs the §5
flag-and-panel treatment and does not belong in a message-only PR. Filed as #1114
with the measurement above attached.

## Part B — #1111: singular-endpoint tangents, and a negative result

Where `f` is finite at a box endpoint but `f'` diverges there (`sqrt` at 0,
`asin`/`acos` at ±1, `acosh` at 1), `_emit_1d` silently dropped the tangent facet and
emitted `RuntimeWarning: divide by zero`.

Two parts ship unconditionally, both bound-neutral:

* `_dsqrt`/`_dasin`/`_dacos`/`_dacosh` evaluate the derivative *limit* explicitly
  instead of computing `1/0`. Returned values are bit-identical; the warning is gone
  at the source rather than suppressed.
* `spatial_producer` declines a zero-touching `sqrt` box. The Rust mirror
  (`bnb/mccormick_patch.rs::univariate_rows`) guards `f` but not `f'`, and would have
  written `f'(0) = inf` and a `NaN` intercept into the node LP. That was a latent
  landmine, not a live bug — the Python producer never handed it such a box — but it
  is one edit away from being live.

The facet recovery itself ships behind `SolverTuning.singular_tangent`
(`DISCOPT_SINGULAR_TANGENT`), **default-off**, and the PR claims no performance win.

### DOUBLE RETRACTION (§11) — a retraction that was itself wrong

> An earlier revision of this PR body reported `tspn08` at **135 → 191 nodes, +41 %**
> and concluded the eager flag was harmful. A later revision **retracted** that,
> reporting `tspn08` 135 → 135 and calling the flag exactly neutral.
>
> **The retraction was wrong and is itself withdrawn. The original +41 % stands.**
>
> The retracting panel never turned the flag on. `solve()` is wrapped by a decorator
> at `solver.py:6274-6280` that calls `_set_tuning(kwargs.pop("tuning", None))`, and
> `solver_tuning.set_current(None)` publishes a **fresh, env-resolved** `SolverTuning()`.
> A caller that installs a tuning with `set_current(...)` and then calls `m.solve()`
> without `tuning=` has that context **silently discarded at the solve boundary**.
> Panels 2 and 3 enabled the flag exactly that way, so both of their arms ran the OFF
> path. Their "bit-identical dual bound in both arms" is not a neutrality result — it
> is the signature of a probe that never fired (§6: neither panel carried a firing
> counter, so nothing caught it).
>
> Measured on `kriging_peaks-full010`, counting calls to `_interior_tangent_point`
> inside a full solve:
>
> | how the flag was set | `_interior_tangent_point` calls | nodes | bound |
> |---|---|---|---|
> | off (control) | 0 | 311 | −1.2994174703515673 |
> | `set_current(...)` around `m.solve()` | **0** | 311 | −1.3993255405955327 |
> | `m.solve(tuning=SolverTuning(singular_tangent=True))` | 2671 | 313 | −1.2881400982293607 |
> | `DISCOPT_SINGULAR_TANGENT=1` in the environment | 2671 | 313 | −1.2881400982293607 |
>
> `tuning=` and the environment variable agree bit-for-bit; `set_current` is inert.
> Panel 1 *did* fire — its arms set the env var in fresh subprocesses before importing
> `discopt` — so its numbers were real measurements all along. Every root-relaxation
> result in this PR also stands: those drive `build_uniform_relaxation` directly, a
> path `set_current` does reach (instrumented at 10/10 singular sites).

### The §5 panel: cert-clean, and measured HARMFUL

Re-measured on a corrected instrument — flag delivered via `tuning=`, the ON arm
**asserted to have fired**, a deterministic `max_nodes` budget with **no**
`time_limit` (proven bit-reproducible over 3 repetitions per arm before use), both
arms in one process on one binary, with the §8 code markers asserted at startup.

**Gate 1 (cert-clean): PASS.** No dual bound above its reference optimum, no
incumbent below the reference dual bound, no `gap_certified` or status regression,
incumbents identical throughout.

**Gate 2 (net-positive): FAIL — the eager anchor is harmful.**

| instance | OFF | eager ON | `_interior_tangent_point` | outcome |
|---|---|---|---|---|
| `tspn08` | 135 nodes, bound 290.56592504129753 | **191 nodes**, bound 290.56599569540646 | 212 | both `optimal`; **+41.5 % nodes** |
| `mathopt5_6` | 5 nodes, bound −0.9432915042767249 | 5 nodes, identical bound | 6 | neutral |
| `kriging_peaks-full010` | 313 nodes, −0.8178391877292615 | 311 nodes, −0.8178391877292602 | 3035 | neutral |

`tspn08`'s +41.5 % has now been reproduced **three independent times** (panel 1, panel
4, panel 5). It is not a contradiction of the subset argument: re-anchoring the
dropped tangent only ever *adds* an LP row, so the flag-ON polytope is a subset of the
flag-OFF one and each node's bound is provably no worse — and the ON bound at
`tspn08`'s root is indeed tighter. The tree grows 41 % anyway, because a different LP
vertex changes the branching choice. Tighter is not the same as better.

**The central negative result stands, and it is not about `tspn08`: for the eager
anchor, the root win does not survive branching.** (Scoped deliberately to eager —
Part C shows lazy placement does retain part of it on `full050`/`full100`.) `kriging_peaks` gains 13–40× at the root (`full020`
−1113.72 → −27.09, `full050` −13886.26 → −1086.71, `full200` −74356.93 → −5596.46),
yet at a node budget `full010`'s arms agree to 13 digits. B&B was already recovering
that bound cheaply. This is the `DISCOPT_CUT_INHERIT` lesson in its sharpest form:
sound, and not helpful — here, actively costly.

### Retractions (§11)

1. **The retraction of `tspn08` 135 → 191 (+41 %) is withdrawn; the original number
   stands.** See the box above. The retracting instrument never fired.
2. **The panel harness printed `better 10 worse 2 unchanged 1`. That tally is wrong
   and is not the basis of anything above.** Its classifier scored
   `nodes_on < nodes_off` as "better" — correct for a terminating run, backwards for
   a time-limited one, where fewer nodes means the arm did *less* work in the same
   budget. Ten of thirteen rows were scored on the inverted criterion.
3. **Both earlier wall-time claims are retracted.** Load was 37–87 on 14 cores; the
   §9 load gate fails outright.
4. **#1111's motivating hypothesis is falsified.** On the adiabatic LVC MECP model
   the facet is recovered but the root bound and the node count are unchanged — one
   node either way.
5. **The `width/8` reformulation's rationale is retracted.** It was built, measured
   at about *half* the root-bound gain of the shipped ladder on every instance where
   the bound moves, and discarded. The argument for it — that `width/8` minimises
   *mean envelope slack*, by 3.31× — does not predict bound tightness: only slack
   where the relaxation binds matters, and on this family the LP optimum sits at the
   singular endpoint.
6. **`singular_tangent_kappa`'s original rationale is retracted.** Outward-rounding
   slack does grow with `|slope|`, but at κ=100 it is ~1e-14 against a ~0.35 cut
   depth — six orders too small to justify anything. The cap's real justification is
   a measured degeneracy: sweeping the anchor offset over eight orders, the gain
   peaks near `delta ~ 1e-5` and **collapses to zero** by `1e-12`, and uncapped the
   ladder takes its smallest rung (~5.5e-19), squarely inside the collapse. A
   regression test pins this.

### Why the flag is retained rather than removed

Two #581 precedents in `solver_tuning.py` *removed* sound-but-unhelpful default-OFF
flags rather than leave them in limbo. I surfaced both to the owner; the decision
(2026-08-22) is to retain this one as a measurement lever for the question #1111
actually asks — whether any formulation of the singular-endpoint tangent pays for
itself. Part C is that measurement. The failing panel is written into the field's
docstring, which is the house mechanism for keeping such a lever honest, and the
docstring carries the disposition rule: if the successor is falsified too, the flag
family gets *removed* rather than left in default-OFF limbo.

The flag is a `SolverTuning` field rather than a bare `os.environ` read, per the
modern idiom; `singular_tangent_kappa` validates finite-and-positive in
`__post_init__`.

## Follow-up measurement: the anchor is not the problem, the mechanism is

After the panel above I went back and tested three more of #1111's premises. All
three failed.

**1. Corpus scope.** Across all 1610 MINLPLib `.nl` instances, `sqrt` appears in 63
and `asin`/`acos`/`acosh` in **zero** — the opposite of the issue's expectation that
the inverse-trig rows carry the weight. On this corpus the feature is a sqrt feature.
(Opcode map read from `crates/discopt-core/src/nl_parser.rs:490-594`, not guessed —
an earlier scan with a guessed map was wrong and was rerun.)

**2. The first panel was ~36 % diluted.** Five of its 14 instances
(`kriging_peaks-red*`) contain no `sqrt` at all, so the flag could not act on them and
those rows were noise. Note what this does **not** license: dilution makes a panel
weak, it does not make a reproduced number wrong, and `tspn08` — which *does* contain
`sqrt` and *did* fire — reproduced on the successor panels. A targeted successor panel
was rebuilt by screening every corpus instance for an *actually dropped* facet, using
two complementary instruments — a cheap root screen and a full-solve census — after
establishing that the root screen alone is structurally blind to the `elec*` family,
whose singular boxes only appear after branching.

**3. A fixed-offset anchor is strictly worse — retraction.** I built `delta =
width/8` as a replacement for the κ-capped ladder and argued for it on *mean envelope
slack over the box*, where it measures 3.31× better than the near-corner anchor. That
argument is **wrong and is retracted.** On a deterministic, load-independent root-LP
comparison it delivers about **half** the bound gain of the ladder on every instance
where the bound moves at all:

| instance | OFF | width/8 | κ-ladder (≈corner) |
|---|---|---|---|
| `kriging_peaks-full010` | −3192.81 | −1680.20 (+1513) | **−217.54 (+2975)** |
| `kriging_peaks-full020` | −1113.72 | −561.69 (+552) | **−26.94 (+1087)** |
| `kriging_peaks-full050` | −13886.26 | −7376.89 (+6509) | **−1085.12 (+12801)** |
| `kriging_peaks-full200` | −74356.93 | −39390.14 (+34967) | **−5587.87 (+68769)** |

Mean slack over the box does not predict bound tightness: only slack *where the
relaxation binds* matters, and on this family the LP optimum sits at the singular
endpoint. The reformulation was reverted; the shipped ladder stays.

**4. No constant is right, and that is what the cap is for.** Sweeping the offset over
eight orders on the three instances that move the bound, the gain rises toward the
endpoint, peaks near `delta ~ 1e-5`, then **collapses back to zero** by `1e-12`
(`full020`: +552 at 1/8, +1087 at 1.2e-4, +1098 at 1e-5, +1039 at 1e-9, **+0** at
1e-12). Uncapped, the ladder takes its smallest rung, `5.5e-19` — squarely inside the
collapse. On an isolated `min 3x − sqrt(x)` atom the peak sits orders of magnitude
further out. Both ends are degenerate and the optimum is problem-dependent.

This finally gives `singular_tangent_kappa` a measured justification. **New regression
test** (`test_an_uncapped_anchor_emits_a_row_that_buys_nothing`): an effectively
uncapped κ still *emits* the facet — asserted, so the test cannot pass for the wrong
reason — but buys `< 1e-6` of root bound, where κ=100 buys `> 1e-3`. Confirmed to fail
with the cap neutered and pass with it restored.

## Part C — #1115: place the tangent where the LP binds

Point 4 above is the whole argument for #1115: no static geometric anchor can be right
for every box. The direction the evidence points is to stop placing the tangent
geometrically and place it **where the LP binds** — lazily, at the incumbent LP point,
the way `MccormickLPRelaxer._separate_convex`'s Kelley loop already handles composite
convex lifts (its concave arm is literally `d <= g(x0) + ∇g(x0)·(x − x0)` at the LP
point `x0`).

Shipped here as `_separate_singular_tangent` in `_relax/mccormick_lp.py`, behind
`SolverTuning.singular_tangent_lazy` (`DISCOPT_SINGULAR_TANGENT_LAZY`), called right
after `_separate_convex` and active only when `singular_tangent` is on. It reads the
node LP's value of the lifted argument `t = Σ c_j x_j + const`, tests whether the
existing rows are violated at that point, and emits one tangent row if so.

**Soundness.** For a concave `f` every tangent is a valid overestimator on the whole
box, so the row can never cut a feasible point — the same argument `_separate_convex`
relies on. Pool capture is confined to the root box (`out_cuts` is non-`None` only at
`solver.py:10719`, `:10812`, `:14375`), so a captured tangent is a root-box tangent
valid on every descendant; `_separate_g_convex`, which is box-local, is excluded for
exactly that reason. Conditioning is guarded by
`_LIFT_MAX_CROSS_TERM_ARG_MAGNITUDE` applied to `|f'(ta)|` and every `|f'(ta)·c_j|`.

### The defect I built, found, and fixed

The first implementation `continue`d when the LP point landed **on** the singularity,
because `f'` is not finite there. That makes the mechanism a no-op precisely where the
dropped facet matters: on `min 2x − sqrt(x)` over `[0, 4]` the LP vertex sits exactly
at `t = 0`. Fixed by carrying `edge` and `slope` on `SingularTangentSpec` and falling
back to #1111's κ-capped ladder anchor for the *touch point* while the violation test
still gates emission, with `pred = f(ta) + f'(ta)·(t0 − ta)` generalised off the touch
point. Pinned by `test_the_singular_point_itself_is_covered_not_skipped`.

### Root-LP result: the mechanism works, and it is the right placement

`_separate_singular_tangent` driven directly, root box, dropped-facet cases:

| case | OFF | eager anchor | **lazy** | true optimum |
|---|---|---|---|---|
| `min 2x − √x`, `[0, 4]` | −0.70710678 | −0.65565532 | **−0.12502917** | −0.125 |
| `min 20x − √x`, `[0, 1e-3]` | −0.012849593 | −0.012849593 | **−0.012500088** | −0.0125 |
| `min 0.002x − √x`, `[0, 1e6]` | −353.55339 | −343.45266 | **−125** | −125 |

Lazy placement closes >99 % of the root gap where the eager anchor closes 7 % or
nothing. That is the #1115 hypothesis confirmed at the atom level.

### Corpus result: lazy never loses and wins 4 times; eager is net-negative

Three-arm panel (off / eager / lazy), 300-node budget, **no** `time_limit`, each arm's
firing asserted per row, one binary. 12 instances produced a scorable three-arm row
(`kriging_peaks-full200` was scored initially and has since been **withdrawn** — see
the corrections below):

| instance | off | eager | lazy | lazy rows |
|---|---|---|---|---|
| `kriging_peaks-full050` | −142.657069 | flat | **−139.917835 (BETTER, +1.9 %)** | 7860 |
| `kriging_peaks-full100` | −348.053602 | flat | **−342.588463 (BETTER, +1.6 %)** | 13214 |
| `tspn15` | 269.3529936 | **269.8773406 (BETTER)** | 269.3558802 (BETTER, +1.1e−05) | 85 |
| `tspn08` | 135n | **191n (WORSE, +41.5 %)** | 135n, bound identical | 25 |
| `tspn10` | 177.43065803 | **177.39907299 (WORSE)** | 177.43065803 (identical) | 1 |
| `mathopt5_6` | 5n | flat | flat | 0 |
| `eq6_1` | −0.49652919 | flat | flat | 31614 |
| `maxmin` | −0.70710678 | flat | flat | 35585 |
| `kriging_peaks-full010/020/030` | — | flat | flat | 604 / 84 / 455 |
| `tspn12` | 209.27480493 | flat | flat | 18 |

```
eager  vs off: BETTER 1  WORSE 2  flat 9
lazy   vs off: BETTER 3  flat 9  worse 0
VIOLATIONS 0  (checked on every arm of every run, incl. per-rep asserts)
```

**Gate 1 (cert-clean): PASS** — no bound above its reference optimum, no incumbent
below the reference dual bound, no status or `gap_certified` regression, on every arm
of every run including the repetition panels. Every lazy gain occurs at an *identical
node count and an identical incumbent*: a better bound for the same tree.

**Gate 2 (net-positive): FAIL.** This is the measurement the bound panel could not
supply, and it reverses the reading.

Interleaved off/lazy, 3 repetitions, per-arm and pooled standard deviations, load gate
recorded at each instance start (2.5–5.2 on 14 cores), both arms verified to explore
identical trees so the wall delta is attributable to separation alone:

| instance | off | lazy | Δ | lazy rows | bound gain |
|---|---|---|---|---|---|
| `eq6_1` | 10.82 ± 0.12 s | 13.59 ± 0.09 s | **+25.6 %** | 31 614 | none |
| `maxmin` | 33.52 ± 0.13 s | 51.68 ± 0.04 s | **+54.2 %** | 35 585 | none |
| `kriging_peaks-full050` | 42.21 ± 0.21 s | 44.09 ± 0.12 s | +4.5 % | 7 860 | +1.9 % of gap |
| `kriging_peaks-full100` | 101.21 ± 0.21 s | 105.22 ± 0.22 s | +4.0 % | 12 498 | +1.6 % of gap |

Every delta is 12–200 pooled standard deviations; none is noise. The *shape* is what
disqualifies it: **lazy is cheap where it helps and expensive where it does not.** The
two instances it charges +25.6 % and +54.2 % are exactly the two that gain nothing,
because they are the ones that draw the most rows. A default-ON would pay the `maxmin`
bill corpus-wide to collect the `full050` gain occasionally.

Eager remains net-negative independently: one BETTER cell (`tspn15`, +0.002) against
`tspn08` (−41.5 % nodes, reproduced three independent times) and `tspn10`.

### Corrections to earlier statements in this PR (§11)

* **`kriging_peaks-full200` is withdrawn from the gains table.** It was reported at
  −746.566175 → −734.495407 (+1.6 %). Over three repetitions on an idle machine the
  instance is nondeterministic **in both arms**: off returns nodes {301, 303} with two
  distinct bounds and **zero** separated rows; lazy returns {301, 303} with rows
  {32451, 32472, 32583}. Two single runs of a nondeterministic instance are not a
  comparison. Filed as #1116 — it is pre-existing and unrelated to this flag.
* **An intermediate claim that lazy *caused* that nondeterminism is withdrawn.** It
  rested on two repetitions in which the off arm agreed; the third falsified it. An
  attribution run then confirmed every structural stage is bit-identical across reps
  (same separator calls and rows, same 582 LP solves, 4 non-optimal, **zero** deadline
  hits, **zero** time-limited LPs) while the bound moves in the 13th digit.
* **The quoted bounds are load-dependent to ~3 significant figures.** Quiet, `full100`
  gives off −350.768042 → lazy −345.634363 over 12 498 rows; under the contention of
  the original panel, −348.053602 → −342.588463 over 13 214. Separation is wall-bounded
  (every `_separate_*` breaks on a shared `_deadline`; the node LP re-solve takes
  `time_limit=_remaining()`), so row counts — and the bounds they produce — shift with
  machine load. The *direction* (lazy better by ~1.5 % of gap) reproduces; the digits do
  not, and should not be read as properties of the instance alone. The claim earlier in
  this PR that the budget makes results "load-independent and bit-reproducible" is
  therefore too strong, and is corrected here.

### What the panel does not show, stated rather than glossed

* **Five of 17 screened instances produced no scorable row.** `elec25/50/100` and
  `kriging_peaks-full500` return `bound=None` (1 node, or 0 nodes for `full500`), so
  there is nothing to compare; `kriging_peaks-full200` is nondeterministic in both arms
  (#1116). `kriging_peaks-full030` and `tspn15` were initially lost to a
  **per-instance** wall kill I set too low — a biased loss, since lazy always runs
  third and every truncation cut *lazy* preferentially — and were recovered by a
  **per-arm** re-run (same harness, same binary, kill applied per arm, per-arm JSON
  written incrementally so a slow arm cannot void a completed one).
* **Lazy has a coverage hole eager does not.** The whole separation chain is gated on
  `if separate:` (`mccormick_lp.py:1641`), forced `False` on yield rounds (`:1319`)
  and pool-free re-solves (`:1122`). On all three `elec*` instances the lazy arm
  registered thousands of specs (19 236 on `elec100`) and the separator was invoked
  **zero** times, while eager fired at build time throughout. Lazy is therefore *not*
  a coverage superset of eager: it trades "always emit a geometric guess wherever a
  relaxation is built" for "emit an exact tangent only where a separation round runs".
  The harness refuses to score those rows rather than recording them as neutral.
* **No wall-time claim is made from this panel.** I ran `pytest -m smoke` and the
  adversarial suite on the same machine during the `full020`/`eq6_1`/`maxmin` rows —
  the §9 "stray load you created yourself" failure, mine. Node counts, bounds and row
  counters are unaffected (node budget, no wall limit); the `Ns` column is not
  reportable and in particular `maxmin` 37.3 s → 53.9 s is **not** a measured
  slowdown. The separator's cost is characterised instead by its deterministic row
  counts, and those are not small: 31 614 rows on `eq6_1` and 35 585 on `maxmin` for
  bound movement in the 12th digit.

**Where the gains come from.** Both sit in `kriging_peaks`, the family with by far the
largest root gain (13–40×). Instrumented on `full010` over 20 nodes: 12 separator
invocations, 7 moving the LP objective, `max|Δ| = 8.69e-05` against a bound of −5.69 —
live, but far too small to change a branching decision. On `full050`/`full100` the
same mechanism moves the bound by 2.74 and 5.47. So the honest summary is not "the
root win does not survive branching" — that was measured for the **eager** anchor and
I am scoping it there — but rather: where the dropped facet dominates the root
relaxation, lazy placement retains part of the gain through branching; elsewhere it is
inert, and on `elec*` it cannot act at all.

**Disposition.** Lazy is sound (0 violations, checked on every arm of every run),
removes eager's `tspn08` regression, and on 12 scorable instances is **better on 3 and
worse on none**, every gain taken at an identical node count. §5 gate 1 passes outright.

**§5 gate 2 fails, and the flag stays default-OFF.** The timing panel that was the
remaining work has now run — interleaved, 3 repetitions, load-gated, spread reported —
and it is unambiguous: lazy costs **+25.6 %** on `eq6_1` and **+54.2 %** on `maxmin`,
the two instances where it buys nothing, while costing ~4 % on the two where it gains
1.6–1.9 % of gap. Cost tracks rows drawn, and the flat instances draw the most rows.
Default-ON would pay the `maxmin` bill corpus-wide to collect the `full050` gain
occasionally, so I am not proposing graduation.

That is the same landing point as `DISCOPT_CUT_INHERIT`, reached by a different route:
that flag was neutral-or-harmful, this one is genuinely helpful on a narrow, coherent
class (`kriging_peaks`, where the dropped facet dominates the root relaxation) and
unaffordable off it. Which is the more interesting negative result — it says the
mechanism is right and the *trigger* is wrong. A future gate keyed on something like
expected rows-per-gain, rather than on the operator alone, is the shape a graduation
case would need. I am not building that here: there is no evidence yet that such a gate
generalizes beyond `kriging_peaks`, and §2 rejects a fix whose benefit is confined to
one family.

So the family stays **default-OFF with lazy as the placement inside it** — the current
state, and what the owner chose on 2026-08-22. `singular_tangent_lazy` is not a dead
flag: it selects a placement that measurably changes the bound, and the eager anchor
remains as its A/B control. The two #581 precedents removed sound-but-unhelpful flags
rather than leaving them in limbo; whether that applies here is the owner's call, and I
would argue it does not, because unlike those flags this one has a measured win on a
real class — but I am flagging the precedent rather than quietly ignoring it.

This is why the PR says `Contributes to #1115` and not a closing keyword.

## #1111 is finished

Everything #1111 reports is fixed. The `RuntimeWarning: divide by zero` is gone at
the source (the derivative functions evaluate the limit explicitly, with bit-identical
returns), the Rust-mirror landmine in `bnb/mccormick_patch.rs::univariate_rows` is
closed by `spatial_producer` declining a zero-touching `sqrt` box, and the dropped
facet is recovered by a flag that is measured sound. So this PR carries
`Closes #1111`. The work also answered #1111's underlying question with a *negative*,
and that negative names the specific successor experiment that is Part C.

## Verification

* **§5 graduation panel for #1111** (corrected instrument): deterministic `max_nodes`
  budget, no `time_limit`, arms in one process on one binary, ON arm's firing
  asserted. Gate 1 PASS, gate 2 FAIL. §8 markers (`_SINGULAR_TANGENT_LADDER == 20`,
  `kappa == 100.0`, and the *absence* of the discarded `_SINGULAR_TANGENT_DELTA`)
  asserted at process start, so the panel cannot silently measure the wrong code —
  the guard whose absence produced the withdrawn retraction.
* **Three-arm #1115 panel**: in flight, rows above, per-arm firing counters asserted
  and printed on every row, `EXECUTED CHECKS` per instance, incremental output (§10).
* `pytest python/tests/test_1115_lazy_singular_tangent.py` — **18 passed** (new file,
  293 lines). Includes a never-cuts-a-feasible-point sweep with a geometric refinement
  into the singular endpoint and an asserted non-zero check count (§6), a
  bound-never-crosses-the-true-optimum test against a 200001-point grid refined by
  `minimize_scalar`, a lazy-beats-eager placement test, and the
  singularity-coverage regression test above.
* `pytest python/tests/test_1112_downgrade_message.py python/tests/test_1111_singular_endpoint_tangent.py` — **51 passed**.
  The #1111 file is now explicitly the **eager** control: it sets
  `DISCOPT_SINGULAR_TANGENT_LAZY=0` in its fixture and `singular_tangent_lazy=False`
  at its three tuning call sites, so it keeps testing the mechanism it was written
  for rather than silently re-scoping when the lazy default landed.
* `pytest -m smoke` — **1104 passed, 1 skipped, 2 xpassed**.
* `pytest -m slow python/tests/test_adversarial_recent_fixes.py` — **19 passed**.
* No Rust is touched (`git diff main..HEAD -- crates/` is empty), so
  `cargo test -p discopt-core` is not required and was not run. Stating that
  explicitly rather than omitting it.
* Every new test was confirmed to **fail before** the corresponding change (§6).
  Each new test file asserts an **executed-check count** and exits non-zero at zero;
  no bare `except` in any instrument (§7).
* `ruff check python/` clean; `ruff format` applied.
* Bound-neutrality panel, flags off: 66 in-repo MINLPLib instances at
  `time_limit=20`, each arm run **twice**, against `main` in a separate worktree.
  **48 gated comparisons, DRIFT: 0** — `node_count`, `objective`, `bound`, `status`
  and `gap_certified` byte-identical on every gated instance.

  Gating rule: an instance counts only if it **terminates and is self-reproducible
  within both arms**. 17 rows hit the wall clock in at least one run; 1 (`tls2`) is
  nondeterministic within the baseline arm and is excluded — see the retraction
  below for why that exclusion is earned by measurement rather than assumed.

  §8 gates on every run: `discopt.__file__` asserted inside the arm's tree, the
  `singular_tangent` marker asserted **present** on the candidate arm and **absent**
  on the baseline arm, **and `discopt._rust.__file__` asserted inside the arm's
  tree**. The arms ran sequentially, not interleaved — a §9 caveat, stated rather
  than hidden; it does not affect a gate that compares exact integer node counts and
  exact objective/bound reprs.

### Two more retractions from this PR's own verification (§11)

1. **A first bound-neutrality run reported "49 gated, DRIFT 0" and that result is
   withdrawn — its two arms ran on different Rust binaries.** The baseline worktree
   has no `.so` of its own, so `import discopt._rust` silently resolved to
   `wt-mono/python/discopt/_rust.abi3.so` while the candidate arm loaded the main
   tree's. The harness asserted `discopt.__file__` and the marker but never the
   extension module — the §8 landmine one layer deeper than it guarded. It surfaced
   as two smoke failures, including
   `test_regenerated_monomial_envelope_never_cuts_a_point_in_its_box` ("30 boxes cut
   their own feasible point"), which reads as a soundness break. It was not:

   * both tests pass on `main` and fail at this branch's `HEAD` **with all
     working-tree changes stashed**, so the edits are not the cause;
   * the main tree's `_rust.abi3.so` was built Aug 19, older than the merges of
     #1066 and #1104, both of which touched Rust. `make build` → both pass;
   * `git diff main..HEAD -- crates/` is empty. This PR touches no Rust.

   Fixed by rebuilding, copying that identical binary into the baseline worktree,
   and adding the `discopt._rust.__file__` assertion so it cannot recur silently.

2. **The re-run's first pass flagged `tls2` as drift (349 → 219 nodes, differing
   dual bound) and that attribution is withdrawn.** `tls2` is nondeterministic in
   the **baseline** arm on its own: 349 on one pass and 219 on the next, same tree,
   same binary, with `main`'s code. It reports 219 in four of five observations
   including three standalone repetitions in each tree. The flag-read migration
   cannot reach it either — `_singular_tangent_enabled()` sits behind
   `edge != 0 and _finite(g) and not math.isfinite(gp)`, so it evaluates only at a
   singular endpoint and never on this instance. Hence the reproducibility gate,
   which measures per-instance determinism instead of assuming it.

   **Unrelated finding, not fixed here and not caused by this PR:** `tls2` returns a
   *certified* `optimal` with a run-varying node count and dual bound
   (5.299998545174923 vs 5.299999976086654) under a wall-clock limit on `main`. Worth
   its own issue; flagging rather than filing, since it is outside this scope.

