### PR TITLE
fix(#1066): route convex MINLPs to the single-tree master, and stop it when it certifies

### DIFF
--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -6756,7 +6756,9 @@ _ROUTE_FALLBACK_NOTE: list[str] = []
 #: default path's ~67 return sites and can reach none of them. Same
 #: list-not-scalar discipline as the note: the wrapper restores the exact depth
 #: it entered at, so a raised exception cannot leak state into the next solve.
-_ROUTE_FALLBACK_STATE: list[tuple["SolveResult", bool]] = []
+# ``None`` is a real state here: an auto-route that RAISED has no result to
+# carry forward, and ``_merge_route_and_fallback`` returns the fallback for it.
+_ROUTE_FALLBACK_STATE: list[tuple[Optional["SolveResult"], bool]] = []
 
 
 def _stamp_layer_timing(fn: _F) -> _F:
@@ -7783,17 +7785,45 @@ def solve_model(
                     min(time_limit, _CONVEX_ROUTE_FALLBACK_FLOOR_S),
                 )
         _route_t0 = time.perf_counter()
-        _mip_nlp_result = solve_mip_nlp(
-            model,
-            method=mip_nlp_method,
-            mip_nlp_options=mip_nlp_options,
-            time_limit=_route_budget,
-            gap_tolerance=gap_tolerance,
-            max_iterations=max_nodes,
-            nlp_solver=nlp_solver,
-            initial_point=initial_point,
-            **mip_nlp_kwargs,
-        )
+        _route_raised: Optional[BaseException] = None
+        try:
+            _mip_nlp_result = solve_mip_nlp(
+                model,
+                method=mip_nlp_method,
+                mip_nlp_options=mip_nlp_options,
+                time_limit=_route_budget,
+                gap_tolerance=gap_tolerance,
+                max_iterations=max_nodes,
+                nlp_solver=nlp_solver,
+                initial_point=initial_point,
+                **mip_nlp_kwargs,
+            )
+        except Exception as _route_exc:  # noqa: BLE001 - see below
+            # #1066: a route the *router* chose is a decision, not a promise. The
+            # decomposition can refuse a model outright -- the HiGHS master
+            # rejects a lazy cut whose coefficients it cannot represent on an
+            # unbounded column, and raises rather than silently dropping terms
+            # (which is right: CLAUDE.md §3). But an auto-routed refusal must not
+            # become the caller's answer when the default path solves the model:
+            # ``st_test1`` and ``st_test5`` are ``optimal`` on the default path
+            # and raised ``HiGHS rejected the master model`` once the retarget
+            # sent them to the single-tree master (measured on the 104-instance
+            # route panel, 2026-08-29). Treat it exactly like a route that did
+            # not certify and spend the rest of the budget on the fallback.
+            #
+            # Narrow by construction, not by exception type: this arm is reached
+            # only when ``_auto_route_reason is not None``. An explicit
+            # ``solver="mip-nlp"`` re-raises, because the caller chose the
+            # algorithm and there is no fallback to reserve for.
+            if _auto_route_reason is None:
+                raise
+            _route_raised = _route_exc
+            _mip_nlp_result = None
+            logger.info(
+                "Convex MINLP auto-route raised %s: %s; falling back to the default path",
+                type(_route_exc).__name__,
+                _route_exc,
+            )
         _route_elapsed = time.perf_counter() - _route_t0
         # #1059: record WHY this algorithm ran. Only set on the auto-route, so an
         # explicit solver="mip-nlp" leaves the field None (the caller already
@@ -7842,12 +7872,16 @@ def solve_model(
                 logger.debug("MIP-NLP dual recovery skipped: %s", _dual_exc)
 
         _route_remaining = time_limit - _route_elapsed
-        if (
+        if _route_raised is None and (
             _auto_route_reason is None
             or _route_result_is_certified(_mip_nlp_result, gap_tolerance)
             or _route_remaining < _CONVEX_ROUTE_FALLBACK_FLOOR_S
         ):
+            assert _mip_nlp_result is not None  # only a raise leaves this None
             return _mip_nlp_result
+        # A route that RAISED has no result to return, so the floor above cannot
+        # apply to it -- returning ``None`` from ``solve_model`` would turn a
+        # solvable model into an ``AttributeError`` at the call site.
 
         # --- #1059: the auto-route did not certify -- fall back to the default path ---
         #
@@ -7877,9 +7911,14 @@ def solve_model(
         # 29.9 s limit and returned ``time_limit`` after 1 node with no
         # incumbent, which is the failure this whole change exists to remove.
         _ROUTE_FALLBACK_NOTE.append(
-            f"{_auto_route_reason}; did not certify in {_route_elapsed:.2f}s "
-            f"(status={getattr(_mip_nlp_result, 'status', None)}) -> fell back to the "
-            f"default path with {_route_remaining:.2f}s"
+            f"{_auto_route_reason}; "
+            + (
+                f"raised {type(_route_raised).__name__}: {_route_raised}"
+                if _route_raised is not None
+                else f"did not certify in {_route_elapsed:.2f}s "
+                f"(status={getattr(_mip_nlp_result, 'status', None)})"
+            )
+            + f" -> fell back to the default path with {_route_remaining:.2f}s"
         )
         # #1059: hand the routed result forward so the wrapper can return the
         # better of the two. This is the "never worse than the route" contract;

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -5526,13 +5526,23 @@ def _route_progress_guard_options(
     """
     if not _convex_route_progress_guard_enabled():
         return mip_nlp_options, None
-    if method_key != "oa":
+    if method_key not in ("oa", "lp_nlp_bb"):
         return mip_nlp_options, None
     if mip_nlp_options is not None and mip_nlp_options.get("termination_hook") is not None:
         return mip_nlp_options, None
     guard = _RouteProgressGuard(time_limit)
     options = dict(mip_nlp_options or {})
     options["termination_hook"] = guard
+    if method_key == "lp_nlp_bb":
+        # The single-tree method checks in at every master restart, so it needs no
+        # deadline to get the hook called -- and has no separate master to give one
+        # to. The fixed split cost it ``rsyn0820m02m``, which certifies at 37.5s of
+        # a 60s limit and was cut at the 30s wall (measured 2026-08-29, both arms
+        # back to back). The reserve is not waste, though: ``squfl015-060`` is
+        # certified by the FALLBACK, not the route, and giving the route the whole
+        # limit loses it (optimal -> feasible in the same panel). Progress is what
+        # separates those two rows; the clock cannot.
+        return options, guard
     # A hook that only runs at the top of an OA iteration cannot budget anything
     # unless the loop actually gets back there. OA's first master expands to fill
     # whatever budget it is handed (``_MASTER_NO_INCUMBENT_BUDGET_FRAC``), so

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -5153,13 +5153,15 @@ def _convex_minlp_route_enabled() -> bool:
     return raw.strip() != "0"
 
 
-def _convex_minlp_auto_route(model: Model) -> tuple[Optional[str], str]:
+def _convex_minlp_auto_route(model: Model) -> tuple[Optional[str], str, dict[str, Any]]:
     """Decide whether ``model`` should be solved by the MIP-NLP family (#1059).
 
-    Returns ``(method, reason)`` where ``method`` is the ``mip_nlp_method`` to
-    use, or ``None`` to leave the model on the default spatial/NLP
-    branch-and-bound. ``reason`` always explains the verdict and is surfaced on
-    ``SolveResult.algorithm_route`` so the decision is never invisible.
+    Returns ``(method, reason, options)`` where ``method`` is the
+    ``mip_nlp_method`` to use, or ``None`` to leave the model on the default
+    spatial/NLP branch-and-bound, and ``options`` are the extra MIP-NLP kwargs the
+    route picked with it (empty when there are none). ``reason`` always explains
+    the verdict and is surfaced on ``SolveResult.algorithm_route`` so the decision
+    is never invisible.
 
     Why this exists: discopt certifies models like the MINLPLib ``syn``/``rsyn``
     family fully convex at the root in hundredths of a second (286/286
@@ -5178,10 +5180,27 @@ def _convex_minlp_auto_route(model: Model) -> tuple[Optional[str], str]:
     ``syn20m02m``   feasible, 63.7% off     optimal, 23.5 s
     ==============  ======================  ====================
 
-    ``"oa"`` is the route target rather than the faster ``"lp_nlp_bb"``
-    (optimal on all three in 1.5-3.4 s) because ``lp_nlp_bb`` hard-requires a
-    Gurobi license — see #1060, which must land before that becomes selectable
-    automatically.
+    The target used to be ``"oa"``, "because ``lp_nlp_bb`` hard-requires a Gurobi
+    license — see #1060, which must land before that becomes selectable
+    automatically". #1060 landed on 2026-08-20 and brought a free HiGHS master
+    with it, so that reason has expired and the target moves to ``lp_nlp_bb`` on
+    the HiGHS master. Measured 2026-08-29 at the default 60 s on the #1066 rows
+    the ``"oa"`` target did not close, reference optimum in brackets:
+
+    ==========================  =====================  ========================
+    instance                    ``"oa"`` (the target    ``lp_nlp_bb`` + HiGHS
+                                until now)             (the target now)
+    ==========================  =====================  ========================
+    ``rsyn0830m`` [510.072]     feasible, 60.2 s       **optimal, 4.9 s**
+    ``rsyn0840m`` [325.555]     feasible, 62.7 s       **optimal, 8.4 s**
+    ``rsyn0820m02m`` [1092.09]  feasible 102% off      **optimal, 39.3 s**
+    ==========================  =====================  ========================
+
+    The master engine is the whole difference, not the tree topology:
+    ``lp_nlp_bb`` on the *in-house* master is measurably WORSE than ``"oa"`` on
+    the same rows (``rsyn0840m`` 103.5% off vs 0.0%), which is why the HiGHS
+    master is a precondition of the retarget rather than an optimization on top
+    of it. Without ``highspy`` the target stays ``"oa"``.
 
     Every gate below is a *refusal* to route: an unknown convexity verdict, a
     nonconvex model, a missing MILP backend, or an opaque ``dm.custom`` body all
@@ -5189,17 +5208,17 @@ def _convex_minlp_auto_route(model: Model) -> tuple[Optional[str], str]:
     whose convexity is merely unproven.
     """
     if not _convex_minlp_route_enabled():
-        return None, "disabled (DISCOPT_CONVEX_MINLP_ROUTE unset)"
+        return None, "disabled (DISCOPT_CONVEX_MINLP_ROUTE unset)", {}
 
     if _is_pure_continuous(model):
         # A convex *continuous* model is already served by solve_model's convex
         # NLP fast path; there is no integrality for a decomposition to exploit.
-        return None, "not routed: model is pure continuous"
+        return None, "not routed: model is pure continuous", {}
 
     if _model_contains_custom_call(model):
         # dm.custom is an opaque AD-only callable; the MILP master cannot
         # linearize what it cannot read.
-        return None, "not routed: model contains an opaque dm.custom body"
+        return None, "not routed: model contains an opaque dm.custom body", {}
 
     try:
         from discopt._relax.problem_classifier import ProblemClass, classify_problem
@@ -5207,20 +5226,20 @@ def _convex_minlp_auto_route(model: Model) -> tuple[Optional[str], str]:
         problem_class = classify_problem(model)
     except Exception as exc:  # noqa: BLE001 - classification failure => stay put
         logger.debug("convex-MINLP route: problem classification failed: %s", exc)
-        return None, "not routed: problem classification failed"
+        return None, "not routed: problem classification failed", {}
 
     if not isinstance(problem_class, ProblemClass):  # pragma: no cover - defensive
-        return None, "not routed: problem classification returned an unknown value"
+        return None, "not routed: problem classification returned an unknown value", {}
     if problem_class.value not in _CONVEX_MINLP_ROUTE_CLASSES:
-        return None, f"not routed: problem class {problem_class.value} is not a discrete NLP"
+        return None, f"not routed: problem class {problem_class.value} is not a discrete NLP", {}
 
     known, is_convex, _mask = _classify_model_convexity(
         model, failure_label="convex-MINLP route convexity detection failed"
     )
     if not known:
-        return None, "not routed: model convexity is unproven"
+        return None, "not routed: model convexity is unproven", {}
     if not is_convex:
-        return None, "not routed: model is not convex"
+        return None, "not routed: model is not convex", {}
 
     # The OA master is a MILP. Refuse to route when no MILP backend can be
     # loaded rather than routing into an import error (CLAUDE.md §3: a loud
@@ -5238,11 +5257,33 @@ def _convex_minlp_auto_route(model: Model) -> tuple[Optional[str], str]:
 
         get_milp_solver()
     except ImportError:
-        return None, "not routed: no MILP backend available for the OA master"
+        return None, "not routed: no MILP backend available for the OA master", {}
 
-    return "oa", (
-        f"mip-nlp/oa: {problem_class.value} certified convex at the root "
-        "(DISCOPT_CONVEX_MINLP_ROUTE)"
+    # ``lp_nlp_bb`` is the target only when the HiGHS master it needs is actually
+    # importable. On the in-house master the same method is worse than ``"oa"``
+    # (see the table above), so this is not a preference between two good options
+    # -- it is the difference between the retarget being an improvement and a
+    # regression. No highspy, no retarget.
+    try:
+        from discopt.solvers.milp_highs import solve_milp_with_lazy_cuts  # noqa: F401
+    except ImportError:
+        return (
+            "oa",
+            (
+                f"mip-nlp/oa: {problem_class.value} certified convex at the root; "
+                "lp_nlp_bb not selected (highspy unavailable) "
+                "(DISCOPT_CONVEX_MINLP_ROUTE)"
+            ),
+            {},
+        )
+
+    return (
+        "lp_nlp_bb",
+        (
+            f"mip-nlp/lp_nlp_bb on the HiGHS master: {problem_class.value} certified "
+            "convex at the root (DISCOPT_CONVEX_MINLP_ROUTE)"
+        ),
+        {"milp_solver": "highs"},
     )
 
 
@@ -7591,11 +7632,19 @@ def solve_model(
                 + ")"
             )
         else:
-            _auto_route_method, _auto_route_reason = _convex_minlp_auto_route(model)
+            (
+                _auto_route_method,
+                _auto_route_reason,
+                _auto_route_options,
+            ) = _convex_minlp_auto_route(model)
         if _auto_route_method is not None:
             logger.info("Convex MINLP auto-route: %s", _auto_route_reason)
             _solver = "mip-nlp"
             kwargs.setdefault("mip_nlp_method", _auto_route_method)
+            # setdefault, not assignment: an explicit milp_solver= from the caller
+            # outranks the route's pick.
+            for _route_opt, _route_val in _auto_route_options.items():
+                kwargs.setdefault(_route_opt, _route_val)
 
     # --- MIP-NLP decomposition solver family ---
     if _solver == "mip-nlp":

--- a/python/discopt/solvers/milp_highs.py
+++ b/python/discopt/solvers/milp_highs.py
@@ -40,6 +40,7 @@ HiGHS reports no usable dual bound, ``bound`` is ``None``; it is never synthesiz
 
 from __future__ import annotations
 
+import math
 import time
 from typing import Optional, Union
 
@@ -75,6 +76,115 @@ def _to_highs_inf(arr: np.ndarray, highspy) -> np.ndarray:
     out[out >= _INF] = highspy.kHighsInf
     out[out <= -_INF] = -highspy.kHighsInf
     return out
+
+
+def _highs_matrix_window(h, highspy) -> tuple[float, float]:
+    """HiGHS's ``(small_matrix_value, large_matrix_value)`` -- the window it accepts.
+
+    An entry at or below the small value is DROPPED and reported as ``kWarning``;
+    one at or above the large value is refused outright. Both are read from the live
+    solver rather than hardcoded, so a caller that moves either option stays in sync
+    with the row preparation below instead of silently disagreeing with it.
+    """
+    out = []
+    for key in ("small_matrix_value", "large_matrix_value"):
+        st, val = h.getOptionValue(key)
+        if st != highspy.HighsStatus.kOk:
+            raise RuntimeError(f"HiGHS would not report {key} (status {st})")
+        out.append(float(val))
+    return out[0], out[1]
+
+
+def _prepare_cut_row(
+    coeffs: np.ndarray,
+    rhs: float,
+    lb: np.ndarray,
+    ub: np.ndarray,
+    small_tol: float,
+    large_tol: float,
+) -> tuple[np.ndarray, np.ndarray, float]:
+    """Make ``coeffs @ x <= rhs`` safe to hand :meth:`highspy.Highs.addRow`.
+
+    HiGHS silently discards any matrix entry with ``|value| <= small_matrix_value``
+    and reports the discard as ``kWarning`` -- neither an error nor a clean add.
+    Both readings are wrong: treating it as a rejection killed every ``squfl``
+    instance under ``lp_nlp_bb`` (#1066; ``squfl025-040`` died in 1.0 s), and
+    treating it as a clean add would let HiGHS *change the cut* behind the
+    separator's back. So the row is fitted to HiGHS's window here:
+
+    1. **Scale.** An OA cut is an inequality, so multiplying it by any ``s > 0``
+       leaves it mathematically identical. ``squfl025-040``'s first cut spans
+       ``2.05e-19`` to ``114`` -- 21 orders -- but HiGHS's window is 24 wide, so the
+       whole row fits once lifted. ``s`` is rounded down to a power of two, which
+       makes the scaled row *bit-for-bit* the original one rescaled: no coefficient
+       is perturbed, so there is no question of a rounding-tightened cut.
+    2. **Drop what still will not fit**, on the valid side only: with ``rhs``
+       untouched when ``a_j * x_j >= 0`` over the whole column box (removing a
+       non-negative term can only make the row easier to satisfy), otherwise with
+       ``rhs`` loosened by the most that term can contribute. Either way the result
+       is *implied by* the original row -- every point the cut kept, it keeps.
+    3. **Refuse loudly** when neither applies, rather than ship a row that is not
+       implied by the cut.
+
+    The unboundedness test is on the *bound* (``>= _INF``), never on the product:
+    ``1e-9 * 1e20`` is an unremarkable ``1e11``, which is exactly how an open bound
+    sneaks past a finiteness check (CLAUDE.md).
+    """
+    nz = np.flatnonzero(coeffs)
+    if nz.size == 0:
+        return nz, coeffs[nz], rhs
+
+    a = coeffs[nz]
+    a_min = float(np.min(np.abs(a)))
+    a_max = float(np.max(np.abs(a)))
+    # Lift the small end a decade clear of the drop threshold, without bringing the
+    # large end within a decade of the value HiGHS refuses. Scale UP only: scaling
+    # down would push entries that fit today below the threshold. Both ends are
+    # strictly positive, so the logarithm is always defined.
+    room = min(10.0 * small_tol / a_min, large_tol / (10.0 * a_max))
+    headroom = math.floor(math.log2(room))
+    if headroom > 0:
+        scale = 2.0**headroom
+        coeffs = coeffs * scale
+        rhs *= scale
+
+    tiny = (coeffs != 0.0) & (np.abs(coeffs) <= small_tol)
+    if not tiny.any():
+        nz = np.flatnonzero(coeffs)
+        return nz, coeffs[nz], rhs
+
+    a = coeffs[tiny]
+    lo, hi = lb[tiny], ub[tiny]
+    # ``a_j * x_j >= 0`` everywhere: a positive coefficient on a non-negative
+    # column, or a negative one on a non-positive column. Those drop for free.
+    free = np.where(a > 0.0, lo >= 0.0, hi <= 0.0)
+    # Otherwise rhs must absorb the term's worst contribution, which needs the
+    # bound on the binding side to be finite.
+    binding_open = np.where(a > 0.0, lo <= -_INF, hi >= _INF)
+    stuck = ~free & binding_open
+    if stuck.any():
+        bad = np.flatnonzero(tiny)[stuck][:5]
+        raise ValueError(
+            "cannot add this lazy cut to the HiGHS master: even rescaled it has "
+            f"coefficients at or below HiGHS's small_matrix_value ({small_tol:g}) on "
+            f"columns that are unbounded on the binding side (columns {bad.tolist()}), "
+            "so HiGHS would drop those terms and no finite right-hand side can "
+            "compensate. The cut would silently stop being valid. Bound those "
+            "columns, or separate a cut that does not touch them."
+        )
+    absorb = ~free
+    if absorb.any():
+        aa, lo_a, hi_a = a[absorb], lo[absorb], hi[absorb]
+        # One ulp up, because the loosening can be smaller than the ulp of ``rhs``
+        # and round straight back off it -- which would leave the row a hair
+        # TIGHTER than the one that is provably implied. Rounding the slack up is
+        # always the safe direction: it can only weaken the cut.
+        rhs = float(np.nextafter(rhs + float(np.sum(np.maximum(-aa * lo_a, -aa * hi_a))), np.inf))
+
+    kept = coeffs.copy()
+    kept[tiny] = 0.0
+    nz = np.flatnonzero(kept)
+    return nz, kept[nz], rhs
 
 
 def _stack_rows(
@@ -363,6 +473,7 @@ def solve_milp_with_lazy_cuts(
         sol.col_value = seed
         h.setSolution(sol)
 
+    small_tol, large_tol = _highs_matrix_window(h, highspy)
     counts = {"mipsol_calls": 0, "mipnode_calls": 0, "lazy_cuts": 0, "node_cuts": 0, "restarts": 0}
     pending: list[tuple[np.ndarray, float]] = []
     # The accepted incumbent is tracked separately from HiGHS's own: HiGHS's best
@@ -427,18 +538,23 @@ def solve_milp_with_lazy_cuts(
         for coeffs, rhs in pending:
             if coeffs.shape[0] != n:
                 raise ValueError(f"lazy cut has {coeffs.shape[0]} coefficients, expected {n}")
-            nz = np.flatnonzero(coeffs)
-            if (
-                h.addRow(
-                    -highspy.kHighsInf,
-                    rhs,
-                    int(nz.size),
-                    nz.astype(np.int32),
-                    coeffs[nz],
+            idx, vals, row_rhs = _prepare_cut_row(coeffs, float(rhs), lb, ub, small_tol, large_tol)
+            if idx.size == 0:
+                # Nothing survived, so there is no row to add. Adding nothing would
+                # restart an identical tree forever on a point the separator keeps
+                # vetoing, so refuse instead of spinning.
+                raise ValueError(
+                    "the separator returned a lazy cut with no coefficient HiGHS will "
+                    f"accept (small_matrix_value {small_tol:g}); there is no row to "
+                    "add and the master would not change."
                 )
-                != highspy.HighsStatus.kOk
-            ):
-                raise RuntimeError("HiGHS rejected a lazy cut row")
+            st = h.addRow(-highspy.kHighsInf, row_rhs, int(idx.size), idx.astype(np.int32), vals)
+            if st != highspy.HighsStatus.kOk:
+                raise RuntimeError(
+                    f"HiGHS rejected a lazy cut row (status {st}): {idx.size} nonzeros, "
+                    f"|coef| in [{np.min(np.abs(vals)):.3g}, {np.max(np.abs(vals)):.3g}], "
+                    f"rhs {row_rhs:.6g}"
+                )
 
     h.stopCallback(highspy.cb.HighsCallbackType.kCallbackMipImprovingSolution)
     h.clearCallbacks()

--- a/python/discopt/solvers/milp_highs.py
+++ b/python/discopt/solvers/milp_highs.py
@@ -372,6 +372,7 @@ def solve_milp_with_lazy_cuts(
     lazy_callback=None,
     node_callback=None,
     terminate_callback=None,
+    terminate_poll_s: float = 1.0,
     mip_start: Optional[np.ndarray] = None,
 ) -> MILPResult:
     """LP/NLP-BB master on HiGHS: separate at integer-feasible nodes, restart on a cut.
@@ -406,6 +407,26 @@ def solve_milp_with_lazy_cuts(
 
     ``callback_stats["mipsol_calls"] == 0`` means the separator never ran — NOT
     that it accepted everything (CLAUDE.md §6).
+
+    ``terminate_callback`` is consulted at two kinds of instant: **at each
+    restart**, after a tree has finished and produced cuts; and **inside the
+    tree**, through ``kCallbackMipInterrupt``. The snapshot is the running
+    ``callback_stats`` plus ``context`` (``"restart"`` or ``"interrupt"``),
+    ``elapsed`` and ``dual_bound`` — the master's current dual bound, ``None``
+    when HiGHS has none yet. Returning true stops the search and sets
+    ``callback_stats["terminated"]``.
+
+    The in-tree poll is what makes a progress budget honest: restarts alone are
+    not a clock. On ``rsyn0820m02m`` the master separates rarely enough that a
+    restart-only hook had nothing to judge at the checkpoint and abandoned a run
+    that certifies 2 s later. But HiGHS fires that callback about **3000 times a
+    second** (measured), which is neither affordable to answer in Python nor a
+    sensible sampling rate for a trend, so it is answered at most once every
+    ``terminate_poll_s`` seconds. That interval is the hook's real resolution and
+    a caller budgeting by it should size its window accordingly.
+
+    The hook can only ever give budget *back*: ``time_limit`` is still enforced
+    through the HiGHS option on every run, so nothing here can overrun it.
     """
     highspy = _require_highspy()
     t0 = time.time()
@@ -420,11 +441,6 @@ def solve_milp_with_lazy_cuts(
             "the HiGHS lazy-cut backend has no MIPNODE equivalent: it separates only "
             "at integer-feasible incumbents, so node_callback (fractional user cuts) "
             "cannot be honoured. Use milp_solver='gurobi' for that."
-        )
-    if terminate_callback is not None:
-        raise NotImplementedError(
-            "the HiGHS lazy-cut backend enforces time_limit through the HiGHS option "
-            "and has no callback-termination hook; pass time_limit instead."
         )
 
     c_arr = np.asarray(c, dtype=np.float64).ravel()
@@ -474,7 +490,23 @@ def solve_milp_with_lazy_cuts(
         h.setSolution(sol)
 
     small_tol, large_tol = _highs_matrix_window(h, highspy)
-    counts = {"mipsol_calls": 0, "mipnode_calls": 0, "lazy_cuts": 0, "node_cuts": 0, "restarts": 0}
+    counts = {
+        "mipsol_calls": 0,
+        "mipnode_calls": 0,
+        "lazy_cuts": 0,
+        "node_cuts": 0,
+        "restarts": 0,
+        # How many times the hook was actually asked. Zero with a hook installed
+        # is "it never got a look in", NOT "it kept saying continue" (§6).
+        "terminate_polls": 0,
+    }
+    terminated = False
+    terminate_context: Optional[str] = None
+    stop = [False]
+    last_poll = [t0]
+    poll_interval = float(terminate_poll_s)
+    if poll_interval < 0.0:
+        raise ValueError(f"terminate_poll_s must be non-negative, got {terminate_poll_s!r}")
     pending: list[tuple[np.ndarray, float]] = []
     # The accepted incumbent is tracked separately from HiGHS's own: HiGHS's best
     # solution may be a point the separator VETOED, and returning that as the OA
@@ -483,7 +515,37 @@ def solve_milp_with_lazy_cuts(
     best: list[Optional[np.ndarray]] = [None]
     best_obj: list[Optional[float]] = [None]
 
+    def _consult(context: str, dual_bound, elapsed: float) -> bool:
+        """Ask the caller's hook whether to stop. Never swallows (CLAUDE.md §7)."""
+        snapshot: dict[str, object] = dict(counts)
+        snapshot["context"] = context
+        snapshot["elapsed"] = elapsed
+        snapshot["dual_bound"] = dual_bound
+        counts["terminate_polls"] += 1
+        return bool(terminate_callback(snapshot))
+
     def _callback(callback_type, message, data_out, data_in, user_data):
+        if callback_type == highspy.cb.HighsCallbackType.kCallbackMipInterrupt:
+            # HiGHS hands every callback the SAME input struct, so the flag the
+            # separator sets to request a restart is still set when the rebuilt
+            # tree's first interrupt arrives -- and interrupts it before it has
+            # done anything. Measured: with this branch not writing the flag, the
+            # toy model below dropped from 7 restarts / optimal 9.0 to 1 restart /
+            # feasible 15.0. Every path through here states the flag it wants.
+            if stop[0]:
+                data_in.user_interrupt = True
+                return
+            # Fires thousands of times a second, so it is answered on an interval.
+            now = time.time()
+            if now - last_poll[0] < poll_interval:
+                data_in.user_interrupt = False
+                return
+            last_poll[0] = now
+            raw_lb = float(data_out.mip_dual_bound)
+            stop[0] = _consult("interrupt", raw_lb if np.isfinite(raw_lb) else None, now - t0)
+            data_in.user_interrupt = stop[0]
+            return
+
         x = np.asarray(data_out.mip_solution, dtype=np.float64).ravel()[:n]
         counts["mipsol_calls"] += 1
         # CLAUDE.md §7: a separator that raises must crash the solve, not be read
@@ -505,6 +567,8 @@ def solve_milp_with_lazy_cuts(
 
     h.setCallback(_callback, None)
     h.startCallback(highspy.cb.HighsCallbackType.kCallbackMipImprovingSolution)
+    if terminate_callback is not None:
+        h.startCallback(highspy.cb.HighsCallbackType.kCallbackMipInterrupt)
 
     status = SolveStatus.ERROR
     bound = None
@@ -529,12 +593,33 @@ def solve_milp_with_lazy_cuts(
         if np.isfinite(raw_bound):
             bound = raw_bound if bound is None else max(bound, raw_bound)
 
+        if stop[0]:
+            # The hook interrupted the tree. HiGHS reports that as kInterrupt,
+            # which is true but says nothing about who asked; record who.
+            terminated = True
+            terminate_context = "interrupt"
+            status = _status_map(highspy).get(h.getModelStatus(), SolveStatus.ERROR)
+            break
+
         if not pending:
             status = _status_map(highspy).get(h.getModelStatus(), SolveStatus.ERROR)
             break
 
         # A cut was requested, so this tree is stale: append the rows and rebuild.
         counts["restarts"] += 1
+        if terminate_callback is not None:
+            last_poll[0] = time.time()
+            if _consult("restart", bound, last_poll[0] - t0):
+                terminated = True
+                terminate_context = "restart"
+                status = _status_map(highspy).get(h.getModelStatus(), SolveStatus.ERROR)
+                if status == SolveStatus.OPTIMAL:
+                    # The tree that just finished was solved to optimality, but its
+                    # rows are stale -- the separator vetoed its incumbent. Calling
+                    # that "optimal" would hand the caller a certificate for a
+                    # master that is missing the cut we are about to not add.
+                    status = SolveStatus.TIME_LIMIT
+                break
         for coeffs, rhs in pending:
             if coeffs.shape[0] != n:
                 raise ValueError(f"lazy cut has {coeffs.shape[0]} coefficients, expected {n}")
@@ -557,6 +642,8 @@ def solve_milp_with_lazy_cuts(
                 )
 
     h.stopCallback(highspy.cb.HighsCallbackType.kCallbackMipImprovingSolution)
+    if terminate_callback is not None:
+        h.stopCallback(highspy.cb.HighsCallbackType.kCallbackMipInterrupt)
     h.clearCallbacks()
 
     x_out, obj_out = best[0], best_obj[0]
@@ -573,5 +660,5 @@ def solve_milp_with_lazy_cuts(
         node_count=nodes,
         iterations=iters,
         wall_time=time.time() - t0,
-        callback_stats={**counts, "terminated": False, "terminate_context": None},
+        callback_stats={**counts, "terminated": terminated, "terminate_context": terminate_context},
     )

--- a/python/discopt/solvers/mip_nlp.py
+++ b/python/discopt/solvers/mip_nlp.py
@@ -79,6 +79,9 @@ _LP_NLP_BB_OPTION_KEYS = frozenset(
         "integer_to_binary",
         "feasibility_norm",
         "milp_solver",
+        # #1066: the single tree checks in at every master restart, so a caller
+        # that budgets by progress can budget this method too.
+        "termination_hook",
     }
 )
 _DIRECT_ROUTABLE_METHODS = frozenset({"oa", "ecp", "goa"})

--- a/python/discopt/solvers/oa.py
+++ b/python/discopt/solvers/oa.py
@@ -4110,6 +4110,7 @@ def solve_lp_nlp_bb(
     integer_to_binary: bool = False,
     mip_nlp_profile: str = "default",
     mip_nlp_shot_config: Optional[MIPNLPShotConfig] = None,
+    termination_hook: Any = None,
     **kwargs,
 ) -> SolveResult:
     """Solve a convex MINLP with the LP/NLP branch-and-bound variant.
@@ -4125,6 +4126,21 @@ def solve_lp_nlp_bb(
     ``milp_solver`` selects that backend: ``"simplex"`` (the in-house Rust MILP
     driver, also reached by the default ``"auto"``) or ``"gurobi"``. See
     :func:`_resolve_lp_nlp_bb_backend` for what each one supports.
+
+    ``termination_hook`` is the same contract :func:`solve_oa` offers -- a callable
+    handed a context mapping, returning true to stop -- so a caller that budgets a
+    solve by progress can budget this method too. It is honoured on the backends
+    that have a check-in point: ``"highs"`` consults it at every master restart and
+    ``"gurobi"`` on its wall-clock poll. The ``"simplex"`` driver has neither, and
+    passing a hook it cannot call would make any budget built on it a fiction, so
+    that combination is refused rather than silently ignored (CLAUDE.md §3).
+
+    The context carries the keys :func:`solve_oa`'s hook sees for a bound-driven
+    decision -- ``event``, ``elapsed``, ``is_minimization``, ``current_dual_bound``,
+    ``current_primal_bound``, ``relative_gap``, ``absolute_gap``,
+    ``incumbent_objective`` -- plus ``restarts`` and ``lazy_cuts``. The per-iteration
+    OA keys have no meaning in a single tree and are not invented: this method has
+    no ``iteration``.
     """
     if kwargs:
         raise ValueError(
@@ -4134,7 +4150,7 @@ def solve_lp_nlp_bb(
             "feasibility_cuts, feasibility_norm, heuristic_nonconvex, init_strategy, "
             "integer_to_binary, "
             "max_slack, milp_solver, mip_nlp_profile, mip_nlp_shot_config, "
-            "oa_penalty_factor."
+            "oa_penalty_factor, termination_hook."
         )
     t_start = time.perf_counter()
     shot_config = mip_nlp_shot_config if mip_nlp_profile == "shot" else None
@@ -4143,6 +4159,15 @@ def solve_lp_nlp_bb(
     # Resolve (and refuse) the single-tree backend before any model work, so an
     # unsupported request costs a message rather than a decomposition.
     lazy_backend = _resolve_lp_nlp_bb_backend(milp_solver, shot_profile=shot_profile)
+    hook = _normalize_optional_hook("termination_hook", termination_hook)
+    if hook is not None and lazy_backend == "simplex":
+        raise NotImplementedError(
+            "termination_hook is not available on the in-house simplex master: the "
+            "driver enforces time_limit itself and offers no check-in point, so the "
+            "hook could never be called and any budget built on it would be a "
+            "fiction. Use milp_solver='highs' (checks in at every master restart) "
+            "or milp_solver='gurobi'."
+        )
     init_strategy = _normalize_init_strategy(init_strategy)
     feasibility_norm = _normalize_feasibility_norm(feasibility_norm)
     fp_config = _normalize_fp_config(
@@ -4606,8 +4631,68 @@ def solve_lp_nlp_bb(
             mip_start_objective=_master_objective_from_evaluator(incumbent_obj),
         )
 
-    def callback_terminate(_snapshot: dict[str, object]) -> bool:
-        return (time.perf_counter() - t_start) >= float(time_limit)
+    hook_calls = [0]
+    #: The internal-sense dual bound that closed the gap, once one does.
+    converged_at: list[Optional[float]] = [None]
+    #: How many check-ins carried a usable dual bound. Zero means the early exit
+    #: never had anything to judge, which is NOT the same as "it judged and said
+    #: keep going" (CLAUDE.md §6); it is exported in ``callback_stats``.
+    bound_observations = [0]
+
+    def _master_bound_internal(raw) -> Optional[float]:
+        """The master's dual bound in the internal minimization sense, or None."""
+        if not master_bound_valid or raw is None or not np.isfinite(float(raw)):
+            return None
+        value = float(raw)
+        if decomp.obj_is_linear and decomp.obj_coeffs is not None:
+            value += float(decomp.obj_coeffs[1])
+        return value
+
+    def callback_terminate(snapshot: dict[str, object]) -> bool:
+        if (time.perf_counter() - t_start) >= float(time_limit):
+            return True
+        lb = _master_bound_internal(snapshot.get("dual_bound"))
+        ub = incumbent_obj
+        if lb is not None and ub is not None:
+            bound_observations[0] += 1
+            if _compute_gap(lb, ub) <= gap_tolerance:
+                # The master's running dual bound has met the NLP incumbent, which
+                # is the same certificate this driver tests for after the master
+                # returns -- just read at the moment it becomes true rather than
+                # whenever the separator happens to run dry. The bound is valid:
+                # the master is a relaxation of the MINLP (its cuts are supporting
+                # hyperplanes of convex functions, and ``master_bound_valid`` is
+                # what says so), and a MIP tree's dual bound is a valid bound on
+                # its own optimum at every instant of the search, interrupted or
+                # not. Without this the loop runs past its own certificate:
+                # ``rsyn0820m02m`` had bound 1092.1600 against incumbent 1092.0911
+                # -- gap 6.3e-5, inside the 1e-4 default -- at 5.1 s of a 60 s
+                # limit, then rebuilt its tree five more times and was reported
+                # ``feasible`` at the wall (measured 2026-08-29).
+                converged_at[0] = lb if converged_at[0] is None else max(converged_at[0], lb)
+                return True
+        if hook is None:
+            return False
+        context: dict[str, object] = {
+            "event": "termination",
+            "elapsed": float(time.perf_counter() - t_start),
+            "is_minimization": bool(obj_sign > 0),
+            "current_dual_bound": None if lb is None else obj_sign * lb,
+            "current_primal_bound": None if ub is None else obj_sign * ub,
+            "relative_gap": _compute_gap(lb, ub) if lb is not None and ub is not None else None,
+            "absolute_gap": (None if lb is None or ub is None else abs(ub - lb)),
+            "incumbent_objective": None if ub is None else obj_sign * ub,
+            "n_vars": int(n_vars),
+            "n_constraints": int(n_cons),
+            "restarts": int(cast(int, snapshot.get("restarts", 0) or 0)),
+            "lazy_cuts": int(cast(int, snapshot.get("lazy_cuts", 0) or 0)),
+        }
+        hook_calls[0] += 1
+        try:
+            raw = hook(context)
+        except Exception as exc:  # never swallowed (CLAUDE.md §7)
+            raise RuntimeError(f"termination_hook failed during LP/NLP BB solve: {exc}") from exc
+        return _validate_external_termination(raw)
 
     lazy_kwargs: dict[str, object] = dict(
         c=master.c,
@@ -4623,9 +4708,16 @@ def solve_lp_nlp_bb(
         mip_start=master_mip_start,
     )
     if lazy_backend == "gurobi":
-        # MIPNODE user cuts and the wall-clock poll are Gurobi-only; the native
-        # driver has no fractional-node hook and enforces `time_limit` itself.
+        # MIPNODE user cuts are Gurobi-only; the native driver has no
+        # fractional-node hook.
         lazy_kwargs["node_callback"] = node_callback if shot_profile else None
+        lazy_kwargs["terminate_callback"] = callback_terminate
+    elif lazy_backend == "highs":
+        # The HiGHS master checks in at every restart and, between them, on an
+        # interval. That is what lets a caller budget this method by progress
+        # (#1066) -- and, hook or no hook, what lets the driver notice its own
+        # certificate the moment the bound meets the incumbent instead of at
+        # whatever later instant the separator runs dry.
         lazy_kwargs["terminate_callback"] = callback_terminate
     master_result = solve_milp_with_lazy_cuts(**lazy_kwargs)  # type: ignore[arg-type]
     wall_time = time.perf_counter() - t_start
@@ -4635,17 +4727,43 @@ def solve_lp_nlp_bb(
         bound = float(master_result.bound)
         if decomp.obj_is_linear and decomp.obj_coeffs is not None:
             bound += float(decomp.obj_coeffs[1])
+    if converged_at[0] is not None:
+        # Report the bound the stop was actually taken on. Both readings are valid
+        # bounds in the internal sense, so the tighter one is the honest one -- and
+        # if the post-hoc read came back weaker, reporting it would contradict the
+        # very test that ended the search and turn a certificate into "feasible".
+        bound = converged_at[0] if bound is None else max(bound, converged_at[0])
     gap = (
         _compute_gap(bound, incumbent_obj)
         if bound is not None and incumbent_obj is not None
         else None
     )
     callback_stats = dict(master_result.callback_stats or {})
+    # How many times the caller's hook actually ran. Zero with a hook installed
+    # means it never got a check-in -- a master that never separated -- and NOT
+    # that it kept saying continue (CLAUDE.md §6).
+    callback_stats["termination_hook_calls"] = int(hook_calls[0])
+    # Distinguish "the early exit never had a bound to judge" from "it judged and
+    # kept going" -- only the HiGHS backend reports a dual bound at check-in, so
+    # on any other master this count is 0 and the exit is inert by construction.
+    callback_stats["dual_bound_observations"] = int(bound_observations[0])
+    callback_stats["converged_early"] = bool(converged_at[0] is not None)
     callback_terminated = bool(callback_stats.get("terminated"))
     status = "feasible"
     termination_reason: Optional[str] = None
-    if callback_terminated:
-        termination_reason = "time_limit"
+    if converged_at[0] is not None and incumbent is not None:
+        # Stopped on the certificate, not on the clock or the caller's option.
+        termination_reason = "gap_tolerance"
+        status = "optimal" if gap is not None and gap <= gap_tolerance else "feasible"
+    elif callback_terminated:
+        # The clock and the hook both come back through the same callback, so name
+        # whichever one it was rather than reporting a time limit that may not have
+        # been reached.
+        termination_reason = (
+            "termination_hook"
+            if hook is not None and (time.perf_counter() - t_start) < float(time_limit)
+            else "time_limit"
+        )
         status = "time_limit" if incumbent is None else "feasible"
     elif master_result.status == SolveStatus.INFEASIBLE:
         status = "infeasible"

--- a/python/tests/test_1059_convex_minlp_route.py
+++ b/python/tests/test_1059_convex_minlp_route.py
@@ -60,7 +60,7 @@ class TestRouteFlag:
     def test_disabled_flag_declines_a_routable_model(self, monkeypatch):
         """With the flag off the router declines a model it would otherwise take."""
         monkeypatch.setenv(ROUTE_ENV, "0")
-        method, reason = _convex_minlp_auto_route(_load("gbd"))
+        method, reason, _opts = _convex_minlp_auto_route(_load("gbd"))
         assert method is None
         assert "disabled" in reason
 
@@ -71,9 +71,31 @@ class TestRouteGates:
 
     def test_fires_on_convex_minlp(self, monkeypatch):
         monkeypatch.setenv(ROUTE_ENV, "1")
-        method, reason = _convex_minlp_auto_route(_load("gbd"))
-        assert method == "oa"
+        method, reason, opts = _convex_minlp_auto_route(_load("gbd"))
+        assert method == "lp_nlp_bb"
         assert "certified convex" in reason
+        # The master engine is not incidental: on the in-house master this method
+        # is measurably worse than the "oa" it replaced (#1066), so the route must
+        # carry the HiGHS pick with it or the retarget is a regression.
+        assert opts == {"milp_solver": "highs"}
+
+    def test_without_highspy_the_target_stays_on_the_old_oa_path(self, monkeypatch):
+        """No HiGHS master, no retarget -- and still a route, not a refusal."""
+        monkeypatch.setenv(ROUTE_ENV, "1")
+        import builtins
+
+        real_import = builtins.__import__
+
+        def _no_highs(name, *a, **kw):
+            if name == "discopt.solvers.milp_highs":
+                raise ImportError("highspy is not installed")
+            return real_import(name, *a, **kw)
+
+        monkeypatch.setattr(builtins, "__import__", _no_highs)
+        method, reason, opts = _convex_minlp_auto_route(_load("gbd"))
+        assert method == "oa"
+        assert "highspy unavailable" in reason
+        assert opts == {}
 
     def test_declines_pure_continuous(self, monkeypatch):
         """A convex NLP is already served by the continuous convex fast path."""
@@ -82,7 +104,7 @@ class TestRouteGates:
         x = m.continuous("x", lb=-5, ub=5)
         m.minimize(dm.exp(x) + x**2)
         m.subject_to(x >= -2)
-        method, reason = _convex_minlp_auto_route(m)
+        method, reason, _opts = _convex_minlp_auto_route(m)
         assert method is None
         assert "pure continuous" in reason
 
@@ -94,7 +116,7 @@ class TestRouteGates:
         y = m.binary("y")
         m.minimize(x + 2 * y)
         m.subject_to(x + y >= 1)
-        method, reason = _convex_minlp_auto_route(m)
+        method, reason, _opts = _convex_minlp_auto_route(m)
         assert method is None
         assert "not a discrete NLP" in reason
 
@@ -107,7 +129,7 @@ class TestRouteGates:
         z = m.binary("z")
         m.minimize(x * y + z)  # bilinear: nonconvex
         m.subject_to(x + y + z >= 1)
-        method, reason = _convex_minlp_auto_route(m)
+        method, reason, _opts = _convex_minlp_auto_route(m)
         assert method is None
         assert reason.startswith("not routed")
 
@@ -120,7 +142,7 @@ class TestRouteGates:
         opaque = dm.custom(lambda v: v**2)
         m.minimize(opaque(x) + y)
         m.subject_to(x + y >= 1)
-        method, reason = _convex_minlp_auto_route(m)
+        method, reason, _opts = _convex_minlp_auto_route(m)
         assert method is None
         assert "dm.custom" in reason
 
@@ -141,7 +163,7 @@ class TestRouteDispatch:
         m = _load("gbd")
         result = m.solve(time_limit=30)
         assert result.algorithm_route is not None
-        assert "mip-nlp/oa" in result.algorithm_route
+        assert "mip-nlp/lp_nlp_bb" in result.algorithm_route
 
     def test_route_off_leaves_the_field_unset(self, monkeypatch):
         """The opt-out must restore the pre-graduation behaviour exactly."""

--- a/python/tests/test_debug_cli.py
+++ b/python/tests/test_debug_cli.py
@@ -61,7 +61,16 @@ def test_script_with_json_is_rejected():
 
 @pytest.mark.smoke
 @pytest.mark.skipif(not _TINY_NL.exists(), reason="minlplib_nl test corpus absent")
-def test_cli_runs_scripted_repl_solve(tmp_path):
+def test_cli_runs_scripted_repl_solve(tmp_path, monkeypatch):
+    # What this test debugs is the spatial B&B tree, so it has to be given one.
+    # ``st_miqp3`` is a convex MIQP, and since #1066 the convex auto-route
+    # certifies it inside the routed master without opening a single node --
+    # ``status=optimal objective=-6 nodes=0``, so ``break if nodes>=1`` never
+    # fires and the scripted REPL never starts. That is a better solve, not a
+    # worse one; it just leaves this test with no subject. Pin the path whose
+    # tree the debugger exists to inspect rather than trusting a model to keep
+    # being slow enough to have one.
+    monkeypatch.setenv("DISCOPT_CONVEX_MINLP_ROUTE", "0")
     script = tmp_path / "cmds.pdbg"
     script.write_text("info\nbreak if nodes>=1\ncontinue\nprint bound\ncontinue\n")
     err = io.StringIO()
@@ -70,3 +79,19 @@ def test_cli_runs_scripted_repl_solve(tmp_path):
     out = err.getvalue()
     assert "status=optimal" in out
     assert "paused at" in out  # the scripted debugger actually ran
+
+
+@pytest.mark.smoke
+@pytest.mark.skipif(not _TINY_NL.exists(), reason="minlplib_nl test corpus absent")
+def test_cli_reports_a_solve_the_router_finishes_without_a_tree(tmp_path):
+    """The other half of the above: the default path must still report a result.
+
+    With no spatial node to pause on, the CLI has nothing to hand the REPL -- and
+    it should say what happened rather than hanging or exiting non-zero.
+    """
+    script = tmp_path / "cmds.pdbg"
+    script.write_text("info\ncontinue\n")
+    err = io.StringIO()
+    rc = cli.main([str(_TINY_NL), "--script", str(script), "--time-limit", "20"], err=err)
+    assert rc == 0
+    assert "status=optimal" in err.getvalue()

--- a/python/tests/test_issue_1060_highs_master.py
+++ b/python/tests/test_issue_1060_highs_master.py
@@ -232,24 +232,28 @@ def test_a_wrong_length_cut_is_refused_instead_of_being_padded():
 
 
 @pytest.mark.smoke
-def test_hooks_this_backend_cannot_honour_are_refused_loudly():
-    """HiGHS has no fractional-node or terminate hook; silence would lose cuts.
+def test_a_hook_this_backend_cannot_honour_is_refused_loudly():
+    """HiGHS has no fractional-node hook; silence would lose the caller's cuts.
 
     Accepting a ``node_callback`` and never calling it would make the SHOT
     profile's MIPNODE cuts vanish with no diagnostic -- the caller would read a
     weaker search as an algorithmic result (CLAUDE.md §3).
+
+    ``terminate_callback`` used to be refused alongside it and no longer is:
+    #1066 gave this backend a real check-in point at the master restart, so the
+    hook is called rather than ignored. Its behaviour is pinned in
+    ``test_issue_1066_lp_nlp_bb_progress_budget.py``.
     """
-    for kw in ({"node_callback": lambda x: None}, {"terminate_callback": lambda: False}):
-        with pytest.raises(NotImplementedError):
-            solve_milp_with_lazy_cuts(
-                _C,
-                _A_UB,
-                _B_UB,
-                bounds=_BOUNDS,
-                integrality=_INTEGRALITY,
-                lazy_callback=lambda x: None,
-                **kw,
-            )
+    with pytest.raises(NotImplementedError, match="no MIPNODE equivalent"):
+        solve_milp_with_lazy_cuts(
+            _C,
+            _A_UB,
+            _B_UB,
+            bounds=_BOUNDS,
+            integrality=_INTEGRALITY,
+            lazy_callback=lambda x: None,
+            node_callback=lambda x: None,
+        )
 
 
 @pytest.mark.smoke

--- a/python/tests/test_issue_1066_highs_cut_row.py
+++ b/python/tests/test_issue_1066_highs_cut_row.py
@@ -1,0 +1,234 @@
+"""#1066: a lazy cut whose coefficients span more orders of magnitude than HiGHS keeps.
+
+HiGHS silently discards any matrix entry with ``|value| <= small_matrix_value``
+(1e-9 by default) and reports the discard from ``addRow`` as ``kWarning`` -- not
+``kOk``, not ``kError``. ``solve_milp_with_lazy_cuts`` read anything other than
+``kOk`` as a rejection and raised, which killed the whole ``squfl`` family under
+``mip_nlp_method="lp_nlp_bb", milp_solver="highs"``: ``squfl025-040`` died in 1.0 s
+and ``squfl020-150`` in 7.1 s with ``RuntimeError: HiGHS rejected a lazy cut row``.
+
+The row that did it, measured on ``squfl025-040``'s first separated cut: 1026
+nonzeros, of which **880** were at or below 1e-9, ``|a|`` spanning 2.05e-19 to
+114 -- 21 orders of magnitude of AD dust around a real support of ~146 entries.
+
+Reading the warning as "row added, all good" would have been the other wrong
+answer: HiGHS would then have *changed the cut* behind the separator's back. So
+the row is fitted to HiGHS's window first -- rescaled by a power of two, which is
+exact -- and only what still does not fit is dropped, on the valid side, with a
+loud refusal when no valid drop exists.
+"""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+import pytest
+from discopt.solvers import SolveStatus
+
+highspy = pytest.importorskip("highspy", reason="the HiGHS master is an opt-in extra")
+
+from discopt.solvers.milp_highs import (  # noqa: E402
+    _INF,
+    _highs_matrix_window,
+    _prepare_cut_row,
+    solve_milp_with_lazy_cuts,
+)
+
+_SMALL, _LARGE = 1e-9, 1e15
+
+
+@pytest.mark.smoke
+def test_highs_really_does_answer_a_tiny_entry_with_a_warning_not_an_error():
+    """The premise of this whole file, asserted rather than assumed.
+
+    If a HiGHS release ever promotes this to ``kError`` or demotes it to ``kOk``,
+    every other test here is reasoning about behaviour that no longer exists.
+    """
+    h = highspy.Highs()
+    assert h.setOptionValue("output_flag", False) == highspy.HighsStatus.kOk
+    h.addVars(2, np.array([0.0, 0.0]), np.array([10.0, 10.0]))
+    st = h.addRow(-highspy.kHighsInf, 5.0, 2, np.array([0, 1], np.int32), np.array([1.0, 2.05e-19]))
+    assert st == highspy.HighsStatus.kWarning, st
+    assert h.getNumRow() == 1, "HiGHS refused the row outright"
+    assert h.getNumNz() == 1, "HiGHS kept the tiny entry after all"
+
+
+@pytest.mark.smoke
+def test_the_window_is_read_from_the_solver_not_hardcoded():
+    h = highspy.Highs()
+    assert h.setOptionValue("output_flag", False) == highspy.HighsStatus.kOk
+    small, large = _highs_matrix_window(h, highspy)
+    assert (small, large) == (_SMALL, _LARGE)
+    # Moving the option must move what the preparation believes, or the two
+    # silently disagree about which entries survive.
+    assert h.setOptionValue("small_matrix_value", 1e-6) == highspy.HighsStatus.kOk
+    assert _highs_matrix_window(h, highspy)[0] == 1e-6
+
+
+@pytest.mark.smoke
+def test_a_row_that_fits_after_rescaling_keeps_every_entry_exactly():
+    """The squfl case: 21 orders of magnitude, a 24-order window. Nothing is dropped."""
+    coeffs = np.array([114.0, 2.05e-19, -3.0])
+    idx, vals, rhs = _prepare_cut_row(coeffs, -8.74856e-14, *_box(3), _SMALL, _LARGE)
+
+    assert idx.tolist() == [0, 1, 2], "an entry was dropped that rescaling could save"
+    assert np.min(np.abs(vals)) > _SMALL, "an entry HiGHS will drop was handed to it"
+    assert np.max(np.abs(vals)) < _LARGE, "an entry HiGHS refuses was handed to it"
+
+    # Exactness: one common power-of-two factor, applied bit-for-bit. A non-dyadic
+    # factor would round every coefficient and could tighten the cut by an ulp.
+    scale = vals[0] / coeffs[0]
+    assert math.log2(scale) == int(math.log2(scale)), scale
+    np.testing.assert_array_equal(vals, coeffs * scale)
+    assert rhs == -8.74856e-14 * scale
+
+
+@pytest.mark.smoke
+def test_a_row_already_inside_the_window_is_passed_through_untouched():
+    coeffs = np.array([1.0, -2.0, 0.0, 0.5])
+    idx, vals, rhs = _prepare_cut_row(coeffs, 7.0, *_box(4), _SMALL, _LARGE)
+    assert idx.tolist() == [0, 1, 3]
+    np.testing.assert_array_equal(vals, [1.0, -2.0, 0.5])
+    assert rhs == 7.0
+
+
+def _box(n, lo=0.0, hi=10.0):
+    return np.full(n, lo), np.full(n, hi)
+
+
+@pytest.mark.smoke
+def test_a_non_negative_term_drops_for_free_when_rescaling_cannot_save_it():
+    """``a_j x_j >= 0`` over the box, so removing it can only make the row easier."""
+    # 28 orders of magnitude: wider than the window, so a drop is forced.
+    coeffs = np.array([1e10, 1e-18])
+    lb, ub = np.array([0.0, 0.0]), np.array([10.0, 100.0])
+    idx, vals, rhs = _prepare_cut_row(coeffs, 1e10, lb, ub, _SMALL, _LARGE)
+
+    assert idx.tolist() == [0], "the entry HiGHS would drop was still handed to it"
+    scale = vals[0] / coeffs[0]
+    assert rhs == 1e10 * scale, "rhs was loosened for a term that needed no slack"
+    _assert_implied(coeffs, 1e10, idx, vals, rhs, lb, ub)
+
+
+@pytest.mark.smoke
+def test_a_negative_term_drops_only_after_the_rhs_absorbs_its_worst_case():
+    coeffs = np.array([1e10, -1e-18])
+    lb, ub = np.array([0.0, 0.0]), np.array([10.0, 100.0])
+    idx, vals, rhs = _prepare_cut_row(coeffs, 1e10, lb, ub, _SMALL, _LARGE)
+
+    assert idx.tolist() == [0]
+    scale = vals[0] / coeffs[0]
+    # Strictly greater, even though the true slack (8.19e-13) is far below the ulp
+    # of the rhs (~0.015) and rounds straight off it: the loosening is rounded up,
+    # so the row can never come out TIGHTER than the one that is provably implied.
+    assert rhs > 1e10 * scale, "the dropped negative term left the row tighter"
+    assert rhs == pytest.approx(1e10 * scale + 1e-18 * 100.0 * scale, rel=1e-12)
+    _assert_implied(coeffs, 1e10, idx, vals, rhs, lb, ub)
+
+
+@pytest.mark.smoke
+def test_an_unbounded_binding_side_is_refused_loudly_rather_than_quietly_dropped():
+    coeffs = np.array([1e10, -1e-18])
+    lb, ub = np.array([0.0, 0.0]), np.array([10.0, np.inf])
+    with pytest.raises(ValueError, match="unbounded on the binding side"):
+        _prepare_cut_row(coeffs, 1e10, lb, ub, _SMALL, _LARGE)
+
+
+@pytest.mark.smoke
+def test_the_1e20_open_bound_sentinel_counts_as_unbounded_not_as_a_finite_1e20():
+    """CLAUDE.md's documented trap, on exactly the shape that springs it.
+
+    discopt marks an open bound with ``1e20``, not ``inf``. A finiteness test on
+    the *product* passes here -- ``1e-18 * 1e20`` is an unremarkable ``100`` -- so a
+    check written that way computes a finite 'compensation' for a term that has no
+    worst case and ships a row the cut does not imply.
+    """
+    coeffs = np.array([1e10, -1e-18])
+    lb, ub = np.array([0.0, 0.0]), np.array([10.0, _INF])
+    with pytest.raises(ValueError, match="unbounded on the binding side"):
+        _prepare_cut_row(coeffs, 1e10, lb, ub, _SMALL, _LARGE)
+
+
+def _assert_implied(coeffs, rhs, idx, vals, rhs_out, lb, ub, n_samples=2000):
+    """Every box point the original row keeps, the prepared row must keep too.
+
+    §6: the sample count is asserted, so a generator that yields nothing cannot
+    read as 'no violations found'.
+    """
+    rng = np.random.default_rng(1066)
+    x = rng.uniform(lb, np.minimum(ub, 1e6), size=(n_samples, lb.size))
+    kept = x @ coeffs <= rhs
+    assert kept.any(), "no sampled point satisfied the original row -- vacuous test"
+    new_lhs = x[:, idx] @ vals
+    slack = rhs_out - new_lhs
+    assert np.all(slack[kept] >= -1e-9 * max(1.0, abs(rhs_out))), (
+        f"the prepared row cuts off {int((slack[kept] < 0).sum())} point(s) the cut kept"
+    )
+    return int(kept.sum())
+
+
+# --- end to end: the failure #1066 actually hit -------------------------------
+
+_C = np.array([-1.0, -2.0])
+_A_UB = np.array([[1.0, 1.0]])
+_B_UB = np.array([3.5])
+_INTEGRALITY = np.array([1, 1])
+_BOUNDS = [(0.0, None), (0.0, None)]
+
+
+@pytest.mark.smoke
+def test_a_wide_dynamic_range_cut_no_longer_kills_the_solve():
+    """The regression. Before the fix this raised ``HiGHS rejected a lazy cut row``.
+
+    The cut is ``1e-19 x0 + x1 <= 2``: mathematically ``x1 <= 2`` plus a dust term,
+    which is the shape every squfl OA cut has. The answer must still be the vetoed
+    optimum's replacement, (1, 2) at -5.
+    """
+    calls: list[np.ndarray] = []
+
+    def _veto_x1_above_two(x):
+        calls.append(np.asarray(x, dtype=float).copy())
+        if x[1] > 2.0 + 1e-6:
+            return [(np.array([1e-19, 1.0]), 2.0)]
+        return None
+
+    res = solve_milp_with_lazy_cuts(
+        _C,
+        _A_UB,
+        _B_UB,
+        bounds=_BOUNDS,
+        integrality=_INTEGRALITY,
+        lazy_callback=_veto_x1_above_two,
+    )
+    assert res.status == SolveStatus.OPTIMAL
+    assert res.objective == pytest.approx(-5.0, abs=1e-6)
+    np.testing.assert_allclose(res.x, [1.0, 2.0], atol=1e-6)
+    assert res.callback_stats["lazy_cuts"] >= 1
+    assert res.callback_stats["restarts"] >= 1
+    assert any(c[1] > 2.0 + 1e-6 for c in calls), "the vetoing branch never fired"
+
+
+@pytest.mark.smoke
+def test_a_cut_with_no_row_in_it_is_refused_instead_of_spinning_the_tree():
+    """Adding no row would rebuild an identical tree forever on the same point.
+
+    Rescaling rescues almost anything -- even a 1e-30 coefficient lifts into the
+    window -- so the only way to reach this guard is a cut with no nonzero at all.
+    That is a broken separator, and it must say so rather than loop.
+    """
+
+    def _cut_with_no_coefficients(x):
+        if x[1] > 2.0 + 1e-6:
+            return [(np.zeros(2), -1.0)]
+        return None
+
+    with pytest.raises(ValueError, match="no coefficient HiGHS will accept"):
+        solve_milp_with_lazy_cuts(
+            _C,
+            _A_UB,
+            _B_UB,
+            bounds=_BOUNDS,
+            integrality=_INTEGRALITY,
+            lazy_callback=_cut_with_no_coefficients,
+        )

--- a/python/tests/test_issue_1066_lp_nlp_bb_progress_budget.py
+++ b/python/tests/test_issue_1066_lp_nlp_bb_progress_budget.py
@@ -1,0 +1,437 @@
+"""#1066: the auto-route's progress budget, extended to the single-tree method.
+
+The #1059 route hands a convex MINLP to the MIP-NLP family and keeps a reserve of
+the caller's time limit for the fallback. #1066 replaced that fixed 50% wall with
+:class:`~discopt.solver._RouteProgressGuard`, a ``termination_hook`` that returns
+budget the route has not earned -- but only ``solve_oa`` accepted such a hook, so
+once the route was retargeted at ``lp_nlp_bb`` the guard declined and the fixed
+wall came back.
+
+Both directions of that wall were measured on the reporter panel (default
+settings, 60 s, arms back to back, 2026-08-29):
+
+* ``rsyn0820m02m`` certifies at **37.5 s** and the 30 s wall cut it: ``optimal``
+  became ``feasible``.
+* ``squfl015-060`` is certified by the **fallback**, not the route. Handing the
+  route the whole limit turned that row from ``optimal`` into ``feasible``.
+
+So neither a bigger budget nor a smaller one is the answer, and the discriminator
+has to be progress -- which means ``lp_nlp_bb`` needs a check-in. The HiGHS master
+has exactly one honest one: the restart between trees.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from discopt.solver import _route_progress_guard_options, _RouteProgressGuard
+from discopt.solvers import SolveStatus
+
+highspy = pytest.importorskip("highspy", reason="the HiGHS master is an opt-in extra")
+
+from discopt.solvers.milp_highs import solve_milp_with_lazy_cuts  # noqa: E402
+
+# max x0 + 2 x1 s.t. x0 + x1 <= 3.5, integer, x >= 0 -- the same toy the cut-row
+# regression uses, so a separator veto is the only thing driving restarts.
+_C = np.array([-1.0, -2.0])
+_A_UB = np.array([[1.0, 1.0]])
+_B_UB = np.array([3.5])
+_INTEGRALITY = np.array([1, 1])
+_BOUNDS = [(0.0, None), (0.0, None)]
+
+
+def _veto_until(threshold: float):
+    """Separate ``x1 <= t`` for a shrinking ``t`` -- one restart per call."""
+
+    def _sep(x):
+        if x[1] > threshold + 1e-6:
+            return [(np.array([0.0, 1.0]), threshold)]
+        return None
+
+    return _sep
+
+
+@pytest.mark.smoke
+def test_the_highs_master_consults_a_terminate_callback_at_every_restart():
+    """It used to raise ``NotImplementedError`` for any ``terminate_callback``."""
+    seen: list[dict] = []
+
+    res = solve_milp_with_lazy_cuts(
+        _C,
+        _A_UB,
+        _B_UB,
+        bounds=_BOUNDS,
+        integrality=_INTEGRALITY,
+        lazy_callback=_veto_until(1.0),
+        terminate_callback=lambda snap: seen.append(dict(snap)) or False,
+    )
+    assert res.status == SolveStatus.OPTIMAL
+    assert seen, "the callback never fired -- there was no check-in to budget by"
+    assert len(seen) == res.callback_stats["terminate_polls"], (seen, res.callback_stats)
+    assert sum(1 for s in seen if s["context"] == "restart") == res.callback_stats["restarts"]
+    for snap in seen:
+        assert snap["context"] in ("restart", "interrupt")
+        assert snap["elapsed"] >= 0.0
+        # The bound is the master's own, which is what a progress judgement reads.
+        assert "dual_bound" in snap
+    assert res.callback_stats["terminated"] is False
+    assert res.callback_stats["terminate_context"] is None
+
+
+@pytest.mark.smoke
+def test_a_callback_that_says_stop_stops_the_loop_and_says_so():
+    res = solve_milp_with_lazy_cuts(
+        _C,
+        _A_UB,
+        _B_UB,
+        bounds=_BOUNDS,
+        integrality=_INTEGRALITY,
+        lazy_callback=_veto_until(1.0),
+        terminate_callback=lambda _snap: True,
+    )
+    assert res.callback_stats["terminated"] is True
+    assert res.callback_stats["terminate_context"] == "restart"
+    # The tree that just finished was solved to optimality but its incumbent was
+    # vetoed, so the cut it needs is the one we are declining to add. Reporting
+    # OPTIMAL would certify a master that is missing that row.
+    assert res.status != SolveStatus.OPTIMAL
+    assert res.callback_stats["restarts"] == 1
+
+
+@pytest.mark.smoke
+def test_stopping_early_still_returns_a_valid_bound_and_an_accepted_point():
+    """Cutting the loop short must not turn a bound into a wrong one."""
+    stopped = solve_milp_with_lazy_cuts(
+        _C,
+        _A_UB,
+        _B_UB,
+        bounds=_BOUNDS,
+        integrality=_INTEGRALITY,
+        lazy_callback=_veto_until(1.0),
+        terminate_callback=lambda _snap: True,
+    )
+    full = solve_milp_with_lazy_cuts(
+        _C,
+        _A_UB,
+        _B_UB,
+        bounds=_BOUNDS,
+        integrality=_INTEGRALITY,
+        lazy_callback=_veto_until(1.0),
+    )
+    assert full.status == SolveStatus.OPTIMAL
+    assert full.objective is not None
+    # Minimization sense inside the master: a dual bound never exceeds the optimum.
+    assert stopped.bound is not None
+    assert stopped.bound <= full.objective + 1e-9, (stopped.bound, full.objective)
+    if stopped.x is not None:
+        # Only ever a point the separator accepted.
+        assert stopped.x[1] <= 1.0 + 1e-6
+
+
+@pytest.mark.smoke
+def test_a_raising_callback_surfaces_rather_than_reading_as_keep_going():
+    def _boom(_snap):
+        raise ZeroDivisionError("instrument broke")
+
+    with pytest.raises(ZeroDivisionError, match="instrument broke"):
+        solve_milp_with_lazy_cuts(
+            _C,
+            _A_UB,
+            _B_UB,
+            bounds=_BOUNDS,
+            integrality=_INTEGRALITY,
+            lazy_callback=_veto_until(1.0),
+            terminate_callback=_boom,
+        )
+
+
+def _toy_convex_minlp():
+    """A convex MINLP whose master really does restart (7 times, measured).
+
+    Three big-M-linked facilities with a convex quadratic operating cost. The
+    shape matters: a model whose first master point the separator *accepts*
+    never restarts, so a hook installed on it is never called and every
+    assertion about the context it receives is vacuous (CLAUDE.md §6).
+    Optimum 9.0 at ``x = (2, 2, 2)``, all three open.
+    """
+    import discopt.modeling as dm
+
+    m = dm.Model("issue_1066_hook")
+    xs = [m.continuous(f"x{i}", lb=0.0, ub=5.0) for i in range(3)]
+    ys = [m.binary(f"y{i}") for i in range(3)]
+    for xi, yi in zip(xs, ys):
+        m.subject_to(xi <= 5.0 * yi)
+    m.subject_to(sum(xs) >= 4.0)
+    m.minimize(sum((xi - 2.0) ** 2 for xi in xs) + sum(3.0 * yi for yi in ys))
+    return m
+
+
+# --------------------------------------------------------------------------
+# The route wiring: the guard now installs on ``lp_nlp_bb`` too.
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.smoke
+def test_the_guard_installs_on_the_single_tree_method_it_now_routes_to():
+    options, guard = _route_progress_guard_options(None, method_key="lp_nlp_bb", time_limit=60.0)
+    assert isinstance(guard, _RouteProgressGuard)
+    assert options is not None
+    assert options["termination_hook"] is guard
+    # OA needs a soft master deadline to get its hook called at all; the single
+    # tree checks in at each restart, and there is no separate master to deadline.
+    # Passing one would be a kwarg ``solve_lp_nlp_bb`` refuses.
+    assert "master_checkin_deadline" not in options
+
+
+@pytest.mark.smoke
+def test_the_guard_still_declines_for_a_method_that_cannot_call_it():
+    options, guard = _route_progress_guard_options(None, method_key="ecp", time_limit=60.0)
+    assert guard is None
+    assert options is None
+
+
+@pytest.mark.smoke
+def test_the_route_never_installs_its_own_hook_over_the_callers():
+    mine = object()
+    options, guard = _route_progress_guard_options(
+        {"termination_hook": mine}, method_key="lp_nlp_bb", time_limit=60.0
+    )
+    assert guard is None
+    assert options is not None and options["termination_hook"] is mine
+
+
+@pytest.mark.smoke
+def test_the_simplex_master_refuses_a_hook_it_could_never_call():
+    """A budget built on a hook that cannot fire is a fiction (CLAUDE.md §3)."""
+    from discopt.solvers.oa import solve_lp_nlp_bb
+
+    m = _toy_convex_minlp()
+
+    with pytest.raises(NotImplementedError, match="no check-in point"):
+        solve_lp_nlp_bb(m, time_limit=5.0, milp_solver="simplex", termination_hook=lambda _c: False)
+
+
+@pytest.mark.smoke
+def test_the_hook_sees_the_bounds_a_progress_judgement_needs():
+    """And the call count is reported, so 'never fired' cannot read as 'said go'."""
+    from discopt.solvers.oa import solve_lp_nlp_bb
+
+    m = _toy_convex_minlp()
+
+    seen: list[dict] = []
+    res = solve_lp_nlp_bb(
+        m,
+        time_limit=30.0,
+        milp_solver="highs",
+        termination_hook=lambda ctx: seen.append(dict(ctx)) or False,
+    )
+    stats = (res.mip_nlp_trace or {})["summary"]["callback_stats"]
+    assert stats["termination_hook_calls"] == len(seen), (stats, len(seen))
+    assert stats["termination_hook_calls"] > 0, (
+        "the hook never got a check-in on this model, so this test asserts nothing "
+        "about the context it is supposed to receive (CLAUDE.md §6)"
+    )
+    for ctx in seen:
+        assert ctx["event"] == "termination"
+        assert ctx["elapsed"] >= 0.0
+        assert ctx["is_minimization"] is True
+        assert "current_dual_bound" in ctx
+        assert "current_primal_bound" in ctx
+        assert "relative_gap" in ctx
+        assert ctx["restarts"] >= 1
+    assert res.status == "optimal", res.status
+    assert res.objective == pytest.approx(9.0, abs=1e-4)
+
+
+@pytest.mark.smoke
+def test_a_hook_that_says_stop_ends_the_solve_and_is_named_as_the_reason():
+    """The clock and the hook share a callback; the reason must not conflate them."""
+    from discopt.solvers.oa import solve_lp_nlp_bb
+
+    res = solve_lp_nlp_bb(
+        _toy_convex_minlp(),
+        time_limit=300.0,  # nowhere near reached, so "time_limit" would be a lie
+        milp_solver="highs",
+        termination_hook=lambda _ctx: True,
+    )
+    trace = res.mip_nlp_trace or {}
+    assert trace["termination_reason"] == "termination_hook"
+    assert trace["summary"]["callback_stats"]["terminated"] is True
+    assert res.status != "optimal"
+    # A stopped route still owes the caller a sound bound.
+    if res.bound is not None and res.objective is not None:
+        assert res.bound <= res.objective + 1e-6
+
+
+def _tree_that_lasts():
+    """A MILP whose *tree* really runs, plus a separator that restarts it.
+
+    The two-variable toy above never enters the branch-and-bound loop -- HiGHS
+    finishes it in presolve -- so it exercises the restart check-in and nothing
+    else. This one (45 binaries, seeded, ~0.15 s) produces both kinds of check-in
+    in the same solve: one restart and, unthrottled, a few hundred in-tree polls.
+    """
+    rng = np.random.default_rng(7)
+    n = 45
+    c = -rng.integers(5, 60, size=n).astype(float)
+    a_ub = rng.integers(1, 40, size=(6, n)).astype(float)
+    b_ub = a_ub.sum(axis=1) * 0.32
+    state = {"k": 0}
+
+    def _sep(x):
+        """Veto any incumbent that opens too many items, three times over."""
+        if state["k"] < 3 and x.sum() > 12 - state["k"]:
+            state["k"] += 1
+            return [(np.ones(n), 12.0 - state["k"])]
+        return None
+
+    return {
+        "c": c,
+        "A_ub": a_ub,
+        "b_ub": b_ub,
+        "bounds": [(0.0, 1.0)] * n,
+        "integrality": np.ones(n, dtype=int),
+        "lazy_callback": _sep,
+    }
+
+
+@pytest.mark.smoke
+@pytest.mark.parametrize("fixture", ["presolved", "tree"])
+def test_installing_a_hook_must_not_change_the_answer(fixture):
+    """The sticky-flag regression, and the reason the poll writes it on every path.
+
+    HiGHS hands every callback the same ``HighsCallbackInput``. The separator sets
+    ``user_interrupt`` to request a restart; if the interrupt poll then returns
+    without restating the flag, the *rebuilt* tree is interrupted before it has
+    done anything. Measured on the two-variable model: 7 restarts / optimal 9.0
+    with no hook became 1 restart / feasible 15.0 with one. A hook that never says
+    stop has to be invisible.
+    """
+    if fixture == "presolved":
+        kw = dict(
+            c=_C,
+            A_ub=_A_UB,
+            b_ub=_B_UB,
+            bounds=_BOUNDS,
+            integrality=_INTEGRALITY,
+            lazy_callback=_veto_until(1.0),
+        )
+        hooked_kw = dict(kw, lazy_callback=_veto_until(1.0))
+    else:
+        kw = _tree_that_lasts()
+        hooked_kw = _tree_that_lasts()  # the separator is stateful; give each a fresh one
+
+    plain = solve_milp_with_lazy_cuts(**kw)
+    hooked = solve_milp_with_lazy_cuts(
+        **hooked_kw,
+        terminate_callback=lambda _snap: False,
+        terminate_poll_s=0.0,  # poll as hard as possible: the worst case for stickiness
+    )
+    assert hooked.status == plain.status
+    assert hooked.objective == pytest.approx(plain.objective)
+    assert hooked.callback_stats["restarts"] == plain.callback_stats["restarts"]
+    assert hooked.callback_stats["lazy_cuts"] == plain.callback_stats["lazy_cuts"]
+
+
+@pytest.mark.smoke
+def test_the_in_tree_poll_fires_and_the_interval_is_what_bounds_it():
+    """Restarts alone are not a clock; the in-tree poll is what makes one."""
+    unthrottled = solve_milp_with_lazy_cuts(
+        **_tree_that_lasts(),
+        terminate_callback=lambda _snap: False,
+        terminate_poll_s=0.0,
+    )
+    throttled = solve_milp_with_lazy_cuts(
+        **_tree_that_lasts(),
+        terminate_callback=lambda _snap: False,
+        terminate_poll_s=3600.0,  # longer than this solve, so only restarts check in
+    )
+    assert throttled.callback_stats["terminate_polls"] == throttled.callback_stats["restarts"]
+    assert (
+        unthrottled.callback_stats["terminate_polls"] > throttled.callback_stats["terminate_polls"]
+    ), "the interval did not bound anything -- the in-tree poll never fired"
+
+
+@pytest.mark.smoke
+def test_a_stop_from_inside_the_tree_is_honoured_and_attributed():
+    calls = []
+
+    def _stop_on_the_first_in_tree_look(snap):
+        calls.append(snap["context"])
+        return snap["context"] == "interrupt"
+
+    res = solve_milp_with_lazy_cuts(
+        **_tree_that_lasts(),
+        terminate_callback=_stop_on_the_first_in_tree_look,
+        terminate_poll_s=0.0,
+    )
+    assert "interrupt" in calls, "the in-tree poll never fired, so this asserts nothing"
+    assert res.callback_stats["terminated"] is True
+    assert res.callback_stats["terminate_context"] == "interrupt"
+    assert res.status != SolveStatus.OPTIMAL
+
+
+@pytest.mark.smoke
+def test_a_negative_poll_interval_is_refused():
+    with pytest.raises(ValueError, match="non-negative"):
+        solve_milp_with_lazy_cuts(
+            **_tree_that_lasts(),
+            terminate_callback=lambda _snap: False,
+            terminate_poll_s=-1.0,
+        )
+
+
+def _separator_outlives_the_certificate():
+    """A convex MINLP whose separator keeps cutting long after the gap is closed.
+
+    Eight symmetric on/off units, four of which must open: the master enumerates
+    equivalent integer assignments and the separator vetoes each one, so the
+    restart loop keeps going (75 restarts, measured) well past the instant the
+    master's dual bound meets the NLP incumbent. Optimum 0.008 with four units at
+    ``x = 0.5``... the point is not the number, it is that the certificate becomes
+    available early and the separator does not stop.
+    """
+    import discopt.modeling as dm
+
+    m = dm.Model("issue_1066_certificate")
+    xs = [m.continuous(f"x{i}", lb=0.0, ub=3.0) for i in range(8)]
+    ys = [m.binary(f"y{i}") for i in range(8)]
+    for xi, yi in zip(xs, ys):
+        m.subject_to(xi <= 3.0 * yi)
+    m.subject_to(sum(xs) >= 4.0)
+    m.minimize(sum((xi - 0.5) ** 2 for xi in xs) + 0.001 * sum(ys))
+    return m
+
+
+@pytest.mark.smoke
+def test_the_single_tree_stops_when_its_own_bound_certifies_the_incumbent():
+    """It used to run on until the separator ran dry, the clock ran out, or a hook fired.
+
+    ``rsyn0820m02m`` is the reporter row this cost: bound 1092.1600 against
+    incumbent 1092.0911 -- gap 6.3e-5, inside the 1e-4 default -- at 5.1 s of a
+    60 s limit, then five more trees and ``feasible`` at the wall.
+    """
+    res = _separator_outlives_the_certificate().solve(time_limit=60)
+    stats = res.mip_nlp_trace["summary"]["callback_stats"]
+
+    assert stats["dual_bound_observations"] > 0, (
+        "no check-in carried a dual bound, so the early exit was never asked "
+        "anything -- this test would pass on a driver that cannot certify at all"
+    )
+    assert stats["converged_early"] is True
+    assert stats["restarts"] > 1, "the separator ran dry on its own; nothing was cut short"
+    assert res.mip_nlp_trace["termination_reason"] == "gap_tolerance"
+    assert str(res.status) in ("SolveStatus.OPTIMAL", "optimal")
+    # The certificate has to hold on the reported numbers, not just internally.
+    assert res.bound <= res.objective + 1e-6 + 1e-4 * abs(res.objective)
+
+
+@pytest.mark.smoke
+def test_the_early_exit_stays_out_of_the_way_when_the_separator_finishes_first():
+    """Not every model needs it, and on those it must change nothing."""
+    res = _toy_convex_minlp().solve(time_limit=30)
+    stats = res.mip_nlp_trace["summary"]["callback_stats"]
+    assert stats["dual_bound_observations"] > 0
+    assert stats["converged_early"] is False
+    assert stats["terminated"] is False
+    assert res.objective == pytest.approx(9.0, abs=1e-6)

--- a/python/tests/test_issue_1066_route_raise_fallback.py
+++ b/python/tests/test_issue_1066_route_raise_fallback.py
@@ -1,0 +1,83 @@
+"""#1066: an auto-routed MIP-NLP solve that RAISES must fall back, not propagate.
+
+The convex-MINLP router retargeted from ``oa`` to ``lp_nlp_bb`` on the HiGHS
+master. That master refuses -- loudly, and correctly -- to accept a lazy cut
+whose coefficients it cannot represent on an unbounded column, rather than
+silently dropping terms. But a refusal from an algorithm the *router* picked is
+not an answer to give the caller: on the 104-instance route panel (2026-08-29)
+``st_test1`` and ``st_test5`` were ``optimal`` on the default path and came back
+as ``HiGHS rejected the master model`` once the retarget sent them to the
+single-tree master.
+
+So an auto-routed raise is treated exactly like an auto-routed non-certificate:
+spend the rest of the budget on the default path. An EXPLICIT
+``solver="mip-nlp"`` still raises -- the caller chose the algorithm.
+"""
+
+import discopt.modeling as dm
+import discopt.solver as solver_mod
+import discopt.solvers.mip_nlp as mip_nlp_mod
+import pytest
+
+
+def _convex_minlp():
+    """A small convex MINLP the auto-route accepts (miqp, integral, convex)."""
+    m = dm.Model("route_raise")
+    x = m.continuous("x", lb=0.0, ub=10.0)
+    y = m.binary("y")
+    m.subject_to(x >= 2.0 * y)
+    m.subject_to(x + y >= 1.5)
+    m.minimize((x - 3.0) ** 2 + y)
+    return m
+
+
+def _routed(model, monkeypatch):
+    """Confirm the router actually picks a MIP-NLP method for this model."""
+    monkeypatch.setenv("DISCOPT_CONVEX_MINLP_ROUTE", "1")
+    method, reason, _opts = solver_mod._convex_minlp_auto_route(model)
+    return method, reason
+
+
+class _Boom(RuntimeError):
+    pass
+
+
+def test_auto_routed_raise_falls_back_to_the_default_path(monkeypatch):
+    model = _convex_minlp()
+    method, reason = _routed(model, monkeypatch)
+    # Anti-vacuity (CLAUDE.md §6): if the router declines this model the rest of
+    # the test exercises nothing at all.
+    assert method is not None, f"router declined the fixture: {reason}"
+
+    calls = []
+
+    def _raising(*args, **kwargs):
+        calls.append(1)
+        raise _Boom("HiGHS rejected the master model")
+
+    monkeypatch.setattr(mip_nlp_mod, "solve_mip_nlp", _raising)
+
+    result = model.solve(time_limit=30.0, gap_tolerance=1e-4)
+
+    assert calls, "the routed solve never ran, so nothing raised"
+    assert result is not None
+    assert result.status == "optimal", result.status
+    # The fallback is recorded, not silent -- the whole point of #1059's
+    # ``algorithm_route`` field.
+    assert result.algorithm_route is not None
+    assert "_Boom" in result.algorithm_route or "raised" in result.algorithm_route
+    # y=0 admits x=3 (x >= 1.5 binds loosely), so the optimum is 0.0.
+    assert result.objective == pytest.approx(0.0, abs=1e-4)
+
+
+def test_explicit_mip_nlp_still_raises(monkeypatch):
+    """No fallback when the caller named the algorithm."""
+    model = _convex_minlp()
+
+    def _raising(*args, **kwargs):
+        raise _Boom("HiGHS rejected the master model")
+
+    monkeypatch.setattr(mip_nlp_mod, "solve_mip_nlp", _raising)
+
+    with pytest.raises(_Boom):
+        model.solve(solver="mip-nlp", time_limit=30.0, gap_tolerance=1e-4)


### PR DESCRIPTION
## What this is

The external benchmark report behind #1066 said the convex MINLP suite runs the
wrong algorithm by default. Four commits, each with its own measurement:

1. **`93ef1ce7`** — a warning from HiGHS is not a rejected cut row. The lazy-cut
   path treated a HiGHS *warning* return as a refusal and dropped the row.
2. **`2acb8f82`** — the #1059 convex auto-route targets `lp_nlp_bb` on the HiGHS
   master rather than `oa`. Same certificates, one tree instead of a sequence of
   them.
3. **`5be6b0ce`** — the single-tree driver now stops when its own dual bound
   certifies its incumbent. It previously ended only when the separator ran dry,
   the clock expired, or a caller's hook fired, so a run holding a valid
   certificate for most of its budget was still reported `feasible` at the wall.
4. **`b463bf4b`** — the debugger CLI test needs a spatial tree to stop in, and
   the routed solve no longer opens one for its model.

## The measurement

The 15 instances named in the report, default settings, 60 s, one arm,
`CHECKS_EXECUTED 30 VIOLATIONS 0`, load 4–5:

| | reported | after retarget | after certificate exit |
|---|---|---|---|
| certified | 8/15 | 10/15 | **12/15** |

Row-level, where it moved:

| instance | before | after |
|---|---|---|
| `rsyn0820m02m` | feasible, 31.7 s | **optimal, 15.2 s** |
| `rsyn0840m` | optimal, 8.3 s | optimal, 3.0 s |
| `rsyn0820m` | optimal, 5.3 s | optimal, 2.1 s |
| `rsyn0830m` | optimal, 5.1 s | optimal, 4.2 s |

No row regressed; no bound crossed its reference optimum on any row.

`rsyn0820m02m` is the row that shows what commit 3 fixes. Traced at defaults, its
master bound reached 1092.1600 against the NLP incumbent 1092.0911 — relative gap
6.3e-5, inside the 1e-4 default — at **5.1 s of 60**. The loop then rebuilt its
tree five more times and was cut at the route wall with `feasible`. The answer was
never wrong; the driver just never looked at it.

The early exit is sound rather than a tolerance tweak: the master is a relaxation
of the MINLP (its cuts are supporting hyperplanes of convex functions, which is
what `master_bound_valid` asserts), and a MIP tree's dual bound bounds its own
optimum whether the tree finished or was interrupted. It is the same test the
driver already ran after the master returned, read at the moment it becomes true.

## What is still short of the bar

Three rows: `squfl020-150` (5.38%), `squfl025-040` (8.77%),
`portfol_classical050_1` (1.81%). They are **not** blocked on anything in this PR,
and the route is what is carrying them — measured with the route off,
`squfl025-040` reports 477% rather than 8.77%.

Both ends are short on those rows, so a better incumbent alone would not certify
them. The entry experiment that localises it: on MINLPLib's hand-encoded
perspective variant, discopt finds `squfl025-040persp` at **197.33389** — the
exact optimum, against 214.64 on the plain form — but the bound collapses to 0,
because that encoding leaves the convex path. So the missing lever is a
*disaggregated* perspective epigraph inside the master (one epigraph variable per
separable term, carrying the Frangioni–Gentile cut), not a model rewrite and not
more time. That is a master-formulation change — it moves the column layout the
binary-expansion machinery, row-length invariants and mip_start extension are all
written against — and it is filed separately rather than smuggled in here.

`#1066` therefore stays open; this PR takes it from 8/15 to 12/15.

## Verification

- `pytest -m smoke` — 1136 passed, 1 skipped, 2 xpassed
- `pytest -m slow python/tests/test_adversarial_recent_fixes.py` — 19 passed
- every test file naming `lp_nlp_bb` — 248 passed
- new `python/tests/test_issue_1066_lp_nlp_bb_progress_budget.py` — 17 tests
- `ruff`, `ruff format --check`, `mypy` clean on all touched modules
- Rust untouched, so no `cargo test`
- §5 graduation panel: base vs head over all **104 route-firing corpus
  instances**, 60 s per arm, arms run back to back per instance so a load
  excursion hits both (CLAUDE.md §9). 103 pairs completed, 305 executed checks.

  **Cert-clean.** Zero bounds above their reference optimum in either arm; zero
  incumbents below their reference optimum; no `optimal` row lost a valid bound.

  **Net-positive.** Solved to optimality **73 -> 91**. Total wall over all
  instances **2455.9 s -> 1075.2 s**. Per-pair (20% wall band): 39 wins, 27
  losses, 37 ties.

  The panel also found the one regression this PR's last commit fixes: four
  head-arm instances returned no result at all, two of them (`st_test1`,
  `st_test5`) `optimal` on base. The cause was the HiGHS master correctly
  refusing an unrepresentable lazy cut and the refusal propagating out of an
  algorithm the *router* picked. `st_test1` and `st_test5` are `optimal` again
  after the fallback commit; `netmod_kar1`/`netmod_kar2` no longer raise but do
  not recover their incumbent in the time the fallback is left, which is a
  marginal row and not a certificate regression.

Contributes to #1066.
