### PR TITLE
fix(relax,tuning): #1114 #1115 #1116 #1117 #1118 — singular-tangent defects, alphaBB gating, and reproducible dual bounds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -317,7 +317,13 @@ jobs:
           # some correctness tests validate global/claim state that xdist can
           # order-mask (the same reason python-claims-serial runs -n0). The subset
           # is ~5 min serially (287 tests locally), so determinism costs little.
+          # discopt_benchmarks/tests/test_correctness.py joins this lane: it is
+          # the repo's only run-to-run reproducibility assertion (TestDeterminism,
+          # the consumer of #1116's `deterministic=`) and it lived its whole life
+          # skipping. It resolves instances from python/tests/data/minlplib_nl/,
+          # which is in the checkout, and skips the ones that are not.
           scripts/run_memory_capped_pytest.sh pytest python/tests/ \
+            discopt_benchmarks/tests/test_correctness.py \
             -q --tb=short --timeout=120 -p no:cacheprovider \
             -m "correctness and not slow and not integration and not amp_benchmark and not requires_cyipopt and not memory_heavy" \
             --ignore=python/tests/test_amp.py \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,32 @@ The release procedure that produces these entries is documented in
 
 ### Fixed
 
+- **A `SolverTuning` installed with `set_current()` was silently discarded at the
+  `solve()` boundary** (`bug`, #1117). `solver._scoped_tuning` published the
+  `tuning=` kwarg for the call, and with the kwarg omitted — every plain
+  `m.solve()` — it published a *fresh env-resolved* `SolverTuning()` rather than
+  inheriting, so a caller who wrapped a solve in `set_current(...)` got env
+  defaults with no warning. Measured on `41abe795`, counting
+  `_interior_tangent_point` calls through a solve of the issue's `sqrt` model:
+  `solve(tuning=...)` → 6, `set_current(...)` around `solve()` → **0**. The solve
+  boundary now calls the new `solver_tuning.enter_scope()`, whose precedence is
+  explicit `tuning=` kwarg > ambient context > environment defaults; `set_current`
+  keeps its documented `None`-means-env-defaults meaning. Nested solves inherit the
+  outer scope for the same reason.
+
+  The same fix in `_scoped_tuning` alone would have been **inert on exactly the
+  large models**: `_run_with_deep_recursion` (models deeper than 700 expression
+  nodes) runs the solve on a worker thread, and a new thread starts with an *empty*
+  `contextvars` context, so the published tuning would not have reached it. It now
+  runs the callable inside `contextvars.copy_context()` — writes on the worker
+  still cannot leak back to the caller.
+
+  This is the instrument defect behind two retracted #1113 panels, where a probe
+  that never fired reported "both arms bit-identical" as a neutrality result
+  (CLAUDE.md §6). `python/tests/test_1117_tuning_scope.py` pins the precedence
+  order, the end-to-end reproducer, and the worker-thread propagation; 6 of its 7
+  tests fail before the change.
+
 - **The McCormick LP downgrade told users to pass the flag they had just passed**
   (`relaxation`, #1112). A model whose nonlinearity lives inside a
   `dm.custom`/`CustomCall` node has no *lifted* relaxation — the body is opaque to

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,18 @@ The release procedure that produces these entries is documented in
 
 ### Changed
 
+- **`discopt_benchmarks/tests/test_correctness.py` runs** (#1116, contributes to
+  #1050). All 98 of its tests skipped unconditionally on a `solve_instance` stub
+  that raised `NotImplementedError`, with the false reason "discopt not yet
+  available" — including the two in `TestDeterminism`, the repository's only
+  run-to-run reproducibility assertions and therefore the only consumer of
+  `solve(deterministic=...)`. They now solve real instances, `TestFeasibility`'s
+  two assertion-free bodies check the incumbent and its integrality, the ten
+  `TestEdgeCases` stubs are real models, and the module joins CI's
+  python-correctness lane. Instances resolve from `python/tests/data/minlplib_nl/`
+  and then `$DISCOPT_MINLPLIB_NL`; a missing one still skips, but for a true
+  reason. 99 collected, 87 passed, 12 skipped locally.
+
 - **`solve(deterministic=...)` now defaults to `False` and is no longer a dead
   parameter** (`solver`, #1116). It was documented as "Ensure deterministic
   results" and read **nowhere** on the solve path — a default that named a
@@ -22,6 +34,20 @@ The release procedure that produces these entries is documented in
   relied on the old *default* get today's behaviour unchanged.
 
 ### Fixed
+
+- **#1119 closed falsified: the singular-endpoint tangent stays default-OFF**
+  (`_relax/mccormick_lp`, #1119). #1115 left the flag off because it costs
+  +25.6 % wall on `eq6_1` and +54.2 % on `maxmin` for no bound; #1119 asked
+  whether gating on *whether the recovered facet binds* could recover that. It
+  cannot: binding is near-tautological (a row is emitted because it is violated,
+  so the next re-solve lands on it), and what separation exists runs backwards —
+  the two instances that pay bind at 1.0000 and 0.9580, the two that gain at
+  0.9173 and 0.8509. `eq6_1` has zero non-binding rows, so the proposed gate drops
+  0 of 22 874 and saves 0 %, while discarding 14.9 % of the rows on the instance
+  the feature is for. `MccormickLPRelaxer.singular_tangent_stats()` keeps the
+  instrument (verified bound-neutral: 40/40 exact `node_count`/`objective`
+  identities, instrumented vs not); the record is `docs/dev/performance-plan.md`
+  §17.
 
 - **The dual bound was a function of machine speed** (`solver`, #1116). The issue
   reported a 13th-digit drift with the node count flipping 301 ↔ 303 on

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,28 @@ The release procedure that produces these entries is documented in
 
 ### Fixed
 
+- **`singular_tangent` recovery missed fractional power atoms (`x**0.5`)**
+  (`relaxation`, #1118). `x**0.5` has exactly the vertical tangent at `t = 0` that
+  `dm.sqrt(x)` has, but `_build_power` built its derivative by bare exponentiation
+  and `p * (0.0 ** (p - 1.0))` RAISES `ZeroDivisionError` for `p < 1` — an
+  `ArithmeticError`, which `_emit_1d._tangent_row` catches one branch ABOVE the
+  #1111/#1115 recovery. So the facet stayed dropped and the flag's behavior
+  depended on how the user spelled the square root (counting
+  `_interior_tangent_point` calls through a solve: `sqrt` 6, `x**0.5` **0**).
+  `_pow_deriv` now evaluates the `t == 0` limit explicitly — `+inf` for
+  `0 < p < 1`, the shape `_dsqrt` already had, and `nan` for `p <= 0` where `f`
+  itself diverges and the recovery must decline. Every `t != 0` value is the bare
+  exponentiation, bit-identical including its exceptions.
+
+  Sound before and after (the facet was merely dropped), and reachable only with
+  the default-OFF flag. `python/tests/test_1118_power_singular_tangent.py` pins
+  spelling parity with `dm.sqrt`, flag-OFF byte identity, non-interference with
+  integer/`p > 1`/`p <= 0` powers, the no-graph-point-cut soundness sample, the
+  differential bound (ON >= OFF and ON <= the true box optimum over 32 objective
+  directions, with a counter proving the facet moved the bound), lazy-spec parity,
+  and the native-kernel decline of a zero-touching fractional power in both flag
+  states; 13 of its 41 tests fail before the change.
+
 - **A `SolverTuning` installed with `set_current()` was silently discarded at the
   `solve()` boundary** (`bug`, #1117). `solver._scoped_tuning` published the
   `tuning=` kwarg for the call, and with the kwarg omitted — every plain

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,94 @@ The release procedure that produces these entries is documented in
 
 ## [Unreleased]
 
+### Changed
+
+- **`solve(deterministic=...)` now defaults to `False` and is no longer a dead
+  parameter** (`solver`, #1116). It was documented as "Ensure deterministic
+  results" and read **nowhere** on the solve path — a default that named a
+  guarantee the solver did not provide. It is now wired to the real mode (below),
+  and defaults OFF because turning that mode on by default is a bound-changing
+  default flip (CLAUDE.md §5) with no graduation panel behind it. Callers who
+  passed `deterministic=True` expecting reproducibility now get it; callers who
+  relied on the old *default* get today's behaviour unchanged.
+
 ### Fixed
+
+- **The dual bound was a function of machine speed** (`solver`, #1116). The issue
+  reported a 13th-digit drift with the node count flipping 301 ↔ 303 on
+  `kriging_peaks-full200`. At `max_nodes=1` the defect is far larger: three root
+  dual bounds spanning **14 %** (−25371.8 / −28852.0 / −28072.6) in three
+  repetitions of one process, with the incumbent bit-identical.
+
+  The cause is **role-2 wall clocks**, in #912's sense: a clock answering *"when do
+  we stop?"* (the user's `time_limit`) is role 1 and correct by definition, while a
+  clock answering *"how much work do we do?"* makes the ANSWER depend on how fast
+  the machine happens to be that minute — what `_work_budget.py` calls "a
+  correctness-of-process bug, not a performance detail". Bisecting a confounded
+  neutralization showed the clock arm **alone** reproduces bit-exactly, and the
+  mechanism is structural rather than float noise: the first root LP came back with
+  a different number of **columns** (1532 vs 1469), because a wall-truncated
+  tightening stage handed the builder a different box — the root fixpoint returned
+  894 vs 898 tightened bounds from *different input boxes*, having spent 237.7 s vs
+  247.55 s in OBBT.
+
+  `SolverTuning.deterministic` / `DISCOPT_DETERMINISTIC` (default **OFF**) renders
+  role-2 budgets inert at their **origin**: 27 call sites via `_role2_budget` /
+  `_role2_deadline` / `_role2_horizon`, 3 direct guards where the budget is a loop
+  condition, and the integer-ratio dive in `mccormick_lp.py`. Both halves of the
+  search are covered — the dual side (root presolve, declared-box tightening, OBBT,
+  per-node OBBT, the root fixpoint, root cuts, the box/probe/pool LP slices, the
+  MILP stall slice) and the primal side (native-kernel seeds, root sub-NLP seeds,
+  ILS, multistart, one-hot swap, dual recovery), since a machine-speed-dependent
+  incumbent moves the cutoff, which moves the tree, which moves the bound. Verified
+  on the reproducing instance: 3/3 repetitions bit-identical
+  (`-1044.8190276107248`, objective `-3.890198803588073`, 3 nodes) where the
+  default arm returns three distinct bounds.
+
+  **Scoped on purpose.** Two role-1 mechanisms are left live — the phase-entry
+  gates (`_deadline_exhausted()` / `_remaining_budget() > x`) and the POUNCE
+  `max_wall_time = min(30.0, caller_limit)` stall backstop — because neutralizing
+  either lets preprocessing overrun the user's `time_limit` without bound, trading
+  a reproducibility bug for a broken role-1 promise. So the guarantee is: **a solve
+  reproduces when the role-1 budget never binds.** A test pins both residuals so
+  widening the flag to swallow role 1 fails loudly.
+
+  **Falsified and recorded** (§4/§11): the issue's own suggested first step (swap
+  five `bnb` hash containers to `BTreeMap`) — the crate has 18 hash-container
+  declarations and **3** iteration sites, all order-insensitive; thread scheduling
+  (rayon + BLAS pinned to 1, still 301 ↔ 303); `Variable.__hash__ = id(self)`
+  (replaced with a stable index across 26 377 430 firings, bound still moves); the
+  #694 anytime build truncation (`build_truncated=False`, 404/404 constraints); and
+  the issue's premise that no `time_limit` was set (`Model.solve` defaults to
+  3600 s). `solver.py`'s prior claim that "a deterministic `max_nodes` budget makes
+  solves bit-reproducible (6/6 identical)" is **retracted in the file**: a node
+  budget bounds the *tree*, not the wall sub-budgets inside a node. Note also that
+  the no-clock bound (−1044.819) is *tighter* than every wall-bounded run — an
+  early-truncated tightening stage is not merely nondeterministic, it leaves bound
+  on the table.
+
+- **alphaBB ran at every node alongside the reduced-space engine** (`relaxation`,
+  #1114). `_use_alphabb` keyed on the *lifted* LP relaxer being absent, which is
+  exactly the `dm.custom`/`CustomCall` class the reduced-space McCormick engine was
+  introduced to bound. The issue asked for a flag and a differential panel on the
+  grounds that dropping a term from a `max()` can only loosen a bound; the entry
+  experiment says that reasoning does not apply, because on this class alphaBB
+  never produces a bound at all. `rigorous_alpha`'s interval-AD walker has no rule
+  for `CustomCall` — an opaque user callable has no symbolic second derivative — so
+  every box returns `+inf` and `_compute_alphabb_bound` abstains with `-inf`, whose
+  only effect at both call sites is `max(lb, -inf)`. The identical function written
+  in native expression ops yields a finite alpha; wrapped in `dm.custom` it does
+  not.
+
+  Measured over 8 CustomCall models: 51 alphaBB node boxes, all 51 abstaining, → 0,
+  with status/node_count/bound/objective bit-identical (32/32 exact-identity
+  assertions — the §5 *bound-neutral* regime, not a bound trade). It therefore
+  ships unflagged: a default-off knob over a provable no-op is a dead flag (§3). It
+  cannot touch the benchmark corpus either, since `CustomCall` is constructed only
+  by `dm.custom` and no `.nl` or QPLIB instance can contain one.
+  `test_1114_alphabb_customcall_suppressed.py` pins the implication the gate rests
+  on, so teaching the interval-AD walker about `CustomCall` later fails loudly here
+  instead of silently discarding real bounds.
 
 - **`singular_tangent` recovery missed fractional power atoms (`x**0.5`)**
   (`relaxation`, #1118). `x**0.5` has exactly the vertical tangent at `t = 0` that
@@ -91,11 +178,11 @@ The release procedure that produces these entries is documented in
   `CustomCall` model can arrive there without `_force_reduced_space`. That
   reachability fact is itself pinned by a test.
 
-  Not addressed, and tracked separately: alphaBB is still enabled alongside the
-  reduced engine because `_use_alphabb` keys on `_mc_lp_relaxer is None` and is
-  computed before `_reduced_space_active`. Suppressing it is bound-changing (if the
-  node bound is currently the better of the two, removing alphaBB can loosen it) and
-  needs the §5 flag-and-panel treatment.
+  Was tracked separately as #1114 and is **now fixed** (entry below). The
+  reasoning recorded here — "suppressing it is bound-changing, because if the node
+  bound is currently the better of the two, removing alphaBB can loosen it" — was
+  **falsified** by #1114's entry experiment (CLAUDE.md §11): on this class alphaBB
+  abstains at every node, so there is no better-of-the-two to lose.
 
 - **`sqrt`/`asin`/`acos`/`acosh` derivatives no longer divide by zero at a singular
   endpoint** (`relaxation`, #1111). `_dsqrt` and friends evaluate the derivative

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -303,8 +303,24 @@ The release procedure that produces these entries is documented in
   `solver_tuning.py` *removed* such flags rather than leaving them in default-OFF
   limbo; this one is retained by owner decision as a measurement lever for **#1115** —
   whether any formulation of the singular-endpoint tangent pays for itself — with the
-  failing panel written into the field's docstring. #1115 carries the same disposition
-  rule: if the successor mechanism is falsified too, the flag gets removed.
+  failing panel written into the field's docstring.
+
+  **#1115 resolved this, and its own definition of done turned out to be a false
+  dichotomy** (§4 — the measurement wins over the plan). #1115 offered two endings:
+  graduate the flag, or record that *no* formulation pays for itself and remove it.
+  Neither happened. Lazy placement is sound (gate 1: 0 violations), never loses the
+  bound anywhere on the corpus, and *does* pay for itself on `kriging_peaks` — a
+  tighter bound at an identical node count and identical incumbent for +4.0–4.5 %
+  wall — while costing +25.6 % (`eq6_1`) and +54.2 % (`maxmin`) where it tightens
+  nothing. So gate 2 fails and the flag cannot graduate, but the removal branch's
+  premise is false: the mechanism does pay for itself, on a class too narrow to
+  justify a corpus-wide default. `singular_tangent` therefore **stays default-OFF and
+  stays in the tree**, with `singular_tangent_lazy` as its placement and the eager
+  anchor retained as the live A/B control. What is missing is not a mechanism but a
+  *trigger* — a gate keyed on whether the facet binds often enough to pay for its
+  rows, rather than on the operator being `sqrt`/`asin`/`acos`. Building that on the
+  present evidence would repeat the #727 RLT mistake (§2: a benefit confined to one
+  family), so it is tracked separately rather than attempted here.
   Flag-OFF is byte-identical to the pre-#1111 relaxation.
 
   **Double retraction (§11) — a retraction that was itself wrong.** An earlier

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -27,11 +27,25 @@ The next planned release is **`v0.9.0`** (minor bump on top of `v0.8.0`).
 - [ ] `JAX_PLATFORMS=cpu JAX_ENABLE_X64=1 pytest python/tests/ -v` -- full Python suite green.
 - [ ] `pytest python/tests/ --cov=discopt` -- coverage >= 85%.
 - [ ] `pytest discopt_benchmarks/tests/ -v` -- benchmark suite green. **Read the
-      skip count, not just the exit code.** As of v0.8.0 this suite reports
-      `321 passed, 118 skipped`, and all 118 are unconditional-skip stubs in
-      `tests/test_correctness.py` and `tests/test_interop.py` that have never
-      executed (#1050) -- not optional-dependency gates. Benchmark-level
-      correctness is therefore *not* covered here; the real gate is the next item.
+      skip count, not just the exit code.** As of v0.8.0 this suite reported
+      `321 passed, 118 skipped`, and all 118 were unconditional-skip stubs in
+      `tests/test_correctness.py` and `tests/test_interop.py` that had never
+      executed (#1050) -- not optional-dependency gates.
+      `tests/test_correctness.py`'s 98 of those now solve real instances; the ~20
+      in `tests/test_interop.py` are still stubs, so #1050 stays open.
+- [ ] `pytest discopt_benchmarks/tests/test_correctness.py -m correctness -v` --
+      **the `-m` is required**, for the same reason as the `python/tests` item
+      below: that file is now marked `correctness`, which the root `addopts`
+      deselects, so the bare command above silently collects and deselects all 99.
+      This is the lane that checks the reported objective against MINLPLib's
+      `.solu`, that no dual bound exceeds a known optimum, that incumbents are
+      feasible and integral, and (`TestDeterminism`) that a `deterministic=True`
+      solve reproduces run to run. Instances resolve from
+      `python/tests/data/minlplib_nl/` and then from the MINLPLib snapshot named
+      by `DISCOPT_MINLPLIB_NL`; anything absent skips with that reason. Raise
+      `DISCOPT_BENCH_TIME_LIMIT` (default 30 s) for a release-grade run -- at the
+      default, instances that do not reach optimality in time skip rather than
+      assert.
 - [ ] `pytest python/tests/ -m "correctness" -v` -- **`incorrect_count == 0`**.
       Non-negotiable per `CLAUDE.md`. **The `-m` is required, not optional.**
       `pyproject.toml`'s `addopts` defaults to

--- a/discopt_benchmarks/tests/test_correctness.py
+++ b/discopt_benchmarks/tests/test_correctness.py
@@ -15,33 +15,111 @@ Test categories:
 
 from __future__ import annotations
 
-import math
+import os
+import pathlib
+
+import numpy as np
 import pytest
-from dataclasses import dataclass
-from typing import Optional
-
 
 # ─────────────────────────────────────────────────────────────
-# Test fixtures and helpers (stubs — replace with actual discopt imports)
+# Test fixtures and helpers
 # ─────────────────────────────────────────────────────────────
+#
+# This file shipped as a scaffold: ``solve_instance`` raised
+# ``NotImplementedError``, every test caught it and called
+# ``pytest.skip("discopt not yet available")``, and all 98 tests skipped —
+# including the two in ``TestDeterminism``, the only assertions anywhere in the
+# repository that the solver reproduces run to run. #1116 made
+# ``deterministic=`` real (it had been a documented-but-unread parameter), and
+# those two tests were the flag's only consumer, so the flag would have had no
+# consumer that ever executed. That is the CLAUDE.md §6 failure mode — an
+# instrument that measures nothing and reports a pass — sitting in the file named
+# ``test_correctness.py``.
+#
+# The skips that remain are now *accurate*: an instance is skipped when its
+# ``.nl`` is not on this machine, which is a real condition (the 4 800-instance
+# MINLPLib snapshot is a developer-local Dropbox tree), and never a claim about
+# discopt itself.
 
-@dataclass
-class MockSolution:
-    """Stand-in for discopt solution object."""
-    status: str
-    objective: Optional[float] = None
-    bound: Optional[float] = None
-    x: Optional[list[float]] = None
-    node_count: int = 0
-    wall_time: float = 0.0
+# The in-repo corpus is searched first so CI, which has no MINLPLib snapshot,
+# still runs the instances it does ship.
+_REPO_NL = pathlib.Path(__file__).resolve().parents[2] / "python/tests/data/minlplib_nl"
+_BENCH_NL = pathlib.Path(
+    os.environ.get(
+        "DISCOPT_MINLPLIB_NL",
+        str(pathlib.Path.home() / "Dropbox/projects/discopt-minlp-benchmark/minlplib/nl"),
+    )
+)
+
+# Wall budget per solve. The scaffold asked for 3600 s on 29 instances across four
+# test classes, which is not a suite anyone runs. These tests skip when an instance
+# does not reach optimality, so a smaller budget narrows *coverage*, never
+# correctness — and every assertion here is a correctness assertion, not a timing
+# one. Raise it with DISCOPT_BENCH_TIME_LIMIT for a wider local run.
+TIME_LIMIT = float(os.environ.get("DISCOPT_BENCH_TIME_LIMIT", "30"))
+
+# These solve real instances, so they belong to the `correctness` marker (which
+# the root `addopts` deselects by default) and run on CI's python-correctness
+# lane. That lane's per-test timeout is 120 s, which TestDeterminism's three
+# sequential solves have to fit inside -- hence 30 s rather than the scaffold's
+# 3600 s.
+pytestmark = pytest.mark.correctness
+
+_SOLVE_CACHE: dict = {}
+_MODEL_CACHE: dict = {}
 
 
-def solve_instance(name: str, **kwargs) -> MockSolution:
-    """Stub: replace with actual discopt solve call."""
-    # from discopt import solve, load_problem
-    # problem = load_problem(f"instances/{name}.nl")
-    # return solve(problem, **kwargs)
-    raise NotImplementedError("Replace with actual discopt API")
+def _resolve(name: str) -> pathlib.Path:
+    for root in (_REPO_NL, _BENCH_NL):
+        p = root / f"{name}.nl"
+        if p.exists():
+            return p
+    pytest.skip(f"instance {name}.nl not present (set DISCOPT_MINLPLIB_NL)")
+
+
+def _load(name: str):
+    """Parse an instance. Cached: parsing is pure, so re-reading buys nothing."""
+    path = _resolve(name)
+    if path not in _MODEL_CACHE:
+        from discopt.modeling.core import from_nl
+
+        _MODEL_CACHE[path] = from_nl(str(path))
+    return _MODEL_CACHE[path]
+
+
+def solve_instance(name: str, *, cache: bool = True, **kwargs):
+    """Solve a MINLPLib instance by name and return discopt's ``SolveResult``.
+
+    ``cache=False`` is mandatory for anything measuring run-to-run behaviour:
+    a memoised solve would hand the SAME result object to every repetition and
+    ``TestDeterminism`` would pass by construction, which is the failure this
+    file already had once.
+    """
+    key = (name, tuple(sorted(kwargs.items())))
+    if cache and key in _SOLVE_CACHE:
+        return _SOLVE_CACHE[key]
+    kwargs.setdefault("time_limit", TIME_LIMIT)
+    # A fresh parse per solve: a Model carries solve-time state, so reusing one
+    # across repetitions would let a determinism test measure inherited state
+    # rather than the solver.
+    from discopt.modeling.core import from_nl
+
+    res = from_nl(str(_resolve(name))).solve(**kwargs)
+    if cache:
+        _SOLVE_CACHE[key] = res
+    return res
+
+
+def _flat_x(name: str, res) -> np.ndarray | None:
+    """``SolveResult.x`` is a dict of name -> array; flatten it in model order."""
+    if not res.x:
+        return None
+    parts = []
+    for v in _load(name)._variables:
+        if v.name not in res.x:
+            return None
+        parts.append(np.asarray(res.x[v.name], dtype=float).flatten())
+    return np.concatenate(parts) if parts else None
 
 
 # ─────────────────────────────────────────────────────────────
@@ -53,42 +131,62 @@ def solve_instance(name: str, **kwargs) -> MockSolution:
 # demonstrably wrong (most ~100-1500x too small) and are corrected here to the
 # authoritative =opt= (proven) / =best= (best known) values.
 KNOWN_OPTIMA = {
-    "ex1221":       7.6672,
-    "ex1222":       1.0765,
-    "ex1223":       4.5796,
-    "ex1223a":      4.5796,
-    "ex1224":      -0.94347,
-    "ex1225":      31.0,           # was 0.0 (=opt=)
-    "ex1226":      -17.0,
-    "ex1233":      155010.6713,    # was 62.1833 (=best=)
-    "ex1243":      83402.50641,    # was 83.6455 (=opt=)
-    "ex1244":      82042.90522,    # was 83.6455 (=opt=)
-    "ex1252":      128893.741,     # was 1169.37 (=opt=; Kocis-Grossmann batch plant)
-    "ex1252a":     128893.741,     # was 1169.37 (=opt=)
-    "ex1263":      19.6,           # was 19.46 (=opt=)
-    "ex1263a":     19.6,           # was 19.46 (=opt=)
-    "ex1264":       8.6,
-    "ex1264a":      8.6,
-    "ex1265":      10.3,
-    "ex1265a":     10.3,
-    "ex1266":      16.3,
-    "ex1266a":     16.3,
-    "fuel":         8566.12,
-    "gastrans":   89.08588,
-    "ghg_1veh":    7.7816348850,   # was -246.04 (=opt=)
+    "ex1221": 7.6672,
+    "ex1222": 1.0765,
+    "ex1223": 4.5796,
+    "ex1223a": 4.5796,
+    "ex1224": -0.94347,
+    "ex1225": 31.0,  # was 0.0 (=opt=)
+    "ex1226": -17.0,
+    "ex1233": 155010.6713,  # was 62.1833 (=best=)
+    "ex1243": 83402.50641,  # was 83.6455 (=opt=)
+    "ex1244": 82042.90522,  # was 83.6455 (=opt=)
+    "ex1252": 128893.741,  # was 1169.37 (=opt=; Kocis-Grossmann batch plant)
+    "ex1252a": 128893.741,  # was 1169.37 (=opt=)
+    "ex1263": 19.6,  # was 19.46 (=opt=)
+    "ex1263a": 19.6,  # was 19.46 (=opt=)
+    "ex1264": 8.6,
+    "ex1264a": 8.6,
+    "ex1265": 10.3,
+    "ex1265a": 10.3,
+    "ex1266": 16.3,
+    "ex1266a": 16.3,
+    "fuel": 8566.12,
+    "gastrans": 89.08588,
+    "ghg_1veh": 7.7816348850,  # was -246.04 (=opt=)
     # `procurement1` (0.0) and `smallinvDAXr1b50` (-3.83) were phantom entries —
     # those names match no MINLPLib instance and the values matched nothing.
     # Replaced with the real instances the suites reference (=best= / =opt=).
-    "procurement1large":      3802.1797490,
-    "procurement1mot":         291.5416577,
-    "procurement2mot":         212.0707488,
-    "smallinvDAXr1b020-022":     1.5715279820,
-    "smallinvDAXr1b050-055":     9.7971434540,
-    "smallinvDAXr1b100-110":    39.1621418600,
+    "procurement1large": 3802.1797490,
+    "procurement1mot": 291.5416577,
+    "procurement2mot": 212.0707488,
+    "smallinvDAXr1b020-022": 1.5715279820,
+    "smallinvDAXr1b050-055": 9.7971434540,
+    "smallinvDAXr1b100-110": 39.1621418600,
 }
 
 ABS_TOL = 1e-4
 REL_TOL = 1e-3
+
+# Resolved at collection time so parametrisation can prefer instances that exist.
+# `_resolve` cannot be used here -- it calls `pytest.skip`, which is a runtime
+# operation.
+AVAILABLE = [
+    n for n in KNOWN_OPTIMA if (_REPO_NL / f"{n}.nl").exists() or (_BENCH_NL / f"{n}.nl").exists()
+]
+
+
+@pytest.mark.smoke
+def test_the_corpus_is_reachable():
+    """Guard: without this, a broken corpus path turns 98 tests into 98 skips.
+
+    That is exactly how this file spent its life before #1116 -- green, and
+    measuring nothing (CLAUDE.md §6).
+    """
+    assert AVAILABLE, (
+        f"no KNOWN_OPTIMA instance resolved under {_REPO_NL} or {_BENCH_NL}; "
+        "every instance-based test below is vacuous"
+    )
 
 
 class TestKnownOptima:
@@ -97,10 +195,7 @@ class TestKnownOptima:
     @pytest.mark.parametrize("instance,expected", list(KNOWN_OPTIMA.items()))
     def test_optimal_value(self, instance: str, expected: float):
         """Solver objective must match known optimum within tolerance."""
-        try:
-            sol = solve_instance(instance, time_limit=3600)
-        except NotImplementedError:
-            pytest.skip("discopt not yet available")
+        sol = solve_instance(instance)
 
         if sol.status != "optimal":
             pytest.skip(f"Not solved to optimality (status={sol.status})")
@@ -116,10 +211,7 @@ class TestKnownOptima:
     @pytest.mark.parametrize("instance,expected", list(KNOWN_OPTIMA.items()))
     def test_bound_validity(self, instance: str, expected: float):
         """Lower bound must never exceed the true optimum."""
-        try:
-            sol = solve_instance(instance, time_limit=3600)
-        except NotImplementedError:
-            pytest.skip("discopt not yet available")
+        sol = solve_instance(instance)
 
         if sol.bound is None:
             pytest.skip("No bound reported")
@@ -135,6 +227,7 @@ class TestKnownOptima:
 # 2. FEASIBILITY VERIFICATION
 # ─────────────────────────────────────────────────────────────
 
+
 class TestFeasibility:
     """Verify that reported solutions actually satisfy constraints."""
 
@@ -143,62 +236,67 @@ class TestFeasibility:
     @pytest.mark.parametrize("instance", list(KNOWN_OPTIMA.keys())[:10])
     def test_solution_feasibility(self, instance: str):
         """Returned solution point must satisfy all constraints."""
-        try:
-            sol = solve_instance(instance, time_limit=3600)
-        except NotImplementedError:
-            pytest.skip("discopt not yet available")
+        sol = solve_instance(instance)
 
         if not sol.x or sol.status not in ("optimal", "feasible"):
             pytest.skip("No feasible solution")
 
-        # Stub: actual implementation would evaluate constraints at sol.x
-        # from discopt import load_problem, evaluate_constraints
-        # problem = load_problem(f"instances/{instance}.nl")
-        # violations = evaluate_constraints(problem, sol.x)
-        # max_violation = max(abs(v) for v in violations)
-        # assert max_violation <= self.FEASIBILITY_TOL, (
-        #     f"Infeasible solution: max violation = {max_violation:.2e}"
-        # )
+        x_flat = _flat_x(instance, sol)
+        assert x_flat is not None, "solution reported but could not be flattened"
+
+        from discopt.warm_start import check_feasibility
+
+        # The reported point is checked against the model the solver was given,
+        # not against the solver's own internal view of it — the point of the
+        # test is to catch a solver that believes an infeasible point.
+        ok, violations = check_feasibility(_load(instance), x_flat, tol=self.FEASIBILITY_TOL)
+        assert ok, f"INFEASIBLE incumbent for {instance}: " + "; ".join(violations[:5])
 
     @pytest.mark.parametrize("instance", list(KNOWN_OPTIMA.keys())[:10])
     def test_integrality(self, instance: str):
         """Integer variables must have integer values in solution."""
-        try:
-            sol = solve_instance(instance, time_limit=3600)
-        except NotImplementedError:
-            pytest.skip("discopt not yet available")
+        sol = solve_instance(instance)
 
         if not sol.x or sol.status not in ("optimal", "feasible"):
             pytest.skip("No feasible solution")
 
-        # Stub: check integrality of integer variables
-        # from discopt import load_problem
-        # problem = load_problem(f"instances/{instance}.nl")
-        # for i in problem.integer_variable_indices:
-        #     assert abs(sol.x[i] - round(sol.x[i])) < 1e-5, (
-        #         f"Variable x[{i}] = {sol.x[i]} is not integer"
-        #     )
+        model = _load(instance)
+        checked = 0
+        for var in model._variables:
+            if var.var_type.value not in ("binary", "integer"):
+                continue
+            for value in np.asarray(sol.x[var.name], dtype=float).ravel():
+                checked += 1
+                assert abs(value - round(value)) < 1e-5, (
+                    f"{instance}: {var.name} = {value!r} is not integral"
+                )
+        if checked == 0:
+            pytest.skip(f"{instance} has no discrete variables")
 
 
 # ─────────────────────────────────────────────────────────────
 # 3. DETERMINISM
 # ─────────────────────────────────────────────────────────────
 
+
 class TestDeterminism:
     """Verify solver produces identical results across runs."""
 
     NUM_RUNS = 3
-    INSTANCES = list(KNOWN_OPTIMA.keys())[:5]
+    # Prefer instances that actually exist here: on CI only the five in-repo
+    # `.nl` files resolve, and slicing the raw dict would spend two of the five
+    # parametrisations on instances that can only skip.
+    INSTANCES = AVAILABLE[:5]
 
     @pytest.mark.parametrize("instance", INSTANCES)
     def test_deterministic_objective(self, instance: str):
         """Objective value must be identical across runs."""
         objectives = []
         for _ in range(self.NUM_RUNS):
-            try:
-                sol = solve_instance(instance, time_limit=600, deterministic=True)
-            except NotImplementedError:
-                pytest.skip("discopt not yet available")
+            # cache=False: a memoised solve would return one object to all three
+            # repetitions and this test would pass without the solver ever having
+            # run twice.
+            sol = solve_instance(instance, cache=False, deterministic=True)
             if sol.objective is not None:
                 objectives.append(sol.objective)
 
@@ -216,10 +314,7 @@ class TestDeterminism:
         """Node count must be identical in deterministic mode."""
         node_counts = []
         for _ in range(self.NUM_RUNS):
-            try:
-                sol = solve_instance(instance, time_limit=600, deterministic=True)
-            except NotImplementedError:
-                pytest.skip("discopt not yet available")
+            sol = solve_instance(instance, cache=False, deterministic=True)
             node_counts.append(sol.node_count)
 
         if len(node_counts) < 2:
@@ -234,52 +329,122 @@ class TestDeterminism:
 # 4. EDGE CASES
 # ─────────────────────────────────────────────────────────────
 
+
 class TestEdgeCases:
-    """Test solver behavior on degenerate and boundary cases."""
+    """Test solver behavior on degenerate and boundary cases.
+
+    These build their models directly rather than reading a corpus, so they run
+    everywhere — including CI, which ships no MINLPLib snapshot.
+    """
+
+    @staticmethod
+    def _model(name: str):
+        from discopt import Model
+
+        return Model(name)
 
     def test_infeasible_detection(self):
         """Solver must correctly report infeasibility."""
-        # Stub: create a known-infeasible problem
-        # from discopt import Problem, solve
-        # p = Problem()
-        # x = p.add_variable(lb=0, ub=1)
-        # p.add_constraint(x >= 2)  # Infeasible
-        # sol = solve(p)
-        # assert sol.status == "infeasible"
-        pytest.skip("discopt not yet available")
+        m = self._model("infeasible")
+        x = m.continuous("x", lb=0, ub=1)
+        m.subject_to(x >= 2)
+        m.minimize(x)
+        assert m.solve(time_limit=TIME_LIMIT).status == "infeasible"
 
     def test_unbounded_detection(self):
         """Solver must correctly report unboundedness."""
-        pytest.skip("discopt not yet available")
+        m = self._model("unbounded")
+        # 1e20 is the LP layer's INF sentinel, so this is an unbounded bound and
+        # not merely a very wide one.
+        x = m.continuous("x", lb=-1e20, ub=1e20)
+        m.minimize(x)
+        assert m.solve(time_limit=TIME_LIMIT).status == "unbounded"
 
     def test_fixed_variables(self):
         """Handle variables with lb == ub."""
-        pytest.skip("discopt not yet available")
+        m = self._model("fixed")
+        x = m.continuous("x", lb=2.0, ub=2.0)
+        y = m.continuous("y", lb=0.0, ub=10.0)
+        m.subject_to(y >= x)
+        m.minimize(x + y)
+        res = m.solve(time_limit=TIME_LIMIT)
+        assert res.status == "optimal"
+        assert res.objective == pytest.approx(4.0, abs=1e-5)
 
     def test_empty_problem(self):
         """Handle problem with no constraints."""
-        pytest.skip("discopt not yet available")
+        m = self._model("unconstrained")
+        x = m.continuous("x", lb=-3.0, ub=5.0)
+        m.minimize(x * x)
+        res = m.solve(time_limit=TIME_LIMIT)
+        assert res.status == "optimal"
+        assert res.objective == pytest.approx(0.0, abs=1e-5)
 
     def test_single_variable(self):
         """Handle trivial single-variable problems."""
-        pytest.skip("discopt not yet available")
+        m = self._model("single")
+        x = m.continuous("x", lb=-5.0, ub=5.0)
+        m.minimize((x - 1.25) ** 2)
+        res = m.solve(time_limit=TIME_LIMIT)
+        assert res.status == "optimal"
+        assert res.objective == pytest.approx(0.0, abs=1e-5)
+        assert float(np.ravel(res.x["x"])[0]) == pytest.approx(1.25, abs=1e-4)
 
     def test_all_integer(self):
         """Handle pure integer (no continuous) problems."""
-        pytest.skip("discopt not yet available")
+        m = self._model("all_integer")
+        a = m.integer("a", lb=0, ub=10)
+        b = m.integer("b", lb=0, ub=10)
+        m.subject_to(a + b >= 7)
+        m.minimize(3 * a + 2 * b)
+        res = m.solve(time_limit=TIME_LIMIT)
+        assert res.status == "optimal"
+        assert res.objective == pytest.approx(14.0, abs=1e-4)
 
     def test_all_continuous(self):
         """Handle pure NLP (no integer) problems."""
-        pytest.skip("discopt not yet available")
+        m = self._model("all_continuous")
+        x = m.continuous("x", lb=-2.0, ub=2.0)
+        y = m.continuous("y", lb=-2.0, ub=2.0)
+        m.subject_to(x + y >= 1)
+        m.minimize((x - 0.5) ** 2 + (y - 0.5) ** 2)
+        res = m.solve(time_limit=TIME_LIMIT)
+        assert res.status == "optimal"
+        assert res.objective == pytest.approx(0.0, abs=1e-5)
 
     def test_linear_constraints_only(self):
         """Handle problems with only linear constraints."""
-        pytest.skip("discopt not yet available")
+        m = self._model("linear_only")
+        x = m.continuous("x", lb=0.0, ub=10.0)
+        y = m.binary("y")
+        m.subject_to(x <= 10 * y)
+        m.subject_to(x >= 3)
+        m.minimize(x + 5 * y)
+        res = m.solve(time_limit=TIME_LIMIT)
+        assert res.status == "optimal"
+        assert res.objective == pytest.approx(8.0, abs=1e-4)
 
     def test_very_tight_bounds(self):
         """Handle near-fixed variables (ub - lb < 1e-8)."""
-        pytest.skip("discopt not yet available")
+        m = self._model("tight_bounds")
+        x = m.continuous("x", lb=1.0, ub=1.0 + 1e-9)
+        y = m.continuous("y", lb=0.0, ub=5.0)
+        m.subject_to(y >= 2 * x)
+        m.minimize(y)
+        res = m.solve(time_limit=TIME_LIMIT)
+        assert res.status == "optimal"
+        assert res.objective == pytest.approx(2.0, abs=1e-5)
 
     def test_large_coefficient_range(self):
         """Handle poorly scaled problems (coefficient range > 1e8)."""
-        pytest.skip("discopt not yet available")
+        m = self._model("badly_scaled")
+        x = m.continuous("x", lb=0.0, ub=1e6)
+        y = m.continuous("y", lb=0.0, ub=1e-3)
+        m.subject_to(1e8 * y + x >= 1e5)
+        m.minimize(x + 1e9 * y)
+        res = m.solve(time_limit=TIME_LIMIT)
+        # Buying the constraint through x costs 1 per unit and through y costs
+        # 10, so the optimum is all-x at 1e5 -- a solver that lets the 1e9
+        # coefficient dominate its scaling would take the y route.
+        assert res.status == "optimal"
+        assert res.objective == pytest.approx(1e5, rel=1e-6)

--- a/docs/dev/performance-plan.md
+++ b/docs/dev/performance-plan.md
@@ -4108,3 +4108,103 @@ Default flipped to on. `DISCOPT_CONVEX_ROUTE_GUARD=0` restores the fixed
 `_CONVEX_ROUTE_BUDGET_FRACTION` split, and that path stays tested
 (`python/tests/test_1066_route_progress_guard.py::TestGraduatedDefault`,
 `test_1059_route_fallback.py::test_auto_route_gets_a_fraction_of_the_limit`).
+
+## 17. #1119 singular-tangent binding trigger: the observable is anti-correlated with payoff (falsified 2026-08-23)
+
+#1115 shipped the singular-endpoint tangent (`SolverTuning.singular_tangent`,
+`singular_tangent_lazy`) **default-OFF** because its timing panel failed gate 2:
+sound and bound-helpful on the `kriging_peaks` family, but +25.6 % wall on
+`eq6_1` and +54.2 % on `maxmin` for no bound at all. #1119 was the successor
+hypothesis: the separator fires on the **operator** (a `sqrt` / `asin` / `acos` /
+`acosh` / fractional-power atom with a singular endpoint), and the fix is to fire
+on whether the recovered facet actually **binds** — keep the rows that constrain
+the LP, drop the ones that do not, and the cost goes away where the gain is
+absent.
+
+Kill criterion, quoted from the issue: *if the binding fraction does not separate
+the gaining instances (`kriging_peaks-full*`) from the paying ones (`eq6_1`,
+`maxmin`) — i.e. if rows bind at a similar rate in both groups — then binding-rate
+is not the predictor, a hit-rate gate cannot recover the cost, and this direction
+is dead. Record the falsification and stop rather than reaching for a second
+heuristic.*
+
+### The entry experiment
+
+`MccormickLPRelaxer` now tallies, per emitted batch, how many singular-tangent
+rows are tight at the optimum of the LP they were added to
+(`singular_tangent_stats()`; `_ST_BINDING_TOL = 1e-7` relative, the separator's
+own violation scale). Verified **bound-neutral** first, per §5: 40/40 exact
+`node_count` / `objective` / `bound` / `status` identities across five instances
+× {flag OFF, flag ON}, instrumentation present vs stashed. Panel:
+`scratchpad/issue1119/binding_probe.py`, `max_nodes=200`, `time_limit=120`,
+`deterministic=True`, flag + lazy placement ON.
+
+| instance | #1115 class | rows | binding | **binding_frac** | Σ LP obj gain | gain/row |
+|---|---|---|---|---|---|---|
+| `eq6_1` | pays +25.6 % wall, gains nothing | 22 874 | 22 874 | **1.0000** | −1.4e−13 | ~0 |
+| `maxmin` | pays +54.2 % wall, gains nothing | 23 189 | 22 214 | **0.9580** | 0.2116 | 9.1e−6 |
+| `kriging_peaks-full050` | gains 1.9 % of gap | 5 418 | 4 610 | **0.8509** | 300.2 | 5.5e−2 |
+| `kriging_peaks-full100` | gains 1.6 % of gap | 8 976 | 8 234 | **0.9173** | 594.4 | 6.6e−2 |
+
+### Verdict: falsified, and in the worst of the three available ways
+
+1. **Binding is near-universal, because it is near-tautological.** A row is
+   emitted precisely because it is violated at the current LP point, so the
+   re-solve that follows lands on it. The whole population sits in 0.85–1.00.
+2. **What separation exists runs backwards.** The two instances that *pay* have
+   the two *highest* binding rates; the two that *gain* have the two lowest. A
+   gate that keeps high-binding rows keeps exactly the rows that buy nothing.
+3. **The gate cannot recover the cost even in principle.** `eq6_1` has **zero**
+   non-binding rows: a rule that drops non-binding rows drops 0 of 22 874 and
+   saves 0 % of the +25.6 % it exists to remove. `maxmin` drops 975 of 23 189 —
+   4.2 % of the rows against +54.2 % wall. Meanwhile on `kriging_peaks-full050`
+   the same rule discards 808 of 5 418 (14.9 %) of the rows on the instance the
+   feature is *for*. Zero saving where it must save; collateral where it must not
+   cut.
+
+The direction is dead. Per the issue's own instruction, stopping here rather than
+reaching for a second heuristic.
+
+### What is deliberately NOT being proposed
+
+Σ LP-objective gain per row does separate the two groups, by three to four orders
+of magnitude (~0 and 9.1e−6 for the payers; 5.5e−2 and 6.6e−2 for the gainers), and
+an age-out gate reading it is the obvious next thought. It is not being built, for
+three reasons and none of them is effort:
+
+* It is a **different hypothesis** from the one #1119 authorized, and the issue's
+  kill criterion explicitly forbids substituting one when the first dies.
+* The figure is **unnormalized across objective scales** (`eq6_1`'s bound is
+  −0.497, `kriging_peaks-full100`'s is −345.6), so the four-point spread is not
+  yet evidence of anything scale-free.
+* The population is **tiny**. A prefilter over MINLPLib for instances whose `.nl`
+  contains `o39`/`o51`/`o52`/`o53` or a fractional-power exponent yields 164
+  candidates; screening the 96 smallest (`max_nodes=1`, 15 s, flag + lazy ON;
+  stopped at `tls7`, whose root does not finish inside the budget) registers a
+  spec on 18 and emits a row on **8**:
+
+  | instance | rows | binding | binding_frac | Σ obj gain |
+  |---|---|---|---|---|
+  | `eq6_1` | 300 | 300 | 1.0000 | −5.6e−17 |
+  | `kriging_peaks-full050` | 170 | 80 | 0.4706 | 3.8e−05 |
+  | `kriging_peaks-full030` | 136 | 76 | 0.5588 | 5.6e−05 |
+  | `kriging_peaks-full020` | 24 | 24 | 1.0000 | 1.2e−04 |
+  | `kall_ellipsoids_tc03c` | 16 | 16 | 1.0000 | 0 |
+  | `kriging_peaks-full010` | 8 | 8 | 1.0000 | 3.8e−05 |
+  | `tspn12` | 2 | 2 | 1.0000 | 8.5e−14 |
+  | `tspn15` | 1 | 1 | 1.0000 | −8.5e−14 |
+
+  Same shape at the root as at 200 nodes, and more starkly: the two payer-profile
+  instances (`eq6_1`, `kall_ellipsoids_tc03c` — many rows, zero gain) bind at
+  1.0000, while the two `kriging_peaks` members with enough rows to have a rate
+  bind at 0.47 and 0.56. The in-repo 66-instance corpus tells the same story from
+  the other end: 12 files contain a singular opcode, 2 emit any lazy row at all
+  (`tspn08` 1 row, `tspn12` 3), both at ~1e−13 of bound. A threshold fitted to
+  four named instances out of a population this size is the single-problem
+  solution CLAUDE.md §2 rejects, not a class fix.
+
+`singular_tangent` therefore stays **default-OFF**, which is already its shipped
+state; #1115's flag and its lazy-placement variant remain in tree, tested, and
+opt-in. The accounting stays in `MccormickLPRelaxer` — it costs one dot product
+per emitted batch on a path that only runs when the default-off flag is on, and it
+is how this verdict would be re-checked.

--- a/python/discopt/_relax/binary_multilinear_reform.py
+++ b/python/discopt/_relax/binary_multilinear_reform.py
@@ -1398,7 +1398,8 @@ def heuristic_incumbent(
     argument does not apply. Purely a primal seed: the MILP driver re-validates
     it, and a better incumbent only prunes — it never changes the certified
     optimum. Fixed ``seed``/``restarts``/``max_flip_probes`` keep the search
-    deterministic (``deterministic=True`` default)."""
+    deterministic unconditionally — this routine reads no clock, so it does not
+    depend on ``solve(deterministic=...)``, whose default is ``False``."""
     meta = getattr(reformed, "_bml_heuristic", None)
     if not meta:
         return None

--- a/python/discopt/_relax/convexity/rules.py
+++ b/python/discopt/_relax/convexity/rules.py
@@ -1318,6 +1318,7 @@ def _run_with_deep_recursion(fn: Callable[[], _T], *, depth_need: int) -> _T:
     raised Python recursion limit cannot overflow the C stack and crash the
     process. The recursion limit is restored afterward; exceptions propagate.
     """
+    import contextvars
     import threading
 
     current = sys.getrecursionlimit()
@@ -1325,12 +1326,19 @@ def _run_with_deep_recursion(fn: Callable[[], _T], *, depth_need: int) -> _T:
         return fn()
 
     box: dict[str, object] = {}
+    # A new thread starts with an EMPTY contextvars context, so anything published
+    # for the call — notably the active ``SolverTuning`` (issue #1117) — would be
+    # invisible to ``fn`` on the worker and the deep-model path would silently run
+    # on env defaults while the shallow path honored the caller. Run ``fn`` inside
+    # a copy of this thread's context instead; the copy is discarded on return, so
+    # writes made by ``fn`` still cannot leak back here.
+    caller_ctx = contextvars.copy_context()
 
     def _worker() -> None:
         old = sys.getrecursionlimit()
         sys.setrecursionlimit(depth_need)
         try:
-            box["value"] = fn()
+            box["value"] = caller_ctx.run(fn)
         except BaseException as exc:  # noqa: BLE001 - re-raised on the caller thread
             box["error"] = exc
         finally:

--- a/python/discopt/_relax/mccormick_lp.py
+++ b/python/discopt/_relax/mccormick_lp.py
@@ -16,6 +16,7 @@ that fits the per-node call shape in :mod:`discopt.solver`.
 
 from __future__ import annotations
 
+import collections
 import dataclasses
 import logging
 import os
@@ -378,6 +379,17 @@ def _no_bound_status(status: str) -> str:
     return "uncertified" if status == "optimal" else status
 
 
+# Rolling window over recent singular-tangent rows (#1119). Sized to a few nodes'
+# worth of separation rounds so the gate reacts within a subtree rather than to the
+# whole tree's history.
+_ST_WINDOW = 256
+# A row counts as binding when its slack at the LP optimum it was added to is within
+# this relative tolerance of zero — the same scale the separator's own violation test
+# uses, so "emitted because violated" and "binding after re-solve" are measured
+# against one yardstick.
+_ST_BINDING_TOL = 1e-7
+
+
 class MccormickLPRelaxer:
     """Reusable per-node LP-form McCormick relaxation.
 
@@ -565,6 +577,21 @@ class MccormickLPRelaxer:
         self._inc = None
         self._inc_warm_basis = None
         self._inc_basis_nrows = -1
+        # Singular-tangent separation accounting (#1119). One relaxer serves every
+        # node, so these persist across the tree and are what a hit-rate gate would
+        # read. ``_st_recent`` is a bounded FIFO of per-row binding outcomes at the
+        # LP optimum the row was added to; the aggregate counters are the panel's
+        # report. Kept unconditionally rather than behind a debug flag: the cost is
+        # one dot product per emitted batch, against a batch that has already been
+        # vstacked into the constraint matrix and re-solved.
+        self._st_recent: collections.deque[bool] = collections.deque(maxlen=_ST_WINDOW)
+        self._st_rows = 0
+        self._st_binding = 0
+        self._st_rounds = 0
+        self._st_nodes = 0
+        self._st_obj_gain = 0.0
+        self._st_calls = 0
+        self._st_specs = 0
         # ``build_incremental=False`` skips this (the structure build + its
         # row-for-row validation cold-build the relaxation a handful of times) for
         # callers that only want the relaxer's model/terms/disc and never invoke
@@ -2227,6 +2254,60 @@ class MccormickLPRelaxer:
         except Exception:
             return res
 
+    def _record_singular_tangent_hits(self, rows, rhs, x) -> None:
+        """Tally how many just-emitted singular-tangent rows BIND at the new optimum.
+
+        #1119's entry experiment. The separator fires on the *operator* -- a
+        ``sqrt``/``asin``/``acos``/``acosh``/fractional-power atom with a singular
+        endpoint -- but what predicts payoff is whether the recovered facet actually
+        constrains the LP. #1115's timing panel charged +25.6 % wall on ``eq6_1``
+        and +54.2 % on ``maxmin``, the two instances that gain nothing and draw
+        3-4x the rows, so the question is whether a binding-rate observable
+        separates them from the instances that do gain.
+
+        Every row here is a ``<=`` row, so its slack at the optimum is
+        ``rhs - row @ x`` and it binds when that slack is ~0 -- measured against the
+        solution of the LP the row was added to, the only point at which "did this
+        row do anything" has an answer.
+
+        Pure accounting: no row is dropped and no bound changes. A shape mismatch
+        returns without recording rather than raising, because a stats mishap must
+        not perturb a certificate -- but it also must not silently read as "nothing
+        bound", which is why the panel asserts a non-zero row count before believing
+        a binding fraction.
+        """
+        if x is None:
+            return
+        xv = np.asarray(x, dtype=np.float64)
+        if xv.ndim != 1:
+            return
+        R = np.asarray(rows, dtype=np.float64)
+        b = np.asarray(rhs, dtype=np.float64)
+        if R.ndim != 2 or R.shape[0] != b.size or R.shape[1] != xv.size:
+            return
+        slack = b - R @ xv
+        scale = _ST_BINDING_TOL * np.maximum(1.0, np.abs(b))
+        hits = np.abs(slack) <= scale
+        self._st_rows += int(hits.size)
+        self._st_binding += int(np.count_nonzero(hits))
+        self._st_recent.extend(bool(h) for h in hits)
+
+    def singular_tangent_stats(self) -> dict:
+        """The #1119 accounting, as a plain dict for panels and tests."""
+        return {
+            "nodes": self._st_nodes,
+            "calls": self._st_calls,
+            "specs": self._st_specs,
+            "rounds": self._st_rounds,
+            "rows": self._st_rows,
+            "binding": self._st_binding,
+            "binding_frac": (self._st_binding / self._st_rows) if self._st_rows else None,
+            "recent_binding_frac": (
+                (sum(self._st_recent) / len(self._st_recent)) if self._st_recent else None
+            ),
+            "obj_gain": self._st_obj_gain,
+        }
+
     def _separate_singular_tangent(self, milp, varmap, res, deadline):
         """Recover a dropped vertical-tangent facet at the LP point (issue #1115).
 
@@ -2256,8 +2337,17 @@ class MccormickLPRelaxer:
         specs = varmap.get("singular_tangent_relaxations") or []
         if not specs:
             return res
+        self._st_specs = max(self._st_specs, len(specs))
         if res is None or res.status != "optimal" or res.x is None:
             return res
+        # Counted here rather than at the first emitted row, so "the separator ran
+        # and emitted nothing" stays distinguishable from "the separator never ran".
+        # #1119 records that on all three ``elec*`` instances the lazy arm
+        # registered thousands of specs and the separator ran zero times, because
+        # the separation chain is gated on ``if separate:`` upstream — conflating
+        # the two would read as a 0 % binding rate on an instance that was never
+        # asked a question.
+        self._st_calls += 1
         try:
             import scipy.sparse as sp
 
@@ -2380,6 +2470,7 @@ class MccormickLPRelaxer:
                 if not rows:
                     break
                 _append(rows, rhs)
+                _prev_obj = res.objective
                 _tl = (
                     None
                     if deadline is None
@@ -2388,6 +2479,15 @@ class MccormickLPRelaxer:
                 new_res = milp.solve(time_limit=_tl, backend=self._backend)
                 if new_res.status != "optimal" or new_res.objective is None:
                     break
+                if _round == 0:
+                    self._st_nodes += 1
+                self._st_rounds += 1
+                self._record_singular_tangent_hits(rows, rhs, new_res.x)
+                if _prev_obj is not None:
+                    # Minimisation form throughout the LP layer, so a tightening
+                    # RAISES the objective; record the gain with that sign so a
+                    # negative total is visible as the anomaly it would be.
+                    self._st_obj_gain += float(new_res.objective) - float(_prev_obj)
                 res = new_res
             return res
         except Exception:

--- a/python/discopt/_relax/mccormick_lp.py
+++ b/python/discopt/_relax/mccormick_lp.py
@@ -1198,7 +1198,16 @@ class MccormickLPRelaxer:
         ):
             return res
         try:
-            deadline = time.perf_counter() + _INTEGER_RATIO_DIVE_BUDGET_S
+            # #1116: a fixed per-node second count is a role-2 clock — it decides
+            # how many piece LPs the dive runs, so the BOUND it returns is a
+            # function of machine speed. Under ``deterministic`` the
+            # partitioner's own LP cap is the only bound (see
+            # ``solver_tuning.SolverTuning.deterministic``).
+            deadline = (
+                None
+                if _tuning().deterministic
+                else time.perf_counter() + _INTEGER_RATIO_DIVE_BUDGET_S
+            )
             lifted = p.node_bound(node_lb, node_ub, deadline=deadline)
         except Exception:
             logger.debug("integer-ratio partition bound abstained", exc_info=True)

--- a/python/discopt/_relax/uniform_relax.py
+++ b/python/discopt/_relax/uniform_relax.py
@@ -2055,6 +2055,33 @@ def _pow_curv(p: float, lo: float, hi: float) -> Optional[str]:
     return "convex"  # p in {0,1} degenerate (won't reach: pow collapses those)
 
 
+def _pow_deriv(p: float) -> Callable[[float], float]:
+    """``d/dt t**p``, with the ``t == 0`` limit evaluated instead of divided (#1118).
+
+    ``p * (0.0 ** (p - 1.0))`` RAISES ``ZeroDivisionError`` for every ``p < 1`` — an
+    ``ArithmeticError``, which ``_emit_1d._tangent_row`` catches ONE BRANCH ABOVE the
+    vertical-tangent recovery. So ``x**0.5`` on a box touching 0 silently lost the
+    facet that ``dm.sqrt(x)`` keeps under ``singular_tangent``: the same function,
+    the same singularity, different behavior depending on how the user spelled it.
+    Evaluating the limit here returns ``+inf`` instead, which is what ``_dsqrt`` and
+    the other named atoms do, and control reaches the recovery unchanged.
+
+    For ``p <= 0`` the limit is still not a vertical tangent of a *finite* ``f`` —
+    ``f(0)`` itself diverges — so ``nan`` keeps ``_finite(g)`` the decliner there.
+    Every ``t != 0`` value is the bare exponentiation, bit-identical to before,
+    including its exceptions (an overflow at a huge base still propagates to
+    ``_tangent_row``'s handler and drops the row exactly as it did).
+    """
+
+    def _dpow(t: float, _p: float = p) -> float:
+        t = float(t)
+        if t == 0.0 and _p < 1.0:
+            return math.inf if _p > 0.0 else math.nan
+        return float(_p * (t ** (_p - 1.0)))
+
+    return _dpow
+
+
 def _odd_power_tangent_point(p: int, endpoint: float, lo: float, hi: float) -> Optional[float]:
     """Tangent point of the line through ``(endpoint, endpoint**p)`` touching ``t**p``.
 
@@ -2264,7 +2291,7 @@ def _build_power(ctx: _Builder, node: CNode, w: int) -> Envelope:
         return Envelope(rows=[], tight=True)
     curv = _pow_curv(p, lo, hi)
     f = lambda t: float(t) ** p  # noqa: E731
-    fp = lambda t: p * (float(t) ** (p - 1.0))  # noqa: E731
+    fp = _pow_deriv(p)
     tight = _emit_1d(ctx, w, lt, lo, hi, f, fp, curv)
     # Sign-straddling odd power: _pow_curv abstains (S-shaped) -> two-piece hull.
     if curv is None and float(p).is_integer():

--- a/python/discopt/_work_budget.py
+++ b/python/discopt/_work_budget.py
@@ -37,6 +37,54 @@ gate. :attr:`WorkBudget.stopped_on` records which one fired, so a panel can
 assert that a run was decided by work and not by the clock — i.e. that the run
 it is about to compare is actually reproducible.
 
+What role-2 clocks cost when they are left in place (#1116)
+----------------------------------------------------------
+
+#912 fixed role (2) at the sites it covered. #1116 measured what the *remaining*
+role-2 clocks do to the answer, and it is larger than the node-count cliff above.
+
+``kriging_peaks-full200``, ``max_nodes=1``, one process, one binary, no user time
+pressure, three repetitions: root dual bounds of −25371.8 / −28852.0 / −28072.6 —
+a 14 % spread — with the incumbent bit-identical to the last digit. At
+``max_nodes=300`` the same defect survives as a 13th-digit bound move that flips
+the node count 301 ↔ 303, which is enough to make CLAUDE.md §5's bound-neutral
+regime (``node_count`` and ``objective`` *exactly* unchanged) inapplicable to the
+instance and to turn an A/B on it into a measurement of noise. One #1115 panel row
+was published and withdrawn for exactly that reason.
+
+The mechanism is structural, not float noise. The first root LP comes back with a
+different number of COLUMNS per repetition (1532 vs 1469 measured), because a
+wall-truncated tightening stage handed the relaxation builder a different box: the
+root fixpoint returned 894 tightened bounds in one repetition and 898 in the next,
+from *different input boxes*, having spent 237.7 s and 247.55 s in OBBT. Three
+plausible non-clock explanations were tested and falsified — the Rust hash
+containers named in the issue (the whole crate has three iteration sites over hash
+containers, all order-insensitive), thread scheduling (pinned to one thread, still
+varies), and ``Variable.__hash__ = id(self)`` (replaced with a stable index across
+26 M patched calls, still varies). Replacing the clock alone with a deterministic
+counter made the solve reproduce bit-exactly, and *tighter* than any wall-bounded
+run (−1044.819 vs the −25 000…−34 000 cluster) — an early-truncated tightening
+stage is not merely nondeterministic, it is leaving bound on the table.
+
+``solver_tuning.SolverTuning.deterministic`` (``DISCOPT_DETERMINISTIC``, default
+OFF) is the switch that renders those budgets inert, via ``solver._role2_budget``
+/ ``_role2_deadline`` / ``_role2_horizon`` at the origin of each one. It is the
+same doctrine applied by suppression rather than by counting: where #912 replaces
+a wall budget with a work counter, the flag removes the wall budget and leaves the
+stage to the deterministic caps it already carries (round counts, iteration caps,
+the node budget), with the user's ``time_limit`` still stopping the search.
+
+Two role-1 mechanisms are deliberately left in place under that flag: the
+phase-entry gates (``_deadline_exhausted()`` / ``_remaining_budget() > x``, which
+decide whether an optional preprocessing phase starts at all) and the POUNCE
+``max_wall_time = min(30.0, caller_limit)`` stall backstop. Neutralizing either
+would let preprocessing overrun the user's ``time_limit`` without bound, which
+trades a reproducibility bug for a broken role-1 promise — so the guarantee is
+scoped to a solve whose role-1 budget never binds, rather than widened until it
+does. Both residuals were measured not to bind on the reproduction instance: the
+30 s POUNCE cap was live during the arm that reproduced bit-exactly, and the
+solve finished in ~7 min against the default 3600 s limit.
+
 Why per-kind counters and not one currency
 ------------------------------------------
 

--- a/python/discopt/modeling/core.py
+++ b/python/discopt/modeling/core.py
@@ -4119,7 +4119,7 @@ class Model:
         llm: bool = False,
         sensitivity: bool = False,
         stream: bool = False,
-        deterministic: bool = True,
+        deterministic: bool = False,
         partitions: int = 0,
         initial_solution: Optional[dict] = None,
         skip_convex_check: bool = False,
@@ -4157,8 +4157,17 @@ class Model:
         stream : bool, default False
             If True, return an iterator of :class:`SolveUpdate` instead of
             the final result.
-        deterministic : bool, default True
-            Ensure reproducible results across runs.
+        deterministic : bool, default False
+            Make the search a function of the model rather than of machine speed,
+            by rendering every **role-2** wall budget inert — the sub-budgets that
+            decide *how much work* a stage does, as opposed to the role-1
+            ``time_limit`` that decides *when to stop*. A solve then reproduces
+            when the role-1 budget never binds — it terminates on work
+            (``max_nodes``, the gap) with real slack against ``time_limit``. Expect
+            a longer run: nothing truncates a stage early any more.
+
+            Until #1116 this defaulted to ``True`` and was read nowhere. See
+            :meth:`discopt.solver.solve_model`.
         partitions : int, default 0
             Number of piecewise McCormick partitions (0 = standard convex
             relaxation, k > 0 = k partitions for tighter relaxations).

--- a/python/discopt/skills/agents/minlp-solver-expert.md
+++ b/python/discopt/skills/agents/minlp-solver-expert.md
@@ -38,7 +38,7 @@ result = m.solve(
     node_callback=None,
     stream=False,                   # True -> iterator[SolveUpdate]
     sensitivity=False,              # True -> populate SolveResult.gradient
-    deterministic=True,
+    deterministic=False,            # True -> role-2 wall budgets inert (#1116)
     llm=False,                      # True -> populate .explain(llm=True)
 )
 ```

--- a/python/discopt/skills/commands/debug.md
+++ b/python/discopt/skills/commands/debug.md
@@ -45,8 +45,10 @@ Read the output carefully:
 Get a deterministic, smallest-possible reproduction:
 - Re-run the exact failing command. For `discopt solve`, add `--no-daemon` to
   rule the daemon out and get the traceback in your own process.
-- In Python, set `m.solve(deterministic=True)` (the default) so the failure is
-  stable across runs.
+- In Python, set `m.solve(deterministic=True)` (NOT the default) so the failure
+  is stable across runs. It makes the solver's role-2 wall budgets inert — those
+  are what otherwise move the dual bound and the node count run to run (#1116).
+  A default solve is not reproducible on a large model.
 - If it's a big model, try to shrink it (fewer variables/constraints) until the
   symptom flips — that localizes the offending structure.
 

--- a/python/discopt/skills/commands/diagnose.md
+++ b/python/discopt/skills/commands/diagnose.md
@@ -93,7 +93,7 @@ inspect the returned `SolveResult`. When the result points to a deeper problem
        psd_cuts=False,         # PSD/eigenvalue cuts for QCQP
        gdp_method="big-m",     # or "hull" for tighter disjunctive relaxations
        nlp_bb=None,            # None=auto, True=NLP-BB, False=spatial B&B
-       deterministic=True,     # reproducible results
+       deterministic=False,    # True -> reproducible (neutralizes role-2 clocks)
        validate=False,         # post-solve KKT check -> result.validation_report
    )
    ```

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -44,8 +44,8 @@ from discopt.modeling.core import (
     VarType,
 )
 from discopt.solver_tuning import current as _tuning
+from discopt.solver_tuning import enter_scope as _enter_tuning_scope
 from discopt.solver_tuning import reset_current as _reset_tuning
-from discopt.solver_tuning import set_current as _set_tuning
 from discopt.solvers import (
     POUNCE_BOUND_RELAX_FACTOR,
     SolveStatus,
@@ -6263,9 +6263,16 @@ def _scoped_tuning(fn: _F) -> _F:
     """Publish the ``tuning`` kwarg as the active :class:`SolverTuning` for the
     call, then restore the previous context. Relaxer read sites consult
     ``solver_tuning.current()`` instead of ``os.environ`` — so the levers are
-    per-call and typed. ``tuning=None`` resolves to a fresh env-default instance
-    (the prior global behavior), and the reset prevents one solve's overrides from
-    leaking into a later relaxer built outside any solve (e.g. in tests).
+    per-call and typed. Precedence is ``tuning=`` kwarg > a context the caller
+    installed with ``solver_tuning.set_current(...)`` > environment defaults, and
+    the reset prevents one solve's overrides from leaking into a later relaxer
+    built outside any solve (e.g. in tests).
+
+    Omitting ``tuning=`` used to publish a *fresh env-default* instance rather than
+    inherit, so ``set_current(...)`` around a plain ``m.solve()`` was discarded at
+    this boundary without a warning — issue #1117, and the instrument defect behind
+    two retracted #1113 panels. ``solver_tuning.enter_scope`` is the None-inherits
+    variant that fixes it.
 
     Typed as ``(_F) -> _F`` so the decorated function keeps its original
     signature/return type for callers and the type checker.
@@ -6273,7 +6280,7 @@ def _scoped_tuning(fn: _F) -> _F:
 
     @functools.wraps(fn)
     def wrapper(*args, **kwargs):
-        token = _set_tuning(kwargs.pop("tuning", None))
+        token = _enter_tuning_scope(kwargs.pop("tuning", None))
         try:
             return fn(*args, **kwargs)
         finally:

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -9,6 +9,7 @@ Connects:
 
 from __future__ import annotations
 
+import dataclasses
 import functools
 import logging
 import math
@@ -46,6 +47,7 @@ from discopt.modeling.core import (
 from discopt.solver_tuning import current as _tuning
 from discopt.solver_tuning import enter_scope as _enter_tuning_scope
 from discopt.solver_tuning import reset_current as _reset_tuning
+from discopt.solver_tuning import set_current as _set_tuning
 from discopt.solvers import (
     POUNCE_BOUND_RELAX_FACTOR,
     SolveStatus,
@@ -939,6 +941,21 @@ def _native_spatial_kernel_enabled() -> bool:
     busy machine (verified end-to-end at load 2.2 rising to 5.9: 4/4 decisive instances
     STABLE, 0 quarantined).
 
+    **RETRACTED 2026-08-23 (#1116, CLAUDE.md §11): "a deterministic ``max_nodes``
+    budget makes solves bit-reproducible" is FALSE as a general claim.** The 6/6 above
+    stands for the instances it was measured on; it does not generalize, and it was
+    written here as though it did. ``kriging_peaks-full200`` under exactly that
+    recipe — ``max_nodes``, one process, one binary, no user time pressure — returned
+    three distinct dual bounds in three repetitions at ``max_nodes=300`` (13th
+    significant digit, node count flipping 301 ↔ 303) and a 14 % spread at
+    ``max_nodes=1`` (−25371.8 / −28852.0 / −28072.6, incumbent bit-identical). A node
+    budget bounds the *tree*; it does not bound the wall-clock sub-budgets inside a
+    node, and those decide how much tightening happens. The bit-reproducibility this
+    paragraph assumed is available — it is what ``deterministic=True`` now buys
+    (``solver_tuning.SolverTuning.deterministic``) — but it was never a property of
+    ``max_nodes`` alone, so a replication panel must keep treating a disagreeing
+    instance as unresolved rather than trusting the budget to have removed the noise.
+
     **RE-GRADUATED default-ON 2026-07-31 (#902), on the first VALID panel this flag has
     ever had.** The 2026-07-27 graduation was not validly earned — the only panel it
     passed was blind on all three counts above — so the default went back to OFF
@@ -1264,7 +1281,9 @@ def _native_kernel_seed_candidates(model, lb, ub, n_orig, deadline):
                         x0,
                         evaluator=ev,
                         backend=backend,
-                        time_budget=max(1e-3, min(3.0, deadline - time.perf_counter())),
+                        time_budget=_role2_budget(
+                            max(1e-3, min(3.0, deadline - time.perf_counter()))
+                        ),
                     )
                 except Exception as exc:  # pragma: no cover - defensive
                     logger.debug("native seed subnlp raised: %s", exc)
@@ -1316,7 +1335,9 @@ def _native_kernel_seed_candidates(model, lb, ub, n_orig, deadline):
                         xr,
                         evaluator=ev,
                         backend=backend,
-                        time_budget=max(1e-3, min(4.0, deadline - time.perf_counter())),
+                        time_budget=_role2_budget(
+                            max(1e-3, min(4.0, deadline - time.perf_counter()))
+                        ),
                     )
                 except Exception as exc:  # pragma: no cover - defensive
                     logger.debug("native seed subnlp raised: %s", exc)
@@ -1360,7 +1381,7 @@ def _native_kernel_seed(model, lb, ub, sign, off, n_orig, outer_deadline=None):
     A verified feasible objective is only ever an *upper bound*: seeding it can prune and
     cutoff-propagate but can never loosen a bound or invent an incumbent, so an
     unverifiable candidate is simply dropped and the full solve runs unseeded."""
-    deadline = time.perf_counter() + float(_NATIVE_SEED_HEURISTIC_S)
+    deadline = _role2_horizon(time.perf_counter() + float(_NATIVE_SEED_HEURISTIC_S))
     if outer_deadline is not None:
         deadline = min(deadline, float(outer_deadline))
     if time.perf_counter() >= deadline:
@@ -4981,7 +5002,7 @@ def _classify_model_convexity(
     # Default cap (15 s) bounds classification even when called outside a budgeted
     # solve_model (e.g. on a model produced by factorable reformulation).
     budget = getattr(model, "_convexity_time_budget", 15.0)
-    deadline = (time.perf_counter() + budget) if budget else None
+    deadline = _role2_deadline((time.perf_counter() + budget) if budget else None)
     solve_deadline = getattr(model, "_solve_deadline", None)
     if solve_deadline is not None:
         deadline = solve_deadline if deadline is None else min(deadline, float(solve_deadline))
@@ -5034,7 +5055,7 @@ _CONVEX_MINLP_ROUTE_CLASSES = frozenset({"miqp", "miqcp", "miqcqp", "minlp"})
 #: severities.
 _MIP_NLP_IGNORED_OPTIONS: tuple[tuple[str, Callable[[Any], bool]], ...] = (
     ("threads", lambda v: v != 1),
-    ("deterministic", lambda v: v is not True),
+    ("deterministic", lambda v: bool(v)),
     ("batch_size", lambda v: v != 16),
     ("strategy", lambda v: v != "best_first"),
     ("ipopt_options", lambda v: v is not None),
@@ -6219,7 +6240,10 @@ def _root_relaxation_lower_bound(
                 # weakens the candidate at worst — it never invalidates one.
                 _sep_budget = min(budget, _fb_left()) if _have else budget
                 node_res = MccormickLPRelaxer(model).solve_at_node(
-                    root_lb, root_ub, time_limit=_sep_budget, build_deadline=_build_deadline
+                    root_lb,
+                    root_ub,
+                    time_limit=_role2_budget(_sep_budget),
+                    build_deadline=_build_deadline,
                 )
                 if node_res.lower_bound is not None and np.isfinite(node_res.lower_bound):
                     sep_bound = float(node_res.lower_bound)
@@ -6263,6 +6287,74 @@ def _root_relaxation_lower_bound(
 
 
 _F = TypeVar("_F", bound=Callable[..., Any])
+
+
+def _role2_budget(seconds):
+    """Return a **role-2** wall budget, or ``None`` when determinism was asked for.
+
+    #912's distinction, applied at the origin. A wall clock that answers *"when do
+    we stop?"* is role 1 — the user's ``time_limit`` — and is correct by
+    definition. A wall clock that answers *"how much work do we do?"* is role 2: a
+    sub-budget carved as a fraction of ``time_limit``, or a fixed number of seconds
+    handed to a stage, that decides how many OBBT passes / heuristic dives /
+    tightening rounds happen before the stage gives up. Role 2 makes the ANSWER a
+    function of machine speed; ``_work_budget.py`` calls that "a correctness-of-
+    process bug, not a performance detail".
+
+    #1116 is the measurement. ``kriging_peaks-full200`` at ``max_nodes=1``, one
+    process, one binary, no user time pressure, returned root dual bounds of
+    −25371.8 / −28852.0 / −28072.6 across three repetitions — a 14 % swing, with
+    the incumbent bit-identical. The mechanism is structural, not float noise: the
+    first root LP came back with a different number of COLUMNS per repetition
+    (1532 vs 1469), because a wall-truncated tightening stage handed the builder a
+    different box. Neutralizing the wall budgets made the solve reproduce exactly.
+
+    Under ``deterministic``, each stage is left to the deterministic caps it
+    already carries (``max_rounds``, ``obbt_rounds``, ``fbbt_max_iter``, iteration
+    caps, the node budget). The role-1 deadline is *not* routed through here and
+    still stops the search.
+    """
+    return None if _tuning().deterministic else seconds
+
+
+def _role2_deadline(deadline):
+    """The absolute-deadline form of :func:`_role2_budget` (``None`` = no clock)."""
+    return None if _tuning().deterministic else deadline
+
+
+def _role2_horizon(seconds):
+    """:func:`_role2_budget` for a callee whose budget parameter is a plain
+    ``float`` rather than ``Optional[float]`` — ``math.inf`` is the no-clock value
+    there, since every such callee compares elapsed time *against* it."""
+    return math.inf if _tuning().deterministic else seconds
+
+
+def _scoped_determinism(fn: _F) -> _F:
+    """Publish ``deterministic=True`` onto the active :class:`SolverTuning`.
+
+    ``deterministic`` was a public parameter of :func:`solve_model` documented as
+    "Ensure deterministic results" that was read **nowhere** on the solve path — a
+    dead flag (CLAUDE.md §3) and a false API promise. #1116 both measured the
+    promise being broken and supplied the mechanism to keep it, so the parameter is
+    wired here instead of deleted. Its default moved ``True`` -> ``False`` in the
+    same change: the old default named a guarantee the solver never provided, and
+    turning the real mode on by default would be a bound-changing default flip
+    (CLAUDE.md §5) with no graduation panel behind it.
+
+    The kwarg is *peeked*, not popped — ``fn`` keeps receiving it.
+    """
+
+    @functools.wraps(fn)
+    def wrapper(*args, **kwargs):
+        if not kwargs.get("deterministic", False):
+            return fn(*args, **kwargs)
+        token = _set_tuning(dataclasses.replace(_tuning(), deterministic=True))
+        try:
+            return fn(*args, **kwargs)
+        finally:
+            _reset_tuning(token)
+
+    return cast(_F, wrapper)
 
 
 def _scoped_tuning(fn: _F) -> _F:
@@ -6708,13 +6800,14 @@ def _stamp_layer_timing(fn: _F) -> _F:
 @_stamp_layer_timing
 @_scoped_deep_recursion
 @_scoped_tuning
+@_scoped_determinism
 @_debug_outermost_solve
 def solve_model(
     model: Model,
     time_limit: float = 3600.0,
     gap_tolerance: float = 1e-4,
     threads: int = 1,
-    deterministic: bool = True,
+    deterministic: bool = False,
     batch_size: int = 16,
     strategy: str = "best_first",
     max_nodes: int = 100_000,
@@ -6791,8 +6884,32 @@ def solve_model(
         Relative optimality gap tolerance for termination.
     threads : int, default 1
         Number of CPU threads (reserved for future use).
-    deterministic : bool, default True
-        Ensure deterministic results.
+    deterministic : bool, default False
+        Make the search a function of the model rather than of machine speed, by
+        rendering every **role-2** wall budget inert (see
+        :class:`~discopt.solver_tuning.SolverTuning.deterministic`). Role-2 clocks
+        are the sub-budgets that decide *how much work* a stage does — a fraction
+        of ``time_limit`` handed to root reduction, a fixed number of seconds for a
+        dive — as opposed to the role-1 ``time_limit`` that decides *when to stop*.
+        With this on, those stages are bounded by the deterministic caps they
+        already carry, so two runs of the same model return the same answer;
+        expect the run to take longer, since nothing truncates a stage early.
+
+        The guarantee covers a run whose role-1 budget never binds — one that
+        terminates on **work** (``max_nodes``, the gap) with real slack against
+        ``time_limit``. ``time_limit`` is role 1 and still stops the search on the
+        real clock, and the phase-entry gates that ask "is there enough time left
+        to bother starting this phase?" are deliberately left alone (neutralizing
+        them would let preprocessing overrun ``time_limit`` without bound). A run
+        cut short by ``time_limit``, or one slow enough to flip such a gate, is
+        not reproducible and does not claim to be; see
+        :class:`~discopt.solver_tuning.SolverTuning.deterministic` for the full
+        residual.
+
+        Until #1116 this parameter defaulted to ``True`` and was read nowhere —
+        it named a guarantee the solver did not provide. The default is now
+        ``False`` because turning the real mode on by default is a bound-changing
+        default flip (CLAUDE.md §5) that has no graduation panel behind it.
     batch_size : int, default 16
         Number of B&B nodes to export per iteration.
     strategy : str, default "best_first"
@@ -7438,7 +7555,7 @@ def solve_model(
     # the box.
     _nbt_budget_s = min(min(max(0.15 * float(time_limit), 2.0), 30.0), _remaining_budget())
     _declared_tightening = _declared_box_tightening(
-        model, deadline=time.perf_counter() + _nbt_budget_s
+        model, deadline=_role2_deadline(time.perf_counter() + _nbt_budget_s)
     )
     _check_finite_bounds(model, _declared_tightening)
     nonlinear_infeasibility = _detect_nonlinear_bound_infeasibility(model, _declared_tightening)
@@ -7654,7 +7771,9 @@ def solve_model(
                     [np.asarray(_routed_x[v.name], dtype=float).ravel() for v in model._variables]
                 )
                 _cd, _bdl, _bdu = _recover_nlp_duals_at_incumbent(
-                    model, _x_flat, time_budget=max(0.1, min(5.0, time_limit * 0.05))
+                    model,
+                    _x_flat,
+                    time_budget=_role2_horizon(max(0.1, min(5.0, time_limit * 0.05))),
                 )
                 if _cd is not None:
                     _mip_nlp_result.constraint_duals = _cd
@@ -7919,7 +8038,7 @@ def solve_model(
                 ignored_amp_options.append(name)
 
         _note_ignored("threads", threads != 1)
-        _note_ignored("deterministic", deterministic is not True)
+        _note_ignored("deterministic", bool(deterministic))
         _note_ignored("batch_size", batch_size != 16)
         _note_ignored("strategy", strategy != "best_first")
         _note_ignored("max_nodes", max_nodes != 100_000)
@@ -7987,7 +8106,7 @@ def solve_model(
                 ignored_gp_options.append(name)
 
         _note_ignored_gp("threads", threads != 1)
-        _note_ignored_gp("deterministic", deterministic is not True)
+        _note_ignored_gp("deterministic", bool(deterministic))
         _note_ignored_gp("batch_size", batch_size != 16)
         _note_ignored_gp("strategy", strategy != "best_first")
         _note_ignored_gp("max_nodes", max_nodes != 100_000)
@@ -8045,7 +8164,7 @@ def solve_model(
                 ignored_gp_minlp_options.append(name)
 
         _note_ignored_gp_minlp("threads", threads != 1)
-        _note_ignored_gp_minlp("deterministic", deterministic is not True)
+        _note_ignored_gp_minlp("deterministic", bool(deterministic))
         _note_ignored_gp_minlp("batch_size", batch_size != 16)
         _note_ignored_gp_minlp("strategy", strategy != "best_first")
         _note_ignored_gp_minlp("partitions", partitions != 0)
@@ -8427,7 +8546,7 @@ def solve_model(
             _origin_lb_chk,
             _origin_ub_chk,
             rules=(PeriodicVariableBoundRule(), FunctionDomainBoundRule()),
-            deadline=time.perf_counter() + _per_budget_s,
+            deadline=_role2_deadline(time.perf_counter() + _per_budget_s),
         )
         if _per_stats.n_tightened > 0:
             from discopt.solvers.amp import _apply_flat_bounds_to_model
@@ -8766,7 +8885,7 @@ def solve_model(
                                     model,
                                     np.asarray(_dcb_lb, dtype=np.float64),
                                     np.asarray(_dcb_ub, dtype=np.float64),
-                                    deadline=time.perf_counter() + _dcb_budget,
+                                    deadline=_role2_deadline(time.perf_counter() + _dcb_budget),
                                     # The wall deadline governs in-solve; the leaf
                                     # cap is a runaway backstop only (the module
                                     # default of 48 would stop a 150 s budget at
@@ -9848,7 +9967,7 @@ def solve_model(
                 lb,
                 ub,
                 rounds=_obbt_rounds,
-                deadline=time.perf_counter() + _obbt_budget,
+                deadline=_role2_deadline(time.perf_counter() + _obbt_budget),
                 prefer_pounce=nlp_solver == "pounce",
                 min_improvement=_obbt_min_impr,
             )
@@ -10649,7 +10768,7 @@ def solve_model(
                                 max(_probe_remaining, _DEADLINE_NODE_FLOOR_S),
                             )
                             _probe = _mc_lp_relaxer.solve_at_node(
-                                _probe_lb, _probe_ub, time_limit=_probe_budget
+                                _probe_lb, _probe_ub, time_limit=_role2_budget(_probe_budget)
                             )
                             # #930: bank the probe's proved bound WITH the box it was
                             # proved over. This solve costs real time (3.4 s on hda)
@@ -10728,7 +10847,7 @@ def solve_model(
                             _pool_res = _mc_lp_relaxer.solve_at_node(
                                 _probe_lb,
                                 _probe_ub,
-                                time_limit=_pool_budget,
+                                time_limit=_role2_budget(_pool_budget),
                                 out_cuts=_pool_chunks,
                                 psd_max_rounds=_root_cut_rounds,
                             )
@@ -10821,7 +10940,7 @@ def solve_model(
                             _pool_res = _mc_lp_relaxer.solve_at_node(
                                 _probe_lb,
                                 _probe_ub,
-                                time_limit=_pool_budget,
+                                time_limit=_role2_budget(_pool_budget),
                                 out_cuts=_pool_chunks,
                             )
                             _pool_solve_wall = time.perf_counter() - _pool_solve_t0
@@ -11056,7 +11175,7 @@ def solve_model(
                     model,
                     np.clip(_ir_seed, lb, ub),
                     evaluator=evaluator,
-                    time_budget=_ir_budget,
+                    time_budget=_role2_horizon(_ir_budget),
                 )
                 if _ir_sn is not None and (_ir_best is None or _ir_sn[1] < _ir_best[1]):
                     _ir_best = _ir_sn
@@ -11928,7 +12047,9 @@ def solve_model(
         # the relaxation, which is what lets a node fathom once its independent
         # drivers are branched (welded-beam / nvs05). Gated + budgeted at setup;
         # here we additionally stop as soon as the cumulative budget is spent.
-        if _per_node_obbt_enabled and _pn_obbt_spent < _pn_obbt_budget_total:
+        if _per_node_obbt_enabled and (
+            _tuning().deterministic or _pn_obbt_spent < _pn_obbt_budget_total
+        ):
             _pn_inc = tree.incumbent()
             _pn_cutoff = (
                 float(_pn_inc[1])
@@ -11951,7 +12072,7 @@ def solve_model(
                     break
                 if node_infeasible_mask[i]:
                     continue
-                if _pn_obbt_spent >= _pn_obbt_budget_total:
+                if not _tuning().deterministic and _pn_obbt_spent >= _pn_obbt_budget_total:
                     break
                 _t_pn = time.perf_counter()
                 if time_limit - (_t_pn - t_start) < _DEADLINE_NODE_FLOOR_S:
@@ -11963,7 +12084,7 @@ def solve_model(
                         ub=np.asarray(batch_ub[i], dtype=np.float64),
                         rounds=_PER_NODE_OBBT_ROUNDS,
                         incumbent_cutoff=_pn_cutoff,
-                        deadline=_t_pn + _PER_NODE_OBBT_PER_NODE_S,
+                        deadline=_role2_deadline(_t_pn + _PER_NODE_OBBT_PER_NODE_S),
                         time_limit_per_lp=_PER_NODE_OBBT_PER_LP_S,
                         prefer_pounce=nlp_solver == "pounce",
                         top_k=_pn_obbt_topk,
@@ -13201,7 +13322,7 @@ def solve_model(
                             # wall clock. ``time_budget`` is only consulted on the
                             # ``DISCOPT_ILS_WORK_BUDGET=0`` legacy path; the solve
                             # deadline rides along purely as a time_limit backstop.
-                            time_budget=min(5.0, 0.15 * max(1.0, time_limit)),
+                            time_budget=_role2_horizon(min(5.0, 0.15 * max(1.0, time_limit))),
                             deadline=_deadline,
                         )
                         if ils is not None:
@@ -13293,7 +13414,9 @@ def solve_model(
                         evaluator=evaluator,
                         deadline=min(
                             _deadline,
-                            time.perf_counter() + max(2.0, min(15.0, 0.2 * float(time_limit))),
+                            _role2_horizon(
+                                time.perf_counter() + max(2.0, min(15.0, 0.2 * float(time_limit)))
+                            ),
                         ),
                         incumbent_obj=_cms_inc_obj,
                     )
@@ -13461,7 +13584,7 @@ def solve_model(
                             # Single root attempt (no loop): give it a fair budget
                             # so it can converge to a feasible incumbent even if
                             # preprocessing already consumed the deadline.
-                            time_budget=min(3.0, float(time_limit)),
+                            time_budget=_role2_budget(min(3.0, float(time_limit))),
                         )
                     except Exception as _e:
                         logger.debug("subnlp (gams seed) raised: %s", _e)
@@ -13503,7 +13626,7 @@ def solve_model(
                         # Single root fallback attempt (no loop): give it a fair
                         # budget so it can converge even if preprocessing already
                         # consumed the deadline.
-                        time_budget=min(3.0, float(time_limit)),
+                        time_budget=_role2_budget(min(3.0, float(time_limit))),
                     )
                 except Exception as _e:
                     logger.debug("subnlp raised: %s", _e)
@@ -13559,7 +13682,7 @@ def solve_model(
                             backend=_subnlp_backend_fn,
                             nlp_options=subnlp_options,
                             evaluator=evaluator,
-                            time_budget=_sn_budget,
+                            time_budget=_role2_budget(_sn_budget),
                         )
                     except Exception as _e:
                         logger.debug("subnlp raised: %s", _e)
@@ -13761,7 +13884,7 @@ def solve_model(
                         # sub-NLP count; ``time_budget`` is only read on the
                         # legacy (``ils_solve_budget=0``) path, and the solve
                         # deadline is the time_limit backstop.
-                        time_budget=_box_budget,
+                        time_budget=_role2_horizon(_box_budget),
                         deadline=_deadline,
                     )
                 except Exception as _e:
@@ -13922,7 +14045,9 @@ def solve_model(
                             model,
                             np.asarray(_lns_inc[0], dtype=np.float64),
                             evaluator=evaluator,
-                            time_budget=min(1.0, _deadline - time.perf_counter() - 0.1),
+                            time_budget=_role2_horizon(
+                                min(1.0, _deadline - time.perf_counter() - 0.1)
+                            ),
                             deadline=_deadline,
                         )
                         if _sw is not None:
@@ -14193,7 +14318,7 @@ def solve_model(
                             ub=np.array(ub),
                             rounds=2,
                             incumbent_cutoff=float(inc_obj),
-                            deadline=time.perf_counter() + 5.0,
+                            deadline=_role2_deadline(time.perf_counter() + 5.0),
                             time_limit_per_lp=0.1,
                             prefer_pounce=nlp_solver == "pounce",
                         )
@@ -14372,7 +14497,7 @@ def solve_model(
                         np.asarray(lb, dtype=np.float64),
                         np.asarray(ub, dtype=np.float64),
                         incumbent_cutoff=_rf_cutoff,
-                        deadline=time.perf_counter() + _rf_budget,
+                        deadline=_role2_deadline(time.perf_counter() + _rf_budget),
                         tol=1e-6,
                         prefer_pounce=nlp_solver == "pounce",
                         measure_bound=False,
@@ -15834,7 +15959,13 @@ def _solve_nlp_bb(
                 _rc_ev = _make_evaluator(model)  # pre-cut evaluator (cached)
                 _rc_budget = max(2.0, min(10.0, 0.2 * float(time_limit)))
                 _rc = generate_root_cuts(
-                    model, _rc_ev, lb, ub, _rc_is_int, _rc_is_bin, time_budget_s=_rc_budget
+                    model,
+                    _rc_ev,
+                    lb,
+                    ub,
+                    _rc_is_int,
+                    _rc_is_bin,
+                    time_budget_s=_role2_horizon(_rc_budget),
                 )
                 jax_time += time.perf_counter() - t_jax_start
                 _rc_cols = flat_column_terms(model)
@@ -20846,8 +20977,8 @@ def _one_hot_swap_reseed(model: Model, x_lifted: np.ndarray, budget: float) -> O
         sw = one_hot_swap_search(
             src,
             np.asarray(x_lifted[: int(n0)], dtype=np.float64),
-            time_budget=min(1.0, budget * 0.5),
-            deadline=time.perf_counter() + budget,
+            time_budget=_role2_horizon(min(1.0, budget * 0.5)),
+            deadline=_role2_deadline(time.perf_counter() + budget),
         )
         if sw is None:
             return None
@@ -20951,7 +21082,15 @@ def _solve_milp_simplex(
     # ~1 s, far inside this cap — so capping costs nothing on the common case while
     # bounding the wasted time before fallback to a few seconds.
     _remaining = float(time_limit) - (time.perf_counter() - t_start)
-    _milp_budget = max(0.5, min(0.5 * _remaining, _SIMPLEX_MILP_BUDGET_CAP_S))
+    # #1116: the half-of-remaining stall slice is a role-2 clock — it decides how
+    # much of the tree the Rust driver explores, so the BOUND it returns depends on
+    # machine speed. Under ``deterministic`` the driver is bounded by ``max_nodes``
+    # (already passed below) and the whole role-1 budget is the only wall.
+    _milp_budget = (
+        float(time_limit)
+        if _tuning().deterministic
+        else max(0.5, min(0.5 * _remaining, _SIMPLEX_MILP_BUDGET_CAP_S))
+    )
     # Interactive debugger: install the Rust checkpoint hook only when a debugger
     # is attached now (bound-neutral otherwise). This is the pure-Rust MILP
     # fast-path — the hook fires the same node-lifecycle checkpoints as the

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -4795,6 +4795,44 @@ def _is_pure_continuous(model: Model) -> bool:
     return all(v.var_type == VarType.CONTINUOUS for v in model._variables)
 
 
+def _expression_contains_custom_call(root) -> bool:
+    """True if the expression DAG rooted at ``root`` contains a ``CustomCall``.
+
+    Shared by :func:`_model_contains_custom_call` (the whole-model test) and the
+    alphaBB gate in :func:`solve_model` (#1114), which asks the same question of
+    a single expression.
+    """
+    if root is None:
+        return False
+    # Explicit-stack DFS (not Python recursion): ``from_nl`` can build a single
+    # body tens of thousands of nodes deep, which a per-node recursive walk would
+    # overflow the default recursion limit on (issue #271).
+    stack = [root]
+    while stack:
+        expr = stack.pop()
+        if isinstance(expr, CustomCall):
+            return True
+        # Generic child traversal mirroring the DAG node fields used elsewhere
+        # (e.g. discopt._relax.cutting_planes): BinaryOp/MatMul -> left/right,
+        # UnaryOp/SumExpression -> operand, FunctionCall/CustomCall -> args,
+        # SumOverExpression -> terms, IndexExpression -> base.
+        left = getattr(expr, "left", None)
+        if left is not None:
+            stack.append(left)
+        right = getattr(expr, "right", None)
+        if right is not None:
+            stack.append(right)
+        operand = getattr(expr, "operand", None)
+        if operand is not None:
+            stack.append(operand)
+        base = getattr(expr, "base", None)
+        if base is not None:
+            stack.append(base)
+        stack.extend(getattr(expr, "args", ()) or ())
+        stack.extend(getattr(expr, "terms", ()) or ())
+    return False
+
+
 def _model_contains_custom_call(model: Model) -> bool:
     """True if any objective/constraint body contains a ``CustomCall`` node.
 
@@ -4803,43 +4841,11 @@ def _model_contains_custom_call(model: Model) -> bool:
     about. The solver uses this to force the local NLP path and to refuse global
     branch-and-bound (see ``solve_model``). See issue #27b.
     """
-
-    def _walk(root) -> bool:
-        # Explicit-stack DFS (not Python recursion): ``from_nl`` can build a
-        # single body tens of thousands of nodes deep, which a per-node recursive
-        # walk would overflow the default recursion limit on (issue #271).
-        stack = [root]
-        while stack:
-            expr = stack.pop()
-            if isinstance(expr, CustomCall):
-                return True
-            # Generic child traversal mirroring the DAG node fields used
-            # elsewhere (e.g. discopt._relax.cutting_planes): BinaryOp/MatMul ->
-            # left/right, UnaryOp/SumExpression -> operand,
-            # FunctionCall/CustomCall -> args, SumOverExpression -> terms,
-            # IndexExpression -> base.
-            left = getattr(expr, "left", None)
-            if left is not None:
-                stack.append(left)
-            right = getattr(expr, "right", None)
-            if right is not None:
-                stack.append(right)
-            operand = getattr(expr, "operand", None)
-            if operand is not None:
-                stack.append(operand)
-            base = getattr(expr, "base", None)
-            if base is not None:
-                stack.append(base)
-            stack.extend(getattr(expr, "args", ()) or ())
-            stack.extend(getattr(expr, "terms", ()) or ())
-        return False
-
     obj = getattr(model, "_objective", None)
-    if obj is not None and getattr(obj, "expression", None) is not None and _walk(obj.expression):
+    if obj is not None and _expression_contains_custom_call(getattr(obj, "expression", None)):
         return True
     for c in model._constraints:
-        body = getattr(c, "body", None)
-        if body is not None and _walk(body):
+        if _expression_contains_custom_call(getattr(c, "body", None)):
             return True
     return False
 
@@ -10866,7 +10872,40 @@ def solve_model(
         # ``evaluate_objective``/``_obj_fn`` minimize ``-f`` for a maximize model,
         # so the expression whose Hessian must be convexified is likewise negated.
         _alphabb_expr = -model._objective.expression if _obj_negate else model._objective.expression
-        _use_alphabb = True
+        # #1114: an opaque ``CustomCall`` in the objective makes alphaBB a
+        # guaranteed no-op, so do not pay for it. ``_compute_alphabb_bound``
+        # derives its bound from ``rigorous_alpha``, which encloses the Hessian
+        # with the interval-AD walker in ``_relax/convexity/interval_ad.py``.
+        # That walker has NO rule for ``CustomCall`` (the opaque user callable
+        # has no symbolic second derivative), so the node falls through to
+        # ``_unbounded`` and the ``unbounded`` flag propagates through every
+        # enclosing operator. ``rigorous_alpha`` therefore returns ``+inf`` for
+        # every variable on EVERY box -- not just wide ones, so subdividing
+        # never recovers it -- and ``_compute_alphabb_bound`` abstains with
+        # ``-inf``, whose only effect at both node-loop call sites is the no-op
+        # ``max(lb, -inf)``. Suppressing it is bound-neutral by construction,
+        # not a bound trade: what is skipped is one interval-Hessian walk per
+        # node with a single possible outcome. (The issue also names a "~2 s root
+        # alpha estimate"; that is stale -- C-17 replaced the sampled root alpha
+        # with the per-node rigorous one, so this block now only builds the
+        # expression. The saving is a per-node call count, not a timing claim.)
+        # Measured over an 8-model CustomCall family (scratchpad/issue1114): 51
+        # node boxes, alphaBB abstained on every one, and suppressing it left
+        # status/node_count/bound/objective bit-identical on all 8 (32/32 exact
+        # identity assertions) -- the CLAUDE.md §5 bound-neutral regime. The
+        # mechanism check shows the identical function written in native
+        # expression ops yields a FINITE alpha while the ``dm.custom`` wrapper
+        # yields ``+inf``. ``test_1114_alphabb_customcall_suppressed.py`` asserts
+        # that implication directly, so adding a ``CustomCall`` interval-AD rule
+        # later fails loudly here instead of silently disabling a working bound.
+        if _expression_contains_custom_call(_alphabb_expr):
+            logger.debug(
+                "alphaBB not enabled: the objective contains an opaque CustomCall, "
+                "for which the interval Hessian is unbounded on every box (#1114)."
+            )
+            _alphabb_expr = None
+        else:
+            _use_alphabb = True
 
     # Soundness guard (issue #120): the McCormick "nlp" objective bound is a
     # valid dual bound only for convex models. The bound solver evaluates the

--- a/python/discopt/solver_tuning.py
+++ b/python/discopt/solver_tuning.py
@@ -1430,10 +1430,16 @@ class SolverTuning:
 
     **That successor was built and measured — #1115, and it is the default
     placement.** See :attr:`singular_tangent_lazy`. Eager anchoring is retained only
-    as the A/B control for that measurement; the two #581 precedents below removed
-    sound-but-unhelpful flags rather than leaving them in default-OFF limbo, and the
-    same rule applies here if the lazy form is falsified in turn. Flag-OFF is
-    byte-identical to the pre-#1111 relaxation."""
+    as the A/B control for that measurement.
+
+    **Final disposition (#1115).** The lazy form was *not* falsified, so the #581
+    removal precedent does not apply: it is sound, it never loses the bound on the
+    corpus, and it buys a real bound gain at an identical node count on
+    ``kriging_peaks``. It fails gate 2 only because it costs +25.6 %/+54.2 % on the
+    instances it does not help. This flag therefore stays default-OFF **and stays in
+    the tree**; what is missing is a trigger keyed on whether the facet binds often
+    enough to pay for its rows, not a better mechanism. Flag-OFF is byte-identical to
+    the pre-#1111 relaxation."""
 
     singular_tangent_lazy: bool = field(
         default_factory=lambda: _env_flag("DISCOPT_SINGULAR_TANGENT_LAZY", default=True)

--- a/python/discopt/solver_tuning.py
+++ b/python/discopt/solver_tuning.py
@@ -1369,13 +1369,20 @@ class SolverTuning:
     ``DISCOPT_SINGULAR_TANGENT=1``                2671    313
     ==========================================  ======  =====
 
-    ``tuning=`` and the environment variable agree bit-for-bit; ``set_current`` is
+    ``tuning=`` and the environment variable agree bit-for-bit; ``set_current`` was
     inert. So "both arms bit-identical" was not a neutrality result — it is the
     signature of a probe that never fired, and it explains exactly why the arms
     agreed to the last digit. That panel carried no drops counter, so nothing caught
     it (§6). Every root-relaxation measurement quoted below is unaffected: those
     drive ``build_uniform_relaxation`` directly, where ``set_current`` does reach
     (instrumented 10/10).
+
+    **That delivery gap is now fixed (#1117)** — the solve boundary calls
+    :func:`enter_scope`, which inherits an ambient context instead of overwriting it,
+    and the deep-recursion worker thread carries the caller's contextvars context
+    across. The table above is kept as the record of what the broken instrument
+    produced, not as current behavior; ``set_current(...)`` around a plain
+    ``m.solve()`` now fires the flag exactly like ``tuning=``.
 
     The reinstated number was re-measured on a corrected instrument — ``tuning=``
     delivery, the ON arm asserted to have fired, a ``max_nodes`` budget with **no**
@@ -1646,6 +1653,33 @@ def current() -> SolverTuning:
 def set_current(tuning: SolverTuning | None):
     """Publish ``tuning`` (or a fresh env-resolved one) as active; returns the token."""
     return _current.set(tuning if tuning is not None else SolverTuning())
+
+
+def enter_scope(tuning: SolverTuning | None):
+    """Publish ``tuning`` for a solve scope, **inheriting** the active context when
+    ``tuning`` is ``None``; returns the token to hand to :func:`reset_current`.
+
+    This is the difference between "no override was requested" and "override with
+    env defaults". :func:`set_current` cannot express the former — ``None`` there
+    means *a fresh env-resolved instance* — so the solve boundary used to overwrite
+    whatever a caller had installed with :func:`set_current`, discarding it in
+    silence (issue #1117). The precedence here is explicit ``tuning=`` kwarg >
+    ambient context > environment defaults, which is what a caller reading
+
+    .. code-block:: python
+
+        token = solver_tuning.set_current(tuning)
+        try:
+            m.solve()
+        finally:
+            solver_tuning.reset_current(token)
+
+    already expects. Nested solves inherit the outer scope for the same reason.
+    """
+    active = _current.get()
+    if tuning is not None:
+        return _current.set(tuning)
+    return _current.set(active if active is not None else SolverTuning())
 
 
 def reset_current(token) -> None:

--- a/python/discopt/solver_tuning.py
+++ b/python/discopt/solver_tuning.py
@@ -1123,6 +1123,56 @@ class SolverTuning:
     objective sign selects — keep the primal path exactly as before.
     """
 
+    # --- determinism (#1116) --------------------------------------------------
+    deterministic: bool = field(
+        default_factory=lambda: _env_flag("DISCOPT_DETERMINISTIC", default=False)
+    )
+    """Make the search a function of the *model* rather than of machine speed by
+    rendering every **role-2** wall budget inert. ``DISCOPT_DETERMINISTIC``,
+    default **OFF**; also reachable as ``Model.solve(deterministic=True)``.
+
+    #912 draws the line this flag acts on. A clock that answers *"when do we
+    stop?"* — the user's ``time_limit`` — is correct by definition (role 1). A
+    clock that answers *"how much work do we do?"* — a sub-budget carved as a
+    fraction of ``time_limit``, or a fixed number of seconds handed to a stage —
+    makes the ANSWER a function of how fast the machine happens to be that
+    minute. ``_work_budget.py`` calls that "a correctness-of-process bug, not a
+    performance detail".
+
+    #1116 measured the consequence. ``kriging_peaks-full200`` at ``max_nodes=1``,
+    same process, same binary, no user time pressure, returned root dual bounds of
+    −25371.8 / −28852.0 / −28072.6 — a 14 % swing — with the incumbent
+    bit-identical. Neutralizing the wall budgets made the same solve reproduce
+    exactly (``-1044.819…`` twice at ``max_nodes=1``, ``-754.478794470719`` twice
+    at ``max_nodes=300``), and *tighter* than every wall-bounded run.
+
+    When this is on, role-2 budgets become ``None``/``math.inf`` at the 27 sites
+    that carve them (``solver._role2_budget`` / ``_role2_deadline`` /
+    ``_role2_horizon``, plus the integer-ratio dive in ``_relax/mccormick_lp.py``)
+    and each stage is bounded by the deterministic caps it already carries (round
+    counts, iteration caps, the node budget). Expect a run to take longer:
+    nothing truncates a stage early any more.
+
+    **What the flag does not cover, and why.** Two role-1 mechanisms are left
+    alone on purpose, because neutralizing them would let preprocessing overrun
+    the user's ``time_limit`` without bound — trading a reproducibility bug for a
+    broken role-1 promise, which CLAUDE.md §1 does not permit:
+
+    * the phase-entry gates (``_deadline_exhausted()`` / ``_remaining_budget() >
+      x``), which decide whether an optional preprocessing phase *starts* at all;
+    * the two POUNCE funnels' ``max_wall_time = min(30.0, caller_limit)`` stall
+      backstop.
+
+    So the guarantee is: **a solve reproduces when the role-1 budget never binds**
+    — i.e. it terminates on work (``max_nodes``/gap) with real slack against
+    ``time_limit``. A run cut short by ``time_limit``, or run on a machine slow
+    enough that a phase-entry gate flips, is not reproducible and does not claim
+    to be. The residual was measured not to bind on the reproduction instance:
+    the 30 s POUNCE cap was live and real during the arm that reproduced
+    bit-exactly, and the solve finished in ~7 min against the default 3600 s
+    limit.
+    """
+
     # --- branch-and-reduce (cert:T2.3 / T2.4) ---------------------------------
     root_fixpoint: bool = field(
         default_factory=lambda: _env_flag("DISCOPT_ROOT_FIXPOINT", default=True)

--- a/python/discopt/solver_tuning.py
+++ b/python/discopt/solver_tuning.py
@@ -1583,6 +1583,21 @@ class SolverTuning:
     small to change a branching decision. So the #1111 finding "the root win does not
     survive branching" is scoped to the **eager** anchor: where the dropped facet
     dominates the root relaxation, lazy placement does retain part of it.
+
+    **Why this stays default-OFF rather than becoming conditional (#1119, closed
+    falsified 2026-08-23).** The successor question was whether a hit-rate gate —
+    keep the rows that bind in the LP optimal basis, drop the ones that do not —
+    could remove the ``eq6_1``/``maxmin`` overhead while retaining the
+    ``kriging_peaks`` gain. It cannot, and the measurement runs the wrong way:
+    over 200 nodes the two instances that PAY bind at 1.0000 and 0.9580, the two
+    that GAIN bind at 0.9173 and 0.8509, and ``eq6_1`` has **zero** non-binding
+    rows — so the gate drops 0 of its 22 874 rows and saves none of the +25.6 %,
+    while discarding 14.9 % of the rows on the instance the feature exists for.
+    Binding is near-tautological here: a row is emitted because it is violated at
+    the current LP point, so the re-solve that follows lands on it. Full record
+    (including the screen showing only 8 of 96 candidate instances emit any row at
+    all) in ``docs/dev/performance-plan.md`` §17; the instrument is
+    ``MccormickLPRelaxer.singular_tangent_stats``.
     """
 
     singular_tangent_kappa: float = field(

--- a/python/tests/test_1059_route_respects_caller_options.py
+++ b/python/tests/test_1059_route_respects_caller_options.py
@@ -40,22 +40,40 @@ class TestIgnoredOptionTable:
     """The table is shared, so its predicates are worth pinning directly."""
 
     def test_an_untouched_default_is_not_caller_intent(self):
-        # Every value here is solve_model's own default. A default solve must
-        # stay routable -- if this regressed, the route would silently switch
-        # itself off for everyone and the graduation panel would be undone.
-        defaults = {
-            "threads": 1,
-            "deterministic": True,
-            "batch_size": 16,
-            "strategy": "best_first",
-            "nlp_bb": None,
-            "node_callback": None,
-            "incumbent_callback": None,
-            "presolve": True,
-            "cuts": "auto",
-            "subnlp_frequency": 20,
-            "in_tree_presolve_stride": 1,
-        }
+        """A default solve must stay routable.
+
+        If this regressed the route would silently switch itself off for
+        everyone and the graduation panel would be undone.
+
+        The defaults are read from ``solve_model``'s own signature rather than
+        transcribed. A transcribed copy goes stale the moment a default moves and
+        then tests a value nobody passes -- which is what happened when #1116
+        moved ``deterministic`` from ``True`` to ``False``.
+        """
+        import inspect
+
+        from discopt.solver import solve_model
+
+        sig = inspect.signature(solve_model).parameters
+        names = [
+            "threads",
+            "deterministic",
+            "batch_size",
+            "strategy",
+            "nlp_bb",
+            "node_callback",
+            "incumbent_callback",
+            "presolve",
+            "cuts",
+            "subnlp_frequency",
+            "in_tree_presolve_stride",
+        ]
+        defaults = {}
+        for n in names:
+            assert n in sig, f"{n} is no longer a solve_model parameter"
+            assert sig[n].default is not inspect.Parameter.empty, f"{n} has no default"
+            defaults[n] = sig[n].default
+        assert len(defaults) == len(names), "a name was dropped -- the probe shrank"
         assert _mip_nlp_ignored_options(defaults) == []
 
     @pytest.mark.parametrize(

--- a/python/tests/test_1114_alphabb_customcall_suppressed.py
+++ b/python/tests/test_1114_alphabb_customcall_suppressed.py
@@ -1,0 +1,182 @@
+"""Issue #1114: alphaBB must not run alongside the reduced-space engine.
+
+``_use_alphabb`` is enabled whenever the *lifted* LP relaxer is absent
+(``solver.py``: ``_alphabb_eligible and _mc_lp_relaxer is None``). That is exactly
+the ``dm.custom``/``CustomCall`` class, on which the reduced-space McCormick engine
+supplies every node bound — so alphaBB ran at every node beside the engine that
+replaced it.
+
+WHY THE SUPPRESSION IS BOUND-NEUTRAL, not a bound trade. ``_compute_alphabb_bound``
+derives its bound from ``rigorous_alpha``, which encloses the Hessian with the
+interval-AD walker in ``_relax/convexity/interval_ad.py``. That walker has no rule
+for ``CustomCall`` (an opaque user callable has no symbolic second derivative), the
+node falls through to ``_unbounded``, and the flag propagates through every
+enclosing operator. So ``rigorous_alpha`` returns ``+inf`` on EVERY box — narrowing
+the box never recovers it — and ``_compute_alphabb_bound`` abstains with ``-inf``,
+whose only effect at both node-loop call sites is ``max(lb, -inf)``.
+
+``test_rigorous_alpha_abstains_on_customcall_but_not_native`` pins that implication
+against the native twin of the same function. It is the test that must fail if
+someone later teaches the interval-AD walker about ``CustomCall``: at that point
+alphaBB would start producing real bounds on this class and the gate in
+``solve_model`` would be silently discarding them.
+
+Measured before/after over an 8-model CustomCall family (``scratchpad/issue1114``):
+51 alphaBB node boxes -> 0, every one of which had abstained, with
+status/node_count/bound/objective bit-identical on all 8 (32/32 exact-identity
+assertions) — the §5 bound-neutral regime.
+
+Every test counts the assertions it executed and the file fails if a count is zero
+(CLAUDE.md §6). No exception is swallowed (§7).
+"""
+
+from __future__ import annotations
+
+import discopt.modeling as dm
+import jax.numpy as jnp
+import numpy as np
+import pytest
+from discopt._alphabb_rigorous import rigorous_alpha
+from discopt._relax.mcbox import MCBox
+
+pytestmark = [pytest.mark.relaxation]
+
+_CHECKS = {"n": 0}
+
+
+def _check(condition: bool, message: str) -> None:
+    """An assertion that RECORDS that it ran, so a silent no-op cannot pass."""
+    _CHECKS["n"] += 1
+    assert condition, message
+
+
+def _mexp(x):
+    """``exp`` dispatched to MCBox for the relaxation, ``jnp`` for the value path.
+
+    The value path is traced by the fused JIT in ``_relax/dag_compiler.py``, so the
+    non-MCBox branch must be ``jnp``: a ``np.exp`` there raises
+    ``TracerArrayConversionError`` and the model never reaches the code under test.
+    """
+    return x.exp() if isinstance(x, MCBox) else jnp.exp(x)
+
+
+def _custom_model():
+    """A nonconvex, reduced-space-admissible CustomCall model.
+
+    All the nonlinearity is inside the opaque node: a bilinear term left outside it
+    would give the lifted LP relaxer something to bound, ``_mc_lp_relaxer`` would not
+    be None, and alphaBB would never have been enabled in the first place.
+    """
+    m = dm.Model("custom")
+    x = m.continuous("x", 2, lb=[0.1, 0.1], ub=[2.0, 2.0])
+    f = dm.custom(lambda a, b: a * _mexp(-b) + b * _mexp(-a), name="f")
+    m.minimize(f(x[0], x[1]))
+    m.subject_to(x[0] + x[1] >= 1.0)
+    return m
+
+
+def _native_model():
+    """The SAME function written in native expression ops — the control."""
+    m = dm.Model("native")
+    y = m.continuous("y", 2, lb=[0.1, 0.1], ub=[2.0, 2.0])
+    m.minimize(y[0] * dm.exp(-y[1]) + y[1] * dm.exp(-y[0]))
+    m.subject_to(y[0] + y[1] >= 1.0)
+    return m
+
+
+def _alpha_over_box(model):
+    from discopt.solver import _alphabb_node_box
+
+    n = sum(v.size for v in model._variables)
+    box = _alphabb_node_box(model, np.full(n, 0.1), np.full(n, 2.0))
+    return np.asarray(rigorous_alpha(model._objective.expression, model, box), dtype=np.float64)
+
+
+def test_rigorous_alpha_abstains_on_customcall_but_not_native():
+    """The implication the suppression rests on, asserted directly."""
+    alpha_custom = _alpha_over_box(_custom_model())
+    alpha_native = _alpha_over_box(_native_model())
+    _check(
+        not np.all(np.isfinite(alpha_custom)),
+        f"rigorous_alpha certified convexity through a CustomCall: {alpha_custom}. "
+        "If the interval-AD walker learned CustomCall, the #1114 gate in solve_model "
+        "is now discarding real alphaBB bounds and must be revisited.",
+    )
+    _check(
+        np.all(np.isfinite(alpha_native)),
+        f"the native control must still yield a finite alpha, got {alpha_native}; "
+        "otherwise this file proves nothing about the CustomCall wrapper.",
+    )
+
+
+def test_alpha_stays_unbounded_on_a_narrow_subbox():
+    """Subdividing cannot recover it — the reason a per-node retry is pointless."""
+    from discopt.solver import _alphabb_node_box
+
+    model = _custom_model()
+    n = sum(v.size for v in model._variables)
+    box = _alphabb_node_box(model, np.full(n, 0.90), np.full(n, 0.91))
+    alpha = np.asarray(rigorous_alpha(model._objective.expression, model, box), dtype=np.float64)
+    _check(
+        not np.all(np.isfinite(alpha)),
+        f"a 0.01-wide box certified convexity through a CustomCall: {alpha}",
+    )
+
+
+def test_alphabb_is_not_invoked_on_a_customcall_model(monkeypatch):
+    """The regression: before #1114 this counted 11 calls, all returning -inf."""
+    import discopt.solver as solver_mod
+
+    calls = {"n": 0, "finite": 0}
+    original = solver_mod._compute_alphabb_bound
+
+    def _counting(evaluator, model, expr, node_lb, node_ub):
+        value = original(evaluator, model, expr, node_lb, node_ub)
+        calls["n"] += 1
+        if np.isfinite(value):
+            calls["finite"] += 1
+        return value
+
+    monkeypatch.setattr(solver_mod, "_compute_alphabb_bound", _counting)
+    result = _custom_model().solve(max_nodes=200, time_limit=60.0)
+
+    _check(
+        result.node_count is not None and result.node_count > 0,
+        "the solve explored no node, so the node loop under test never ran",
+    )
+    _check(
+        calls["n"] == 0,
+        f"alphaBB ran {calls['n']} times on a CustomCall model "
+        f"({calls['finite']} produced a finite bound)",
+    )
+    # The bound source that remains must still be a real spatial bound.
+    _check(
+        result.bound is not None and np.isfinite(result.bound),
+        f"no dual bound after suppressing alphaBB: {result.bound}",
+    )
+    _check(
+        result.objective is not None and result.bound <= result.objective + 1e-6,
+        f"certificate invariant violated: bound={result.bound} > obj={result.objective}",
+    )
+
+
+def test_predicate_separates_custom_from_native():
+    from discopt.solver import _expression_contains_custom_call
+
+    _check(
+        _expression_contains_custom_call(_custom_model()._objective.expression),
+        "the CustomCall objective was not detected",
+    )
+    _check(
+        not _expression_contains_custom_call(_native_model()._objective.expression),
+        "the native objective was misreported as containing a CustomCall",
+    )
+    _check(not _expression_contains_custom_call(None), "None must be handled")
+
+
+@pytest.fixture(autouse=True)
+def _assert_probe_fired():
+    """§6: a test whose model stops reaching the path must fail, not pass silently."""
+    before = _CHECKS["n"]
+    yield
+    assert _CHECKS["n"] > before, "this test executed no recorded assertion"

--- a/python/tests/test_1116_deterministic_mode.py
+++ b/python/tests/test_1116_deterministic_mode.py
@@ -1,0 +1,158 @@
+"""``deterministic=True`` must neutralize the role-2 wall budgets (#1116).
+
+``kriging_peaks-full200`` at ``max_nodes=1`` — one process, one binary, no user
+time pressure — returned root dual bounds of −25371.8 / −28852.0 / −28072.6 across
+three repetitions: a 14 % swing with the incumbent bit-identical. The cause is not
+float noise and not hash iteration order (the whole Rust crate has three iteration
+sites over hash containers, all order-insensitive, and replacing
+``Variable.__hash__`` with a stable index left the drift untouched). It is
+structural: the first root LP came back with a different number of COLUMNS per
+repetition, because a wall-truncated tightening stage handed the builder a
+different box. Replacing the clock with a deterministic counter made the same
+solve reproduce exactly.
+
+#912 named the distinction this test pins. A clock answering *"when do we stop?"*
+— the user's ``time_limit`` — is role 1 and correct by definition. A clock
+answering *"how much work do we do?"* is role 2, and makes the ANSWER a function of
+machine speed; ``_work_budget.py`` calls that "a correctness-of-process bug, not a
+performance detail".
+
+``deterministic`` was a public parameter documented as "Ensure deterministic
+results" that was read **nowhere** — a dead flag (CLAUDE.md §3) promising exactly
+the guarantee #1116 measured being broken. These tests fail on the pre-fix tree:
+the helpers do not exist, the tuning field does not exist, and the parameter has no
+observable effect.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import re
+from pathlib import Path
+
+import discopt.modeling as dm
+import discopt.solver as solver
+import discopt.solver_tuning as solver_tuning
+import pytest
+
+pytestmark = [pytest.mark.relaxation]
+
+
+def _model():
+    m = dm.Model()
+    x = m.continuous("x", lb=-2, ub=2)
+    y = m.continuous("y", lb=-2, ub=2)
+    m.subject_to(x * y >= 0.5)
+    m.minimize(x * x + y * y)
+    return m
+
+
+def test_role2_default_is_off_and_passes_the_clock_through():
+    """Off by default: turning the real mode on is a bound-changing default flip."""
+    assert solver_tuning.SolverTuning().deterministic is False
+    token = solver_tuning.set_current(
+        dataclasses.replace(solver_tuning.SolverTuning(), deterministic=False)
+    )
+    try:
+        assert solver._role2_deadline(123.0) == 123.0
+        assert solver._role2_horizon(4.0) == 4.0
+    finally:
+        solver_tuning.reset_current(token)
+
+
+def test_role2_budgets_are_inert_under_the_flag():
+    token = solver_tuning.set_current(
+        dataclasses.replace(solver_tuning.SolverTuning(), deterministic=True)
+    )
+    try:
+        assert solver._role2_deadline(123.0) is None
+        assert solver._role2_horizon(4.0) == float("inf")
+    finally:
+        solver_tuning.reset_current(token)
+
+
+def test_role1_deadline_is_not_routed_through_the_role2_helpers():
+    """The user's ``time_limit`` still stops the search under the flag.
+
+    A ``deterministic`` mode that also silenced role 1 would turn ``time_limit``
+    into a suggestion. The guarantee is scoped to a run that terminates on *work*.
+    """
+    res = _model().solve(deterministic=True, max_nodes=50, time_limit=60.0)
+    assert res.status in {"optimal", "feasible"}
+
+
+@pytest.mark.parametrize("flag", [True, False])
+def test_the_parameter_is_no_longer_dead(monkeypatch, flag):
+    """``deterministic=`` must be *observable* on the solve path.
+
+    Pre-fix this parameter was accepted, documented as a guarantee, and read
+    nowhere. The assertion is that the role-2 helpers fire during a real solve and
+    that the flag decides what they return — a dead parameter fires nothing.
+    """
+    seen: list[bool] = []
+    real = solver._role2_deadline
+
+    def spy(deadline):
+        out = real(deadline)
+        seen.append(out is None)
+        return out
+
+    monkeypatch.setattr(solver, "_role2_deadline", spy)
+    _model().solve(deterministic=flag, max_nodes=50)
+
+    assert seen, "the role-2 helper never fired — the probe measured nothing"
+    assert all(s is flag for s in seen), (
+        f"deterministic={flag} but suppression pattern was {set(seen)}"
+    )
+
+
+def test_flag_does_not_leak_out_of_the_solve():
+    before = solver_tuning.current().deterministic
+    _model().solve(deterministic=True, max_nodes=20)
+    assert solver_tuning.current().deterministic == before
+
+
+def test_role2_budget_is_the_optional_seconds_form_and_is_used():
+    """``_role2_budget`` is the ``Optional[float]``-seconds sibling of the other two.
+
+    Callees split into two conventions for "no clock": ``None`` (``subnlp``'s
+    ``time_budget``, ``solve_at_node``'s ``time_limit``) and ``math.inf`` (a plain
+    ``float`` parameter compared against elapsed time). Both need a helper, and a
+    helper with no call site is a dead flag (CLAUDE.md §3) — so this also asserts
+    every one of the three is actually wired into the solve path.
+    """
+    token = solver_tuning.set_current(
+        dataclasses.replace(solver_tuning.SolverTuning(), deterministic=True)
+    )
+    try:
+        assert solver._role2_budget(3.0) is None
+    finally:
+        solver_tuning.reset_current(token)
+    assert solver._role2_budget(3.0) == 3.0
+
+    src = Path(solver.__file__).read_text()
+    for helper in ("_role2_budget", "_role2_deadline", "_role2_horizon"):
+        # -1 for the ``def`` line; docstring mentions are stripped first.
+        body = re.sub(r'"""(?:.|\n)*?"""', "", src)
+        assert body.count(f"{helper}(") - 1 >= 1, f"{helper} has no call site"
+
+
+def test_role1_phase_entry_gates_are_deliberately_left_live():
+    """The documented residual, pinned so it stays a decision and not an oversight.
+
+    Neutralizing ``_deadline_exhausted`` / ``_remaining_budget`` under the flag
+    would let preprocessing overrun the user's ``time_limit`` without bound —
+    trading a reproducibility bug for a broken role-1 promise (CLAUDE.md §1). The
+    guarantee is therefore scoped to a solve whose role-1 budget never binds, and
+    both docstrings say so. This test fails if someone later widens the flag to
+    swallow role 1 without revisiting that trade.
+    """
+    body = re.sub(r'"""(?:.|\n)*?"""', "", Path(solver.__file__).read_text())
+    for gate in ("_deadline_exhausted(", "_remaining_budget()"):
+        assert gate in body
+        assert f"_role2_budget({gate}" not in body
+        assert f"_role2_horizon({gate}" not in body
+
+    field_doc = Path(solver_tuning.__file__).read_text()
+    assert "_deadline_exhausted" in field_doc, "the residual must stay documented"
+    assert "max_wall_time" in field_doc, "the POUNCE stall backstop must stay documented"

--- a/python/tests/test_1116_deterministic_mode.py
+++ b/python/tests/test_1116_deterministic_mode.py
@@ -156,3 +156,39 @@ def test_role1_phase_entry_gates_are_deliberately_left_live():
     field_doc = Path(solver_tuning.__file__).read_text()
     assert "_deadline_exhausted" in field_doc, "the residual must stay documented"
     assert "max_wall_time" in field_doc, "the POUNCE stall backstop must stay documented"
+
+
+def test_shipped_docs_do_not_advertise_the_old_default():
+    """The default flip must not leave user-facing docs stating the old value.
+
+    ``deterministic`` shipped as ``True`` for a long time while being read
+    nowhere, so several docs in the package present it as the default. #1116 made
+    the flag real and flipped it to ``False``; a doc still saying "(the default)"
+    now tells a user they already have a guarantee they do not have. These three
+    are the shipped skill/agent files a user reads before touching the source.
+    """
+    import inspect
+
+    from discopt.solver import solve_model
+
+    default = inspect.signature(solve_model).parameters["deterministic"].default
+    assert default is False, "the default moved — update these docs and this test"
+
+    root = Path(solver.__file__).parent
+    checked = 0
+    for rel in (
+        "skills/commands/debug.md",
+        "skills/commands/diagnose.md",
+        "skills/agents/minlp-solver-expert.md",
+    ):
+        text = (root / rel).read_text()
+        assert "deterministic" in text, f"{rel} no longer mentions the flag"
+        checked += 1
+        for line in text.splitlines():
+            if "deterministic=True" not in line:
+                continue
+            assert "NOT the default" in line, (
+                f"{rel}: presents deterministic=True without saying it is not the "
+                f"default — {line.strip()}"
+            )
+    assert checked == 3, "the probe stopped reading files (rule 6)"

--- a/python/tests/test_1117_tuning_scope.py
+++ b/python/tests/test_1117_tuning_scope.py
@@ -1,0 +1,206 @@
+"""A ``SolverTuning`` installed with ``set_current()`` must survive ``solve()`` (#1117).
+
+``solve()`` is wrapped by ``solver._scoped_tuning``, which published the ``tuning=``
+kwarg for the call. With the kwarg omitted — every plain ``m.solve()`` — it used to
+publish a *fresh env-resolved* ``SolverTuning()``, overwriting whatever the caller had
+installed with ``solver_tuning.set_current(...)``. No warning, no error: the solve just
+ran on env defaults.
+
+That is not a cosmetic API wart. It is the instrument defect behind two retracted #1113
+measurement panels: a probe that delivered ``singular_tangent`` via ``set_current()``
+measured zero effect on a full solve, and "both arms bit-identical" was written up as a
+neutrality result when it was the signature of a probe that never fired (CLAUDE.md §6).
+
+The contract pinned here is a precedence order — explicit ``tuning=`` kwarg > ambient
+context > environment defaults — plus the two ways a scope can be lost silently:
+``set_current`` semantics (``None`` means "env defaults", which callers of ``enter_scope``
+must not inherit) and the deep-recursion worker thread, which starts with an EMPTY
+contextvars context and so would have kept the deep-model path on env defaults while the
+shallow path honored the caller.
+"""
+
+from __future__ import annotations
+
+import contextvars
+import os
+import sys
+
+import discopt.modeling as dm
+import discopt.solver_tuning as solver_tuning
+import pytest
+from discopt._relax import uniform_relax
+from discopt._relax.convexity.rules import _run_with_deep_recursion
+from discopt.solver import _scoped_tuning
+
+pytestmark = [pytest.mark.relaxation]
+
+FLAG = "DISCOPT_SINGULAR_TANGENT"
+LAZY = "DISCOPT_SINGULAR_TANGENT_LAZY"
+
+
+@pytest.fixture
+def no_env_flag():
+    """Guarantee the flag is OFF in the environment, so any ON observation is
+    attributable to the delivery under test and not to an inherited env var."""
+    saved = {k: os.environ.pop(k, None) for k in (FLAG, LAZY)}
+    yield
+    for k, v in saved.items():
+        if v is None:
+            os.environ.pop(k, None)
+        else:
+            os.environ[k] = v
+
+
+def _eager_tuning():
+    return solver_tuning.current().replace(singular_tangent=True, singular_tangent_lazy=False)
+
+
+# --------------------------------------------------------------------------- #
+# 1. enter_scope's precedence, at the context layer
+# --------------------------------------------------------------------------- #
+def test_enter_scope_inherits_the_ambient_context(no_env_flag):
+    tuning = _eager_tuning()
+    outer = solver_tuning.set_current(tuning)
+    try:
+        inner = solver_tuning.enter_scope(None)
+        try:
+            assert solver_tuning.current().singular_tangent is True, (
+                "enter_scope(None) means 'no override was requested' and must inherit; "
+                "publishing a fresh env-default here is exactly bug #1117"
+            )
+        finally:
+            solver_tuning.reset_current(inner)
+        assert solver_tuning.current().singular_tangent is True
+    finally:
+        solver_tuning.reset_current(outer)
+    assert solver_tuning.current().singular_tangent is False
+
+
+def test_explicit_tuning_still_wins_over_the_ambient_context(no_env_flag):
+    outer = solver_tuning.set_current(_eager_tuning())
+    try:
+        inner = solver_tuning.enter_scope(solver_tuning.SolverTuning())
+        try:
+            assert solver_tuning.current().singular_tangent is False
+        finally:
+            solver_tuning.reset_current(inner)
+    finally:
+        solver_tuning.reset_current(outer)
+
+
+def test_enter_scope_outside_any_context_is_env_defaults(no_env_flag):
+    token = solver_tuning.enter_scope(None)
+    try:
+        assert solver_tuning.current().singular_tangent is False
+    finally:
+        solver_tuning.reset_current(token)
+
+
+def test_set_current_none_still_means_env_defaults(no_env_flag):
+    """``set_current`` keeps its documented meaning; ``enter_scope`` is the new one."""
+    outer = solver_tuning.set_current(_eager_tuning())
+    try:
+        inner = solver_tuning.set_current(None)
+        try:
+            assert solver_tuning.current().singular_tangent is False
+        finally:
+            solver_tuning.reset_current(inner)
+    finally:
+        solver_tuning.reset_current(outer)
+
+
+# --------------------------------------------------------------------------- #
+# 2. The decorator that guards every solve entry point
+# --------------------------------------------------------------------------- #
+def test_scoped_tuning_decorator_honors_the_ambient_context(no_env_flag):
+    @_scoped_tuning
+    def observe():
+        return solver_tuning.current().singular_tangent
+
+    token = solver_tuning.set_current(_eager_tuning())
+    try:
+        assert observe() is True
+        assert observe(tuning=solver_tuning.SolverTuning()) is False
+    finally:
+        solver_tuning.reset_current(token)
+    assert observe() is False
+
+
+# --------------------------------------------------------------------------- #
+# 3. End to end: the issue's own reproducer
+# --------------------------------------------------------------------------- #
+def _sqrt_model():
+    m = dm.Model()
+    x = m.continuous("x", lb=0.0, ub=4.0)
+    y = m.continuous("y", lb=-1e3, ub=1e3)
+    m.subject_to(y == dm.sqrt(x))
+    m.minimize(2 * x - y)
+    return m
+
+
+def _count_tangent_calls(monkeypatch, run):
+    calls = {"n": 0}
+    orig = uniform_relax._interior_tangent_point
+
+    def counting(*a, **k):
+        calls["n"] += 1
+        return orig(*a, **k)
+
+    monkeypatch.setattr(uniform_relax, "_interior_tangent_point", counting)
+    run()
+    return calls["n"]
+
+
+def test_set_current_reaches_a_plain_solve(monkeypatch, no_env_flag):
+    """The reproducer from #1117: identical delivery via kwarg and via context."""
+    tuning = _eager_tuning()
+
+    via_kwarg = _count_tangent_calls(
+        monkeypatch, lambda: _sqrt_model().solve(tuning=tuning, max_nodes=20)
+    )
+    assert via_kwarg > 0, "control arm never fired — the probe measures nothing (§6)"
+
+    def _via_context():
+        token = solver_tuning.set_current(tuning)
+        try:
+            assert solver_tuning.current().singular_tangent is True
+            _sqrt_model().solve(max_nodes=20)
+        finally:
+            solver_tuning.reset_current(token)
+
+    via_context = _count_tangent_calls(monkeypatch, _via_context)
+    assert via_context > 0, (
+        "set_current() around a plain solve() was discarded at the solve boundary (#1117)"
+    )
+
+    off = _count_tangent_calls(monkeypatch, lambda: _sqrt_model().solve(max_nodes=20))
+    assert off == 0, "flag-OFF control fired the recovery — the env fixture is not clean"
+
+
+# --------------------------------------------------------------------------- #
+# 4. The deep-model worker thread must carry the context across
+# --------------------------------------------------------------------------- #
+_PROBE: contextvars.ContextVar[str] = contextvars.ContextVar("discopt_test_1117", default="unset")
+
+
+def test_deep_recursion_worker_sees_the_callers_context():
+    """``_run_with_deep_recursion`` runs ``fn`` on a fresh thread for deep models.
+
+    A new thread's contextvars context is EMPTY, so without an explicit copy the
+    ``SolverTuning`` published for the solve would be invisible on exactly the large
+    models — the fix for #1117 would be inert where it matters most.
+    """
+    need = sys.getrecursionlimit() + 1000  # above the current limit -> the thread path
+    token = _PROBE.set("published")
+    try:
+        assert _run_with_deep_recursion(_PROBE.get, depth_need=need) == "published"
+
+        # ...and writes on the worker do not leak back to the caller's context.
+        def _writes():
+            _PROBE.set("mutated")
+            return _PROBE.get()
+
+        assert _run_with_deep_recursion(_writes, depth_need=need) == "mutated"
+        assert _PROBE.get() == "published"
+    finally:
+        _PROBE.reset(token)

--- a/python/tests/test_1118_power_singular_tangent.py
+++ b/python/tests/test_1118_power_singular_tangent.py
@@ -1,0 +1,317 @@
+"""``x**0.5`` must recover the same vertical-tangent facet as ``dm.sqrt(x)`` (#1118).
+
+The two spellings are the same function with the same singularity at ``t = 0``, but
+the ``singular_tangent`` recovery of #1111/#1115 could act only on the named atom. The
+power path built its derivative by bare exponentiation, and ``p * (0.0 ** (p - 1.0))``
+RAISES ``ZeroDivisionError`` for ``p < 1`` — an ``ArithmeticError``, caught by
+``_emit_1d._tangent_row`` one branch ABOVE the recovery — so the facet stayed dropped
+and the flag's behavior depended on how the user spelled the square root.
+
+``_pow_deriv`` evaluates the ``t == 0`` limit explicitly (``+inf`` for ``0 < p < 1``,
+the shape ``_dsqrt`` already had) so control reaches the recovery unchanged.
+
+What this file pins, in the order CLAUDE.md §5 asks for on a bound-CHANGING path:
+
+1. **Spelling parity** — ``x**0.5`` and ``dm.sqrt(x)`` produce identical rows in BOTH
+   flag states, which is the issue's actual complaint.
+2. **Flag-OFF byte identity** and non-interference with the powers that have no
+   vertical tangent (integer ``p``, ``p > 1``, ``p <= 0``).
+3. **Soundness** — no point of the graph is cut, sampled densely to the singularity.
+4. **Differential bound** — ON >= OFF and ON <= the true box optimum, over a sweep of
+   objective directions, with a counter proving the facet actually moved something.
+5. The **lazy** placement (#1115, the default inside the flag) registers a spec for a
+   power atom too, not just for the named ones.
+6. The native spatial kernel keeps DECLINING a zero-touching fractional-power box, in
+   both flag states — ``mccormick_patch::univariate_rows`` regenerates an endpoint
+   tangent unconditionally and would write an ``inf`` slope into a node LP.
+"""
+
+from __future__ import annotations
+
+import math
+import os
+
+import discopt.modeling as dm
+import discopt.solver_tuning as solver_tuning
+import numpy as np
+import pytest
+import scipy.sparse as sp
+from discopt._relax.spatial_producer import build_spatial_kernel_spec
+from discopt._relax.uniform_relax import _pow_deriv, build_uniform_relaxation
+from scipy.optimize import linprog
+
+pytestmark = [pytest.mark.relaxation]
+
+FLAG = "DISCOPT_SINGULAR_TANGENT"
+LAZY = "DISCOPT_SINGULAR_TANGENT_LAZY"
+
+#: Fractional powers whose derivative diverges at 0, on a box that reaches it.
+#: ``p`` spans an order of magnitude on both sides of ``0.5`` so nothing here can be
+#: a sqrt special case, and two box widths pin scale-freeness.
+SINGULAR_POWERS = [
+    ("x**0.5 [0,4]", 0.5, 0.0, 4.0),
+    ("x**0.25 [0,4]", 0.25, 0.0, 4.0),
+    ("x**0.75 [0,1e-3]", 0.75, 0.0, 1e-3),
+    ("x**(1/3) [0,8]", 1.0 / 3.0, 0.0, 8.0),
+]
+
+#: Powers with NO vertical tangent on a zero-touching box: ``f'`` is finite (``p > 1``)
+#: or ``f`` itself diverges (``p <= 0``), so the recovery must decline both.
+REGULAR_POWERS = [
+    ("x**2 [0,4]", 2.0, 0.0, 4.0),
+    ("x**3 [0,4]", 3.0, 0.0, 4.0),
+    ("x**1.5 [0,4]", 1.5, 0.0, 4.0),
+    ("x**-1 [0,4]", -1.0, 0.0, 4.0),
+    ("x**0.5 [1,4]", 0.5, 1.0, 4.0),  # fractional, but away from the singularity
+]
+
+
+@pytest.fixture
+def flag():
+    """Set/restore the flag in EAGER mode (see the #1111 file's fixture)."""
+    prev, prev_lazy = os.environ.get(FLAG), os.environ.get(LAZY)
+
+    def _set(value: str | None):
+        if value is None:
+            os.environ.pop(FLAG, None)
+            os.environ.pop(LAZY, None)
+        else:
+            os.environ[FLAG] = value
+            os.environ[LAZY] = "0"
+
+    yield _set
+    for key, val in ((FLAG, prev), (LAZY, prev_lazy)):
+        if val is None:
+            os.environ.pop(key, None)
+        else:
+            os.environ[key] = val
+
+
+def _pow_model(p: float, lo: float, hi: float, obj_coeffs=(0.0, -1.0)):
+    """``y == x**p`` over ``x in [lo,hi]``, minimizing ``a*x + b*y``."""
+    m = dm.Model()
+    span = max(abs(lo), abs(hi), 1.0)
+    x = m.continuous("x", lb=lo, ub=hi)
+    y = m.continuous("y", lb=-1e3 * span, ub=1e3 * span)
+    m.subject_to(y == x**p)
+    m.minimize(obj_coeffs[0] * x + obj_coeffs[1] * y)
+    return m
+
+
+def _sqrt_model(lo: float, hi: float, obj_coeffs=(0.0, -1.0)):
+    m = dm.Model()
+    span = max(abs(lo), abs(hi), 1.0)
+    x = m.continuous("x", lb=lo, ub=hi)
+    y = m.continuous("y", lb=-1e3 * span, ub=1e3 * span)
+    m.subject_to(y == dm.sqrt(x))
+    m.minimize(obj_coeffs[0] * x + obj_coeffs[1] * y)
+    return m
+
+
+def _rows(model):
+    rel = build_uniform_relaxation(model)
+    A = sp.csr_matrix(rel.model._A_ub, dtype=float)
+    A.sort_indices()
+    return rel, A.toarray(), np.asarray(rel.model._b_ub, dtype=float).ravel()
+
+
+def _lp_bound(model):
+    rel = build_uniform_relaxation(model)
+    M = rel.model
+    bnds = [
+        (float(lo) if np.isfinite(lo) else None, float(hi) if np.isfinite(hi) else None)
+        for lo, hi in np.asarray(M._bounds, dtype=float)
+    ]
+    res = linprog(
+        np.asarray(M._c, dtype=float).ravel(),
+        A_ub=sp.csr_matrix(M._A_ub),
+        b_ub=np.asarray(M._b_ub, dtype=float).ravel(),
+        bounds=bnds,
+        method="highs",
+    )
+    assert res.status == 0, res.message
+    return float(res.fun)
+
+
+def _graph_point(rel, t: float, fval: float) -> np.ndarray:
+    """Lifted point for the graph point ``(t, f(t))`` of a single-atom model.
+
+    The power path registers no ``univariate_atom_specs`` entry, so the aux column is
+    located structurally instead: a one-atom ``y == f(x)`` model lifts to ``[x, y,
+    atom_aux, residual_aux]`` (verified against the identical ``sqrt`` build), and the
+    residual aux is pinned to 0 by its own two rows."""
+    z = np.zeros(len(rel.model._bounds), dtype=float)
+    assert z.shape[0] == 4, f"unexpected lifted layout with {z.shape[0]} columns"
+    z[0] = t
+    z[1] = fval
+    z[2] = fval
+    return z
+
+
+# --------------------------------------------------------------------------- #
+# 0. The derivative itself
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize("p", [0.5, 0.25, 0.75, 1.0 / 3.0])
+def test_pow_deriv_returns_the_limit_at_zero_instead_of_raising(p):
+    assert _pow_deriv(p)(0.0) == math.inf
+    # ...and is bit-identical to the bare exponentiation everywhere else.
+    for t in (1e-8, 1e-3, 0.25, 1.0, 3.0, 1e6):
+        assert _pow_deriv(p)(t) == p * (t ** (p - 1.0))
+
+
+@pytest.mark.parametrize("p", [-1.0, -0.5, 0.0])
+def test_pow_deriv_declines_a_nonfinite_f(p):
+    """``p <= 0``: ``f(0)`` itself diverges, so the recovery must NOT be offered a
+    finite ``f`` with a divergent ``f'`` — ``nan`` keeps ``_finite(g)`` the decliner."""
+    assert math.isnan(_pow_deriv(p)(0.0))
+
+
+# --------------------------------------------------------------------------- #
+# 1. Spelling parity — the issue's actual complaint
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize("state", ["0", "1"])
+def test_pow_and_sqrt_are_the_same_relaxation(flag, state):
+    flag(state)
+    _rp, a_pow, b_pow = _rows(_pow_model(0.5, 0.0, 4.0))
+    _rs, a_sqrt, b_sqrt = _rows(_sqrt_model(0.0, 4.0))
+    assert a_pow.shape == a_sqrt.shape, (
+        f"x**0.5 emitted {a_pow.shape[0]} rows vs sqrt(x) {a_sqrt.shape[0]} with the "
+        f"flag {state} — the facet depends on how the user spelled it (#1118)"
+    )
+    # Same rows, not the same bits: ``np.sqrt(t)`` and ``t**0.5`` differ by an ULP
+    # at some points, so the two builds' coefficients agree to rounding, and the
+    # sparsity pattern agrees exactly.
+    assert np.array_equal(a_pow != 0.0, a_sqrt != 0.0)
+    assert np.allclose(a_pow, a_sqrt, rtol=1e-12, atol=1e-12)
+    assert np.allclose(b_pow, b_sqrt, rtol=1e-12, atol=1e-12)
+
+
+# --------------------------------------------------------------------------- #
+# 2. Flag-OFF identity and the facet count with the flag ON
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize("label,p,lo,hi", SINGULAR_POWERS + REGULAR_POWERS)
+def test_flag_off_is_unchanged_by_the_new_code(flag, label, p, lo, hi):
+    flag(None)
+    _r, a_unset, b_unset = _rows(_pow_model(p, lo, hi))
+    flag("0")
+    _r, a_off, b_off = _rows(_pow_model(p, lo, hi))
+    assert np.array_equal(a_unset, a_off), label
+    assert np.array_equal(b_unset, b_off), label
+
+
+@pytest.mark.parametrize("label,p,lo,hi", SINGULAR_POWERS)
+def test_singular_facet_is_recovered(flag, label, p, lo, hi):
+    flag("0")
+    _r0, a0, _b0 = _rows(_pow_model(p, lo, hi))
+    flag("1")
+    _r1, a1, _b1 = _rows(_pow_model(p, lo, hi))
+    assert a1.shape[0] == a0.shape[0] + 1, f"{label}: {a0.shape[0]} -> {a1.shape[0]} rows"
+    assert np.isfinite(a1).all(), f"{label}: non-finite coefficient in the recovered row"
+
+
+@pytest.mark.parametrize("label,p,lo,hi", REGULAR_POWERS)
+def test_powers_without_a_vertical_tangent_are_untouched(flag, label, p, lo, hi):
+    """``p > 1`` (finite ``f'(0)``), integer powers, ``p <= 0`` (``f`` itself
+    divergent) and a fractional power away from 0 must be byte-identical ON vs OFF —
+    the recovery is for a finite ``f`` with a divergent ``f'`` only."""
+    flag("0")
+    _r0, a0, b0 = _rows(_pow_model(p, lo, hi))
+    flag("1")
+    _r1, a1, b1 = _rows(_pow_model(p, lo, hi))
+    assert np.array_equal(a0, a1), f"{label}: the flag changed a non-singular power"
+    assert np.array_equal(b0, b1), label
+
+
+# --------------------------------------------------------------------------- #
+# 3. Soundness — no graph point is cut
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize("label,p,lo,hi", SINGULAR_POWERS)
+def test_no_graph_point_is_cut(flag, label, p, lo, hi):
+    flag("1")
+    rel = build_uniform_relaxation(_pow_model(p, lo, hi))
+    A = sp.csr_matrix(rel.model._A_ub, dtype=float)
+    b = np.asarray(rel.model._b_ub, dtype=float).ravel()
+
+    ts = [lo, hi, 0.5 * (lo + hi)]
+    ts += list(np.linspace(lo, hi, 200))
+    for k in range(1, 25):  # cluster at the singular endpoint, where the facet lives
+        d = 0.5 * 2.0**-k
+        ts += [lo + d * (hi - lo), hi - d * (hi - lo)]
+    checked = 0
+    for t in ts:
+        if not (lo <= t <= hi):
+            continue
+        fval = float(t) ** p
+        if not np.isfinite(fval):
+            continue
+        z = _graph_point(rel, t, fval)
+        resid = A @ z - b
+        viol = float(np.max(resid / np.maximum(1.0, np.abs(b))))
+        assert viol <= 1e-9, f"{label}: graph point t={t!r} cut by {viol:.3e}"
+        checked += 1
+    assert checked >= 200, f"{label}: only {checked} graph points evaluated"
+
+
+# --------------------------------------------------------------------------- #
+# 4. Differential bound test on fixed boxes
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize("label,p,lo,hi", SINGULAR_POWERS)
+def test_bound_tightens_and_never_crosses(flag, label, p, lo, hi):
+    grid = np.linspace(lo, hi, 200001)
+    fv = grid**p
+    xs = max(hi - lo, 1e-300)
+    fs = max(abs(float(fv[-1]) - float(fv[0])), 1e-300)
+
+    compared = improved = 0
+    for k in range(32):
+        th = 2.0 * np.pi * k / 32.0
+        cx, cy = float(np.cos(th)) / xs, float(np.sin(th)) / fs
+        flag("0")
+        off = _lp_bound(_pow_model(p, lo, hi, (cx, cy)))
+        flag("1")
+        on = _lp_bound(_pow_model(p, lo, hi, (cx, cy)))
+        true_min = float(np.min(cx * grid + cy * fv))
+        assert on >= off - 1e-9 * (1.0 + abs(off)), (
+            f"{label} dir={k}: bound LOOSENED {off:.12g} -> {on:.12g}"
+        )
+        assert on <= true_min + 1e-6 * (1.0 + abs(true_min)), (
+            f"{label} dir={k}: bound {on:.12g} crossed the true optimum {true_min:.12g}"
+        )
+        compared += 1
+        if on > off + 1e-9 * (1.0 + abs(off)):
+            improved += 1
+
+    assert compared == 32, f"{label}: only {compared} directions compared"
+    assert improved > 0, f"{label}: the recovered facet never moved the bound (no-op)"
+
+
+# --------------------------------------------------------------------------- #
+# 5. The lazy placement (#1115) sees power atoms too
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize("label,p,lo,hi", SINGULAR_POWERS)
+def test_lazy_placement_registers_a_spec_for_a_power_atom(label, p, lo, hi):
+    tuning = solver_tuning.current().replace(singular_tangent=True, singular_tangent_lazy=True)
+    token = solver_tuning.set_current(tuning)
+    try:
+        rel = build_uniform_relaxation(_pow_model(p, lo, hi))
+        specs = list(rel.singular_tangent_specs)
+    finally:
+        solver_tuning.reset_current(token)
+    assert len(specs) == 1, f"{label}: lazy mode registered {len(specs)} specs, expected 1"
+    assert specs[0].edge == -1, f"{label}: the singular endpoint is lo, so edge = -1"
+    assert not math.isfinite(specs[0].fp(lo)), f"{label}: the spec's f' must diverge at lo"
+
+
+# --------------------------------------------------------------------------- #
+# 6. The native kernel must keep declining a zero-touching fractional power
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize("state", ["0", "1"])
+def test_native_kernel_declines_zero_touching_power(flag, state):
+    """The Rust ``mccormick_patch::univariate_rows`` regenerates an endpoint tangent
+    unconditionally; an ``inf`` slope in a node LP is the landmine #1113 closed for
+    ``sqrt``. A fractional power reaches the kernel through no term family at all, so
+    the producer must decline it — asserted rather than assumed, because the recovery
+    now emits a row on this path where it used to emit none."""
+    flag(state)
+    assert build_spatial_kernel_spec(_pow_model(0.5, 0.0, 4.0)) is None
+    assert build_spatial_kernel_spec(_pow_model(0.5, 1.0, 4.0)) is None

--- a/python/tests/test_1119_singular_tangent_accounting.py
+++ b/python/tests/test_1119_singular_tangent_accounting.py
@@ -1,0 +1,165 @@
+"""#1119 — the singular-tangent binding accounting, and why it did not become a gate.
+
+#1115 shipped ``SolverTuning.singular_tangent`` default-OFF: sound, bound-helpful
+on ``kriging_peaks``, but +25.6 % wall on ``eq6_1`` and +54.2 % on ``maxmin`` for
+no bound at all. #1119 proposed gating the separator on whether the recovered
+facet BINDS rather than on the operator that produced it, and required the
+observable to be measured before the gate was written.
+
+It was, and it falsified the gate — see ``docs/dev/performance-plan.md`` §17. The
+two instances that pay have the two HIGHEST binding rates (1.0000 and 0.9580) and
+the two that gain have the two lowest (0.9173 and 0.8509), and ``eq6_1`` has zero
+non-binding rows, so a rule that drops non-binding rows drops none of the 22 874
+it exists to remove. The direction is dead; the flag stays default-OFF.
+
+These tests pin the instrument that produced that verdict, so the number can be
+re-derived rather than re-argued. They assert self-consistency and read-only-ness,
+never a specific row count: the counts move with the relaxation and are evidence,
+not contract.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+
+import discopt._relax.mccormick_lp as mlp
+import numpy as np
+import pytest
+from discopt.modeling.core import from_nl
+from discopt.solver_tuning import SolverTuning
+
+# ``tspn12`` is in-repo and emits singular-tangent rows through the LAZY separator
+# (the eager anchor is a different code path). It is a probe, not a target: nothing
+# here asserts anything specific to it, and any in-repo instance that emits rows
+# would serve.
+_EMITTING = "tspn12"
+
+
+def _solve_with_stats(stem: str, *, on: bool, max_nodes: int = 20, time_limit: float = 30.0):
+    """Solve *stem* and return (result, summed stats over every relaxer built).
+
+    One relaxer serves the whole tree in the common case, but the solver builds
+    several for its own purposes, so the stats are summed rather than read off a
+    single instance -- reading one would silently under-report.
+    """
+    built = []
+    original = mlp.MccormickLPRelaxer.__init__
+
+    def spy(self, *args, **kwargs):
+        original(self, *args, **kwargs)
+        built.append(self)
+
+    mlp.MccormickLPRelaxer.__init__ = spy
+    try:
+        tuning = dataclasses.replace(
+            SolverTuning(),
+            singular_tangent=on,
+            singular_tangent_lazy=on,
+            deterministic=True,
+        )
+        path = _nl_path(stem)
+        res = from_nl(str(path)).solve(time_limit=time_limit, max_nodes=max_nodes, tuning=tuning)
+    finally:
+        mlp.MccormickLPRelaxer.__init__ = original
+
+    total = {"nodes": 0, "calls": 0, "specs": 0, "rounds": 0, "rows": 0, "binding": 0}
+    for relaxer in built:
+        stats = relaxer.singular_tangent_stats()
+        for key in total:
+            total[key] += stats[key]
+    total["relaxers"] = len(built)
+    return res, total
+
+
+def _nl_path(stem: str):
+    import pathlib
+
+    path = pathlib.Path(__file__).parent / "data" / "minlplib_nl" / f"{stem}.nl"
+    if not path.exists():
+        pytest.skip(f"{stem}.nl not in the in-repo corpus")
+    return path
+
+
+@pytest.mark.correctness
+def test_the_separator_records_what_it_emits():
+    """With the flag ON the accounting must be non-empty and internally consistent.
+
+    An accounting that reports zero rows on an instance that emits them is the
+    CLAUDE.md §6 failure this whole instrument exists to avoid, so the row count
+    is asserted non-zero before any fraction derived from it is believed.
+    """
+    res, stats = _solve_with_stats(_EMITTING, on=True)
+    assert res.status in ("optimal", "feasible", "node_limit", "time_limit"), res.status
+
+    assert stats["calls"] >= 1, (
+        f"the separator never ran on {_EMITTING} ({stats}) — with the flag ON and a "
+        "registered spec this test is measuring nothing"
+    )
+    assert stats["rows"] >= 1, (
+        f"the separator ran {stats['calls']}x but emitted no rows ({stats}); a binding "
+        "fraction over zero rows is not a measurement"
+    )
+    assert 0 <= stats["binding"] <= stats["rows"], stats
+    assert stats["rounds"] >= 1 and stats["nodes"] >= 1, stats
+
+
+@pytest.mark.correctness
+def test_the_flag_off_arm_records_nothing():
+    """The control must be uncontaminated: no rows, and therefore no fraction.
+
+    #1119's panel would read a shared-state leak as "the feature costs nothing",
+    which is the most flattering possible wrong answer.
+    """
+    _, stats = _solve_with_stats(_EMITTING, on=False)
+    assert stats["rows"] == 0 and stats["binding"] == 0, (
+        f"flag-OFF emitted singular-tangent rows ({stats}) — the arms share state"
+    )
+    assert stats["calls"] == 0, f"flag-OFF ran the separator ({stats})"
+
+
+@pytest.mark.unit
+def test_the_tally_is_read_only():
+    """It must not touch the rows it measures, and must not raise on a bad shape.
+
+    The tally is called from inside the separator's ``try/except Exception``, so a
+    raise there would silently abandon separation and move a bound. A shape
+    mismatch therefore returns without recording -- but the panel above asserts a
+    non-zero row count, so "recorded nothing" cannot pass as "nothing bound".
+    """
+
+    class _Probe:
+        pass
+
+    probe = _Probe()
+    for attr, value in (
+        ("_st_rows", 0),
+        ("_st_binding", 0),
+        ("_st_recent", __import__("collections").deque(maxlen=8)),
+    ):
+        setattr(probe, attr, value)
+
+    rows = [[1.0, 0.0], [0.0, 1.0]]
+    rhs = [1.0, 2.0]
+    rows_before = [list(r) for r in rows]
+    rhs_before = list(rhs)
+    x = np.array([1.0, 0.5])
+
+    record = mlp.MccormickLPRelaxer._record_singular_tangent_hits
+    assert record(probe, rows, rhs, x) is None
+    assert rows == rows_before and rhs == rhs_before, "the tally mutated its inputs"
+    assert probe._st_rows == 2, probe._st_rows
+    # x1 = 1.0 hits `x1 <= 1`; x2 = 0.5 leaves `x2 <= 2` slack by 1.5.
+    assert probe._st_binding == 1, probe._st_binding
+
+    checked = 0
+    for bad_rows, bad_rhs, bad_x in (
+        ([[1.0, 0.0]], [1.0], np.array([[1.0, 0.5]])),  # x not 1-D
+        ([[1.0, 0.0]], [1.0, 2.0], x),  # rhs/rows disagree
+        ([[1.0, 0.0, 0.0]], [1.0], x),  # width disagrees
+        ([[1.0, 0.0]], [1.0], None),  # no solution
+    ):
+        before = probe._st_rows
+        assert record(probe, bad_rows, bad_rhs, bad_x) is None
+        assert probe._st_rows == before, "a malformed batch was recorded"
+        checked += 1
+    assert checked == 4, "the malformed-input probe stopped running (rule 6)"

--- a/python/tests/test_912_wall_budget_inventory.py
+++ b/python/tests/test_912_wall_budget_inventory.py
@@ -48,6 +48,34 @@ Categories:
     consumption, plus (for the bound-changing ones — OBBT, NBT, root cuts, PSD
     separation, convexity classification) its own differential-bound panel.
 
+What #1116 changed about the residuals
+--------------------------------------
+
+#1116 measured a residual gate doing exactly what this file exists to prevent:
+``kriging_peaks-full200`` at ``max_nodes=1`` returned root dual bounds spanning
+14 % across three repetitions of the same binary on the same machine, because a
+wall-truncated tightening stage handed the relaxation builder a different box
+(first root LP: 1532 columns one run, 1469 the next). That is the "large
+instance" case the paragraph below names as the trigger to revisit — and it
+arrived, so the trigger fired.
+
+The response was not a per-gate conversion to deterministic units (§9 below still
+falsifies that as a blanket move) but a switch that makes the whole role-2 class
+*inert on request*: ``Model.solve(deterministic=True)`` / ``DISCOPT_DETERMINISTIC``
+routes each budget through ``solver._role2_budget`` / ``_role2_deadline`` /
+``_role2_horizon``, which return the no-clock value (``None`` or ``math.inf``)
+under the flag. Eleven of the entries below changed spelling for that reason and
+for that reason only — the same gate at the same site, now wrapped. They keep the
+``residual`` category because the flag is **default-off**: with it off the gate
+still decides how much work runs, which is what ``residual`` means. Turning it on
+is bound-changing and needs the panel in CLAUDE.md §5.
+
+The wrapping is not a conversion, so the count below does not move. It does give
+the residual class a documented escape hatch it did not have, and it puts the
+role-1 gates that were deliberately *not* wrapped (the phase-entry
+``_deadline_exhausted()`` checks, the POUNCE stall backstop) on record in
+``solver_tuning.SolverTuning.deterministic``.
+
 Why the residuals were left, and when to revisit
 ------------------------------------------------
 
@@ -236,7 +264,7 @@ KNOWN: tuple[tuple[str, str, str], ...] = (
     ),
     (
         "solver.py",
-        "deadline = time.perf_counter() + float(_NATIVE_SEED_HEURISTIC_S)",
+        "deadline = _role2_horizon(time.perf_counter() + float(_NATIVE_SEED_HEURISTIC_S))",
         "residual",
     ),
     (
@@ -246,7 +274,7 @@ KNOWN: tuple[tuple[str, str, str], ...] = (
     ),
     (
         "solver.py",
-        "deadline = (time.perf_counter() + budget) if budget else None",
+        "deadline = _role2_deadline((time.perf_counter() + budget) if budget else None)",
         "residual",
     ),
     # The #138 root-relaxation fallback's rule-2 stop. This was ``residual`` and is
@@ -267,27 +295,27 @@ KNOWN: tuple[tuple[str, str, str], ...] = (
     ),
     (
         "solver.py",
-        "deadline=time.perf_counter() + _per_budget_s,",
+        "deadline=_role2_deadline(time.perf_counter() + _per_budget_s),",
         "residual",
     ),
     (
         "solver.py",
-        "deadline=time.perf_counter() + _dcb_budget,",
+        "deadline=_role2_deadline(time.perf_counter() + _dcb_budget),",
         "residual",
     ),
     (
         "solver.py",
-        "model, deadline=time.perf_counter() + _nbt_budget_s",
+        "model, deadline=_role2_deadline(time.perf_counter() + _nbt_budget_s)",
         "residual",
     ),
     (
         "solver.py",
-        "deadline=time.perf_counter() + _obbt_budget,",
+        "deadline=_role2_deadline(time.perf_counter() + _obbt_budget),",
         "residual",
     ),
     (
         "solver.py",
-        "time.perf_counter() + max(2.0, min(15.0, 0.2 * float(time_limit))),",
+        "time.perf_counter() + max(2.0, min(15.0, 0.2 * float(time_limit)))",
         "residual",
     ),
     # The #823/#993 GDP configuration constructor's slice: 15% of what is left,
@@ -305,12 +333,12 @@ KNOWN: tuple[tuple[str, str, str], ...] = (
     ),
     (
         "solver.py",
-        "deadline=time.perf_counter() + 5.0,",
+        "deadline=_role2_deadline(time.perf_counter() + 5.0),",
         "residual",
     ),
     (
         "solver.py",
-        "deadline=time.perf_counter() + _rf_budget,",
+        "deadline=_role2_deadline(time.perf_counter() + _rf_budget),",
         "residual",
     ),
     (
@@ -325,7 +353,7 @@ KNOWN: tuple[tuple[str, str, str], ...] = (
     ),
     (
         "solver.py",
-        "deadline=time.perf_counter() + budget,",
+        "deadline=_role2_deadline(time.perf_counter() + budget),",
         "residual",
     ),
     (
@@ -406,7 +434,7 @@ KNOWN: tuple[tuple[str, str, str], ...] = (
     ),
     (
         "_relax/mccormick_lp.py",
-        "deadline = time.perf_counter() + _INTEGER_RATIO_DIVE_BUDGET_S",
+        "else time.perf_counter() + _INTEGER_RATIO_DIVE_BUDGET_S",
         "residual",
     ),
     (
@@ -554,6 +582,10 @@ def test_residual_count_is_visible():
     # 19 -> 20: ``_gdp_config_deadline`` — not a new gate, a newly *visible* one.
     # It predates this bump; the scanner could not see it until it learned to
     # follow a clock read through a function argument (#993).
+    # 20 -> 20 across #1116: eleven entries changed spelling when their gate was
+    # routed through ``solver._role2_*``, but a wrap is not a conversion — the
+    # flag is default-off, so with it off the gate still decides how much work
+    # runs. Pinned separately by ``test_1116_wrapped_gates_stay_wrapped``.
     assert len(residual) == 20, (
         f"the #912 residual inventory changed ({len(residual)} entries, expected 20). "
         "If you converted one, drop it from KNOWN and lower this number; if you added "
@@ -561,3 +593,56 @@ def test_residual_count_is_visible():
         "backlog — see the module docstring for the evidence and the condition that "
         "would justify shrinking it.\n" + "\n".join(f"  {p}: {s}" for p, s in residual)
     )
+
+
+@pytest.mark.unit
+def test_1116_wrapped_gates_stay_wrapped():
+    """The gates #1116 made flag-suppressible must not quietly lose the wrapper.
+
+    Unwrapping one is invisible to the two ratchets above — the line text would
+    change, the author would re-record it, and both tests would pass while
+    ``deterministic=True`` silently stopped covering that site. So the count is
+    pinned here.
+
+    Suppression is read from the *source window* around each recorded gate rather
+    than from the recorded text, because two of the eleven do not show it on their
+    own line: ``mccormick_lp``'s integer-ratio dive is guarded by a bare
+    ``_tuning().deterministic`` conditional (the budget is a loop condition, not an
+    argument), and the continuous-multistart gate carries its ``_role2_horizon(``
+    on the line above after formatting. A record-text check would have scored those
+    two as unwrapped and, worse, would keep scoring them by their spelling.
+
+    Lowering the count means a gate left the role-2 class (converted to a
+    deterministic budget, or reclassified ``contract``); raising it means another
+    was brought in, which is the direction this is meant to encourage.
+    """
+    marks = ("_role2_", "_tuning().deterministic")
+    wrapped = []
+    checked = 0
+    for path, line in sorted(_KNOWN_KEYS):
+        lines = (_PKG / path).read_text().splitlines()
+        hits = [i for i, raw in enumerate(lines) if raw.strip() == line]
+        # A KNOWN line that matches nothing is ``test_recorded_gates_still_exist``'s
+        # business, not this one — except for the multi-line records, which are
+        # stored implicitly concatenated and never match a single source line.
+        if not hits:
+            continue
+        checked += 1
+        for i in hits:
+            window = "\n".join(lines[max(0, i - 2) : i + 2])
+            if any(m in window for m in marks):
+                wrapped.append((path, line))
+                break
+
+    assert checked >= len(_KNOWN_KEYS) - 3, (
+        f"only {checked} of {len(_KNOWN_KEYS)} recorded gates were located in source "
+        "— this probe has stopped measuring (rule 6)"
+    )
+    assert len(wrapped) == 11, (
+        f"the #1116 role-2 suppression count changed ({len(wrapped)} gates, expected 11).\n"
+        + "\n".join(f"  {p}: {s}" for p, s in sorted(wrapped))
+    )
+    for path, line in wrapped:
+        assert _CATEGORY[(path, line)] == "residual", (
+            f"{path}: a role-2-suppressed gate is by construction role 2 — {line}"
+        )

--- a/scratchpad/issue1114/alpha_mechanism.py
+++ b/scratchpad/issue1114/alpha_mechanism.py
@@ -1,0 +1,61 @@
+"""#1114 mechanism check: WHY does alphaBB abstain on the reduced-space class?
+
+The entry experiment measured 0/52 finite alphaBB bounds on 8 CustomCall models.
+This turns that sample into a class statement by calling ``rigorous_alpha``
+directly on a CustomCall objective and reporting what it does (raise / +inf /
+finite). No exception is swallowed (CLAUDE.md §7): a raise is reported as the
+answer, not hidden.
+"""
+
+import sys
+
+import numpy as np
+
+import discopt
+import discopt.modeling as dm
+from discopt._alphabb_rigorous import rigorous_alpha
+from discopt._relax.mcbox import MCBox
+
+import jax.numpy as jnp
+
+print(f"discopt.__file__={discopt.__file__}", flush=True)
+
+
+def _exp(x):
+    return x.exp() if isinstance(x, MCBox) else jnp.exp(x)
+
+
+checks = 0
+
+# (a) a CustomCall objective -- the class #1114 is about.
+m = dm.Model("custom")
+x = m.continuous("x", 2, lb=[0.1, 0.1], ub=[2.0, 2.0])
+f = dm.custom(lambda a, b: a * _exp(-b) + b * _exp(-a), name="f")
+m.minimize(f(x[0], x[1]))
+
+# (b) the same function written in NATIVE expression ops -- the control. If (b)
+# yields a finite alpha and (a) does not, the abstention is caused by the opaque
+# CustomCall node, not by the box or the algebra.
+m2 = dm.Model("native")
+y = m2.continuous("y", 2, lb=[0.1, 0.1], ub=[2.0, 2.0])
+m2.minimize(y[0] * dm.exp(-y[1]) + y[1] * dm.exp(-y[0]))
+
+from discopt.solver import _alphabb_node_box  # the real box builder
+
+for label, mm in (("customcall", m), ("native", m2)):
+    n = sum(v.size for v in mm._variables)
+    box = _alphabb_node_box(mm, np.full(n, 0.1), np.full(n, 2.0))
+    expr = mm._objective.expression
+    checks += 1
+    try:
+        alpha = np.asarray(rigorous_alpha(expr, mm, box), dtype=np.float64)
+    except Exception as e:  # reported, never swallowed
+        print(f"{label:12s} RAISED {type(e).__name__}: {e}", flush=True)
+        continue
+    finite = bool(np.all(np.isfinite(alpha)))
+    print(f"{label:12s} alpha={alpha} all_finite={finite}", flush=True)
+
+print(f"checks={checks}", flush=True)
+if checks == 0:
+    print("PROBE FIRED NOTHING", flush=True)
+    sys.exit(2)

--- a/scratchpad/issue1114/entry_experiment.py
+++ b/scratchpad/issue1114/entry_experiment.py
@@ -1,0 +1,260 @@
+"""#1114 entry experiment (CLAUDE.md §4): does alphaBB ever WIN a node the
+reduced-space engine also bounded?
+
+`_use_alphabb` keys on `_mc_lp_relaxer is None`, which is exactly the hidden-function
+(`dm.custom` / CustomCall) class where the reduced-space engine is forced on. Both
+engines therefore run at every node and are combined with `max()`. This probe counts,
+per model and per node box:
+
+  * nodes where alphaBB returned a finite bound,
+  * nodes where the reduced engine returned a bound,
+  * nodes where BOTH did, and of those, nodes where `alphabb_lb > reduced_lb`
+    (strictly, beyond a relative tolerance).
+
+KILL CRITERION (from the issue): if `alphabb_lb > reduced_lb` on a non-trivial
+fraction of nodes, the redundancy claim is false and #1114 must be re-scoped to the
+root alpha estimate alone.
+
+Usage: python -u entry_experiment.py [max_nodes] [time_limit]
+
+The corpus is a FAMILY of MCBox-traceable CustomCall models with different structures
+and dimensions (§2: the class, not an instance). Exceptions are never swallowed (§7);
+the executed-comparison count is printed and a zero count exits non-zero (§6).
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+
+import numpy as np
+
+import discopt
+import discopt.modeling as dm
+import discopt.solver as solver_mod
+from discopt._relax import mccormick_subgradient as _mcs
+from discopt._relax.mcbox import MCBox
+
+import jax.numpy as jnp
+
+print(f"discopt.__file__={discopt.__file__}", flush=True)
+
+MAX_NODES = int(sys.argv[1]) if len(sys.argv) > 1 else 200
+TIME_LIMIT = float(sys.argv[2]) if len(sys.argv) > 2 else 30.0
+
+
+# --- MCBox/numpy dual-dispatch helpers (the canonical notebook idiom) --------- #
+def _exp(x):
+    return x.exp() if isinstance(x, MCBox) else jnp.exp(x)
+
+
+def _log(x):
+    return x.log() if isinstance(x, MCBox) else jnp.log(x)
+
+
+def _sqrt(x):
+    return x.sqrt() if isinstance(x, MCBox) else jnp.sqrt(x)
+
+
+def _tanh(x):
+    return x.tanh() if isinstance(x, MCBox) else jnp.tanh(x)
+
+
+def _sigmoid(x):
+    return x.sigmoid() if isinstance(x, MCBox) else 1.0 / (1.0 + jnp.exp(-x))
+
+
+def _atan(x):
+    return x.atan() if isinstance(x, MCBox) else jnp.arctan(x)
+
+
+def _sinh(x):
+    return x.sinh() if isinstance(x, MCBox) else jnp.sinh(x)
+
+
+def _model_exp_product():
+    m = dm.Model("exp_product")
+    x = m.continuous("x", 2, lb=[0.1, 0.1], ub=[2.0, 2.0])
+    f = dm.custom(lambda a, b: a * _exp(-b) + b * _exp(-a), name="f")
+    m.minimize(f(x[0], x[1]))
+    m.subject_to(x[0] + x[1] >= 1.0)
+    return m
+
+
+def _model_bilinear_chain():
+    m = dm.Model("bilinear_chain")
+    x = m.continuous("x", 3, lb=[-1.0, -1.0, -1.0], ub=[1.5, 1.5, 1.5])
+    f = dm.custom(lambda a, b, c: a * b + b * c - 0.7 * a * c, name="f")
+    m.minimize(f(x[0], x[1], x[2]))
+    m.subject_to(x[0] + x[1] + x[2] <= 2.0)
+    return m
+
+
+def _model_log_ratio():
+    m = dm.Model("log_ratio")
+    x = m.continuous("x", 2, lb=[0.5, 0.5], ub=[3.0, 3.0])
+    f = dm.custom(lambda a, b: _log(a + 0.5 * b) - a / (b + 0.25), name="f")
+    m.minimize(f(x[0], x[1]))
+    m.subject_to(x[0] - x[1] <= 1.0)
+    return m
+
+
+def _model_sqrt_sum():
+    m = dm.Model("sqrt_sum")
+    x = m.continuous("x", 3, lb=[0.05, 0.05, 0.05], ub=[4.0, 4.0, 4.0])
+    f = dm.custom(lambda a, b, c: _sqrt(a) * b - 0.4 * _sqrt(b * c + 0.1), name="f")
+    m.minimize(f(x[0], x[1], x[2]))
+    m.subject_to(x[0] + x[2] >= 1.0)
+    return m
+
+
+def _model_tanh_net():
+    m = dm.Model("tanh_net")
+    x = m.continuous("x", 2, lb=[-1.5, -1.5], ub=[1.5, 1.5])
+    f = dm.custom(
+        lambda a, b: 1.3 * _tanh(0.7 * a - 0.4 * b + 0.1) - 0.8 * _tanh(-0.3 * a + 0.9 * b),
+        name="f",
+    )
+    m.minimize(f(x[0], x[1]))
+    return m
+
+
+def _model_sigmoid_mix():
+    m = dm.Model("sigmoid_mix")
+    x = m.continuous("x", 3, lb=[-2.0, -2.0, -2.0], ub=[2.0, 2.0, 2.0])
+    f = dm.custom(
+        lambda a, b, c: _sigmoid(a * b) + 0.5 * _sigmoid(b - c) - 0.3 * a * c, name="f"
+    )
+    m.minimize(f(x[0], x[1], x[2]))
+    m.subject_to(x[0] + x[1] + x[2] >= -1.0)
+    return m
+
+
+def _model_atan_sinh():
+    m = dm.Model("atan_sinh")
+    x = m.continuous("x", 2, lb=[-1.0, -1.0], ub=[1.0, 1.0])
+    f = dm.custom(lambda a, b: _atan(3.0 * a * b) + 0.2 * _sinh(a - b), name="f")
+    m.minimize(f(x[0], x[1]))
+    return m
+
+
+def _model_pow_mix():
+    m = dm.Model("pow_mix")
+    x = m.continuous("x", 3, lb=[0.2, 0.2, 0.2], ub=[2.5, 2.5, 2.5])
+    f = dm.custom(lambda a, b, c: a**3 - 2.0 * a * b + b**2 * c - 0.5 * c**2, name="f")
+    m.minimize(f(x[0], x[1], x[2]))
+    m.subject_to(x[0] + x[1] >= 0.8)
+    return m
+
+
+MODELS = [
+    _model_exp_product,
+    _model_bilinear_chain,
+    _model_log_ratio,
+    _model_sqrt_sum,
+    _model_tanh_net,
+    _model_sigmoid_mix,
+    _model_atan_sinh,
+    _model_pow_mix,
+]
+
+_orig_alphabb = solver_mod._compute_alphabb_bound
+_orig_reduced = _mcs.reduced_mccormick_lp_bound
+
+REL_TOL = 1e-9
+
+
+def _key(lb, ub, k):
+    a = np.asarray(lb, dtype=np.float64)[:k]
+    b = np.asarray(ub, dtype=np.float64)[:k]
+    return (a.tobytes(), b.tobytes())
+
+
+rows = []
+comparisons = 0
+for factory in MODELS:
+    model = factory()
+    alpha_calls: dict = {}
+    reduced_calls: dict = {}
+
+    def _alphabb_probe(evaluator, mdl, expr, node_lb, node_ub, _o=_orig_alphabb, _a=alpha_calls):
+        val = _o(evaluator, mdl, expr, node_lb, node_ub)
+        _a.setdefault(_key(node_lb, node_ub, len(np.asarray(node_lb))), []).append(float(val))
+        return val
+
+    def _reduced_probe(mdl, lo, hi, *args, _o=_orig_reduced, _r=reduced_calls, **kwargs):
+        res = _o(mdl, lo, hi, *args, **kwargs)
+        _r.setdefault(_key(lo, hi, len(np.asarray(lo))), []).append(
+            (res.status, None if res.bound is None else float(res.bound))
+        )
+        return res
+
+    solver_mod._compute_alphabb_bound = _alphabb_probe
+    _mcs.reduced_mccormick_lp_bound = _reduced_probe
+    try:
+        result = model.solve(max_nodes=MAX_NODES, time_limit=TIME_LIMIT)
+    finally:
+        solver_mod._compute_alphabb_bound = _orig_alphabb
+        _mcs.reduced_mccormick_lp_bound = _orig_reduced
+
+    # Pair by node box: the reduced engine is called on the ORIGINAL-variable slice,
+    # alphaBB on the (possibly lifted) node box, so match on the shorter prefix.
+    n_alpha_finite = 0
+    n_reduced_bound = 0
+    n_both = 0
+    n_alpha_wins = 0
+    worst_win = 0.0
+    for rkey, rvals in reduced_calls.items():
+        lb_r = np.frombuffer(rkey[0], dtype=np.float64)
+        k = len(lb_r)
+        rbounds = [v for (s, v) in rvals if s == "optimal" and v is not None and np.isfinite(v)]
+        if rbounds:
+            n_reduced_bound += 1
+        akey = None
+        for cand in alpha_calls:
+            if np.frombuffer(cand[0], dtype=np.float64)[:k].tobytes() == rkey[0] and (
+                np.frombuffer(cand[1], dtype=np.float64)[:k].tobytes() == rkey[1]
+            ):
+                akey = cand
+                break
+        if akey is None:
+            continue
+        avals = [v for v in alpha_calls[akey] if np.isfinite(v)]
+        if avals:
+            n_alpha_finite += 1
+        if avals and rbounds:
+            n_both += 1
+            a_best, r_best = max(avals), max(rbounds)
+            comparisons += 1
+            if a_best > r_best + REL_TOL * (1.0 + abs(r_best)):
+                n_alpha_wins += 1
+                worst_win = max(worst_win, a_best - r_best)
+
+    row = {
+        "model": model.name if hasattr(model, "name") else str(factory.__name__),
+        "status": result.status,
+        "nodes": int(result.node_count or 0),
+        "bound": None if result.bound is None else float(result.bound),
+        "objective": None if result.objective is None else float(result.objective),
+        "alpha_boxes": len(alpha_calls),
+        "reduced_boxes": len(reduced_calls),
+        "boxes_alpha_finite": n_alpha_finite,
+        "boxes_reduced_bound": n_reduced_bound,
+        "boxes_both": n_both,
+        "boxes_alpha_wins": n_alpha_wins,
+        "worst_alpha_margin": worst_win,
+    }
+    rows.append(row)
+    print(json.dumps(row), flush=True)
+
+tot_both = sum(r["boxes_both"] for r in rows)
+tot_wins = sum(r["boxes_alpha_wins"] for r in rows)
+print(
+    f"--- TOTAL both={tot_both} alpha_wins={tot_wins} "
+    f"frac={0.0 if tot_both == 0 else tot_wins / tot_both:.4f}",
+    flush=True,
+)
+print(f"comparisons={comparisons}", flush=True)
+if comparisons == 0:
+    print("PROBE FIRED NOTHING — no node box had both bounds; the experiment is void.")
+    sys.exit(2)

--- a/scratchpad/issue1116/README.md
+++ b/scratchpad/issue1116/README.md
@@ -1,0 +1,73 @@
+# #1116 — `kriging_peaks-full200` does not reproduce run-to-run
+
+Probes for the root-cause investigation. Every one prints an executed-comparison
+count and exits non-zero when it made none (CLAUDE.md §6), swallows no exception
+(§7), and prints `discopt.__file__` (§8). `.log` outputs are gitignored; the
+harnesses are kept so any verdict here can be re-run.
+
+## Verdict
+
+The cause is the **wall clock**, in #912's role 2 ("how much work do we do?"), not
+role 1 ("when do we stop?"). Fixed by `Model.solve(deterministic=True)` /
+`DISCOPT_DETERMINISTIC` — see `solver_tuning.SolverTuning.deterministic` and
+`solver._role2_deadline` / `_role2_horizon`.
+
+| probe | question | verdict |
+|---|---|---|
+| `repro_probe.py` | does it reproduce at all? | **no** — 3 bounds, nodes 301↔303 at `max_nodes=300` |
+| `min_budget_scan.py` | cheapest reproducing budget | `max_nodes=1`: 3 bounds spanning **14 %** (−25371.8/−28852.0/−28072.6), incumbent bit-identical |
+| `rust_hash_iteration_scan.py` | the issue's "suggested first step" | **falsified** — 79 files / 61 404 lines / 18 hash-container decls / **3** iteration sites, all order-insensitive; the five named `bnb` sites are only `insert`/`entry`/`remove`/`get`/`len`ed |
+| `run_e3_e2.sh` (E3) | thread scheduling? | **falsified** — rayon+BLAS pinned to 1, still 301↔303 |
+| `e5_stable_hash.py` | `Variable.__hash__ = id(self)`? | **falsified** — patched to `self._index` (26 377 430 firings), bound still moves |
+| `lp_seam_bisect.py` | is the Rust simplex a faithful function of its input? | **yes** — `first_differing_OUTPUT_at_equal_input = None`; divergence is upstream, at LP call 0 |
+| `build_component_bisect.py` | how does LP call 0 differ? | **structurally** — `c` (1532,) vs (1469,), `A_ub` (4860,1532) vs (4734,1469). Not float noise |
+| `build_truncation_probe.py` | is the #694 anytime build truncating? | **falsified** — `build_truncated=False`, `cons_done == cons_total` (404/404) |
+| `root_fixpoint_probe.py` | does the deadline-driven root fixpoint return a different box? | **yes** — `n_tightened` 894 vs 898, out_box hashes differ, OBBT 237.7 s vs 247.55 s, *and the input box already differs* (an upstream role-2 clock too) |
+| `no_wall_probe.py` (E4) | wall clocks at all? | **yes, and confounded** — clock+LP+NLP patched together reproduces bit-exactly |
+| `wall_arm_probe.py` (E6) | *which* wall seam? | **the clock alone**: `clock` arm −1044.8190276107248 twice; `nlp` arm still varies (−32525.9 / −34452.9); the LP seam never binds (`timelimited=0`) |
+| `stage_trace.py` | where does divergence first appear? | at the **root LP**, not in a later stage — every structural quantity before it agrees |
+| `build_hash_probe.py` | is the built relaxation itself bit-identical? | **yes, within one process** — the divergence is in the box handed to the builder, not the builder |
+| `clock_trace.py` | which wall-gated call site differs? | tallies `perf_counter` calls per `(file, line)`; the differing sites are the tightening budgets |
+| `nlp_trace.py` | is the first divergence in a local NLP? | **no** — the incumbent's last digits move but the dual bound diverges first |
+| `deterministic_verify.py` | does the shipped fix reproduce? | **yes** — acceptance test for `deterministic=True`; see below |
+
+Note the no-clock bound (−1044.819) is **three orders of magnitude tighter** than
+every wall-bounded run: an early-truncated tightening stage is not merely
+nondeterministic, it leaves bound on the table.
+
+## What the fix covers, and what it deliberately does not
+
+The flag neutralizes role-2 clocks at their **origin** — 27 call sites in
+`solver.py` (via `_role2_budget` / `_role2_deadline` / `_role2_horizon`), 3 direct
+`_tuning().deterministic` guards where the budget is a loop condition rather than
+an argument, and the integer-ratio dive in `_relax/mccormick_lp.py` — rather than at the seam, so the
+class is fixed and not the instance (CLAUDE.md §2). The wrapped sites span both
+sides of the search: the dual side (root presolve, declared-box tightening, OBBT,
+per-node OBBT, the root fixpoint, root cuts, the box/probe/pool LP slices, the
+MILP stall slice) and the primal side (native-kernel seeds, root sub-NLP seeds,
+ILS, continuous multistart, one-hot swap, dual recovery at the incumbent) — a
+machine-speed-dependent *incumbent* moves the cutoff, which moves the tree, which
+moves the bound, so the primal half is not optional.
+
+Two role-1 mechanisms are left live on purpose:
+
+* the phase-entry gates (`_deadline_exhausted()` / `_remaining_budget() > x`) that
+  decide whether an optional preprocessing phase *starts*;
+* the two POUNCE funnels' `max_wall_time = min(30.0, caller_limit)` stall backstop.
+
+Neutralizing either lets preprocessing overrun the user's `time_limit` without
+bound — trading a reproducibility bug for a broken role-1 promise, which §1 does
+not permit. So the guarantee is scoped: **a solve reproduces when the role-1
+budget never binds.** Both residuals were measured not to bind here — the 30 s
+POUNCE cap was live and real during the `clock` arm that reproduced bit-exactly,
+and the solve finishes in ~7 min against the default 3600 s limit.
+
+## Re-running
+
+    python -u repro_probe.py <instance-stem> <max_nodes> <reps>
+    python -u wall_arm_probe.py <stem> <max_nodes> <reps> <none|clock|lp|nlp[,...]>
+    python -u deterministic_verify.py <stem> <max_nodes> <reps> <0|1>
+
+`<instance-stem>` is resolved under
+`~/Dropbox/projects/discopt-minlp-benchmark/minlplib/nl/`. `full200` costs ~5-6
+min per repetition at `max_nodes=1` and ~7 min at `max_nodes=300`.

--- a/scratchpad/issue1116/build_component_bisect.py
+++ b/scratchpad/issue1116/build_component_bisect.py
@@ -1,0 +1,125 @@
+"""#1116 stage 3: WHICH part of the very first root LP differs between two runs?
+
+Usage: python -u build_component_bisect.py <instance-stem> <max_nodes> [n_calls]
+
+``lp_seam_bisect.py`` established that ``first_differing_INPUT = 0`` — the FIRST
+``MilpRelaxationModel.solve`` of the run is already handed a different problem in
+two repetitions of the same solve in the same process. So the divergence is in
+the relaxation BUILD (or in the presolve/FBBT box it is built over), not in the
+simplex and not in the search.
+
+This probe splits that first LP (and the next few) into its components — ``c``,
+``A_ub``, ``b_ub``, ``bounds``, ``integrality`` — hashes each separately, and for
+any component that differs reports the first differing entry with both values and
+their ULP distance. A last-bit difference means order-of-summation; a large or
+structural difference (different shape, different nnz) means a different amount
+of work was done.
+
+Per-rep progress (§10), module assertion (§8), executed-comparison count with a
+non-zero exit when it is zero (§6), no swallowed exceptions (§7).
+"""
+
+import hashlib
+import sys
+
+import discopt
+import numpy as np
+import scipy.sparse as sp
+from discopt._relax.milp_relaxation import MilpRelaxationModel
+from discopt.modeling.core import from_nl
+
+print(f"discopt.__file__={discopt.__file__}", flush=True)
+
+NL = "/Users/jkitchin/Dropbox/projects/discopt-minlp-benchmark/minlplib/nl/{}.nl"
+stem = sys.argv[1]
+max_nodes = int(sys.argv[2])
+N_CALLS = int(sys.argv[3]) if len(sys.argv) > 3 else 5
+
+
+def _flat(p):
+    """Component -> (label, dense 1-D float view) for hashing and diffing."""
+    if p is None:
+        return "none", np.zeros(0)
+    if sp.issparse(p):
+        m = sp.csr_matrix(p)
+        return (
+            f"sparse{m.shape}nnz={m.nnz}",
+            np.concatenate(
+                [
+                    m.indptr.astype(np.float64),
+                    m.indices.astype(np.float64),
+                    np.asarray(m.data, dtype=np.float64),
+                ]
+            ),
+        )
+    a = np.asarray(p, dtype=np.float64).ravel()
+    return f"dense{a.shape}", a
+
+
+def _hash(a: np.ndarray) -> str:
+    return hashlib.blake2b(np.ascontiguousarray(a).tobytes(), digest_size=10).hexdigest()
+
+
+COMPONENTS = ("c", "A_ub", "b_ub", "bounds", "integrality")
+
+records: list[list[tuple[str, str, np.ndarray]]] = []
+_cur: list[tuple[str, str, np.ndarray]] = []
+_orig = MilpRelaxationModel.solve
+
+
+def _traced(self, *a, **kw):
+    if len(_cur) < N_CALLS * len(COMPONENTS):
+        raw = (
+            self._c,
+            self._A_ub,
+            self._b_ub,
+            np.asarray(self._bounds, dtype=np.float64) if self._bounds else None,
+            self._integrality,
+        )
+        for name, p in zip(COMPONENTS, raw):
+            label, flat = _flat(p)
+            _cur.append((name, f"{label}|{_hash(flat)}", flat))
+    return _orig(self, *a, **kw)
+
+
+MilpRelaxationModel.solve = _traced
+
+for rep in range(2):
+    _cur = []
+    model = from_nl(NL.format(stem))
+    r = model.solve(max_nodes=max_nodes)
+    records.append(_cur)
+    print(
+        f"rep={rep} captured={len(_cur) // len(COMPONENTS)} calls "
+        f"nodes={r.node_count} bound={r.bound!r} objective={r.objective!r}",
+        flush=True,
+    )
+
+A, B = records
+comparisons = 0
+for k in range(min(len(A), len(B))):
+    name, sig_a, arr_a = A[k]
+    _, sig_b, arr_b = B[k]
+    call = k // len(COMPONENTS)
+    comparisons += 1
+    if sig_a == sig_b:
+        continue
+    print(f"CALL {call} component {name}: DIFFERS  rep0={sig_a}  rep1={sig_b}", flush=True)
+    if arr_a.shape != arr_b.shape:
+        print(f"    shapes differ: {arr_a.shape} vs {arr_b.shape}", flush=True)
+        continue
+    idx = np.flatnonzero(arr_a != arr_b)
+    print(f"    differing entries: {idx.size} of {arr_a.size}", flush=True)
+    for j in idx[:5]:
+        x, y = float(arr_a[j]), float(arr_b[j])
+        ulps = (
+            abs(int(np.asarray(x).view(np.int64)) - int(np.asarray(y).view(np.int64)))
+            if np.isfinite(x) and np.isfinite(y) and np.sign(x) == np.sign(y)
+            else -1
+        )
+        print(f"    [{j}] {x!r} vs {y!r}   ulps={ulps}", flush=True)
+
+print(f"comparisons={comparisons}", flush=True)
+if comparisons == 0:
+    print("PROBE FIRED NOTHING", flush=True)
+    sys.exit(2)

--- a/scratchpad/issue1116/build_hash_probe.py
+++ b/scratchpad/issue1116/build_hash_probe.py
@@ -1,0 +1,78 @@
+"""#1116 stage 1: is the BUILT relaxation itself bit-identical across reps?
+
+Usage: python -u build_hash_probe.py <instance-stem> <reps>
+
+Builds the root uniform relaxation N times in ONE process and hashes the LP data
+(A_ub structure+values, b_ub, c, bounds, integrality) plus the varmap orderings.
+No exception is caught (CLAUDE.md §7); the number of executed comparisons is
+printed and a zero count exits non-zero (§6).
+"""
+
+import hashlib
+import json
+import sys
+import time
+
+import discopt
+import numpy as np
+import scipy.sparse as sp
+from discopt._relax.uniform_relax import build_uniform_relaxation
+from discopt.modeling.core import from_nl
+
+print(f"discopt.__file__={discopt.__file__}", flush=True)
+
+NL = "/Users/jkitchin/Dropbox/projects/discopt-minlp-benchmark/minlplib/nl/{}.nl"
+stem, reps = sys.argv[1], int(sys.argv[2])
+
+
+def _h(*arrays) -> str:
+    m = hashlib.sha1()
+    for a in arrays:
+        m.update(np.ascontiguousarray(np.asarray(a, dtype=np.float64)).tobytes())
+    return m.hexdigest()[:12]
+
+
+def _hs(obj) -> str:
+    return hashlib.sha1(repr(obj).encode()).hexdigest()[:12]
+
+
+rows = []
+for rep in range(reps):
+    t0 = time.perf_counter()
+    model = from_nl(NL.format(stem))
+    rel = build_uniform_relaxation(model)
+    M = rel.model
+    A = sp.csr_matrix(M._A_ub)
+    row = {
+        "rep": rep,
+        # RAW (unsorted) CSR triple: catches row/column ORDER changes, not just values
+        "A_raw": _h(A.data, A.indices, A.indptr),
+        "b": _h(M._b_ub),
+        "c": _h(M._c),
+        "bounds": _hs(M._bounds),
+        "integrality": _hs(list(M._integrality) if M._integrality is not None else None),
+        "shape": list(A.shape),
+        "nnz": int(A.nnz),
+        "bilinear_map": _hs(list(rel.bilinear_map.items())),
+        "monomial_map": _hs(list(rel.monomial_map.items())),
+        "multilinear_map": _hs(list(rel.multilinear_map.items())),
+        "univariate_square_map": _hs(list(rel.univariate_square_map.items())),
+        "composite_specs_n": len(rel.composite_multivar_specs),
+        "univariate_atom_specs": _hs(rel.univariate_atom_specs),
+        "bilinear_linform_specs": _hs(rel.bilinear_linform_specs),
+        "coverage_kinds": _hs(sorted(rel.coverage.values())),
+        "wall": round(time.perf_counter() - t0, 2),
+    }
+    rows.append(row)
+    print(json.dumps(row), flush=True)
+
+comparisons = 0
+for key in rows[0]:
+    if key in ("rep", "wall"):
+        continue
+    vals = sorted({repr(r[key]) for r in rows})
+    comparisons += len(rows) - 1
+    print(f"{key:24s} {'STABLE' if len(vals) == 1 else 'VARIES'}  {vals}", flush=True)
+print(f"comparisons={comparisons}", flush=True)
+if comparisons == 0:
+    sys.exit(2)

--- a/scratchpad/issue1116/build_truncation_probe.py
+++ b/scratchpad/issue1116/build_truncation_probe.py
@@ -1,0 +1,102 @@
+"""#1116 stage 4: is the root relaxation BUILD being truncated by a wall deadline?
+
+Usage: python -u build_truncation_probe.py <instance-stem> <max_nodes> [n_calls]
+
+``build_component_bisect.py`` showed the first root LP has a DIFFERENT NUMBER OF
+COLUMNS in two repetitions of the same solve in the same process — rep0
+``(4860, 1532)`` vs rep1 ``(4734, 1469)``. That is not float noise and not
+iteration order: a different relaxation was built.
+
+The #694 "anytime build" is the mechanism that can do exactly that.
+``build_uniform_relaxation`` stops its constraint-row loop once ``build_deadline``
+(a ``perf_counter`` time) is spent and records the fact on the model:
+``_build_truncated`` / ``_build_constraints_done`` / ``_build_constraints_total``.
+A build truncated at a machine-speed-dependent point yields fewer rows AND fewer
+lifted columns — the observed signature.
+
+This probe reads those three provenance fields (plus shapes) at every
+``MilpRelaxationModel.solve`` and compares two repetitions.
+
+Kill criterion: if ``_build_truncated`` is False on every call in both reps while
+the shapes still differ, deadline truncation is NOT the cause and this direction
+is dead — the differing column count then has to come from upstream (presolve /
+term detection) instead.
+
+Per-rep progress (§10), module assertion (§8), executed-comparison count with a
+non-zero exit when it is zero (§6), no swallowed exceptions (§7).
+"""
+
+import json
+import sys
+
+import discopt
+import scipy.sparse as sp
+from discopt._relax.milp_relaxation import MilpRelaxationModel
+from discopt.modeling.core import from_nl
+
+print(f"discopt.__file__={discopt.__file__}", flush=True)
+
+NL = "/Users/jkitchin/Dropbox/projects/discopt-minlp-benchmark/minlplib/nl/{}.nl"
+stem = sys.argv[1]
+max_nodes = int(sys.argv[2])
+N_CALLS = int(sys.argv[3]) if len(sys.argv) > 3 else 6
+
+runs: list[list[dict]] = []
+_cur: list[dict] = []
+_orig = MilpRelaxationModel.solve
+
+
+def _traced(self, *a, **kw):
+    if len(_cur) < N_CALLS:
+        A = self._A_ub
+        shape = None if A is None else tuple(sp.csr_matrix(A).shape)
+        nnz = None if A is None else int(sp.csr_matrix(A).nnz)
+        _cur.append(
+            {
+                "call": len(_cur),
+                "n_cols": int(len(self._c)),
+                "shape": shape,
+                "nnz": nnz,
+                "build_truncated": bool(getattr(self, "_build_truncated", False)),
+                "cons_done": getattr(self, "_build_constraints_done", None),
+                "cons_total": getattr(self, "_build_constraints_total", None),
+            }
+        )
+        print(json.dumps({"rep": len(runs), **_cur[-1]}), flush=True)
+    return _orig(self, *a, **kw)
+
+
+MilpRelaxationModel.solve = _traced
+
+for rep in range(2):
+    _cur = []
+    model = from_nl(NL.format(stem))
+    r = model.solve(max_nodes=max_nodes)
+    runs.append(_cur)
+    print(
+        f"rep={rep} calls={len(_cur)} nodes={r.node_count} bound={r.bound!r} "
+        f"objective={r.objective!r}",
+        flush=True,
+    )
+
+A, B = runs
+comparisons = 0
+truncated_seen = 0
+for k in range(min(len(A), len(B))):
+    comparisons += 1
+    a, b = A[k], B[k]
+    truncated_seen += int(a["build_truncated"]) + int(b["build_truncated"])
+    same = a["shape"] == b["shape"] and a["n_cols"] == b["n_cols"] and a["nnz"] == b["nnz"]
+    print(
+        f"CALL {k}: {'SAME' if same else 'DIFFERS'}  "
+        f"rep0 cols={a['n_cols']} shape={a['shape']} nnz={a['nnz']} "
+        f"trunc={a['build_truncated']} done={a['cons_done']}/{a['cons_total']}  |  "
+        f"rep1 cols={b['n_cols']} shape={b['shape']} nnz={b['nnz']} "
+        f"trunc={b['build_truncated']} done={b['cons_done']}/{b['cons_total']}",
+        flush=True,
+    )
+
+print(f"comparisons={comparisons} truncated_flags_seen={truncated_seen}", flush=True)
+if comparisons == 0:
+    print("PROBE FIRED NOTHING", flush=True)
+    sys.exit(2)

--- a/scratchpad/issue1116/clock_trace.py
+++ b/scratchpad/issue1116/clock_trace.py
@@ -1,0 +1,79 @@
+"""#1116 localization: WHICH wall-clock-gated decision differs between reps?
+
+Usage: python -u clock_trace.py <instance-stem> <max_nodes> <reps>
+
+Wraps ``time.perf_counter`` with a tracer that tallies calls per (file, line)
+call site. A loop whose iteration count is decided by the wall clock shows up as
+a call site whose tally differs across otherwise identical repetitions -- which
+localizes the divergence without changing the solve route (no callbacks, no
+flags; CLAUDE.md §8). Prints per-rep progress (§10), the number of executed
+comparisons (§6), and exits non-zero if it compared nothing. Exceptions are not
+caught (§7).
+"""
+
+import collections
+import json
+import sys
+import time
+
+_orig_perf = time.perf_counter
+_counts: collections.Counter = collections.Counter()
+_on = [False]
+
+
+def _traced() -> float:
+    if _on[0]:
+        f = sys._getframe(1)
+        _counts[(f.f_code.co_filename.rsplit("/", 1)[-1], f.f_lineno)] += 1
+    return _orig_perf()
+
+
+time.perf_counter = _traced
+
+import discopt  # noqa: E402
+from discopt.modeling.core import from_nl  # noqa: E402
+
+print(f"discopt.__file__={discopt.__file__}", flush=True)
+
+NL = "/Users/jkitchin/Dropbox/projects/discopt-minlp-benchmark/minlplib/nl/{}.nl"
+stem, max_nodes, reps = sys.argv[1], int(sys.argv[2]), int(sys.argv[3])
+
+per_rep = []
+results = []
+for rep in range(reps):
+    model = from_nl(NL.format(stem))
+    _counts.clear()
+    _on[0] = True
+    t0 = _orig_perf()
+    r = model.solve(max_nodes=max_nodes)
+    _on[0] = False
+    wall = _orig_perf() - t0
+    per_rep.append(dict(_counts))
+    results.append(
+        {
+            "rep": rep,
+            "nodes": int(r.node_count or 0),
+            "bound": None if r.bound is None else float(r.bound),
+            "objective": None if r.objective is None else float(r.objective),
+            "status": r.status,
+            "clock_calls": sum(_counts.values()),
+            "clock_sites": len(_counts),
+            "wall": round(wall, 2),
+        }
+    )
+    print(json.dumps(results[-1]), flush=True)
+
+sites = sorted({s for c in per_rep for s in c})
+comparisons = 0
+differing = []
+for s in sites:
+    vals = [c.get(s, 0) for c in per_rep]
+    comparisons += len(vals) - 1
+    if len(set(vals)) > 1:
+        differing.append((s, vals))
+print(f"--- {len(differing)} differing call sites of {len(sites)} ---", flush=True)
+for s, vals in sorted(differing, key=lambda kv: -max(kv[1])):
+    print(f"{s[0]}:{s[1]:<6d} {vals}", flush=True)
+print(f"comparisons={comparisons}", flush=True)
+if comparisons == 0:
+    sys.exit(2)

--- a/scratchpad/issue1116/deterministic_verify.py
+++ b/scratchpad/issue1116/deterministic_verify.py
@@ -1,0 +1,80 @@
+"""#1116 verification: does ``deterministic=True`` actually reproduce?
+
+Usage: python -u deterministic_verify.py <stem> <max_nodes> <reps> <0|1>
+
+Runs the same solve N times in one process with ``deterministic`` set to the
+given value and reports whether (nodes, bound, objective, status) is bit-stable.
+This is the acceptance test for the fix: the arm with the flag ON must be STABLE
+on an instance whose OFF arm is measurably not.
+
+Asserts the flag reached the solver (``_role2_deadline`` / ``_role2_horizon``
+firing counts, split by whether they suppressed a clock) and exits non-zero when
+the role-2 helpers never fired at all -- otherwise "it reproduced" could just mean
+"the code under test was never entered" (CLAUDE.md §6, §8).
+"""
+
+import json
+import sys
+
+import discopt
+import discopt.solver as S
+from discopt.modeling.core import from_nl
+
+print(f"discopt.__file__={discopt.__file__}", flush=True)
+
+stem, max_nodes, reps = sys.argv[1], int(sys.argv[2]), int(sys.argv[3])
+det = bool(int(sys.argv[4]))
+
+fired = {"deadline_suppressed": 0, "deadline_kept": 0, "horizon_suppressed": 0, "horizon_kept": 0}
+
+_rd, _rh = S._role2_deadline, S._role2_horizon
+
+
+def _spy_deadline(d):
+    r = _rd(d)
+    fired["deadline_suppressed" if r is None else "deadline_kept"] += 1
+    return r
+
+
+def _spy_horizon(x):
+    r = _rh(x)
+    fired["horizon_suppressed" if r == float("inf") else "horizon_kept"] += 1
+    return r
+
+
+S._role2_deadline = _spy_deadline
+S._role2_horizon = _spy_horizon
+
+NL = "/Users/jkitchin/Dropbox/projects/discopt-minlp-benchmark/minlplib/nl/{}.nl"
+rows = []
+for rep in range(reps):
+    r = from_nl(NL.format(stem)).solve(max_nodes=max_nodes, deterministic=det)
+    row = {
+        "rep": rep,
+        "deterministic": det,
+        "nodes": int(r.node_count or 0),
+        "bound": repr(float(r.bound)) if r.bound is not None else None,
+        "objective": repr(float(r.objective)) if r.objective is not None else None,
+        "status": r.status,
+        "role2": dict(fired),
+    }
+    rows.append(row)
+    print(json.dumps(row), flush=True)
+
+comparisons = 0
+varies = 0
+for key in ("nodes", "bound", "objective", "status"):
+    distinct = sorted({repr(x[key]) for x in rows})
+    comparisons += len(rows) - 1
+    varies += len(distinct) > 1
+    print(
+        f"{key:10s} {'STABLE' if len(distinct) == 1 else 'VARIES'} "
+        f"distinct={len(distinct)} {distinct}",
+        flush=True,
+    )
+
+print(f"ARM deterministic={det}: {'REPRODUCES' if varies == 0 else 'STILL VARIES'}", flush=True)
+print(f"comparisons={comparisons} role2_firings={fired}", flush=True)
+if comparisons == 0 or sum(fired.values()) == 0:
+    print("PROBE FIRED NOTHING", flush=True)
+    sys.exit(2)

--- a/scratchpad/issue1116/e5_stable_hash.py
+++ b/scratchpad/issue1116/e5_stable_hash.py
@@ -1,0 +1,81 @@
+"""#1116 E5: is the run-to-run drift caused by ``Variable.__hash__ = id(self)``?
+
+Usage: python -u e5_stable_hash.py <instance-stem> <max_nodes> <reps>
+
+Hypothesis
+----------
+``Variable.__hash__`` returns ``id(self)`` (``modeling/core.py:680``). Every
+``set``/``dict`` keyed by a ``Variable`` therefore iterates in an order that is a
+function of the ALLOCATOR, not of the model: it differs between two
+``from_nl`` calls in the same process and between processes. Any float
+accumulation or order-sensitive selection downstream of such an iteration then
+differs in its last bits, while every *structural* count (rows separated, LP
+solves) stays identical -- exactly the signature #1116 reports.
+
+Kill criterion
+--------------
+Replace the hash with a value that is a pure function of the model
+(``self._index``, the variable's position in the flat vector, assigned at
+construction) and re-run the 3-rep probe. If the bound is STILL not
+bit-reproducible, address-dependent hash order is NOT the cause and this
+direction is dead.
+
+Collisions are safe here: ``Constraint.__bool__`` raises, so if two variables
+from different models ever collided the probe would crash loudly rather than
+report a quiet wrong answer (CLAUDE.md §3/§7).
+
+Prints per-rep progress (§10), asserts the module it loaded (§8), and counts both
+patched-hash calls and comparisons, exiting non-zero if either is zero (§6).
+"""
+
+import json
+import sys
+
+import discopt
+from discopt.modeling.core import Variable, from_nl
+
+print(f"discopt.__file__={discopt.__file__}", flush=True)
+
+NL = "/Users/jkitchin/Dropbox/projects/discopt-minlp-benchmark/minlplib/nl/{}.nl"
+stem, max_nodes, reps = sys.argv[1], int(sys.argv[2]), int(sys.argv[3])
+
+_hash_calls = [0]
+_orig_hash = Variable.__hash__
+
+
+def _stable_hash(self):
+    _hash_calls[0] += 1
+    return self._index
+
+
+Variable.__hash__ = _stable_hash
+assert Variable.__hash__ is not _orig_hash, "patch did not take"
+
+rows = []
+for rep in range(reps):
+    model = from_nl(NL.format(stem))
+    r = model.solve(max_nodes=max_nodes)
+    row = {
+        "rep": rep,
+        "nodes": int(r.node_count or 0),
+        "bound": repr(float(r.bound)) if r.bound is not None else None,
+        "objective": repr(float(r.objective)) if r.objective is not None else None,
+        "status": r.status,
+        "hash_calls": _hash_calls[0],
+    }
+    rows.append(row)
+    print(json.dumps(row), flush=True)
+
+comparisons = 0
+for key in ("nodes", "bound", "objective", "status"):
+    distinct = sorted({repr(x[key]) for x in rows})
+    comparisons += len(rows) - 1
+    print(
+        f"{key:10s} {'STABLE' if len(distinct) == 1 else 'VARIES'} "
+        f"distinct={len(distinct)} {distinct}",
+        flush=True,
+    )
+print(f"comparisons={comparisons} patched_hash_calls={_hash_calls[0]}", flush=True)
+if comparisons == 0 or _hash_calls[0] == 0:
+    print("PROBE FIRED NOTHING", flush=True)
+    sys.exit(2)

--- a/scratchpad/issue1116/lp_seam_bisect.py
+++ b/scratchpad/issue1116/lp_seam_bisect.py
@@ -1,0 +1,114 @@
+"""#1116 first-divergence bisection at the LP seam.
+
+Usage: python -u lp_seam_bisect.py <instance-stem> <max_nodes>
+
+Solves the SAME instance twice in ONE process, recording for every
+``MilpRelaxationModel.solve`` call, in call order, a hash of the LP *input*
+(c, A_ub, b_ub, bounds, integrality) and of the LP *output* (status, objective,
+x). Then it reports the FIRST call index at which the two runs disagree, and
+which side disagreed:
+
+* inputs already differ  -> the divergence happened UPSTREAM of the LP (build,
+  separation, branching, bound propagation); the LP is a faithful function.
+* inputs match, outputs differ -> the LP solver itself is not a function of its
+  input (a genuine simplex-level nondeterminism).
+
+Prints per-rep progress (CLAUDE.md §10), asserts which module it loaded (§8),
+counts executed comparisons and exits non-zero when it made none (§6). No
+exception is swallowed anywhere in the instrument (§7).
+"""
+
+import hashlib
+import sys
+
+import discopt
+import numpy as np
+import scipy.sparse as sp
+from discopt._relax.milp_relaxation import MilpRelaxationModel
+from discopt.modeling.core import from_nl
+
+print(f"discopt.__file__={discopt.__file__}", flush=True)
+
+NL = "/Users/jkitchin/Dropbox/projects/discopt-minlp-benchmark/minlplib/nl/{}.nl"
+stem, max_nodes = sys.argv[1], int(sys.argv[2])
+
+_MAXLEN = 400_000  # cap per-call hashing cost; layout+prefix is plenty to separate runs
+
+
+def _h(*parts) -> str:
+    d = hashlib.blake2b(digest_size=12)
+    for p in parts:
+        if p is None:
+            d.update(b"\x00None")
+            continue
+        if sp.issparse(p):
+            m = sp.csr_matrix(p)
+            d.update(b"\x01sp")
+            d.update(np.asarray(m.shape, dtype=np.int64).tobytes())
+            for arr in (m.indptr, m.indices, m.data):
+                a = np.ascontiguousarray(arr)
+                d.update(a.tobytes()[:_MAXLEN])
+            continue
+        a = np.ascontiguousarray(np.asarray(p, dtype=np.float64))
+        d.update(b"\x02np")
+        d.update(np.asarray(a.shape, dtype=np.int64).tobytes())
+        d.update(a.tobytes()[:_MAXLEN])
+    return d.hexdigest()
+
+
+trace: list[tuple[str, str]] = []
+_orig = MilpRelaxationModel.solve
+
+
+def _traced(self, *a, **kw):
+    bounds = np.asarray(self._bounds, dtype=np.float64) if self._bounds else None
+    hin = _h(self._c, self._A_ub, self._b_ub, bounds, self._integrality)
+    res = _orig(self, *a, **kw)
+    hout = _h(
+        np.asarray([float(res.objective) if res.objective is not None else np.nan]),
+        getattr(res, "x", None),
+    )
+    trace.append((hin, f"{res.status}|{hout}"))
+    return res
+
+
+MilpRelaxationModel.solve = _traced
+
+runs = []
+for rep in range(2):
+    trace = []
+    model = from_nl(NL.format(stem))
+    r = model.solve(max_nodes=max_nodes)
+    runs.append(trace)
+    print(
+        f"rep={rep} lp_calls={len(trace)} nodes={r.node_count} "
+        f"bound={r.bound!r} objective={r.objective!r} status={r.status}",
+        flush=True,
+    )
+
+a, b = runs
+comparisons = 0
+first_in = None
+first_out = None
+for i in range(min(len(a), len(b))):
+    comparisons += 1
+    if a[i][0] != b[i][0] and first_in is None:
+        first_in = i
+    if a[i][0] == b[i][0] and a[i][1] != b[i][1] and first_out is None:
+        first_out = i
+    if first_in is not None:
+        break
+
+print(f"lp_calls rep0={len(a)} rep1={len(b)}", flush=True)
+print(f"first_differing_INPUT  = {first_in}", flush=True)
+print(f"first_differing_OUTPUT_at_equal_input = {first_out}", flush=True)
+if first_in is None and first_out is None:
+    print("VERDICT: LP seam is IDENTICAL on every compared call", flush=True)
+elif first_out is not None and (first_in is None or first_out < first_in):
+    print("VERDICT: the LP SOLVER is not a function of its input", flush=True)
+else:
+    print(f"VERDICT: divergence is UPSTREAM of the LP, first at call {first_in}", flush=True)
+print(f"comparisons={comparisons}", flush=True)
+if comparisons == 0:
+    print("PROBE FIRED NOTHING", flush=True)
+    sys.exit(2)

--- a/scratchpad/issue1116/min_budget_scan.py
+++ b/scratchpad/issue1116/min_budget_scan.py
@@ -1,0 +1,52 @@
+"""#1116: find the SMALLEST node budget at which the instance is already unstable.
+
+Usage: python -u min_budget_scan.py <instance-stem> <reps> <budget> [<budget> ...]
+
+Every subsequent #1116 experiment costs one solve per rep, so the whole
+investigation is priced by the smallest budget that still reproduces the bug.
+For each budget this solves the instance ``reps`` times in one process and
+reports STABLE/VARIES on (nodes, bound, objective).
+
+Per-rep progress (§10), loaded-module assertion (§8), executed-comparison count
+with a non-zero exit when it is zero (§6), and no swallowed exceptions (§7).
+"""
+
+import json
+import sys
+
+import discopt
+from discopt.modeling.core import from_nl
+
+print(f"discopt.__file__={discopt.__file__}", flush=True)
+
+NL = "/Users/jkitchin/Dropbox/projects/discopt-minlp-benchmark/minlplib/nl/{}.nl"
+stem, reps = sys.argv[1], int(sys.argv[2])
+budgets = [int(x) for x in sys.argv[3:]]
+
+comparisons = 0
+for budget in budgets:
+    rows = []
+    for rep in range(reps):
+        model = from_nl(NL.format(stem))
+        r = model.solve(max_nodes=budget)
+        row = {
+            "budget": budget,
+            "rep": rep,
+            "nodes": int(r.node_count or 0),
+            "bound": repr(float(r.bound)) if r.bound is not None else None,
+            "objective": repr(float(r.objective)) if r.objective is not None else None,
+            "status": r.status,
+        }
+        rows.append(row)
+        print(json.dumps(row), flush=True)
+    verdicts = []
+    for key in ("nodes", "bound", "objective", "status"):
+        distinct = {repr(x[key]) for x in rows}
+        comparisons += len(rows) - 1
+        verdicts.append(f"{key}={'STABLE' if len(distinct) == 1 else 'VARIES'}({len(distinct)})")
+    print(f"BUDGET {budget}: " + "  ".join(verdicts), flush=True)
+
+print(f"comparisons={comparisons}", flush=True)
+if comparisons == 0:
+    print("PROBE FIRED NOTHING", flush=True)
+    sys.exit(2)

--- a/scratchpad/issue1116/nlp_trace.py
+++ b/scratchpad/issue1116/nlp_trace.py
@@ -1,0 +1,164 @@
+"""#1116 localization, stage 2: is the FIRST divergence in a local NLP solve?
+
+Usage: python -u nlp_trace.py <instance-stem> <max_nodes> <reps>
+
+The baseline probe showed the INCUMBENT objective moves in its last digits across
+repetitions, not just the dual bound, so the local NLP is a prime suspect: several
+call sites clamp it with ``max_wall_time`` (e.g. ``solver.py:1227`` caps a seed
+solve at 4 s), and a wall-clamped NLP returns a different iterate on a differently
+loaded machine.
+
+This probe wraps every NLP entry point (``nlp_pounce.solve_nlp`` and POUNCE's
+``solve_nlp_batch``) and records, per call, a hash of the INPUTS and of the
+OUTPUTS. Comparing the two repetitions' call sequences gives the first index where
+they diverge and says whether the inputs at that index were already different
+(divergence upstream) or identical (the NLP itself is not reproducible).
+
+Nothing about the solve route changes (no callbacks, no flags; §8). Exceptions are
+not caught (§7); the executed-comparison count is printed and a zero count exits
+non-zero (§6).
+"""
+
+import hashlib
+import json
+import sys
+import time
+
+import discopt
+import numpy as np
+import pounce
+from discopt.modeling.core import from_nl
+from discopt.solvers import nlp_pounce
+
+print(f"discopt.__file__={discopt.__file__}", flush=True)
+print(f"pounce.__file__={pounce.__file__}", flush=True)
+
+NL = "/Users/jkitchin/Dropbox/projects/discopt-minlp-benchmark/minlplib/nl/{}.nl"
+stem, max_nodes, reps = sys.argv[1], int(sys.argv[2]), int(sys.argv[3])
+
+_calls: list = []
+_on = [False]
+
+
+def _h(obj) -> str:
+    m = hashlib.sha1()
+
+    def feed(o):
+        if isinstance(o, np.ndarray):
+            m.update(np.ascontiguousarray(o).tobytes())
+        elif isinstance(o, (list, tuple)):
+            for e in o:
+                feed(e)
+        elif isinstance(o, dict):
+            for k in sorted(o, key=repr):
+                m.update(repr(k).encode())
+                feed(o[k])
+        else:
+            m.update(repr(o).encode())
+
+    feed(obj)
+    return m.hexdigest()[:12]
+
+
+_orig_solve = nlp_pounce.solve_nlp
+_orig_batch = getattr(pounce, "solve_nlp_batch", None)
+
+
+def _traced_solve(evaluator, x0, constraint_bounds=None, options=None, **kw):
+    if not _on[0]:
+        return _orig_solve(evaluator, x0, constraint_bounds, options, **kw)
+    t0 = time.perf_counter()
+    r = _orig_solve(evaluator, x0, constraint_bounds, options, **kw)
+    dt = time.perf_counter() - t0
+    _calls.append(
+        {
+            "kind": "solve_nlp",
+            "in": _h([np.asarray(x0, dtype=np.float64), constraint_bounds, options]),
+            "wall_cap": None if not options else options.get("max_wall_time"),
+            "elapsed": round(dt, 4),
+            "status": getattr(r, "status", None),
+            "out": _h(np.asarray(getattr(r, "x", []), dtype=np.float64)),
+            "obj": None if getattr(r, "objective", None) is None else float(r.objective),
+            "iters": int(getattr(r, "iterations", 0) or 0),
+        }
+    )
+    return r
+
+
+nlp_pounce.solve_nlp = _traced_solve
+
+if _orig_batch is not None:
+
+    def _traced_batch(*args, **kw):
+        if not _on[0]:
+            return _orig_batch(*args, **kw)
+        t0 = time.perf_counter()
+        rs = _orig_batch(*args, **kw)
+        dt = time.perf_counter() - t0
+        _calls.append(
+            {
+                "kind": "solve_nlp_batch",
+                "in": _h([args, kw]),
+                "wall_cap": None,
+                "elapsed": round(dt, 4),
+                "status": _h([getattr(r, "status", None) for r in rs]),
+                "out": _h([np.asarray(getattr(r, "x", []), dtype=np.float64) for r in rs]),
+                "obj": _h([getattr(r, "objective", None) for r in rs]),
+                "iters": _h([getattr(r, "iterations", None) for r in rs]),
+            }
+        )
+        return rs
+
+    pounce.solve_nlp_batch = _traced_batch
+
+per_rep = []
+for rep in range(reps):
+    model = from_nl(NL.format(stem))
+    _calls.clear()
+    _on[0] = True
+    t0 = time.perf_counter()
+    r = model.solve(max_nodes=max_nodes)
+    _on[0] = False
+    per_rep.append(list(_calls))
+    print(
+        json.dumps(
+            {
+                "rep": rep,
+                "nodes": int(r.node_count or 0),
+                "bound": None if r.bound is None else float(r.bound),
+                "objective": None if r.objective is None else float(r.objective),
+                "nlp_calls": len(per_rep[-1]),
+                "wall_capped_calls": sum(1 for c in per_rep[-1] if c["wall_cap"] is not None),
+                "wall": round(time.perf_counter() - t0, 2),
+            }
+        ),
+        flush=True,
+    )
+
+comparisons = 0
+first_div = None
+a, b = per_rep[0], per_rep[1]
+for i in range(min(len(a), len(b))):
+    comparisons += 1
+    if a[i]["in"] != b[i]["in"] or a[i]["out"] != b[i]["out"] or a[i]["obj"] != b[i]["obj"]:
+        first_div = i
+        break
+print(f"calls rep0={len(a)} rep1={len(b)}", flush=True)
+if first_div is None:
+    print("NO DIVERGENCE in the NLP call sequence prefix", flush=True)
+else:
+    print(f"FIRST DIVERGENCE at call index {first_div}", flush=True)
+    for tag, c in (("rep0", a[first_div]), ("rep1", b[first_div])):
+        print(f"  {tag}: {json.dumps(c)}", flush=True)
+    print(
+        "  inputs identical -> the NLP itself is not reproducible"
+        if a[first_div]["in"] == b[first_div]["in"]
+        else "  inputs ALREADY differ -> divergence is upstream of this call",
+        flush=True,
+    )
+    for j in range(max(0, first_div - 3), first_div):
+        print(f"  prior[{j}] rep0={json.dumps(a[j])}", flush=True)
+        print(f"  prior[{j}] rep1={json.dumps(b[j])}", flush=True)
+print(f"comparisons={comparisons}", flush=True)
+if comparisons == 0:
+    sys.exit(2)

--- a/scratchpad/issue1116/no_wall_probe.py
+++ b/scratchpad/issue1116/no_wall_probe.py
@@ -1,0 +1,145 @@
+"""#1116 E4: is the run-to-run drift caused by WALL-CLOCK-derived budgets?
+
+Neutralizes every wall-derived budget the Python layer can reach, then runs the
+same reproduction as ``repro_probe.py``:
+
+  1. ``time.perf_counter`` -> a deterministic counter (fixed step per call), so
+     every budget the solver DERIVES from the clock is a pure function of the
+     call sequence, not of machine speed.
+  2. ``MilpRelaxationModel.solve(time_limit=...)`` -> ``None`` (the LP seam into the
+     Rust simplex; the simplex stays bounded by its iteration cap).
+  3. ``nlp_pounce.solve_nlp`` opts / ``pounce.solve_nlp_batch`` options ->
+     ``max_wall_time`` removed (the two seams through which every NLP wall clamp
+     reaches POUNCE, which measures REAL wall internally and so is immune to 1).
+
+Every patch counts its firings and the probe exits non-zero if the patch set as a
+whole never fired (CLAUDE.md §6) -- a patch that silently matched nothing would
+turn "the clock is not the cause" into an unfalsifiable pass. Nothing is wrapped
+in try/except (§7).
+
+Usage: python -u no_wall_probe.py <instance-stem> <max_nodes> <reps>
+"""
+
+import json
+import sys
+import time
+
+# ---- 1. deterministic clock -------------------------------------------------
+_CLOCK_STEP = 1e-4
+_clock = {"t": 0.0, "n": 0}
+
+
+def _fake_perf_counter() -> float:
+    _clock["n"] += 1
+    _clock["t"] += _CLOCK_STEP
+    return _clock["t"]
+
+
+_real_perf_counter = time.perf_counter
+time.perf_counter = _fake_perf_counter  # type: ignore[assignment]
+time.monotonic = _fake_perf_counter  # type: ignore[assignment]
+
+# Prove which tree we loaded (CLAUDE.md §8).
+import discopt  # noqa: E402
+import pounce  # noqa: E402
+from discopt._relax.milp_relaxation import MilpRelaxationModel  # noqa: E402
+from discopt.modeling.core import from_nl  # noqa: E402
+from discopt.solvers import nlp_pounce  # noqa: E402
+
+print(f"discopt.__file__={discopt.__file__}", flush=True)
+
+counts = {"milp_solve": 0, "solve_nlp": 0, "batch": 0, "batch_qp": 0}
+
+# ---- 2. LP seam -------------------------------------------------------------
+_real_milp_solve = MilpRelaxationModel.solve
+
+
+def _milp_solve(self, time_limit=None, *a, **kw):
+    counts["milp_solve"] += 1
+    return _real_milp_solve(self, None, *a, **kw)
+
+
+MilpRelaxationModel.solve = _milp_solve  # type: ignore[method-assign]
+
+# ---- 3. NLP seams -----------------------------------------------------------
+_real_solve_nlp = nlp_pounce.solve_nlp
+
+
+def _strip(d):
+    return {k: v for k, v in d.items() if k != "max_wall_time"}
+
+
+def _solve_nlp(*a, **kw):
+    counts["solve_nlp"] += 1
+    # ``options`` is the 4th positional parameter; callers use both forms.
+    if len(a) >= 4 and isinstance(a[3], dict):
+        a = a[:3] + (_strip(a[3]),) + a[4:]
+    opts = kw.get("options")
+    if isinstance(opts, dict):
+        kw["options"] = _strip(opts)
+    return _real_solve_nlp(*a, **kw)
+
+
+nlp_pounce.solve_nlp = _solve_nlp
+
+_real_batch = pounce.solve_nlp_batch
+
+
+def _batch(*a, **kw):
+    counts["batch"] += 1
+    opts = kw.get("options")
+    if isinstance(opts, dict) and "max_wall_time" in opts:
+        kw["options"] = {k: v for k, v in opts.items() if k != "max_wall_time"}
+    return _real_batch(*a, **kw)
+
+
+pounce.solve_nlp_batch = _batch
+
+if hasattr(pounce, "solve_qp_batch"):
+    _real_qp_batch = pounce.solve_qp_batch
+
+    def _qp_batch(*a, **kw):
+        counts["batch_qp"] += 1
+        opts = kw.get("options")
+        if isinstance(opts, dict) and "max_wall_time" in opts:
+            kw["options"] = {k: v for k, v in opts.items() if k != "max_wall_time"}
+        return _real_qp_batch(*a, **kw)
+
+    pounce.solve_qp_batch = _qp_batch
+
+NL = "/Users/jkitchin/Dropbox/projects/discopt-minlp-benchmark/minlplib/nl/{}.nl"
+stem, max_nodes, reps = sys.argv[1], int(sys.argv[2]), int(sys.argv[3])
+
+rows = []
+for rep in range(reps):
+    model = from_nl(NL.format(stem))
+    t0 = _real_perf_counter()
+    r = model.solve(max_nodes=max_nodes)
+    wall = _real_perf_counter() - t0
+    row = {
+        "rep": rep,
+        "nodes": int(r.node_count or 0),
+        "bound": float(r.bound) if r.bound is not None else None,
+        "objective": float(r.objective) if r.objective is not None else None,
+        "status": r.status,
+        "wall": round(wall, 2),
+        "clock_calls": _clock["n"],
+        "patch_counts": dict(counts),
+    }
+    rows.append(row)
+    print(json.dumps(row), flush=True)
+
+comparisons = 0
+for key in ("nodes", "bound", "objective", "status"):
+    vals = [r[key] for r in rows]
+    distinct = sorted({repr(v) for v in vals})
+    comparisons += len(vals) - 1
+    verdict = "STABLE" if len(distinct) == 1 else "VARIES"
+    print(f"{key:10s} {verdict}  distinct={len(distinct)}  {distinct}", flush=True)
+
+fired = sum(counts.values())
+print(f"patch_firings={counts} total={fired}", flush=True)
+print(f"comparisons={comparisons}", flush=True)
+if comparisons == 0 or fired == 0:
+    print("PROBE FIRED NOTHING", flush=True)
+    sys.exit(2)

--- a/scratchpad/issue1116/repro_probe.py
+++ b/scratchpad/issue1116/repro_probe.py
@@ -1,0 +1,54 @@
+"""#1116 reproduction probe: is <instance> bit-reproducible run to run?
+
+Usage: python -u repro_probe.py <instance-stem> <max_nodes> <reps>
+
+Solves the same instance REPS times in ONE process with a node budget and NO wall
+limit, and reports the distinct (node_count, bound, objective) values seen. Prints
+per-rep progress as it goes (CLAUDE.md §10) and an executed-comparison count, and
+exits non-zero when it made no comparisons (§6).
+"""
+
+import hashlib
+import json
+import sys
+import time
+
+from discopt.modeling.core import from_nl
+
+NL = "/Users/jkitchin/Dropbox/projects/discopt-minlp-benchmark/minlplib/nl/{}.nl"
+
+stem, max_nodes, reps = sys.argv[1], int(sys.argv[2]), int(sys.argv[3])
+path = NL.format(stem)
+
+rows = []
+for rep in range(reps):
+    model = from_nl(path)
+    t0 = time.perf_counter()
+    r = model.solve(max_nodes=max_nodes)
+    wall = time.perf_counter() - t0
+    row = {
+        "rep": rep,
+        "nodes": int(r.node_count or 0),
+        "bound": float(r.bound) if r.bound is not None else None,
+        "objective": float(r.objective) if r.objective is not None else None,
+        "status": r.status,
+        "wall": round(wall, 2),
+    }
+    rows.append(row)
+    print(json.dumps(row), flush=True)
+
+comparisons = 0
+for key in ("nodes", "bound", "objective", "status"):
+    vals = [r[key] for r in rows]
+    distinct = sorted({repr(v) for v in vals})
+    comparisons += len(vals) - 1
+    verdict = "STABLE" if len(distinct) == 1 else "VARIES"
+    print(f"{key:10s} {verdict}  distinct={len(distinct)}  {distinct}", flush=True)
+
+digest = hashlib.sha1(
+    json.dumps([[r["nodes"], r["bound"]] for r in rows], sort_keys=True).encode()
+).hexdigest()[:10]
+print(f"comparisons={comparisons} digest={digest}", flush=True)
+if comparisons == 0:
+    print("PROBE FIRED NOTHING", flush=True)
+    sys.exit(2)

--- a/scratchpad/issue1116/root_fixpoint_probe.py
+++ b/scratchpad/issue1116/root_fixpoint_probe.py
@@ -1,0 +1,99 @@
+"""#1116 E7: does the deadline-driven ROOT FIXPOINT return a different box per run?
+
+``run_root_fixpoint`` (solver.py:14370, flag ``root_fixpoint`` default **ON**) is
+handed ``deadline=perf_counter() + min(max(time_limit*0.10, 1.0), remaining)`` --
+360 s at the default ``time_limit=3600``. Its docstring: "The loop stops the
+moment it is reached", and inside, S3 OBBT gets 85% of the remaining budget and is
+itself deadline-clamped. That is a role-2 clock in the #912 sense: it does not
+answer "when do we stop?" (the user's ``time_limit``), it answers "how much
+tightening do we do?" -- so the returned box, and therefore the whole downstream
+relaxation, is a function of machine speed.
+
+``build_component_bisect.py`` showed the first root LP has a different number of
+COLUMNS between two reps in one process, and ``build_truncation_probe.py`` showed
+the build itself was NOT truncated (``cons_done == cons_total``, 404/404). A
+different box entering an untruncated build explains both.
+
+This probe records what the fixpoint returned -- rounds, bounds tightened, and a
+hash of the (lb, ub) box -- for every call, across reps.
+
+Kill criterion: if the box hash is IDENTICAL across reps while the bound still
+varies, the fixpoint is not the source and this direction is dead.
+
+§6 executed-comparison count with non-zero exit; §7 no swallowed exceptions;
+§8 module identity printed; §10 per-rep flush.
+"""
+
+import hashlib
+import json
+import sys
+
+import discopt
+import numpy as np
+from discopt._relax import root_reduce
+from discopt.modeling.core import from_nl
+
+print(f"discopt.__file__={discopt.__file__}", flush=True)
+
+
+def _h(a):
+    return hashlib.sha1(np.ascontiguousarray(a, dtype=np.float64).tobytes()).hexdigest()[:12]
+
+
+runs: list[list[dict]] = []
+_cur: list[dict] = []
+_real = root_reduce.run_root_fixpoint
+
+
+def _traced(model, lb, ub, **kw):
+    res = _real(model, lb, ub, **kw)
+    rec = {
+        "call": len(_cur),
+        "in_box": _h(np.concatenate([np.asarray(lb, float), np.asarray(ub, float)])),
+        "out_box": _h(np.concatenate([np.asarray(res.lb, float), np.asarray(res.ub, float)])),
+        "n_tightened": int(res.n_tightened),
+        "n_rounds": int(res.n_rounds),
+        "infeasible": bool(res.infeasible),
+        "stage_time": {k: round(v, 2) for k, v in dict(res.stage_time).items()},
+    }
+    _cur.append(rec)
+    print(json.dumps({"rep": len(runs), **rec}), flush=True)
+    return res
+
+
+root_reduce.run_root_fixpoint = _traced
+
+NL = "/Users/jkitchin/Dropbox/projects/discopt-minlp-benchmark/minlplib/nl/{}.nl"
+stem, max_nodes, reps = sys.argv[1], int(sys.argv[2]), int(sys.argv[3])
+
+bounds = []
+for rep in range(reps):
+    _cur = []
+    r = from_nl(NL.format(stem)).solve(max_nodes=max_nodes)
+    runs.append(_cur)
+    bounds.append(repr(float(r.bound)) if r.bound is not None else None)
+    print(
+        f"rep={rep} fixpoint_calls={len(_cur)} nodes={r.node_count} bound={bounds[-1]}",
+        flush=True,
+    )
+
+comparisons = 0
+n_calls = min(len(r) for r in runs) if runs else 0
+for k in range(n_calls):
+    recs = [r[k] for r in runs]
+    for key in ("in_box", "out_box", "n_tightened", "n_rounds"):
+        distinct = sorted({repr(x[key]) for x in recs})
+        comparisons += len(recs) - 1
+        print(
+            f"CALL {k} {key:12s} {'STABLE' if len(distinct) == 1 else 'VARIES'} {distinct}",
+            flush=True,
+        )
+
+print(
+    f"bound across reps: {'STABLE' if len(set(bounds)) == 1 else 'VARIES'} {sorted(set(bounds))}",
+    flush=True,
+)
+print(f"comparisons={comparisons} fixpoint_calls_per_rep={[len(r) for r in runs]}", flush=True)
+if comparisons == 0:
+    print("PROBE FIRED NOTHING (run_root_fixpoint was never called)", flush=True)
+    sys.exit(2)

--- a/scratchpad/issue1116/run_e3_e2.sh
+++ b/scratchpad/issue1116/run_e3_e2.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -u
+# Wait for the baseline probe to finish so nothing overlaps (CLAUDE.md §9).
+while pgrep -f "repro_probe.py kriging_peaks-full200" >/dev/null; do sleep 20; done
+echo "=== E3: single-threaded arm (rayon + BLAS pinned to 1) ==="
+RAYON_NUM_THREADS=1 OMP_NUM_THREADS=1 OPENBLAS_NUM_THREADS=1 VECLIB_MAXIMUM_THREADS=1 \
+  MKL_NUM_THREADS=1 NUMEXPR_NUM_THREADS=1 \
+  python -u scratchpad/issue1116/repro_probe.py kriging_peaks-full200 300 3
+echo "=== E2: clock-call-site trace, default threading ==="
+python -u scratchpad/issue1116/clock_trace.py kriging_peaks-full200 300 2

--- a/scratchpad/issue1116/rust_hash_iteration_scan.py
+++ b/scratchpad/issue1116/rust_hash_iteration_scan.py
@@ -1,0 +1,60 @@
+"""#1116: does ANY std hash container in the Rust crate get iterated?
+
+The issue's "Suggested first step" is to swap five named ``bnb`` HashMap/HashSet
+sites to a deterministic container, on the theory that Rust's per-instance
+``RandomState`` seed makes their iteration order vary within a process. That
+only matters if the container is ever *iterated*: ``insert`` / ``get`` /
+``entry`` / ``remove`` / ``len`` / ``contains`` are all order-free.
+
+This scan is the general form of that check: it collects every identifier
+declared as a ``HashMap``/``HashSet`` anywhere in ``crates/`` and then looks for
+any site that iterates one (``for x in c``, ``.iter()``, ``.iter_mut()``,
+``.into_iter()``, ``.keys()``, ``.values()``, ``.values_mut()``, ``.drain()``,
+``.retain()``).
+
+Prints the number of files and lines actually scanned and the number of
+declarations found, and exits non-zero if it scanned nothing — a scan that
+matched no declarations would report "0 iteration sites" and read as a pass
+(CLAUDE.md §6).
+"""
+
+import collections
+import pathlib
+import re
+import sys
+
+ROOT = pathlib.Path(__file__).resolve().parents[2] / "crates"
+
+DECL = re.compile(
+    r"(?:let\s+mut\s+|let\s+|pub\s+|\s)([A-Za-z_][A-Za-z0-9_]*)\s*:\s*(?:&mut\s+)?Hash(?:Map|Set)\s*<"
+)
+ITER = re.compile(
+    r"\b([A-Za-z_][A-Za-z0-9_]*)\s*\.\s*"
+    r"(iter|iter_mut|into_iter|keys|values|values_mut|drain|retain)\s*\("
+)
+FORIN = re.compile(r"for\s+[^\n]*\s+in\s+&?\s*(?:mut\s+)?(?:self\.)?([A-Za-z_][A-Za-z0-9_]*)\s*\{")
+
+files = sorted(ROOT.rglob("*.rs"))
+names: dict[str, set[str]] = collections.defaultdict(set)
+for f in files:
+    for m in DECL.finditer(f.read_text(errors="replace")):
+        names[m.group(1)].add(str(f))
+
+hits = []
+lines_scanned = 0
+for f in files:
+    for i, line in enumerate(f.read_text(errors="replace").splitlines(), 1):
+        lines_scanned += 1
+        for pat in (ITER, FORIN):
+            m = pat.search(line)
+            if m and m.group(1) in names:
+                hits.append((str(f), i, line.strip()[:140]))
+                break
+
+print(f"files_scanned={len(files)} lines_scanned={lines_scanned} declarations={len(names)}")
+print(f"iteration_sites={len(hits)}")
+for path, i, line in sorted(hits):
+    print(f"  {path}:{i}: {line}")
+if not files or not names:
+    print("SCAN FIRED NOTHING", flush=True)
+    sys.exit(2)

--- a/scratchpad/issue1116/stage_trace.py
+++ b/scratchpad/issue1116/stage_trace.py
@@ -1,0 +1,77 @@
+"""#1116 attribution: WHERE does the run-to-run divergence first appear?
+
+Usage: python -u stage_trace.py <instance-stem> <max_nodes> <reps>
+
+Traces, per repetition and without changing the solve route (no callbacks — those
+decline the native kernel, CLAUDE.md §8):
+
+  * a hash of the parsed model (does `from_nl` itself vary?),
+  * the root relaxation LP bound built directly from the parsed model,
+  * the solve's reported root_bound / bound / objective / node_count.
+
+Every quantity is compared across reps and the number of comparisons executed is
+printed; the probe exits non-zero if it compared nothing (§6).
+"""
+
+import hashlib
+import json
+import sys
+import time
+
+import numpy as np
+import scipy.sparse as sp
+from discopt._relax.uniform_relax import build_uniform_relaxation
+from discopt.modeling.core import from_nl
+
+NL = "/Users/jkitchin/Dropbox/projects/discopt-minlp-benchmark/minlplib/nl/{}.nl"
+stem, max_nodes, reps = sys.argv[1], int(sys.argv[2]), int(sys.argv[3])
+
+
+def _h(*arrays) -> str:
+    m = hashlib.sha1()
+    for a in arrays:
+        b = np.ascontiguousarray(np.asarray(a, dtype=np.float64))
+        m.update(b.tobytes())
+    return m.hexdigest()[:12]
+
+
+rows = []
+for rep in range(reps):
+    t0 = time.perf_counter()
+    model = from_nl(NL.format(stem))
+    bounds = np.asarray(model._bounds if hasattr(model, "_bounds") else [], dtype=float)
+    rel = build_uniform_relaxation(model)
+    M = rel.model
+    A = sp.csr_matrix(M._A_ub, dtype=float)
+    A.sort_indices()
+    relax_hash = _h(A.data, A.indices.astype(float), A.indptr.astype(float), M._b_ub, M._c)
+    t_build = time.perf_counter() - t0
+
+    t1 = time.perf_counter()
+    r = from_nl(NL.format(stem)).solve(max_nodes=max_nodes)
+    row = {
+        "rep": rep,
+        "model_bounds_hash": _h(bounds) if bounds.size else "n/a",
+        "relax_hash": relax_hash,
+        "relax_rows": int(A.shape[0]),
+        "root_bound": None if r.root_bound is None else float(r.root_bound),
+        "bound": None if r.bound is None else float(r.bound),
+        "objective": None if r.objective is None else float(r.objective),
+        "nodes": int(r.node_count or 0),
+        "status": r.status,
+        "build_wall": round(t_build, 2),
+        "solve_wall": round(time.perf_counter() - t1, 2),
+    }
+    rows.append(row)
+    print(json.dumps(row), flush=True)
+
+comparisons = 0
+for key in rows[0]:
+    if key in ("rep", "build_wall", "solve_wall"):
+        continue
+    vals = sorted({repr(r[key]) for r in rows})
+    comparisons += len(rows) - 1
+    print(f"{key:20s} {'STABLE' if len(vals) == 1 else 'VARIES'}  {vals}", flush=True)
+print(f"comparisons={comparisons}", flush=True)
+if comparisons == 0:
+    sys.exit(2)

--- a/scratchpad/issue1116/wall_arm_probe.py
+++ b/scratchpad/issue1116/wall_arm_probe.py
@@ -1,0 +1,133 @@
+"""#1116 E6: WHICH wall seam causes the drift? (bisection of E4)
+
+E4 neutralized three things at once and the solve became bit-reproducible:
+  clock  - time.perf_counter -> deterministic counter
+  lp     - MilpRelaxationModel.solve(time_limit=...) -> None
+  nlp    - max_wall_time stripped from the POUNCE options at both seams
+
+That is a confounded result: it proves "a wall clock is the cause" but not which
+one. This probe enables an arbitrary SUBSET so the arms can be run singly.
+
+Usage: python -u wall_arm_probe.py <stem> <max_nodes> <reps> <arms>
+  arms: comma-separated subset of {clock,lp,nlp}, or "none" for the baseline.
+
+Kill criterion per arm: if an arm reproduces (all reps bit-identical) the seams
+it patches are sufficient; if it varies they are not the whole story.
+
+Each patch counts its firings; the probe exits non-zero if a requested patch
+never fired (CLAUDE.md §6) so a mis-targeted patch cannot masquerade as
+"this seam is not the cause". No exception is swallowed (§7). Module identity is
+printed (§8) and per-rep progress is flushed (§10).
+"""
+
+import json
+import sys
+import time
+
+stem, max_nodes, reps = sys.argv[1], int(sys.argv[2]), int(sys.argv[3])
+arms = set() if sys.argv[4] == "none" else set(sys.argv[4].split(","))
+assert arms <= {"clock", "lp", "nlp"}, f"unknown arm in {arms}"
+
+_real_perf_counter = time.perf_counter
+_clock = {"n": 0, "t": 0.0}
+
+if "clock" in arms:
+
+    def _fake():
+        _clock["n"] += 1
+        _clock["t"] += 1e-4
+        return _clock["t"]
+
+    time.perf_counter = _fake  # type: ignore[assignment]
+    time.monotonic = _fake  # type: ignore[assignment]
+
+import discopt  # noqa: E402
+import pounce  # noqa: E402
+from discopt._relax.milp_relaxation import MilpRelaxationModel  # noqa: E402
+from discopt.modeling.core import from_nl  # noqa: E402
+from discopt.solvers import nlp_pounce  # noqa: E402
+
+print(f"discopt.__file__={discopt.__file__} arms={sorted(arms)}", flush=True)
+
+counts = {"lp": 0, "nlp_single": 0, "nlp_batch": 0}
+
+if "lp" in arms:
+    _real_milp_solve = MilpRelaxationModel.solve
+
+    def _milp_solve(self, time_limit=None, *a, **kw):
+        counts["lp"] += 1
+        return _real_milp_solve(self, None, *a, **kw)
+
+    MilpRelaxationModel.solve = _milp_solve  # type: ignore[method-assign]
+
+if "nlp" in arms:
+
+    def _strip(d):
+        return {k: v for k, v in d.items() if k != "max_wall_time"}
+
+    _real_solve_nlp = nlp_pounce.solve_nlp
+
+    def _solve_nlp(*a, **kw):
+        counts["nlp_single"] += 1
+        if len(a) >= 4 and isinstance(a[3], dict):
+            a = a[:3] + (_strip(a[3]),) + a[4:]
+        if isinstance(kw.get("options"), dict):
+            kw["options"] = _strip(kw["options"])
+        return _real_solve_nlp(*a, **kw)
+
+    nlp_pounce.solve_nlp = _solve_nlp
+
+    _real_batch = pounce.solve_nlp_batch
+
+    def _batch(*a, **kw):
+        counts["nlp_batch"] += 1
+        if isinstance(kw.get("options"), dict):
+            kw["options"] = _strip(kw["options"])
+        return _real_batch(*a, **kw)
+
+    pounce.solve_nlp_batch = _batch
+
+NL = "/Users/jkitchin/Dropbox/projects/discopt-minlp-benchmark/minlplib/nl/{}.nl"
+rows = []
+for rep in range(reps):
+    model = from_nl(NL.format(stem))
+    t0 = _real_perf_counter()
+    r = model.solve(max_nodes=max_nodes)
+    row = {
+        "rep": rep,
+        "nodes": int(r.node_count or 0),
+        "bound": repr(float(r.bound)) if r.bound is not None else None,
+        "objective": repr(float(r.objective)) if r.objective is not None else None,
+        "status": r.status,
+        "wall": round(_real_perf_counter() - t0, 2),
+        "counts": dict(counts),
+        "clock_reads": _clock["n"],
+    }
+    rows.append(row)
+    print(json.dumps(row), flush=True)
+
+comparisons = 0
+varies = 0
+for key in ("nodes", "bound", "objective", "status"):
+    distinct = sorted({repr(r[key]) for r in rows})
+    comparisons += len(rows) - 1
+    varies += len(distinct) > 1
+    print(
+        f"{key:10s} {'STABLE' if len(distinct) == 1 else 'VARIES'} "
+        f"distinct={len(distinct)} {distinct}",
+        flush=True,
+    )
+
+print(
+    f"ARM {sorted(arms) or ['none']}: {'REPRODUCES' if varies == 0 else 'STILL VARIES'}", flush=True
+)
+print(f"comparisons={comparisons} patch_counts={counts} clock_reads={_clock['n']}", flush=True)
+
+missing = (
+    [a for a in arms if a == "lp" and counts["lp"] == 0]
+    + [a for a in arms if a == "nlp" and counts["nlp_single"] + counts["nlp_batch"] == 0]
+    + [a for a in arms if a == "clock" and _clock["n"] == 0]
+)
+if comparisons == 0 or missing:
+    print(f"PROBE FIRED NOTHING (missing={missing})", flush=True)
+    sys.exit(2)


### PR DESCRIPTION
Five issues from the relaxation/tuning backlog, one commit each on a single branch.
They are grouped because #1117 and #1118 are both defects *in* the #1111/#1115
singular-tangent path and #1116 was found while measuring #1115.

## Per issue

### #1117 — a `set_current()` tuning was silently discarded at the solve boundary
`_scoped_tuning` published the `tuning=` kwarg for the call, and with the kwarg
omitted — every plain `m.solve()` — it published a **fresh env-resolved**
`SolverTuning()` instead of inheriting the active one. A caller who wrapped a solve
in `solver_tuning.set_current(...)` ran on env defaults with no warning. Measured on
`41abe795` by counting `_interior_tangent_point` calls through a solve of the issue's
sqrt model: `solve(tuning=...)` → 6, `set_current(...)` around a plain solve → 0.

### #1118 — `x**0.5` never reached the singular-tangent recovery
`x**0.5` has exactly the vertical tangent at `t = 0` that `dm.sqrt(x)` has, but
`_build_power` built its derivative by bare exponentiation and
`p * (0.0 ** (p - 1.0))` **raises** `ZeroDivisionError` for every `p < 1`. That is an
`ArithmeticError`, caught one branch *above* the #1111/#1115 recovery, so the facet
stayed dropped. `_pow_deriv` now evaluates the `t == 0` limit explicitly (`+inf` for
`0 < p < 1`, `nan` for `p <= 0` where `f` itself diverges and the recovery must keep
declining); every `t != 0` value is the bare exponentiation, bit-identical including
its exceptions. Sound before and after — the facet was merely dropped — and reachable
only with the default-OFF `singular_tangent` flag.

### #1114 — alphaBB ran alongside the reduced-space engine
`_use_alphabb` keyed on the *lifted* LP relaxer being absent, which is exactly the
`dm.custom`/`CustomCall` class the reduced-space McCormick engine was introduced to
bound, so alphaBB ran at every node of every such model. The issue asked for a flag
and a differential panel because dropping a term from a `max()` can only loosen a
bound; the entry experiment says that reasoning does not apply, because on this class
alphaBB never produces a bound at all. `rigorous_alpha`'s interval-AD walker has no
rule for `CustomCall`, returns `+inf` on every box, and `_compute_alphabb_bound`
abstains with `-inf` — whose only effect at both call sites is `max(lb, -inf)`.
Measured over 8 CustomCall models: 51 alphaBB node boxes, all 51 abstaining, → 0,
with status/node_count/bound/objective bit-identical (32/32 exact-identity
assertions — the §5 bound-neutral regime). Ships unflagged for that reason: a
default-off knob over a provable no-op is a dead flag (§3).

### #1115 — disposition recorded; the flag stays default-OFF
The tangent is placed where the LP binds (`_separate_singular_tangent`, lazy) rather
than at a geometric offset. Gate 1 passes (0 soundness violations across every arm,
checked per repetition against `minlplib.solu`). **Gate 2 fails**: +25.6 % wall on
`eq6_1` and +54.2 % on `maxmin`, each 12–200 pooled sd, on the two instances that
gain nothing — they draw the most rows. But the removal branch's premise is false
too: lazy never loses the bound anywhere on the corpus and does pay on
`kriging_peaks` (tighter bound, identical node count and incumbent, +4.0–4.5 % wall).
The issue's DoD offered only "graduate" or "remove", so per §4 the plan loses: the
flag stays default-OFF and stays in the tree. The gap is a *trigger*, not a better
mechanism, and building it on evidence that all sits in one family would be the #727
RLT mistake — tracked as #1119 instead.

### #1116 — the dual bound was a function of machine speed
The issue reported a 13th-digit drift with the node count flipping 301 ↔ 303. At
`max_nodes=1` the defect is far larger: three root dual bounds spanning **14 %**
(−25371.8 / −28852.0 / −28072.6) with the incumbent bit-identical.

**Root cause: wall-clock role-2 budgets.** #912's distinction — a clock answering
"when do we stop?" is role 1 and correct by definition; a clock answering "how much
work do we do?" is role 2 and makes the *answer* a function of machine speed.
Bisecting the arms of a confounded neutralization showed the `clock` arm **alone**
reproduces bit-exactly (`-1044.8190276107248` twice), while the NLP arm still varies
and the LP seam never binds. The mechanism is structural, not float noise: the first
root LP comes back with a different number of **columns** (1532 vs 1469), because a
wall-truncated tightening stage handed the builder a different box — the root
fixpoint returned 894 vs 898 tightened bounds from *different input boxes*, having
spent 237.7 s vs 247.55 s in OBBT.

**Fix.** `deterministic` was a public `solve()` parameter documented as "Ensure
deterministic results" and read **nowhere** — a dead flag promising exactly the
guarantee being broken. It is now wired: `SolverTuning.deterministic` /
`DISCOPT_DETERMINISTIC`, default **OFF**, rendering role-2 budgets inert at their
**origin** — 27 call sites via `_role2_budget` / `_role2_deadline` /
`_role2_horizon`, 3 direct guards where the budget is a loop condition, and the
integer-ratio dive in `mccormick_lp.py`. Both halves of the search are covered: the
dual side (root presolve, declared-box tightening, OBBT, per-node OBBT, the root
fixpoint, root cuts, the box/probe/pool LP slices, the MILP stall slice) and the
primal side (native-kernel seeds, root sub-NLP seeds, ILS, multistart, one-hot swap,
dual recovery) — a machine-speed-dependent incumbent moves the cutoff, which moves
the tree, which moves the bound.

The default moved `True` → `False` in the same change: the old default named a
guarantee the solver never provided, and turning the real mode on by default would be
a bound-changing default flip (§5) with no graduation panel behind it.

**Scoped, on purpose.** Two role-1 mechanisms are left live — the phase-entry gates
(`_deadline_exhausted()` / `_remaining_budget() > x`) and the POUNCE
`max_wall_time = min(30.0, caller_limit)` stall backstop. Neutralizing either lets
preprocessing overrun the user's `time_limit` without bound, trading a
reproducibility bug for a broken role-1 promise, which §1 does not permit. So the
guarantee is: **a solve reproduces when the role-1 budget never binds.** Both
residuals were measured not to bind here, and a test pins them so widening the flag
to swallow role 1 fails loudly instead of quietly.

**Falsifications recorded (§4/§11).**
* The issue's own "suggested first step" (swap five `bnb` HashMap/HashSet sites to
  BTreeMap) is dead: the crate has 18 hash-container declarations and **3** iteration
  sites, all order-insensitive; the five named sites are only
  `insert`/`entry`/`remove`/`get`/`len`ed.
* Thread scheduling: falsified (rayon + all BLAS pinned to 1, still 301 ↔ 303).
* `Variable.__hash__ = id(self)`: falsified (patched to `self._index`, 26 377 430
  firings, bound still moves).
* The #694 anytime build truncation: falsified (`build_truncated=False`,
  `cons_done == cons_total`, 404/404).
* The Rust simplex is a faithful function of its input
  (`first_differing_OUTPUT_at_equal_input = None`).
* The issue's premise "no `time_limit`" is wrong — `Model.solve` defaults to 3600 s.
* **Retracted in `solver.py` (§11):** "a deterministic `max_nodes` budget makes solves
  bit-reproducible (6/6 identical)". A node budget bounds the *tree*; it does not
  bound the wall sub-budgets inside a node.

One more thing the measurement says: the no-clock bound (−1044.819) is *tighter* than
every wall-bounded run. An early-truncated tightening stage is not merely
nondeterministic — it leaves bound on the table.

## Verification

* `pytest -m smoke` — 1104 passed, 1 skipped, 9352 deselected, 2 xpassed (136.88 s), on the final tree
* `pytest -m slow python/tests/test_adversarial_recent_fixes.py` — 19 passed (145.68 s)
* `deterministic_verify.py kriging_peaks-full200 1 3 1` on the final tree — 3/3
  repetitions bit-identical (bound `-1044.8190276107248`, objective
  `-3.890198803588073`, 3 nodes), `ARM deterministic=True: REPRODUCES`, 24 role-2
  suppressions fired — against a default arm that returns three distinct bounds
* New regression tests, each failing before its change and passing after:
  `test_1117_tuning_scope.py`, `test_1118_power_singular_tangent.py` (41 tests, 13
  failing pre-change), `test_1114_alphabb_customcall_suppressed.py`,
  `test_1116_deterministic_mode.py` (8 tests)
* `ruff check python/`, `ruff format --check python/`, `mypy` — clean
* No Rust touched, so `cargo test -p discopt-core` does not apply.
* Probe harnesses for #1116 are kept under `scratchpad/issue1116/` with a README
  table of every probe and its verdict; each prints an executed-comparison count and
  exits non-zero on zero (§6), swallows no exception (§7), and prints
  `discopt.__file__` (§8).


---

## Follow-on 1 — #1116's flag gets a consumer that actually runs (`8747588f`)

#1116 shipped `deterministic=True`, and the repo's *only* reproducibility assertions
were `discopt_benchmarks/tests/test_correctness.py::TestDeterminism` — two tests that
pass `deterministic=True` and assert a bit-identical objective and node count across
three runs. They had never executed. Neither had the other 96 tests in that file:
`solve_instance` raised `NotImplementedError`, every test caught it and skipped with
the reason "discopt not yet available", and `TestFeasibility`'s two tests contained
zero assertions — the bodies were commented-out sketches. CI never ran the directory
at all, so nothing reported the gap.

The file now solves real instances. `solve_instance` resolves a stem against the
in-repo `python/tests/data/minlplib_nl/` corpus, then the MINLPLib snapshot
(`DISCOPT_MINLPLIB_NL`), parses through `from_nl`, caches per `(name, kwargs)`, and
honours `DISCOPT_BENCH_TIME_LIMIT` (30 s default). `TestFeasibility` calls the real
`warm_start.check_feasibility` and asserts the returned `ok`; `test_integrality`
walks `model._variables`, counts how many discrete entries it checked, and skips
rather than silently passing when that count is zero (§6). All ten `TestEdgeCases`
bodies build actual models. `test_the_corpus_is_reachable` is a `smoke` test that
fails if the whole thing degrades back to skipping.

    99 collected — 87 passed, 12 skipped, 0 failed (5 m 04 s), 29 instances resolved

The 12 skips are honest: eight instances did not reach optimality within 30 s, four
had no feasible point. **No bound exceeded its reference optimum on any of the 29.**
`.github/workflows/ci.yml` adds the file to the `python-correctness` lane, and
`RELEASE.md` records that `-m correctness` is required to select it.

`discopt_benchmarks/tests/test_interop.py` (15 tests) is still a stub. That is a
genuine scope expansion, not part of this PR, so #1050 stays open.

## Follow-on 2 — #1119 falsified: binding rate is anti-correlated with payoff (`2074fb5a`)

#1115 left `singular_tangent` default-OFF because its timing panel failed gate 2.
#1119 was the successor hypothesis — fire the separator on whether the recovered
facet *binds* rather than on the operator that produced it — with an explicit kill
criterion: if binding rate does not separate the gaining instances from the paying
ones, the direction is dead; record it and stop rather than reaching for a second
heuristic.

Entry experiment first (§4). `MccormickLPRelaxer` now tallies, per emitted batch, how
many singular-tangent rows are tight at the optimum of the LP they were added to,
plus the objective movement across separation rounds (`singular_tangent_stats()`).
That instrumentation was verified **bound-neutral before it was used to measure
anything** (§5, bound-neutral regime): 40/40 exact `node_count` / `objective` /
`bound` / `status` identities across five instances × {flag OFF, flag ON},
instrumentation present vs. stashed.

Panel — `max_nodes=200`, `time_limit=120`, `deterministic=True`, flag + lazy ON:

| instance | #1115 class | rows | binding | binding frac | Σ obj gain |
|---|---|---|---|---|---|
| `eq6_1` | pays +25.6 %, no gain | 22 874 | 22 874 | **1.0000** | −1.4e−13 |
| `maxmin` | pays +54.2 %, no gain | 23 189 | 22 214 | **0.9580** | 0.2116 |
| `kriging_peaks-full050` | gains 1.9 % of gap | 5 418 | 4 610 | **0.8509** | 300.2 |
| `kriging_peaks-full100` | gains 1.6 % of gap | 8 976 | 8 234 | **0.9173** | 594.4 |

Falsified in the worst of the three available ways:

1. **Binding is near-tautological.** A row is emitted *because* it is violated at the
   current LP point, so the re-solve that follows lands on it. The whole population
   sits in 0.85–1.00.
2. **What separation exists runs backwards.** The two instances that pay have the two
   *highest* binding rates; the two that gain have the two lowest.
3. **The gate cannot recover the cost even in principle.** `eq6_1` has **zero**
   non-binding rows — dropping non-binding rows drops 0 of 22 874 and saves 0 % of the
   +25.6 % it exists to remove; `maxmin` drops 4.2 % against +54.2 %. The same rule
   would discard 14.9 % of the rows on `kriging_peaks-full050`, the instance the
   feature exists for.

Σ objective gain per row *does* separate, by three to four orders of magnitude, and is
deliberately **not** being built: it is a different hypothesis than the one #1119
authorized (whose kill criterion forbids exactly that substitution), it is
unnormalized across objective scales, and the population is too small to fit a
threshold to without becoming the §2 single-problem solution. No follow-up issue is
filed; the question is closed.

Coverage behind the verdict: a prefilter for `o39`/`o51`/`o52`/`o53`/fractional-power
gives 164 MINLPLib candidates; the 96 smallest register a spec on 18 and emit a row on
8. The in-repo 66-instance corpus emits on 2 (`tspn08` 1 row, `tspn12` 3), both at
~1e−13 of bound.

The accounting stays — one dot product per emitted batch, on a path that only runs when
the default-off flag is on, and it is how this verdict gets re-checked rather than
re-argued. `test_1119_singular_tangent_accounting.py` pins it: the separator records
what it emits, the flag-OFF arm records nothing (an uncontaminated control), and the
tally is read-only and refuses malformed batches *without raising* — it runs inside the
separator's `except Exception`, so a raise there would silently abandon separation and
move a bound.

`singular_tangent` stays default-OFF, its shipped state. Recorded in
`docs/dev/performance-plan.md` §17, the `SolverTuning.singular_tangent_lazy` docstring,
and the CHANGELOG.

### Verification for the two follow-on commits

* `pytest -m smoke` — 1104 passed, 1 skipped, 2 xpassed (133.93 s)
* `pytest -m slow python/tests/test_adversarial_recent_fixes.py` — 19 passed (144.06 s)
* `test_1111_*` + `test_1119_*` — 49 passed (22.45 s)
* `discopt_benchmarks/tests/test_correctness.py -m "correctness or smoke"` — 99
  collected, 87 passed, 12 skipped, 0 failed (5 m 04 s)
* 40/40 bound-neutrality comparisons for the #1119 instrumentation, 0 mismatches
* `ruff check`, `ruff format --check`, `mypy` — clean on every touched file

Closes #1114
Closes #1115
Closes #1116
Closes #1117
Closes #1118
Closes #1119
Contributes to #1050

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013Gx9G9rH3r2k5xnMfQCn2E
