### PR TITLE
fix(#1141): the root-cut stage's time budget never bounded the stage

### DIFF
--- a/docs/dev/performance-plan.md
+++ b/docs/dev/performance-plan.md
@@ -4527,3 +4527,31 @@ mutation that was wrong, not the test: it neutralised `_remaining()` but left
 because "the mutation survived" and "the test is vacuous" look identical from
 the exit code, and only reading the mutation apart from the result tells them
 apart.
+
+### The owed panel (tracked in #1141)
+
+`DISCOPT_ROOT_CUT_DEADLINE` merges default-OFF, which means the shipped default
+is the arm where the docstring's promise is false. That is acceptable only for
+as long as the graduation panel is actually owed to someone, so it is recorded
+here and in **#1141**: the flag graduates or is deleted, and "neither" is not an
+outcome. A flag that ships off and is never panelled is the dead flag CLAUDE.md
+§3 forbids; the difference between this and that is whether the debt is written
+down.
+
+Re-confirmed live on `main` at 2026-08-30, before merging — the defect is not an
+artefact of the #1066-era tree:
+
+- `_root_cuts.py` calls `oa_converge()` and only *then* sets `t0`, so the
+  prologue is still outside the budget.
+- `_solve_lp` still sets `output_flag` and nothing else, so no LP carries a
+  deadline.
+- `nlpbb_root_cuts_enabled()` is **default-ON** (graduated 2026-08-20, §21) and
+  `solver.py` hands the stage `max(2.0, min(10.0, 0.2 * time_limit))`, so this
+  is a default-path stage with a budget it cannot enforce, not an opt-in one.
+
+The panel to run is the standard §5 regime-2 A/B — `DISCOPT_ROOT_CUT_DEADLINE`
+ON vs OFF over the in-repo corpus — under a load gate (§9), since *net-positive*
+here is entirely a wall-clock claim. Soundness is not what the panel is for:
+truncation only removes cuts, so neither arm can produce a bound tighter than
+the truth. The question is whether 81 s of root cuts buys more than 81 s of
+branch-and-bound, and only the panel answers it.

--- a/docs/dev/performance-plan.md
+++ b/docs/dev/performance-plan.md
@@ -4437,3 +4437,93 @@ can in principle spend its whole deadline cutting before a single B&B node runs.
 The escalation is not exposed to it in any measurement here — the strong arm is
 entered only after a node-capped probe has already returned, and no panel row hit
 it — but the loop should honour the deadline regardless of who calls it.
+
+## 24. #1066 root cuts: the stage's time budget never covered the stage (2026-08-29)
+
+§23's probe-then-escalate fixed the OA *master*. It did not close `rsyn0830m`
+or `rsyn0840m` at default settings, so this is where the remaining wall went.
+
+### The measurement
+
+A default solve of `rsyn0830m` (`time_limit=150`, `gap_tolerance=1e-4`) under
+`cProfile`, against the escalation-ON tree. Top of the cumulative profile:
+
+```
+   ncalls  tottime  cumtime  filename:lineno(function)
+        1   81.281   81.281  discopt/solvers/_root_cuts.py:276(_solve_lp)
+        1    0.003   75.230  discopt/solvers/mip_nlp.py:662(solve_mip_nlp)
+        8   74.469   74.469  {built-in method discopt._rust.solve_milp_csc_py}
+```
+
+**A single `_solve_lp` call cost 81.3 s of a 150 s solve.** The two figures are
+disjoint (81.3 + 75.2 ≈ the 150.6 s wall): the root cutting-plane stage runs to
+completion, and only then does the OA search get what is left. The instance
+finishes `feasible`, not `optimal`, having spent 54% of its budget in a stage
+whose caller allots it `max(2.0, min(10.0, 0.2 * time_limit))` = **10.0 s**.
+
+### The defect
+
+`generate_root_cuts`' docstring says "``time_budget_s`` bounds the stage's wall
+time." It did not, in two independent ways:
+
+1. **The clock started in the wrong place.** `t0 = _time.perf_counter()` sat
+   *below* the initial `obj, x, duals, h = oa_converge()`. The whole OA
+   prologue — up to `OA_MAX_ITERS` = 60 LP solves — ran before the budget was
+   armed. Nothing measured it and nothing could stop it.
+2. **The check was between rounds, and the overrun is inside one call.** Even
+   with the clock started correctly, `if perf_counter() - t0 > time_budget_s`
+   is only consulted at the top of the round loop. `_solve_lp` passed no
+   `time_limit` to HiGHS, so one LP could run arbitrarily long — and on
+   `rsyn0830m` exactly one did. **A between-rounds budget cannot bound a stage
+   whose unit of work is unbounded.** This is the same shape as the Rust
+   root-cut-loop deadline defect recorded in §23.6.
+
+Note which of these the 81.3 s was: `ncalls` is **1**. Not 60 cheap LPs adding
+up past a budget — one LP that never had a deadline.
+
+### The fix (`DISCOPT_ROOT_CUT_DEADLINE`, default-OFF)
+
+- The stage clock (`t_stage`) starts before the prologue, and `_remaining()`
+  is what every LP is bounded by.
+- `_solve_lp` gains a `time_limit` and sets HiGHS' own `time_limit` option,
+  floored at 1e-3 — HiGHS reads `<= 0` as *no limit*, which would silently
+  restore the overrun.
+- `oa_converge` checks the remaining budget between its iterations.
+- Budget exhausted before the first LP closes → the stage returns no cuts,
+  which is identical to the stage being switched off.
+
+**Soundness.** Truncation can only ever *remove* cuts. A partially converged OA
+is an outer approximation over *fewer* constraints than the true feasible set —
+a relaxation of a relaxation — so its bound and every cut separated from it stay
+valid; only their strength is given up. There is no arm of this change that can
+produce a bound tighter than the truth.
+
+**Why it still ships default-off.** It is bound-changing (CLAUDE.md §5 regime 2):
+on an instance whose prologue outruns the budget it changes which cuts the stage
+separates, hence that instance's root bound. Soundness is not the open question —
+*net-positive* is. Spending 81 s of root cuts is not obviously worse than not
+spending it; the graduation panel is what answers that, and until it clears both
+bars the flag stays off.
+
+### Verification
+
+Deterministic and load-immune: a fake `perf_counter` the stub advances, so no
+assertion here depends on machine load (CLAUDE.md §9). Five new tests in
+`python/tests/test_nlpbb_root_cuts_781.py`. Mutation battery, each restored to
+identical afterwards:
+
+| mutation | result |
+| --- | --- |
+| round-loop clock starts late in both arms (the original bug) | 1 failed |
+| prologue LPs unbounded (deadline only inside the round loop) | 1 failed |
+| HiGHS never gets the `time_limit` option | 1 failed |
+| no positive floor on the limit handed to HiGHS | 1 failed |
+| the flag defaults ON | 1 failed |
+| flag OFF also gets a deadline (legacy path not intact) | 1 failed |
+
+A first battery run reported the bug-revert mutation as *surviving*. It was the
+mutation that was wrong, not the test: it neutralised `_remaining()` but left
+`t0 = t_stage`, so the round-loop check still fired at the same point. Recorded
+because "the mutation survived" and "the test is vacuous" look identical from
+the exit code, and only reading the mutation apart from the result tells them
+apart.

--- a/python/discopt/solvers/_root_cuts.py
+++ b/python/discopt/solvers/_root_cuts.py
@@ -100,6 +100,12 @@ def nlpbb_root_cuts_enabled() -> bool:
 #: default-off pending a graduation panel that clears both bars. The truncation
 #: is sound in either arm (fewer cuts can only loosen a bound, never invalidate
 #: one); the open question the panel answers is whether it is *net-positive*.
+#:
+#: That panel is owed, not optional: OFF is the arm in which ``generate_root_cuts``'
+#: docstring promise ("``time_budget_s`` bounds the stage's wall time") is false,
+#: and the stage is default-ON, so the shipped default is a default-path stage
+#: with a budget it cannot enforce. **Tracked in #1141** -- this flag graduates
+#: or is deleted; leaving it off forever is the dead flag CLAUDE.md §3 forbids.
 _ROOT_CUT_DEADLINE_DEFAULT = False
 
 

--- a/python/discopt/solvers/_root_cuts.py
+++ b/python/discopt/solvers/_root_cuts.py
@@ -93,6 +93,32 @@ def nlpbb_root_cuts_enabled() -> bool:
     return val not in ("0", "false", "off", "no")
 
 
+#: Whether an unset ``DISCOPT_ROOT_CUT_DEADLINE`` enforces the stage budget on
+#: the individual LPs. Enforcing it changes which cuts the stage separates on an
+#: instance whose OA prologue outruns the budget, hence that instance's root
+#: bound -- a bound-changing knob (CLAUDE.md §5 regime 2), so it ships
+#: default-off pending a graduation panel that clears both bars. The truncation
+#: is sound in either arm (fewer cuts can only loosen a bound, never invalidate
+#: one); the open question the panel answers is whether it is *net-positive*.
+_ROOT_CUT_DEADLINE_DEFAULT = False
+
+
+def _deadline_enabled() -> bool:
+    """Is the #1066 per-LP stage deadline switched on (``DISCOPT_ROOT_CUT_DEADLINE``)?
+
+    With it off, ``generate_root_cuts`` behaves exactly as before: the initial OA
+    convergence and every LP inside it run unbounded, and ``time_budget_s`` is
+    consulted only between cut rounds. That legacy path stays tested.
+
+    Read per call, not cached at import, so a test can flip it without reloading
+    the module and an A/B panel can drive both arms from one build.
+    """
+    raw = os.environ.get("DISCOPT_ROOT_CUT_DEADLINE")
+    if raw is None:
+        return _ROOT_CUT_DEADLINE_DEFAULT
+    return raw.strip().lower() not in ("0", "false", "off", "no")
+
+
 def flat_column_terms(model) -> list:
     """One modeling term per *flat* column, in the model's own column order.
 
@@ -273,8 +299,15 @@ class _RootLP:
         return out
 
 
-def _solve_lp(root: _RootLP, cuts_a, cuts_b):
-    """Solve the root LP with HiGHS. Returns (obj_in_model_sense, x, duals, highs)."""
+def _solve_lp(root: _RootLP, cuts_a, cuts_b, time_limit: float | None = None):
+    """Solve the root LP with HiGHS. Returns (obj_in_model_sense, x, duals, highs).
+
+    ``time_limit`` (seconds) is handed to HiGHS so a single LP cannot outrun the
+    stage budget. Measured on ``rsyn0830m`` (#1066): one unbounded call here
+    burned 81.3 s of a 150 s solve against a 10 s stage budget. A run that stops
+    on the limit returns a non-optimal status and is reported as a declined LP
+    (all-``None``), exactly as any other non-optimal status already was.
+    """
     import highspy
 
     inf = highspy.kHighsInf
@@ -304,6 +337,10 @@ def _solve_lp(root: _RootLP, cuts_a, cuts_b):
     lp.a_matrix_.value_ = np.array(vals, float)
     h = highspy.Highs()
     h.setOptionValue("output_flag", False)
+    if time_limit is not None:
+        # Floor at a strictly positive value: HiGHS treats <= 0 as "no limit",
+        # which would restore the very overrun this bounds.
+        h.setOptionValue("time_limit", max(1e-3, float(time_limit)))
     h.passModel(lp)
     h.run()
     if h.getModelStatus() != highspy.HighsModelStatus.kOptimal:
@@ -523,16 +560,38 @@ def generate_root_cuts(
                 added += 1
         return added
 
+    # The STAGE clock starts HERE, before the first OA convergence -- not after
+    # it. #1066: the round loop's clock used to start below, so the whole
+    # prologue ran outside the budget the docstring promises, and on rsyn0830m
+    # that prologue took 81.3 s against a 10 s budget. ``_remaining`` is what
+    # every LP below is bounded by. With the flag off, ``t_stage`` is read and
+    # never used: the round loop keeps its own late clock (see ``t0``), so the
+    # legacy path is unchanged to the instruction.
+    t_stage = _time.perf_counter()
+
+    def _remaining() -> float:
+        return time_budget_s - (_time.perf_counter() - t_stage)
+
     def oa_converge():
-        obj, x, duals, h = _solve_lp(root, cuts_a, cuts_b)
+        deadline = _deadline_enabled()
+        obj, x, duals, h = _solve_lp(root, cuts_a, cuts_b, _remaining() if deadline else None)
         for _ in range(OA_MAX_ITERS):
             if x is None or add_oa(x) == 0:
                 break
-            obj, x, duals, h = _solve_lp(root, cuts_a, cuts_b)
+            if deadline and _remaining() <= 0.0:
+                # Out of budget mid-convergence. The OA is incomplete, so the LP
+                # is over FEWER constraints than the true feasible set -- a
+                # relaxation of a relaxation. Its bound and every cut separated
+                # from it stay valid; only their strength is given up.
+                break
+            obj, x, duals, h = _solve_lp(root, cuts_a, cuts_b, _remaining() if deadline else None)
         return obj, x, duals, h
 
     obj, x, duals, h = oa_converge()
     if x is None:
+        # Includes "the budget expired before the first LP closed": the stage
+        # then contributes no cuts, which is always sound -- it is the same
+        # outcome as the stage being switched off.
         return RootCutResult()
     b0 = obj  # OA-only root LP bound (pre-cut baseline for the quality gate)
 
@@ -547,7 +606,9 @@ def generate_root_cuts(
     # quality gate uses, so "not improving" here means "on track to be
     # discarded there" rather than a second, unrelated notion of progress.
     gate_tol = 1e-6 * max(1.0, abs(b0))
-    t0 = _time.perf_counter()
+    # Flag ON: the round loop is bounded by what is LEFT of the stage budget.
+    # Flag OFF: it restarts the clock here, exactly as it always did.
+    t0 = t_stage if _deadline_enabled() else _time.perf_counter()
     lb_s = np.where(np.isfinite(root.lb_sep), root.lb_sep, 0.0)
     ub_s = np.where(np.isfinite(root.ub_sep), root.ub_sep, 1e5)
 

--- a/python/tests/test_nlpbb_root_cuts_781.py
+++ b/python/tests/test_nlpbb_root_cuts_781.py
@@ -267,7 +267,7 @@ def test_stalling_loop_exits_after_stall_rounds(monkeypatch):
     x_fixed = np.array([1.0, 1.0, 0.5, 0.5])
     calls = {"lp": 0, "sel": 0}
 
-    def _frozen_lp(root, cuts_a, cuts_b):
+    def _frozen_lp(root, cuts_a, cuts_b, time_limit=None):
         calls["lp"] += 1
         return 5.0, x_fixed.copy(), None, None  # bound never moves
 
@@ -453,3 +453,204 @@ def test_vector_and_scalar_forms_agree(monkeypatch):
     vector = _build_convex_minlp_vector().solve(time_limit=30, nlp_bb=True)
     assert scalar.objective is not None and vector.objective is not None
     assert scalar.objective == pytest.approx(vector.objective, abs=1e-4, rel=1e-4)
+
+
+# ── #1066: the stage budget must bound the LPs, not only the round boundaries ──
+
+
+def _deadline_flag(monkeypatch, on: bool) -> None:
+    monkeypatch.setenv("DISCOPT_ROOT_CUT_DEADLINE", "1" if on else "0")
+
+
+def _fake_clock(monkeypatch):
+    """A clock only the stub advances, so nothing here depends on machine load.
+
+    ``generate_root_cuts`` does ``import time as _time`` at call time, so
+    patching the module attribute reaches it. Returns the mutable holder.
+    """
+    import time as _t
+
+    now = {"t": 1000.0}
+    monkeypatch.setattr(_t, "perf_counter", lambda: now["t"])
+    return now
+
+
+def _charging_lp_stub(monkeypatch, now, cost):
+    """Stub ``_solve_lp`` that charges ``cost`` seconds per call to the fake clock.
+
+    Records the ``time_limit`` each call was handed. Returns a frozen bound so
+    the round loop's own stall guard is the only other thing that can stop it.
+    """
+    import discopt.solvers._root_cuts as rc
+
+    seen = {"limits": [], "calls": 0}
+    x_fixed = np.array([1.0, 1.0, 0.5, 0.5])
+
+    def _stub(root, cuts_a, cuts_b, time_limit=None):
+        seen["calls"] += 1
+        seen["limits"].append(time_limit)
+        now["t"] += cost
+        return 5.0, x_fixed.copy(), None, None
+
+    def _always_a_cut(candidates, x, **kw):
+        a = np.zeros(len(x_fixed))
+        a[0] = 1.0
+        return [(a, 99.0)]
+
+    monkeypatch.setattr(rc, "_solve_lp", _stub)
+    monkeypatch.setattr(rc, "_select_cuts", _always_a_cut)
+    return seen
+
+
+def _run_stage(time_budget_s):
+    import discopt.solvers._root_cuts as rc
+    from discopt._relax.nlp_evaluator import NLPEvaluator
+
+    m = _build_convex_minlp("max")
+    return rc.generate_root_cuts(
+        m,
+        NLPEvaluator(m),
+        np.array([0.0, 0.0, 0.0, 0.0]),
+        np.array([10.0, 10.0, 1.0, 1.0]),
+        np.array([False, False, True, True]),
+        np.array([False, False, True, True]),
+        time_budget_s=time_budget_s,
+    )
+
+
+def test_the_budget_covers_the_oa_prologue_not_only_the_round_loop(monkeypatch):
+    """The #1066 defect, stated exactly.
+
+    ``generate_root_cuts``' docstring promises ``time_budget_s`` bounds the
+    stage's wall time. It did not: the clock was started AFTER the initial
+    ``oa_converge()``, so the prologue -- up to ``OA_MAX_ITERS`` unbounded LPs --
+    ran entirely outside it. Measured on rsyn0830m at default settings: one
+    ``_solve_lp`` call burned 81.3 s of a 150 s solve against a 10 s budget,
+    which is the whole reason that instance misses the 60 s default.
+
+    Here the very first LP costs more than the entire budget. With the deadline
+    on, the stage must notice and stop; with it off it does not, which is the
+    bug this reproduces.
+    """
+    now = _fake_clock(monkeypatch)
+    _deadline_flag(monkeypatch, True)
+    seen_on = _charging_lp_stub(monkeypatch, now, cost=25.0)
+    res_on = _run_stage(time_budget_s=10.0)
+
+    now["t"] = 1000.0
+    _deadline_flag(monkeypatch, False)
+    seen_off = _charging_lp_stub(monkeypatch, now, cost=25.0)
+    _run_stage(time_budget_s=10.0)
+
+    assert seen_on["calls"] > 0 and seen_off["calls"] > 0, (
+        "stubs never ran — probe measured nothing"
+    )
+    assert seen_on["calls"] == 1, (
+        f"the deadline arm spent {seen_on['calls']} LPs on a budget the first one "
+        f"had already blown; the stage clock must cover the prologue"
+    )
+    assert res_on.stop_reason == "budget", f"stopped on {res_on.stop_reason!r}, not the budget"
+    assert seen_off["calls"] > seen_on["calls"], (
+        f"legacy arm made {seen_off['calls']} calls, deadline arm {seen_on['calls']} — "
+        f"the flag made no difference, so this test is not measuring the fix"
+    )
+
+
+def test_each_lp_is_handed_what_is_left_of_the_stage_budget(monkeypatch):
+    """Every LP gets a deadline, and it shrinks as the budget is spent.
+
+    An unbounded LP defeats a between-rounds budget check no matter how tight
+    that check is: the overrun happens inside one call. So the budget has to
+    reach the LP itself.
+    """
+    now = _fake_clock(monkeypatch)
+    _deadline_flag(monkeypatch, True)
+    seen = _charging_lp_stub(monkeypatch, now, cost=3.0)
+    _run_stage(time_budget_s=10.0)
+
+    limits = seen["limits"]
+    assert len(limits) >= 2, f"only {len(limits)} LP(s) ran; nothing to compare"
+    assert all(v is not None for v in limits), "an LP ran with no deadline"
+    assert all(v <= 10.0 + 1e-9 for v in limits), f"a limit exceeded the budget: {limits}"
+    assert limits == sorted(limits, reverse=True), f"limits not non-increasing: {limits}"
+    assert limits[0] == pytest.approx(10.0), f"first LP got {limits[0]}, not the full budget"
+    # Total charged cannot exceed the budget by more than the call in flight.
+    assert len(limits) * 3.0 <= 10.0 + 3.0, f"{len(limits)} LPs x 3.0 s overran a 10 s budget"
+
+
+def test_the_deadline_flag_is_default_off_with_an_opt_in(monkeypatch):
+    """CLAUDE.md §5 regime 2: bound-changing, so it ships default-off."""
+    import discopt.solvers._root_cuts as rc
+
+    monkeypatch.delenv("DISCOPT_ROOT_CUT_DEADLINE", raising=False)
+    assert rc._deadline_enabled() is False
+    for on in ("1", "true", "on", "yes"):
+        monkeypatch.setenv("DISCOPT_ROOT_CUT_DEADLINE", on)
+        assert rc._deadline_enabled() is True, f"{on!r} did not switch it on"
+    for off in ("0", "false", "off", "no"):
+        monkeypatch.setenv("DISCOPT_ROOT_CUT_DEADLINE", off)
+        assert rc._deadline_enabled() is False, f"{off!r} did not switch it off"
+
+
+def test_the_legacy_lp_call_is_unchanged_when_the_flag_is_off(monkeypatch):
+    """Flag OFF hands every LP ``time_limit=None`` — the legacy path, intact."""
+    now = _fake_clock(monkeypatch)
+    _deadline_flag(monkeypatch, False)
+    seen = _charging_lp_stub(monkeypatch, now, cost=0.0)
+    _run_stage(time_budget_s=10.0)
+    assert seen["calls"] > 0, "stub never ran — probe measured nothing"
+    assert all(v is None for v in seen["limits"]), (
+        f"the legacy arm passed a deadline to HiGHS: {seen['limits']}"
+    )
+
+
+def test_the_deadline_reaches_highs_not_just_the_python_loop(monkeypatch):
+    """``_solve_lp`` must hand the limit to HiGHS itself.
+
+    The tests above stub ``_solve_lp``, so they prove the loop computes a
+    deadline but not that HiGHS is told about it -- and a deadline HiGHS never
+    sees bounds nothing, which is the exact shape of the bug (a between-rounds
+    check cannot stop an overrun that happens inside one ``h.run()``).
+    """
+    import discopt.solvers._root_cuts as rc
+    import highspy
+    from discopt._relax.nlp_evaluator import NLPEvaluator
+
+    m = _build_convex_minlp("max")
+    is_int = np.array([False, False, True, True])
+    root = rc._RootLP(
+        m,
+        NLPEvaluator(m),
+        np.array([0.0, 0.0, 0.0, 0.0]),
+        np.array([10.0, 10.0, 1.0, 1.0]),
+        is_int,
+        is_int.copy(),
+        True,
+    )
+
+    opts: list = []
+    real_highs = highspy.Highs
+
+    class _Recording(real_highs):  # type: ignore[misc,valid-type]
+        def setOptionValue(self, key, val):  # noqa: N802 - HiGHS' own spelling
+            opts.append((key, val))
+            return super().setOptionValue(key, val)
+
+    monkeypatch.setattr(highspy, "Highs", _Recording)
+
+    rc._solve_lp(root, [], [], 4.25)
+    assert ("time_limit", 4.25) in opts, f"HiGHS never got the deadline; options seen: {opts}"
+
+    opts.clear()
+    rc._solve_lp(root, [], [], None)
+    assert not [k for k, _ in opts if k == "time_limit"], (
+        f"a deadline was set on the legacy path: {opts}"
+    )
+
+    opts.clear()
+    rc._solve_lp(root, [], [], -5.0)
+    tl = [v for k, v in opts if k == "time_limit"]
+    assert tl and tl[0] > 0.0, (
+        f"a non-positive limit reached HiGHS as {tl}; HiGHS reads <= 0 as "
+        f"'no limit', which would restore the overrun this bounds"
+    )


### PR DESCRIPTION
## The defect

`generate_root_cuts`' docstring says "`time_budget_s` bounds the stage's wall time." It does not, in two independent ways:

1. **The clock starts in the wrong place.** `t0 = _time.perf_counter()` sits *below* the initial `oa_converge()`. The whole OA prologue — up to `OA_MAX_ITERS` = 60 LP solves — runs before the budget is armed. Nothing measures it and nothing can stop it.
2. **The check is between rounds; the overrun is inside one call.** `_solve_lp` passes no `time_limit` to HiGHS. A between-rounds budget cannot bound a stage whose unit of work is unbounded — the same shape as the Rust root-cut-loop deadline defect recorded in `performance-plan.md` §23.6.

This is on the **default** path. `nlpbb_root_cuts_enabled()` is default-ON (graduated 2026-08-20, #1061/#1062, `performance-plan.md` §21), and `solver.py` hands the stage `max(2.0, min(10.0, 0.2 * time_limit))`. So every convex model on a default solve today can lose an unbounded slice of its time limit to a stage nominally capped at 10 s.

## The measurement

A default solve of `rsyn0830m` (`time_limit=150`, `gap_tolerance=1e-4`) under `cProfile`:

```
   ncalls  tottime  cumtime  filename:lineno(function)
        1   81.281   81.281  discopt/solvers/_root_cuts.py:276(_solve_lp)
        1    0.003   75.230  discopt/solvers/mip_nlp.py:662(solve_mip_nlp)
        8   74.469   74.469  {built-in method discopt._rust.solve_milp_csc_py}
```

**One `_solve_lp` call cost 81.3 s of a 150 s solve.** The two figures are disjoint (81.3 + 75.2 is the 150.6 s wall): the root cutting-plane stage runs to completion, then the OA search gets what is left. The instance finishes `feasible`, not `optimal`, having spent 54% of its budget in a stage allotted 10.0 s.

Note `ncalls` is **1**. Not sixty cheap LPs adding up past a budget — one LP that never had a deadline.

**Re-confirmed live on `main` at 2026-08-30**, so this is not an artefact of the tree it was found in: the clock still starts below `oa_converge()`, `_solve_lp` still sets `output_flag` and nothing else, and the stage is still default-ON.

## The fix

Behind `DISCOPT_ROOT_CUT_DEADLINE`, **default-OFF**.

- The stage clock starts before the prologue; `_remaining()` bounds every LP.
- `_solve_lp` sets HiGHS' own `time_limit` option, floored at 1e-3 — HiGHS reads `<= 0` as *no limit*, which would silently restore the overrun.
- `oa_converge` checks the remaining budget between its iterations.
- Budget exhausted before the first LP closes gives no cuts, identical to the stage being off.

**Soundness.** Truncation only ever *removes* cuts. A partially converged OA is an outer approximation over *fewer* constraints than the true feasible set — a relaxation of a relaxation — so its bound and every cut separated from it stay valid; only their strength is given up. No arm of this change can produce a bound tighter than the truth.

**Why default-off anyway.** Bound-changing per CLAUDE.md §5 regime 2: on an instance whose prologue outruns the budget it changes which cuts the stage separates, hence that instance's root bound. Soundness is not the open question — *net-positive* is. Spending 81 s of root cuts is not obviously worse than not spending it, and the graduation panel is what answers that.

**Flag OFF is the legacy path to the instruction**: the round loop keeps its own late clock and every LP is still handed `time_limit=None`.

## The panel this owes

Default-OFF here is unusual in one respect worth naming: ON is the arm that honours a documented contract, and OFF is the arm in which the docstring stays false. That is defensible only while the graduation panel is genuinely owed — a flag that ships off and is never panelled is the dead flag CLAUDE.md §3 forbids.

So the debt is written down rather than assumed: **tracked in #1141**, and named in the flag's own comment in `_root_cuts.py` and in `performance-plan.md` §24. The flag graduates or it is deleted; "neither" is not an outcome.

The panel is the standard §5 regime-2 A/B — `DISCOPT_ROOT_CUT_DEADLINE` ON vs OFF over the in-repo corpus — under a load gate (§9), since net-positive here is entirely a wall-clock claim. It has not run: the box has been at load 50–140 from unrelated Rust builds.

## Verification

Deterministic and load-immune — a fake `perf_counter` the stub advances, so no assertion depends on machine load (CLAUDE.md §9). This matters here: the box was at load average 120 throughout the original work, from an unrelated workload.

Five new tests in `python/tests/test_nlpbb_root_cuts_781.py`. Mutation battery, each restored to identical afterwards:

| mutation | result |
| --- | --- |
| round-loop clock starts late in both arms (the original bug) | 1 failed |
| prologue LPs unbounded (deadline only inside the round loop) | 1 failed |
| HiGHS never gets the `time_limit` option | 1 failed |
| no positive floor on the limit handed to HiGHS | 1 failed |
| the flag defaults ON | 1 failed |
| flag OFF also gets a deadline (legacy path not intact) | 1 failed |

A first battery run reported the bug-revert mutation as *surviving*. The mutation was wrong, not the test: it neutralised `_remaining()` but left `t0 = t_stage`, so the round-loop check still fired at the same point. Recorded in the plan doc because "the mutation survived" and "the test is vacuous" look identical from the exit code.

Ran:
- `pytest -m smoke` — 1109 passed, 1 skipped, 2 xpassed (645 s)
- `pytest -m slow python/tests/test_adversarial_recent_fixes.py` — 19 passed (165 s)
- `pytest python/tests/test_nlpbb_root_cuts_781.py` — 17 passed, re-run after merging current `main` (31 commits) into the branch

No Rust touched.

## Relationship to #1066

The investigation happened under #1066, which has since been closed at 14/15. This PR is not part of that count — its flag is off — and it does not change #1066's state. The remaining convex-MINLP work, including this flag's graduation panel, lives in #1141.
