### PR TITLE
test(#1064): the round-budget regression test measured the machine, not the budget

### DIFF
--- a/docs/dev/performance-plan.md
+++ b/docs/dev/performance-plan.md
@@ -3435,6 +3435,55 @@ declined", not "the panel never ran".
 
 Per §5 the flag is now **default-ON**, with `DISCOPT_PERSPECTIVE_OA_CUT=0` kept
 as the opt-out and the plain-tangent path intact.
+
+### 19.5 The round-budget regression test measured the machine, not the budget (2026-08-29)
+
+`test_1064_round_fix_resolve.py::test_the_time_budget_is_what_bounds_the_spend`
+failed on `main` at `1b8866ec` with *"budget frac made no difference: 7 attempts
+budgeted vs 7 unbudgeted"*, and reproduced on a rerun. It was not a solver
+regression, and the budget it tests is correct.
+
+The test ran two full `solve_model` calls with a stub that declines and sleeps
+0.3 s, and compared how many times each reached the round gate — the budgeted
+arm bounded by `_ROUND_TIME_FRAC * T = 2.0 s` (7 attempts), the unbudgeted arm
+expected to run to the solve's own limit. That comparison is only meaningful if
+the search reaches the gate many more than 14 times, and how often a
+wall-clock-bounded search reaches it is not reproducible. Ten identical runs of
+the fixture, one box, one build, arms interleaved (load1 4.5–10.0):
+
+| frac | gate visits | nodes | status | wall |
+|---|---|---|---|---|
+| 0.2 | 7, 7, 0, 0, 0 | 97, 97, 0, 0, 0 | optimal | 8.6–6.0 s |
+| 1e6 | 15, 15, 15, 0, 0 | 31, 31, 31, 0, 0 | feasible/optimal | 10.9–5.7 s |
+
+The `0` rows are the important ones: the model does not always route to
+`_solve_miqp_bb` at all, so on this box the test usually failed its own
+"round-fix-resolve never ran" precondition — the invariant was untested on any
+developer machine and only ever evaluated on CI, where it eventually drew
+`7 vs 7`. Entering `_solve_miqp_bb` **directly** is by contrast exactly
+reproducible (5/5 runs: 91 nodes, `optimal`, budget built once, gate consulted
+once), which is what the wiring test now does.
+
+**Retraction (§11).** Mid-session I told the owner the CI failure was "a real
+failure, not flaky" because a rerun reproduced it. The reproduction was real; the
+conclusion was wrong. Reruns land on similar runners, so reproducing a
+load-sensitive race is not evidence against it being one.
+
+The rule (`_RoundBudget`, `_round_fix_resolve_attempt`) was lifted out of
+`_solve_miqp_bb`'s node loop so it can be exercised directly instead of raced to.
+That is strictly more coverage, not less: the extracted gate also pins the
+opt-out and no-incumbent conjuncts, which nothing tested before, and the whole
+file dropped from ~25 s (two flaky tests) to 0.7 s (none). Five mutations of the
+production rule — dropping the time term from `may_attempt`, handing an attempt
+the solve deadline, dropping the `enabled`/`has_incumbent` conjuncts, not
+recording the spend, and bypassing the gate entirely — each fail at least one
+test.
+
+**Standing lesson.** A wall-clock-bounded search is not a fixture. Any assertion
+that counts how many times such a search reaches an internal gate is measuring
+the machine; extract the rule and assert on it directly.
+
+
 ## 20. #1061 root cuts: `DISCOPT_NLPBB_ROOT_CUTS` is sound but not helpful — stays OFF (rejected 2026-08-20)
 
 > **Superseded by §21 (2026-08-20).** The re-run panel below — on a build with

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -20049,6 +20049,104 @@ _ROUND_TIME_FRAC = 0.2
 _ROUND_ATTEMPT_CAP = 64
 
 
+class _RoundBudget:
+    """The spend rule for #1064's round-fix-resolve, as an object.
+
+    The real bound is *time*, not calls: one attempt is up to two
+    ``_pounce_recover_node_bound`` re-solves whose cost varies by orders of
+    magnitude across instances, so an attempt count bounds nothing.
+    ``_ROUND_ATTEMPT_CAP`` is only a backstop for a family whose roundings are
+    each cheap enough that the time budget alone would allow unboundedly many.
+
+    Split out of ``_solve_miqp_bb``'s node loop so the rule can be exercised
+    directly. Counting attempts through a real solve measures the machine, not
+    the budget: how many times a wall-clock-bounded search reaches this gate is
+    not reproducible even on one box (measured 2026-08-29, ten identical runs of
+    the UFL fixture -- 0, 7 or 15 gate visits, 0/31/97 nodes, status flipping
+    between ``optimal`` and ``feasible``), which is how the end-to-end version of
+    this test came to compare two coin flips and fail on main.
+    """
+
+    __slots__ = ("attempts", "secs", "budget")
+
+    def __init__(self, time_limit: float, frac: float | None = None) -> None:
+        # Read the module global at construction time so a test can retune it.
+        self.budget = (_ROUND_TIME_FRAC if frac is None else float(frac)) * float(time_limit)
+        self.attempts = 0
+        self.secs = 0.0
+
+    def may_attempt(self) -> bool:
+        return self.attempts < _ROUND_ATTEMPT_CAP and self.secs < self.budget
+
+    def attempt_deadline(self, time_limit: float, elapsed: float) -> float:
+        """Per-attempt limit: what is left of the budget, never past the solve.
+
+        ``_pounce_recover_node_bound`` derives its own limit as
+        ``time_limit - (now - t_start)``, so handing it the global limit would
+        let one attempt run all the way to the solve deadline.
+        """
+        return min(float(time_limit), float(elapsed) + max(0.0, self.budget - self.secs))
+
+    def begin_attempt(self) -> None:
+        self.attempts += 1
+
+    def add_spend(self, secs: float) -> None:
+        self.secs += float(secs)
+
+
+def _round_fix_resolve_attempt(
+    x_row,
+    int_offsets,
+    int_sizes,
+    node_lb_i,
+    node_ub_i,
+    c,
+    obj_const,
+    A_ub,
+    b_ub,
+    A_eq,
+    b_eq,
+    t_start,
+    time_limit,
+    Q,
+    budget,
+    *,
+    enabled,
+    has_incumbent,
+):
+    """#1064's round-fix-resolve gate: a rounded completion, or a declined gate.
+
+    Spent only while the tree has no incumbent -- with one in hand there is
+    already a primal bound, and a rounded completion can only ever supply an
+    upper bound (see :func:`_pounce_round_incumbent`) -- and only while
+    ``budget`` allows. The spend is recorded even when the attempt raises, so a
+    failing rounding cannot buy unlimited retries.
+    """
+    if not enabled or has_incumbent or not budget.may_attempt():
+        return None
+    budget.begin_attempt()
+    t0 = time.perf_counter()
+    try:
+        return _pounce_round_incumbent(
+            x_row,
+            int_offsets,
+            int_sizes,
+            node_lb_i,
+            node_ub_i,
+            c,
+            obj_const,
+            A_ub,
+            b_ub,
+            A_eq,
+            b_eq,
+            t_start,
+            budget.attempt_deadline(time_limit, t0 - t_start),
+            Q=Q,
+        )
+    finally:
+        budget.add_spend(time.perf_counter() - t0)
+
+
 def _round_into_box(vals: np.ndarray, lo: np.ndarray, hi: np.ndarray):
     """Round to the nearest integer that actually lies inside ``[lo, hi]``.
 
@@ -22274,20 +22372,16 @@ def _solve_miqp_bb(
         )
 
     # #1064: round-fix-resolve is a *first incumbent* mechanism, so it is spent
-    # only while the tree has none, and it is capped so a family where every
-    # rounding is infeasible cannot eat the search. Both are counted, not
-    # assumed: ``_round_attempts`` is what the regression test asserts on.
-    _round_attempts = 0
-    # The real bound is time, not calls (see _ROUND_TIME_FRAC). Both are
-    # counted, not assumed: the regression test asserts on _round_attempts and
-    # on the seconds actually spent here.
-    _round_budget = _ROUND_TIME_FRAC * float(time_limit)
-    _round_secs = 0.0
+    # only while the tree has none, and it is bounded by time (with an attempt
+    # cap as a backstop) so a family where every rounding is infeasible cannot
+    # eat the search. The rule lives in :class:`_RoundBudget` /
+    # :func:`_round_fix_resolve_attempt` so it is testable without racing a
+    # wall-clock-bounded search to this gate.
+    _round = _RoundBudget(time_limit)
 
     def _maybe_inject_snapped(x_row, node_lb_i, node_ub_i):
         # Purification (increment 3): near-integral interior points become
         # exact incumbents via snap-fix-resolve.
-        nonlocal _round_attempts, _round_secs
         inc = _pounce_snap_incumbent(
             x_row,
             int_offsets,
@@ -22305,28 +22399,10 @@ def _solve_miqp_bb(
             Q=_Q_m,
         )
         how = "snapped"
-        if (
-            inc is None
-            and _tuning().round_fix_resolve
-            and tree.incumbent() is None
-            and _round_attempts < _ROUND_ATTEMPT_CAP
-            and _round_secs < _round_budget
-        ):
+        if inc is None:
             # The snap path declined, i.e. this point is genuinely fractional.
-            # With no incumbent in hand there is no primal bound at all, so a
-            # rounded completion is strictly better than nothing — and it can
-            # only ever supply an upper bound (see _pounce_round_incumbent).
-            _round_attempts += 1
-            # Bound this single attempt by whatever is left of the heuristic's
-            # budget as well as by the solve deadline: _pounce_recover_node_bound
-            # derives its own limit as ``time_limit - (now - t_start)``, so
-            # handing it the global limit lets one attempt run to the deadline.
-            _t_round = time.perf_counter()
-            _round_tl = min(
-                float(time_limit),
-                (_t_round - t_start) + max(0.0, _round_budget - _round_secs),
-            )
-            inc = _pounce_round_incumbent(
+            # The gate itself decides whether an attempt is affordable.
+            inc = _round_fix_resolve_attempt(
                 x_row,
                 int_offsets,
                 int_sizes,
@@ -22339,11 +22415,14 @@ def _solve_miqp_bb(
                 _A_eq_m,
                 _b_eq_m,
                 t_start,
-                _round_tl,
-                Q=_Q_m,
+                time_limit,
+                _Q_m,
+                _round,
+                enabled=_tuning().round_fix_resolve,
+                has_incumbent=tree.incumbent() is not None,
             )
-            _round_secs += time.perf_counter() - _t_round
-            how = "rounded"
+            if inc is not None:
+                how = "rounded"
         if inc is not None:
             x_inc = np.asarray(inc[1][:n_vars], dtype=np.float64).copy()
             # #952: an injected incumbent goes straight into the tree as a

--- a/python/tests/test_1064_round_fix_resolve.py
+++ b/python/tests/test_1064_round_fix_resolve.py
@@ -21,6 +21,8 @@ These tests pin the rounding arithmetic and the retry, not the timing -- a
 wall-clock assertion would need a load gate and a spread to mean anything (§9).
 """
 
+import time
+
 import numpy as np
 import pytest
 from discopt import solver as S
@@ -192,91 +194,270 @@ def _ufl_model(n_i=6, n_j=12):
     return m
 
 
-_STUB_SLEEP = 0.3
+_ROUND_ATTEMPT_CAP_REF = 64
+_STUB_COST = 0.3
 _STUB_TIME_LIMIT = 10.0
 
 
-def _run_with_declining_stub(monkeypatch, frac):
-    """Solve the UFL fixture with a stub that always declines and costs time.
+# --- The spend rule: exercised directly, not raced to -------------------------
+#
+# These two tests used to run the UFL fixture below through two full solves and
+# compare how many times each reached the round gate. That measures the machine,
+# not the budget: the gate sits inside a wall-clock-bounded search, and ten
+# identical runs on one box (2026-08-29) gave 0, 7 or 15 gate visits, 0/31/97
+# nodes, and a status flipping between ``optimal`` and ``feasible``. On CI both
+# arms clamped at 7 and the comparison failed on main while the budget was
+# working correctly; on this developer box the fixture usually reached the gate
+# zero times, so the invariant was not tested at all. The rule now lives in
+# ``_RoundBudget``/``_round_fix_resolve_attempt`` and is asserted on directly --
+# which also pins the two conjuncts (opt-out, no-incumbent) nothing tested
+# before. ``test_the_miqp_search_wires_the_budget_in`` keeps the end-to-end
+# claim that the solver actually uses the rule.
 
-    Standing in for the expensive ``_pounce_recover_node_bound`` re-solve keeps
-    the bound under test the *budget* rather than POUNCE's convergence.
+
+def _drive_gate(monkeypatch, budget, *, cost=_STUB_COST, enabled=True, has_incumbent=False):
+    """Call the gate until it declines, with an attempt that costs ``cost``.
+
+    The stub charges the budget itself rather than sleeping, so the rule is
+    exercised at its own arithmetic instead of at the clock -- deterministic,
+    and it does not spend ``cost`` seconds of the suite per attempt. The real
+    elapsed time the gate also charges is microseconds, far below ``cost``.
     """
-    import time as _time
-
+    lb, ub, c, k, A_ub, b_ub, A_eq, b_eq, Q = _fix_or_free_qp()
     seen = {"calls": 0, "limits": []}
 
     def _stub(*args, **kwargs):
         seen["calls"] += 1
         # Signature: (..., t_start, time_limit, Q=None) -- time_limit is arg 13.
         seen["limits"].append(float(args[12]))
-        _time.sleep(_STUB_SLEEP)
+        budget.add_spend(cost)
         return None
 
     monkeypatch.setattr(S, "_pounce_round_incumbent", _stub)
-    monkeypatch.setattr(S, "_ROUND_TIME_FRAC", frac)
-    monkeypatch.setenv("DISCOPT_ROUND_FIX_RESOLVE", "1")
-
-    t0 = _time.perf_counter()
-    S.solve_model(_ufl_model(), time_limit=_STUB_TIME_LIMIT)
-    seen["wall"] = _time.perf_counter() - t0
-    # The probe must have fired, or every assertion downstream is vacuous.
-    assert seen["calls"] > 0, (
-        "round-fix-resolve never ran: this model no longer reaches the MIQP "
-        "round gate, so the budget is untested -- fix the fixture, not the bound"
-    )
+    # The solver passes a perf_counter reading; 0.0 would make the elapsed
+    # term the machine's whole uptime and clamp every deadline to the solve.
+    t_start = time.perf_counter()
+    for _ in range(_ROUND_ATTEMPT_CAP_REF + 5):
+        before = seen["calls"]
+        S._round_fix_resolve_attempt(
+            np.array([0.4, 0.6]),
+            [0],
+            [1],
+            lb,
+            ub,
+            c,
+            k,
+            A_ub,
+            b_ub,
+            A_eq,
+            b_eq,
+            t_start,
+            _STUB_TIME_LIMIT,
+            Q,
+            budget,
+            enabled=enabled,
+            has_incumbent=has_incumbent,
+        )
+        if seen["calls"] == before:
+            break  # the gate declined; the stub was not reached
+    else:  # pragma: no cover - runaway guard
+        pytest.fail("the gate never declined -- the rule bounds nothing")
     return seen
 
 
-def test_round_fix_resolve_is_bounded_by_a_time_budget(monkeypatch):
-    """The heuristic may not spend the solve.
+def test_the_budget_not_the_attempt_cap_is_what_bounds_the_spend(monkeypatch):
+    """The binding constraint must be *time*, and neutralising it must show that.
 
-    ``_ROUND_ATTEMPT_CAP`` caps the *number* of attempts, but each attempt is up
+    ``_ROUND_ATTEMPT_CAP`` caps the number of attempts, but each attempt is up
     to two ``_pounce_recover_node_bound`` calls -- a full POUNCE re-solve whose
     cost varies by orders of magnitude across instances -- so a count cap bounds
     nothing. Measured on slay05h at T=60 s before this budget existed: 31
-    attempts, 0 hits, 66.5 s = 98.3% of the wall, turning a certified optimum
+    attempts, 0 hits, 66.5 s = 98.3 % of the wall, turning a certified optimum
     (1335 nodes, 15.5 s) into a time_limit with no incumbent (63 nodes).
     """
     budget = S._ROUND_TIME_FRAC * _STUB_TIME_LIMIT
-    seen = _run_with_declining_stub(monkeypatch, S._ROUND_TIME_FRAC)
-
-    assert seen["calls"] < _ROUND_ATTEMPT_CAP_REF
-    spent = seen["calls"] * _STUB_SLEEP
-    assert spent <= budget + _STUB_SLEEP + 0.5, (
-        f"spent {spent:.2f}s of a {budget:.2f}s budget over {seen['calls']} attempts"
+    budgeted = _drive_gate(monkeypatch, S._RoundBudget(_STUB_TIME_LIMIT))
+    # Stopped by the budget, well short of the cap.
+    assert budgeted["calls"] < _ROUND_ATTEMPT_CAP_REF
+    spent = budgeted["calls"] * _STUB_COST
+    assert spent <= budget + _STUB_COST, (
+        f"spent {spent:.2f}s of a {budget:.2f}s budget over {budgeted['calls']} attempts"
     )
-    # Each attempt is handed the budget's deadline, not the solve's: passing the
-    # global limit lets a single attempt run all the way to the deadline.
-    assert max(seen["limits"]) < _STUB_TIME_LIMIT
-    assert seen["wall"] < _STUB_TIME_LIMIT + 5.0
 
-
-def test_the_time_budget_is_what_bounds_the_spend(monkeypatch):
-    """Neutralising only the budget restores the unbounded behaviour.
-
-    Without this arm the test above would pass on any solve that happens to make
-    few attempts, and would not show that the *budget* is the binding constraint
-    rather than the attempt cap or the search finishing early.
-    """
-    default_frac = S._ROUND_TIME_FRAC
-    budgeted = _run_with_declining_stub(monkeypatch, default_frac)
-    unbudgeted = _run_with_declining_stub(monkeypatch, 1e6)
-
+    # Neutralise only the budget: now nothing but the backstop stops it.
+    unbudgeted = _drive_gate(monkeypatch, S._RoundBudget(_STUB_TIME_LIMIT, frac=1e6))
+    assert unbudgeted["calls"] == _ROUND_ATTEMPT_CAP_REF
     assert unbudgeted["calls"] > 2 * budgeted["calls"], (
-        f"budget frac made no difference: {budgeted['calls']} attempts budgeted "
+        f"budget made no difference: {budgeted['calls']} attempts budgeted "
         f"vs {unbudgeted['calls']} unbudgeted"
     )
-    # Unbudgeted, the stub alone outruns the solve's own time limit.
-    assert unbudgeted["calls"] * _STUB_SLEEP > _STUB_TIME_LIMIT * default_frac
+    # Unbudgeted, the attempts alone outrun the solve's own time limit.
+    assert unbudgeted["calls"] * _STUB_COST > _STUB_TIME_LIMIT * S._ROUND_TIME_FRAC
 
 
-_ROUND_ATTEMPT_CAP_REF = 64
+def test_each_attempt_gets_the_budget_deadline_not_the_solve_deadline(monkeypatch):
+    """Handing an attempt the global limit lets one attempt run to the deadline.
+
+    ``_pounce_recover_node_bound`` derives its own limit as
+    ``time_limit - (now - t_start)``, so the per-attempt deadline has to be the
+    budget's remainder, and it has to shrink as the budget is spent.
+    """
+    seen = _drive_gate(monkeypatch, S._RoundBudget(_STUB_TIME_LIMIT))
+    assert seen["limits"], "no attempt was made, so no deadline was handed out"
+    assert max(seen["limits"]) < _STUB_TIME_LIMIT
+    assert seen["limits"] == sorted(seen["limits"], reverse=True), (
+        f"per-attempt deadline did not shrink with the budget: {seen['limits']}"
+    )
+    assert seen["limits"][0] == pytest.approx(S._ROUND_TIME_FRAC * _STUB_TIME_LIMIT, abs=1e-3)
 
 
-def test_attempt_cap_is_still_a_backstop():
-    assert S._ROUND_ATTEMPT_CAP == _ROUND_ATTEMPT_CAP_REF
-    assert 0.0 < S._ROUND_TIME_FRAC < 1.0
+def test_the_gate_is_spent_only_while_the_tree_has_no_incumbent(monkeypatch):
+    """With a primal bound in hand a rounded completion can add nothing.
+
+    ``_pounce_round_incumbent`` only ever supplies an upper bound, so spending
+    the budget once the tree already has one is pure loss.
+    """
+    budget = S._RoundBudget(_STUB_TIME_LIMIT)
+    lb, ub, c, k, A_ub, b_ub, A_eq, b_eq, Q = _fix_or_free_qp()
+    called = {"n": 0}
+
+    def _stub(*args, **kwargs):
+        called["n"] += 1
+        return None
+
+    monkeypatch.setattr(S, "_pounce_round_incumbent", _stub)
+    for has_inc, enabled in ((True, True), (False, False)):
+        assert (
+            S._round_fix_resolve_attempt(
+                np.array([0.4, 0.6]),
+                [0],
+                [1],
+                lb,
+                ub,
+                c,
+                k,
+                A_ub,
+                b_ub,
+                A_eq,
+                b_eq,
+                time.perf_counter(),
+                _STUB_TIME_LIMIT,
+                Q,
+                budget,
+                enabled=enabled,
+                has_incumbent=has_inc,
+            )
+            is None
+        )
+    assert called["n"] == 0, "the gate ran an attempt it should have declined"
+    assert budget.attempts == 0 and budget.secs == 0.0
+    # And the same budget still works, so the declines above were the gate's
+    # doing rather than an exhausted budget.
+    assert _drive_gate(monkeypatch, budget)["calls"] > 0
+
+
+def test_a_raising_attempt_still_charges_the_budget(monkeypatch):
+    """Otherwise a rounding that always throws buys unlimited retries."""
+    budget = S._RoundBudget(_STUB_TIME_LIMIT)
+    lb, ub, c, k, A_ub, b_ub, A_eq, b_eq, Q = _fix_or_free_qp()
+
+    def _boom(*args, **kwargs):
+        raise RuntimeError("rounding blew up")
+
+    monkeypatch.setattr(S, "_pounce_round_incumbent", _boom)
+    with pytest.raises(RuntimeError, match="blew up"):
+        S._round_fix_resolve_attempt(
+            np.array([0.4, 0.6]),
+            [0],
+            [1],
+            lb,
+            ub,
+            c,
+            k,
+            A_ub,
+            b_ub,
+            A_eq,
+            b_eq,
+            time.perf_counter(),
+            _STUB_TIME_LIMIT,
+            Q,
+            budget,
+            enabled=True,
+            has_incumbent=False,
+        )
+    assert budget.attempts == 1, "a raising attempt was not counted"
+    assert budget.secs > 0.0, "a raising attempt was not charged any time"
+
+
+def _ufl_model(n_i=6, n_j=12):
+    """Uncapacitated-facility-location shape -- the #1064 class.
+
+    Binary ``y_i``, continuous ``x_ij``, VUB links ``x_ij <= y_i``, covering
+    equalities ``sum_i x_ij == 1``, convex quadratic objective. This routes to
+    ``_solve_miqp_bb``, which is what makes the wiring test below meaningful.
+    """
+    from discopt import Model
+
+    m = Model("ufl")
+    y = m.binary("y", shape=(n_i,))
+    x = m.continuous("x", shape=(n_i, n_j), lb=0.0, ub=1.0)
+    rng = np.random.default_rng(0)
+    serve = rng.uniform(1.0, 9.0, size=(n_i, n_j))
+    opens = rng.uniform(5.0, 15.0, size=n_i)
+    for i in range(n_i):
+        for j in range(n_j):
+            m.subject_to(x[i, j] <= y[i])
+    for j in range(n_j):
+        m.subject_to(sum(x[i, j] for i in range(n_i)) == 1)
+    m.minimize(
+        sum(opens[i] * y[i] for i in range(n_i))
+        + sum(serve[i, j] * x[i, j] * x[i, j] for i in range(n_i) for j in range(n_j))
+    )
+    return m
+
+
+def test_the_miqp_search_wires_the_budget_in():
+    """The unit tests above are worthless if the search does not use the rule.
+
+    ``_solve_miqp_bb`` is entered directly rather than through ``solve_model``:
+    whether a given model *routes* to the convex-MIQP engine is itself not
+    reproducible (measured 2026-08-29 -- five identical ``solve_model`` runs of
+    the fixture below entered it zero times, other runs of the same build
+    entered it and reached the round gate 7 or 15 times). Calling the engine
+    makes the wiring claim deterministic; the ``_RoundBudget`` the engine builds
+    is the one the gate consults, and it is built from the solve's own limit.
+    """
+    built, asked = [], []
+    real = S._RoundBudget
+
+    class _Recording(real):
+        def __init__(self, time_limit, frac=None):
+            built.append(float(time_limit))
+            super().__init__(time_limit, frac)
+
+        def may_attempt(self):
+            asked.append(True)
+            return super().may_attempt()
+
+    saved, S._RoundBudget = S._RoundBudget, _Recording
+    try:
+        S._solve_miqp_bb(
+            _ufl_model(),
+            _STUB_TIME_LIMIT,
+            1e-4,
+            1,
+            "best_first",
+            10_000,
+            time.perf_counter(),
+            prefer_pounce=True,
+        )
+    finally:
+        S._RoundBudget = saved
+    assert built, "the MIQP search never built a round budget -- the rule is unwired"
+    assert built[0] == pytest.approx(_STUB_TIME_LIMIT)
+    # Building it is not using it: the gate has to actually consult the rule.
+    assert asked, "the round gate never consulted the budget -- the rule is bypassed"
+    assert real is saved, "the recording subclass leaked out of the test"
 
 
 # --- The candidate ladder (#1064: switch structure) ---------------------------


### PR DESCRIPTION
## What broke

`Python coverage` on `main` at `1b8866ec`:

```
test_1064_round_fix_resolve.py::test_the_time_budget_is_what_bounds_the_spend
AssertionError: budget frac made no difference: 7 attempts budgeted vs 7 unbudgeted
```

It reproduced on a rerun, and the same job passed twice at `83371f54`. **The
budget it tests is correct.** The test was racing a wall-clock-bounded search to
an internal gate and comparing two coin flips.

## Evidence

The test ran two full `solve_model` calls with a stub that declines and sleeps
0.3 s, then compared how many times each reached the round gate — budgeted arm
bounded at `_ROUND_TIME_FRAC * T = 2.0 s` (7 attempts), unbudgeted arm expected
to run to the solve's own limit. That comparison only means anything if the
search reaches the gate well past 14 times, and how often it gets there is not
reproducible. Ten identical runs, one box, one build, arms interleaved
(load1 4.5–10.0):

| frac | gate visits | nodes | status | wall |
|---|---|---|---|---|
| 0.2 | 7, 7, 0, 0, 0 | 97, 97, 0, 0, 0 | optimal | 8.6–6.0 s |
| 1e6 | 15, 15, 15, 0, 0 | 31, 31, 31, 0, 0 | feasible/optimal | 10.9–5.7 s |

The `0` rows matter most: the fixture does not always route to `_solve_miqp_bb`
at all, so on this box the test usually failed its *own* precondition
("round-fix-resolve never ran"). The invariant was untested on any developer
machine and only ever evaluated on CI, where it eventually drew `7 vs 7`.

Entering `_solve_miqp_bb` directly is by contrast exactly reproducible: 5/5 runs
give 91 nodes, `optimal`, budget built once and consulted once.

## The fix

Lift the rule out of the node loop into `_RoundBudget` and
`_round_fix_resolve_attempt`, and assert on it directly instead of racing to it.

Solver behaviour is unchanged — `_tuning()` and `tree.incumbent()` were already
evaluated ahead of the budget checks in the old conjunction, so the same calls
happen in the same situations.

Per CLAUDE.md §1 this had to be more coverage, not less, and it is:

- the extracted gate pins the **opt-out** and **no-incumbent** conjuncts, which
  nothing tested before;
- the spend is recorded through a `finally`, so a rounding that raises cannot
  buy unlimited retries (also newly tested);
- `test_the_miqp_search_wires_the_budget_in` keeps the end-to-end claim, and now
  asserts the gate *consults* the budget rather than merely that one was built.

Five mutations of the production rule each fail at least one test:

| mutation | result |
|---|---|
| `may_attempt` drops the time term | 2 failed |
| attempt handed the solve deadline | 1 failed |
| gate drops `enabled`/`has_incumbent` | 1 failed |
| spend not recorded | 1 failed |
| gate bypassed entirely | 1 failed |

The file drops from ~25 s with two flaky tests to 0.7 s with none, and no test in
it is marked `slow` any more.

## Retraction (CLAUDE.md §11)

Mid-session I told the owner this CI failure was "a real failure, not flaky"
because a rerun reproduced it. The reproduction was real; the conclusion was
wrong. Reruns land on similar runners, so reproducing a load-sensitive race is
not evidence against it being one. Recorded in
`docs/dev/performance-plan.md` §19.5 along with the measurement.

## Verification

- `pytest -m smoke` — 1109 passed, 1 skipped, 2 xpassed
- `pytest -m slow python/tests/test_adversarial_recent_fixes.py` — 19 passed
- `python/tests/test_1064_round_fix_resolve.py` — 18 passed, under random
  ordering ×3 and under `--cov`
- No Rust touched, so no `cargo test`.

Fixes the `Python coverage` failure on `main`. Leaves #1064 closed as it was —
the mechanism it shipped is unchanged here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019GYp9wAZ2Xt1Mz9rEvLdry
