### PR TITLE
feat(#1066): a disaggregated perspective epigraph for the single-tree master

### DIFF
--- a/python/discopt/_relax/perspective.py
+++ b/python/discopt/_relax/perspective.py
@@ -63,7 +63,11 @@ from .term_classifier import _compute_var_offset
 
 logger = logging.getLogger(__name__)
 
-__all__ = ["perspective_objective_terms", "perspective_oa_cut_enabled"]
+__all__ = [
+    "perspective_objective_terms",
+    "perspective_oa_cut_enabled",
+    "perspective_disaggregation_enabled",
+]
 
 #: Coefficients below this are treated as structurally zero when reading the
 #: objective Hessian. Matches the classifier's own quadratic-term tolerance.
@@ -286,3 +290,34 @@ def perspective_oa_cut_enabled() -> bool:
     import, so a test can flip it without reloading.
     """
     return os.environ.get("DISCOPT_PERSPECTIVE_OA_CUT", "1").strip() not in ("", "0")
+
+
+def perspective_disaggregation_enabled() -> bool:
+    """Is the #1066 *disaggregated* perspective epigraph switched on?
+
+    The strengthening above puts the perspective correction into the master's
+    single aggregate objective epigraph row, so what the master gets each round
+    is ``sup_z sum_i g_i(z)`` -- the sum of the per-term perspective cuts taken
+    at one *common* reference point. The disaggregated form gives each term its
+    own epigraph column, so the master's own LP relaxation combines each term's
+    best reference independently and gets ``sum_i sup_z g_i(z)``, which is the
+    full perspective closure and never weaker.
+
+    Measured on the real instances before implementing (CLAUDE.md §4), as the
+    cutting-plane closure of the master's LP relaxation with the binaries
+    relaxed to ``[0, 1]``:
+
+    ==============  ==========  =========  ==========  ============
+    instance        aggregate   disagg.    optimum     disagg. % opt
+    ==============  ==========  =========  ==========  ============
+    squfl015-060      173.401   362.941     366.622        99.0%
+    ==============  ==========  =========  ==========  ============
+
+    The aggregate arm was still climbing after 250 cutting-plane rounds and
+    51.6 s; the disaggregated arm converged in 41 rounds and 5.9 s.
+
+    **Default OFF** pending the CLAUDE.md §5 graduation panel:
+    ``DISCOPT_PERSPECTIVE_DISAGG=1`` switches it on. Read per call, not cached at
+    import, so a test can flip it without reloading.
+    """
+    return os.environ.get("DISCOPT_PERSPECTIVE_DISAGG", "0").strip() not in ("", "0")

--- a/python/discopt/_relax/perspective.py
+++ b/python/discopt/_relax/perspective.py
@@ -316,8 +316,31 @@ def perspective_disaggregation_enabled() -> bool:
     The aggregate arm was still climbing after 250 cutting-plane rounds and
     51.6 s; the disaggregated arm converged in 41 rounds and 5.9 s.
 
-    **Default OFF** pending the CLAUDE.md §5 graduation panel:
-    ``DISCOPT_PERSPECTIVE_DISAGG=1`` switches it on. Read per call, not cached at
-    import, so a test can flip it without reloading.
+    **Default ON** since the CLAUDE.md §5 graduation panel of 2026-08-29: 111
+    instances (the 104 that reach the convex auto-route, plus the seven rows the
+    #1066 report names that the route panel did not already carry), ON vs OFF,
+    interleaved arm-by-arm per instance at a 60 s limit and default settings.
+
+    ==========================  ==========  ==========
+    metric                      OFF         ON
+    ==========================  ==========  ==========
+    solved to optimality        98          **99**
+    total wall, all instances   1398.5 s    **1348.9 s**
+    total nodes                 298 840     **292 065**
+    status regressions          --          0
+    ==========================  ==========  ==========
+
+    *Cert-clean*: 438 executed checks, 0 violations -- no bound above its
+    reference optimum, no incumbent below one, no instance that certified with
+    the flag OFF failing to certify with it ON, and no solve error on either arm.
+    *Net-positive*: one instance gains a certificate (``squfl025-040``, whose
+    dual bound moves 143.83 -> 197.33 against a 197.334 optimum and which
+    finishes in 32.5 s instead of exhausting the limit), and the aggregate wall
+    and node counts both fall. The only material single-instance slowdown is
+    ``slay07h`` (23.9 -> 27.5 s), still optimal.
+
+    ``DISCOPT_PERSPECTIVE_DISAGG=0`` is the opt-out and keeps the aggregate path
+    exactly as it was. Read per call, not cached at import, so a test can flip it
+    without reloading.
     """
-    return os.environ.get("DISCOPT_PERSPECTIVE_DISAGG", "0").strip() not in ("", "0")
+    return os.environ.get("DISCOPT_PERSPECTIVE_DISAGG", "1").strip() not in ("", "0")

--- a/python/discopt/solvers/oa.py
+++ b/python/discopt/solvers/oa.py
@@ -871,6 +871,11 @@ class _MasterMILPData:
     slack_index: Optional[int]
     integer_binary_expansion: Optional["_IntegerBinaryExpansion"] = None
     integer_binary_start: Optional[int] = None
+    #: #1066: first column of the disaggregated perspective epigraph block, one
+    #: column per term in ``perspective_terms``. ``None`` means the master
+    #: carries the single aggregate epigraph and nothing else.
+    perspective_start: Optional[int] = None
+    perspective_terms: tuple[tuple[int, int, float], ...] = ()
 
 
 @dataclass(frozen=True)
@@ -1184,8 +1189,23 @@ def _extend_master_mip_start(
     if master.use_objective_epigraph:
         if mip_start_objective is None or not np.isfinite(float(mip_start_objective)):
             return None
+        eta_value = float(mip_start_objective)
+        if master.perspective_start is not None:
+            # eta carries the residual objective in a disaggregated master, so a
+            # start that put the whole objective here would violate the very
+            # epigraph rows it is meant to satisfy.
+            term_values = np.array(
+                [q * start[xc] * start[xc] for xc, _yc, q in master.perspective_terms],
+                dtype=np.float64,
+            )
+            eta_value -= float(term_values.sum())
+            for k, value in enumerate(term_values):
+                lo_k, hi_k = master.bounds[master.perspective_start + k]
+                full[master.perspective_start + k] = min(
+                    max(float(value), float(lo_k)), float(hi_k)
+                )
         lo, hi = master.bounds[next_index]
-        full[next_index] = min(max(float(mip_start_objective), float(lo)), float(hi))
+        full[next_index] = min(max(eta_value, float(lo)), float(hi))
     if master.slack_index is not None:
         lo, hi = master.bounds[master.slack_index]
         full[master.slack_index] = min(max(0.0, float(lo)), float(hi))
@@ -2340,6 +2360,188 @@ def _strengthen_objective_cut_perspective(coeffs, rhs, x_star, n_vars, terms):
     return coeffs, rhs, applied
 
 
+#: #1066 §6 telemetry, the disaggregated counterparts of the counter above:
+#: how many per-term epigraph rows were emitted, and how many objective cuts
+#: were *refused* because a reference coordinate was not finite. A panel arm
+#: reporting zero rows ran the aggregate master whatever the flag said.
+_PERSPECTIVE_DISAGG_ROWS: list[int] = [0]
+_PERSPECTIVE_DISAGG_REFUSED: list[int] = [0]
+
+
+def _perspective_disagg_enabled() -> bool:
+    """Thin re-export so ``oa.py`` does not import ``solver.py`` (cycle)."""
+    from discopt._relax.perspective import perspective_disaggregation_enabled
+
+    return perspective_disaggregation_enabled()
+
+
+@dataclass
+class _PerspectiveEpigraph:
+    """One epigraph column per separable perspective term (#1066).
+
+    The master's aggregate ``eta`` is left covering only the *residual*
+    objective ``f - sum_k q_k x_k**2``; each term gets its own column ``s_k``
+    and its own Frangioni-Gentile rows
+
+        ``2*q*z*x_k - q*z**2*y_k - s_k <= 0``
+
+    one per reference ``z`` the search visits. The master objective is
+    ``eta + sum_k s_k``, so the sum is still a valid underestimator of ``f``
+    (each row is valid on both integral values of ``y_k`` -- see
+    ``_relax.perspective``), and the master's LP relaxation is free to pick a
+    *different* reference for each term at a fractional point, which is the one
+    thing the aggregate row cannot do.
+    """
+
+    terms: tuple[tuple[int, int, float], ...]
+    rows: list[tuple[int, float]] = field(default_factory=list)
+    _seen: set[tuple[int, float]] = field(default_factory=set)
+    #: Column-wise copies of ``terms`` and of the pooled references, so a whole
+    #: pool can be scored in one vectorised pass. The pool reaches tens of
+    #: thousands of rows on the squfl family (69 NLP solves x ~930 live terms,
+    #: measured on squfl025-040); materialising a dense master row per pool
+    #: entry just to test it for violation cost more than the cuts bought.
+    _x_cols: np.ndarray = field(default_factory=lambda: np.zeros(0, dtype=np.intp))
+    _y_cols: np.ndarray = field(default_factory=lambda: np.zeros(0, dtype=np.intp))
+    _q: np.ndarray = field(default_factory=lambda: np.zeros(0, dtype=np.float64))
+    _row_k: list[int] = field(default_factory=list)
+    _row_z: list[float] = field(default_factory=list)
+    #: Row indices created since the last drain. A per-term row born with the
+    #: aggregate cut it was split out of must reach the master *with* it: it is
+    #: exactly tight at the point it was generated from, so a violation filter
+    #: scores it at 0 and drops it, and the term's ``s_k`` is then left free at
+    #: its lower bound while the residual row it was subtracted from is already
+    #: in. That asymmetry -- and not the disaggregation itself -- is what made
+    #: the first cut of this report a *looser* dual bound than the aggregate
+    #: row on squfl025-040 (120.652 vs 142.510).
+    _pending: list[int] = field(default_factory=list)
+
+    def __post_init__(self) -> None:
+        self._x_cols = np.array([t[0] for t in self.terms], dtype=np.intp)
+        self._y_cols = np.array([t[1] for t in self.terms], dtype=np.intp)
+        self._q = np.array([t[2] for t in self.terms], dtype=np.float64)
+
+    def add(self, k: int, z: float) -> bool:
+        """Record a reference for term ``k``; False if it is already carried."""
+        key = (int(k), float(z))
+        if key in self._seen:
+            return False
+        self._seen.add(key)
+        self.rows.append(key)
+        self._row_k.append(int(k))
+        self._row_z.append(float(z))
+        self._pending.append(len(self.rows) - 1)
+        _PERSPECTIVE_DISAGG_ROWS[0] += 1
+        return True
+
+    def drain_pending(self) -> list[int]:
+        """Row indices created since the last call, and clear the list."""
+        pending = self._pending
+        self._pending = []
+        return pending
+
+    def violations(self, master_x, *, perspective_start: int) -> np.ndarray:
+        """``a^T x`` of every pooled row (rhs is 0), vectorised over the pool."""
+        if not self.rows:
+            return np.zeros(0, dtype=np.float64)
+        x = np.asarray(master_x, dtype=np.float64).ravel()
+        ks = np.asarray(self._row_k, dtype=np.intp)
+        zs = np.asarray(self._row_z, dtype=np.float64)
+        q = self._q[ks]
+        scores = (
+            2.0 * q * zs * x[self._x_cols[ks]]
+            - q * zs * zs * x[self._y_cols[ks]]
+            - x[perspective_start + ks]
+        )
+        return np.asarray(scores, dtype=np.float64)
+
+    def row_for(self, index: int, *, n_master: int, perspective_start: int) -> np.ndarray:
+        k, z = self.rows[index]
+        x_col, y_col, q = self.terms[k]
+        row = np.zeros(n_master, dtype=np.float64)
+        row[x_col] = 2.0 * q * z
+        row[y_col] = -q * z * z
+        row[perspective_start + k] = -1.0
+        return row
+
+    def term_values(self, x) -> np.ndarray:
+        """``q_k * x_k**2`` per term: the epigraph values at a point."""
+        arr = np.asarray(x, dtype=np.float64).ravel()
+        return np.array([q * arr[xc] * arr[xc] for xc, _yc, q in self.terms], dtype=np.float64)
+
+
+def _perspective_epigraph_for(terms, n_vars: int) -> Optional[_PerspectiveEpigraph]:
+    """Build the epigraph, or ``None`` when the term table cannot carry one.
+
+    Every term must be usable: the split below removes *all* of them from every
+    aggregate row, so a term that can be removed from one row and not another
+    would leave the master double-counting it -- an over-estimate of ``f``, i.e.
+    an invalid bound. Refuse the whole disaggregation rather than part of it.
+    """
+    if not terms:
+        return None
+    for x_col, y_col, q in terms:
+        if not (0 <= int(x_col) < n_vars and 0 <= int(y_col) < n_vars):
+            return None
+        if not np.isfinite(q) or q <= 0.0:
+            return None
+    return _PerspectiveEpigraph(terms=tuple((int(a), int(b), float(c)) for a, b, c in terms))
+
+
+def _disaggregate_objective_cut(coeffs, rhs, x_star, epigraph: _PerspectiveEpigraph):
+    """Move every perspective term out of an aggregate epigraph row.
+
+    ``coeffs``/``rhs`` are ``grad^T x - eta <= rhs``; term ``k`` contributes
+    ``2*q*z`` to ``coeffs[x_col]`` and ``q*z**2`` to ``rhs`` (the tangent's
+    ``grad.z - f(z)``), so removing it is exact arithmetic and leaves the row a
+    valid tangent of the residual objective. The term is re-added as its own
+    perspective row against ``s_k``.
+
+    Returns ``(coeffs, rhs)``, or ``None`` when a reference coordinate is not
+    finite -- in which case the caller must drop the cut entirely rather than
+    emit a row that removes some terms and not others.
+    """
+    for x_col, _y_col, _q in epigraph.terms:
+        if not np.isfinite(float(x_star[x_col])):
+            _PERSPECTIVE_DISAGG_REFUSED[0] += 1
+            return None
+    for k, (x_col, _y_col, q) in enumerate(epigraph.terms):
+        z = float(x_star[x_col])
+        coeffs[x_col] -= 2.0 * q * z
+        rhs -= q * z * z
+        if z != 0.0:
+            # z == 0 makes the row ``0 <= s_k``, which the column bound already
+            # says; the removal above still has to happen either way.
+            epigraph.add(k, z)
+    return coeffs, rhs
+
+
+def _split_or_strengthen_objective_cut(
+    evaluator, coeffs, rhs, x_star, n_vars, *, strengthen_aggregate: bool = True
+):
+    """Apply whichever perspective treatment this master is configured for.
+
+    ``strengthen_aggregate=False`` opts a call site out of the #1064 in-place
+    strengthening while keeping the #1066 split, which every site that writes
+    into a disaggregated master must take. It is how the ECP site stays
+    bound-neutral when disaggregation is off: #1064 graduated on a panel that
+    measured the OA site only.
+
+    Returns ``(coeffs, rhs)`` or ``None`` to mean "do not emit this cut".
+    """
+    epigraph = getattr(evaluator, "_perspective_epigraph", None)
+    if epigraph is not None:
+        return _disaggregate_objective_cut(coeffs, rhs, x_star, epigraph)
+    terms = getattr(evaluator, "_perspective_oa_terms", None)
+    if terms and strengthen_aggregate:
+        coeffs, rhs, n_applied = _strengthen_objective_cut_perspective(
+            coeffs, rhs, x_star, n_vars, terms
+        )
+        if n_applied:
+            _PERSPECTIVE_OA_CUT_APPLIED[0] += n_applied
+    return coeffs, rhs
+
+
 def _add_oa_cuts(
     evaluator,
     x_star,
@@ -2460,17 +2662,18 @@ def _add_oa_cuts(
         obj_cut = generate_objective_oa_cut(evaluator, x_star, n_master, z_index=n_vars)
         obj_coeffs_row = obj_cut.coeffs.copy()
         obj_rhs = float(obj_cut.rhs)
-        # #1064: strengthen the aggregate tangent with the perspective of every
-        # separable convex square over a semicontinuous variable. Globally valid
-        # (see ``_relax.perspective``), so ``global_valid=True`` below is
-        # unchanged, and a no-op when the model has no such structure.
-        _persp_terms = getattr(evaluator, "_perspective_oa_terms", None)
-        if _persp_terms:
-            obj_coeffs_row, obj_rhs, _n_persp = _strengthen_objective_cut_perspective(
-                obj_coeffs_row, obj_rhs, x_star, n_vars, _persp_terms
-            )
-            if _n_persp:
-                _PERSPECTIVE_OA_CUT_APPLIED[0] += _n_persp
+        # #1064/#1066: treat the perspective of every separable convex square
+        # over a semicontinuous variable -- either strengthening this aggregate
+        # row in place, or splitting the terms out into their own epigraph
+        # columns. Globally valid either way (see ``_relax.perspective``), so
+        # ``global_valid=True`` below is unchanged, and a no-op when the model
+        # has no such structure.
+        _split = _split_or_strengthen_objective_cut(
+            evaluator, obj_coeffs_row, obj_rhs, x_star, n_vars
+        )
+        if _split is None:
+            return
+        obj_coeffs_row, obj_rhs = _split
         _append_master_cut(
             oa_A_rows,
             oa_b_rows,
@@ -2634,16 +2837,32 @@ def _add_ecp_cuts(
                     local_added += 1
                 n_added += 1
 
+    _ecp_obj_coeffs = None
+    _ecp_obj_rhs = None
+    obj_support = None
     if not obj_is_linear and objective_is_convex:
         n_master = n_vars + 1
         obj_value = float(evaluator.evaluate_objective(x_master))
         obj_support = np.concatenate([np.asarray(x_master, dtype=np.float64), [obj_value]])
         obj_cut = generate_objective_oa_cut(evaluator, x_master, n_master, z_index=n_vars)
+        # Same perspective treatment as the OA site: an ECP objective row lands
+        # in the *same* master, so leaving a term in this row while the OA rows
+        # split it out would double-count it against the epigraph columns.
+        _split = _split_or_strengthen_objective_cut(
+            evaluator,
+            obj_cut.coeffs.copy(),
+            float(obj_cut.rhs),
+            x_master,
+            n_vars,
+            strengthen_aggregate=False,
+        )
+        _ecp_obj_coeffs, _ecp_obj_rhs = _split if _split is not None else (None, None)
+    if _ecp_obj_coeffs is not None:
         _append_master_cut(
             oa_A_rows,
             oa_b_rows,
-            obj_cut.coeffs.copy(),
-            obj_cut.rhs,
+            _ecp_obj_coeffs,
+            _ecp_obj_rhs,
             oa_cut_relaxable,
             relaxable=False,
             cut_provenance=cut_provenance,
@@ -2886,6 +3105,17 @@ def _add_esh_cuts(
             )
 
     if not obj_is_linear and objective_epigraph_available:
+        if getattr(evaluator, "_perspective_epigraph", None) is not None:
+            # An ESH objective hyperplane is built, filtered and possibly
+            # discarded downstream, so it cannot carry the all-or-nothing term
+            # split a disaggregated master requires. The two are never combined
+            # (``solve_lp_nlp_bb`` refuses to disaggregate under a SHOT
+            # profile); refuse loudly rather than emit a row that double-counts
+            # every perspective term against its own epigraph column.
+            raise RuntimeError(
+                "ESH objective hyperplanes cannot be generated into a master "
+                "with a disaggregated perspective epigraph (#1066)"
+            )
         n_master = n_vars + 1
         objective_global_valid = bool(objective_is_convex)
         obj_value = float(evaluator.evaluate_objective(support))
@@ -3178,6 +3408,7 @@ def _build_master_milp_data(
     oa_cut_relaxable=None,
     use_objective_epigraph=None,
     integer_binary_expansion: Optional[_IntegerBinaryExpansion] = None,
+    perspective_epigraph: Optional[_PerspectiveEpigraph] = None,
 ) -> _MasterMILPData:
     """Build matrix data for an OA-style MILP master."""
     # ``use_objective_epigraph`` controls master layout when supplied; the
@@ -3202,6 +3433,23 @@ def _build_master_milp_data(
     if integer_binary_expansion is not None and integer_binary_expansion.bit_count > 0:
         integer_binary_start = n_master
         n_master += integer_binary_expansion.bit_count
+    # #1066: the disaggregated perspective epigraph is appended *after* every
+    # existing block, so ``n_vars``, the eta column, the slack column and the
+    # binary-expansion offsets all keep the values the rest of this module is
+    # written against, and a stored row shorter than the master still maps by
+    # prefix copy with zeros in the new columns.
+    perspective_start = None
+    n_perspective = 0
+    if perspective_epigraph is not None:
+        if not use_objective_epigraph:
+            raise ValueError(
+                "a disaggregated perspective epigraph needs the objective "
+                "epigraph column: the split leaves eta covering the residual "
+                "objective, and without eta the residual has nowhere to go"
+            )
+        n_perspective = len(perspective_epigraph.terms)
+        perspective_start = n_master
+        n_master += n_perspective
 
     # Build A_ub, b_ub from linear <= constraints + OA cuts
     A_ub_rows = []
@@ -3248,6 +3496,16 @@ def _build_master_milp_data(
         A_ub_rows.append(row)
         b_ub_vals.append(oa_b_rows[i])
 
+    if perspective_start is not None:
+        assert perspective_epigraph is not None
+        for row_index in range(len(perspective_epigraph.rows)):
+            A_ub_rows.append(
+                perspective_epigraph.row_for(
+                    row_index, n_master=n_master, perspective_start=perspective_start
+                )
+            )
+            b_ub_vals.append(0.0)
+
     # Equality constraints from linear
     A_eq_rows = []
     b_eq_vals = []
@@ -3285,6 +3543,10 @@ def _build_master_milp_data(
         c[:n_vars] = c_vec
     elif use_objective_epigraph:
         c[n_vars] = 1.0  # minimize eta
+    if perspective_start is not None:
+        # eta now underestimates only the residual objective; the split-out
+        # terms are minimised through their own columns.
+        c[perspective_start : perspective_start + n_perspective] = 1.0
     if slack_index is not None:
         c[slack_index] = oa_penalty_factor
 
@@ -3296,6 +3558,10 @@ def _build_master_milp_data(
         bounds_list.append((0.0, max_slack))
     if integer_binary_expansion is not None and integer_binary_expansion.bit_count > 0:
         bounds_list.extend((0.0, 1.0) for _ in range(integer_binary_expansion.bit_count))
+    if perspective_start is not None:
+        # q_k * x_k**2 >= 0, and the lower bound is what makes the z == 0
+        # reference row redundant rather than missing.
+        bounds_list.extend((0.0, 1e20) for _ in range(n_perspective))
 
     # Integrality
     int_vec = np.zeros(n_master, dtype=np.int32)
@@ -3325,6 +3591,8 @@ def _build_master_milp_data(
         slack_index=slack_index,
         integer_binary_expansion=integer_binary_expansion,
         integer_binary_start=integer_binary_start,
+        perspective_start=perspective_start,
+        perspective_terms=(perspective_epigraph.terms if perspective_epigraph is not None else ()),
     )
 
 
@@ -4406,6 +4674,26 @@ def solve_lp_nlp_bb(
     incumbent_obj: Optional[float] = None
     nlp_subproblem_count = 0
 
+    # #1066: give every separable perspective term its own epigraph column, so
+    # the master's LP relaxation can combine each term's best reference at a
+    # fractional point instead of being held to one common reference per row.
+    # Only on this driver's own master: it builds exactly one, which is what
+    # makes the all-or-nothing term split checkable. Not under a SHOT profile,
+    # whose ESH hyperplanes cannot carry the split (they are filtered after
+    # generation), and not without the epigraph column the residual needs.
+    perspective_epigraph: Optional[_PerspectiveEpigraph] = None
+    if (
+        _perspective_disagg_enabled()
+        and not shot_profile
+        and not decomp.obj_is_linear
+        and decomp.oa_objective_is_convex
+    ):
+        perspective_epigraph = _perspective_epigraph_for(
+            getattr(evaluator, "_perspective_oa_terms", None) or [], n_vars
+        )
+        if perspective_epigraph is not None:
+            evaluator._perspective_epigraph = perspective_epigraph  # type: ignore[attr-defined]
+
     def accept_incumbent(x: np.ndarray, obj: float) -> None:
         nonlocal incumbent, incumbent_obj
         if incumbent_obj is None or obj < incumbent_obj:
@@ -4526,10 +4814,47 @@ def solve_lp_nlp_bb(
         oa_cut_relaxable=oa_cut_relaxable,
         use_objective_epigraph=(not decomp.obj_is_linear and decomp.oa_objective_is_convex),
         integer_binary_expansion=integer_binary_expansion,
+        perspective_epigraph=perspective_epigraph,
+    )
+    #: Perspective epigraph rows already in the master. The build below takes
+    #: whatever the pool holds at that moment; everything the search adds after
+    #: it has to reach the tree as a lazy row like any other cut. Rows that are
+    #: not violated yet stay in the pool and are offered again later rather than
+    #: being dropped -- a term's reference earns its place at a *fractional*
+    #: point, which is the whole reason the epigraph is disaggregated.
+    perspective_rows_emitted = set(
+        range(len(perspective_epigraph.rows)) if perspective_epigraph is not None else ()
     )
 
-    def collect_new_lazy_cuts(start: int, master_x: np.ndarray) -> list[tuple[np.ndarray, float]]:
+    def collect_new_perspective_rows(master_x: np.ndarray) -> list[tuple[np.ndarray, float]]:
+        if perspective_epigraph is None or master.perspective_start is None:
+            return []
         rows: list[tuple[np.ndarray, float]] = []
+        scores = perspective_epigraph.violations(
+            master_x, perspective_start=master.perspective_start
+        )
+        # Freshly split rows go in unconditionally (see ``_pending``); older
+        # pooled rows only when the master point actually violates them.
+        candidates = perspective_epigraph.drain_pending()
+        candidates.extend(np.flatnonzero(scores > 1e-6).tolist())
+        for row_index in candidates:
+            if row_index in perspective_rows_emitted:
+                continue
+            rows.append(
+                (
+                    perspective_epigraph.row_for(
+                        row_index,
+                        n_master=len(master.c),
+                        perspective_start=master.perspective_start,
+                    ),
+                    0.0,
+                )
+            )
+            perspective_rows_emitted.add(row_index)
+        return rows
+
+    def collect_new_lazy_cuts(start: int, master_x: np.ndarray) -> list[tuple[np.ndarray, float]]:
+        rows: list[tuple[np.ndarray, float]] = list(collect_new_perspective_rows(master_x))
         for idx in range(start, len(oa_A_rows)):
             relaxable = bool(oa_cut_relaxable[idx]) if idx < len(oa_cut_relaxable) else True
             row = _format_lazy_master_cut(

--- a/python/tests/test_issue_1066_perspective_disaggregation.py
+++ b/python/tests/test_issue_1066_perspective_disaggregation.py
@@ -1,0 +1,158 @@
+"""#1066: the disaggregated perspective epigraph in the single-tree master.
+
+The shipped (#1064) treatment strengthens the master's ONE aggregate epigraph
+row in place, which yields ``sup_z sum_i g_i(z)`` -- every term forced to share a
+single reference. Giving each separable term ``q_k x_k**2`` its own epigraph
+column ``s_k`` yields ``sum_i sup_z g_i(z)``, the full perspective closure,
+because the master's own LP relaxation combines each term's best reference at a
+fractional point for free.
+
+Measured on the real instances before implementing (CLAUDE.md §4), cutting-plane
+closure of the master LP with binaries relaxed to [0, 1] on ``squfl015-060``
+(optimum 366.6218167): plain 129.998 (35.5%), aggregate 173.401 (47.3%) -- both
+still climbing after 250 rounds -- disaggregated **362.941 (99.0%)**, converged
+in 41 rounds.
+
+Default OFF pending the §5 graduation panel; ``DISCOPT_PERSPECTIVE_DISAGG=1``.
+"""
+
+import numpy as np
+import pytest
+from discopt._relax.perspective import perspective_disaggregation_enabled
+from discopt.solvers import oa
+
+
+def _epigraph(terms):
+    ep = oa._perspective_epigraph_for(terms, n_vars=8)
+    assert ep is not None
+    return ep
+
+
+def test_flag_defaults_off_and_reads_the_environment(monkeypatch):
+    monkeypatch.delenv("DISCOPT_PERSPECTIVE_DISAGG", raising=False)
+    assert perspective_disaggregation_enabled() is False
+    monkeypatch.setenv("DISCOPT_PERSPECTIVE_DISAGG", "0")
+    assert perspective_disaggregation_enabled() is False
+    monkeypatch.setenv("DISCOPT_PERSPECTIVE_DISAGG", "1")
+    assert perspective_disaggregation_enabled() is True
+
+
+def test_split_is_all_or_nothing():
+    """A term the split cannot carry refuses the WHOLE disaggregation.
+
+    Removing a term from one aggregate row and not another leaves the master
+    double-counting it against ``s_k`` -- an over-estimate of ``f``, i.e. an
+    invalid bound. Refusal is the only safe answer (CLAUDE.md §1/§3).
+    """
+    assert oa._perspective_epigraph_for([], n_vars=8) is None
+    # column out of range
+    assert oa._perspective_epigraph_for([(0, 1, 2.0), (99, 2, 1.0)], n_vars=8) is None
+    # non-positive / non-finite curvature
+    assert oa._perspective_epigraph_for([(0, 1, 2.0), (2, 3, 0.0)], n_vars=8) is None
+    assert oa._perspective_epigraph_for([(0, 1, np.nan)], n_vars=8) is None
+    # all usable -> built
+    assert oa._perspective_epigraph_for([(0, 1, 2.0), (2, 3, 1.5)], n_vars=8) is not None
+
+
+def test_row_underestimates_the_term_at_both_integral_y():
+    """The Frangioni-Gentile row is valid at y=0 and y=1, which is what makes
+    the disaggregation sound rather than merely tighter."""
+    q, z = 1.75, 2.5
+    ep = _epigraph([(0, 1, q)])
+    ep.add(0, z)
+    n_master, start = 12, 10
+    row = ep.row_for(0, n_master=n_master, perspective_start=start)
+    checks = 0
+    for y in (0.0, 1.0):
+        for x in np.linspace(0.0, 4.0, 25):
+            if y == 0.0 and x != 0.0:
+                continue  # x is semicontinuous: y=0 forces x=0
+            s_true = q * x * x
+            point = np.zeros(n_master)
+            point[0], point[1], point[start] = x, y, s_true
+            # row @ point <= 0 means the cut does not remove the true epigraph point
+            checks += 1
+            assert float(row @ point) <= 1e-9, (x, y, float(row @ point))
+    assert checks > 0, "vacuous: no (x, y) pair was tested"
+
+
+def test_new_rows_are_pending_so_they_reach_the_master_with_their_cut():
+    """A freshly split row is exactly TIGHT at the point it came from, so a
+    violation filter scores it at 0 and drops it. It must be emitted anyway --
+    dropping it left ``squfl025-040``'s dual bound at 120.652 against the
+    aggregate row's 142.510."""
+    ep = _epigraph([(0, 1, 2.0), (2, 3, 1.0)])
+    assert ep.drain_pending() == []
+    assert ep.add(0, 1.5) is True
+    assert ep.add(1, 2.0) is True
+    assert ep.add(0, 1.5) is False, "duplicate reference must not create a row"
+    assert ep.drain_pending() == [0, 1]
+    assert ep.drain_pending() == [], "drain must clear"
+
+
+def test_violations_match_the_dense_row_it_replaces():
+    """The vectorised pool scan and the dense row must agree exactly: the scan
+    is an optimisation of ``row_for(...) @ x``, not a different test."""
+    rng = np.random.default_rng(1066)
+    ep = _epigraph([(0, 1, 2.0), (2, 3, 0.75), (4, 5, 3.25)])
+    for k, z in ((0, 1.5), (1, 0.25), (2, 2.0), (0, 3.0)):
+        ep.add(k, z)
+    n_master, start = 11, 8
+    x = rng.normal(size=n_master)
+    fast = ep.violations(x, perspective_start=start)
+    slow = np.array(
+        [
+            float(ep.row_for(i, n_master=n_master, perspective_start=start) @ x)
+            for i in range(len(ep.rows))
+        ]
+    )
+    assert fast.shape == slow.shape
+    # Not bit-identical: the scan multiplies ``2*q*z*x`` where the dense row
+    # folds ``2*q*z`` into a coefficient first, so the two associate the same
+    # product differently (max observed 3.6e-15 absolute). The 1e-12 band is
+    # tighter than the 1e-6 violation threshold the scan feeds by six orders of
+    # magnitude, so no row can be classified differently by it.
+    np.testing.assert_allclose(fast, slow, rtol=1e-12, atol=1e-12)
+
+
+def test_disaggregating_a_cut_is_exact_arithmetic():
+    """Removing term k from the aggregate row and re-adding its own row must
+    reproduce the aggregate row's value at the reference point."""
+    q0, q1 = 2.0, 0.5
+    ep = _epigraph([(0, 1, q0), (2, 3, q1)])
+    n = 8
+    x_star = np.zeros(n)
+    x_star[0], x_star[2] = 1.5, 3.0
+    # aggregate tangent of f = q0 x0^2 + q1 x2^2 at x_star: grad^T x - eta <= grad.z - f(z)
+    coeffs = np.zeros(n + 1)
+    coeffs[0] = 2.0 * q0 * x_star[0]
+    coeffs[2] = 2.0 * q1 * x_star[2]
+    coeffs[n] = -1.0
+    rhs = q0 * x_star[0] ** 2 + q1 * x_star[2] ** 2
+    split = oa._disaggregate_objective_cut(coeffs.copy(), rhs, x_star, ep)
+    assert split is not None
+    residual_coeffs, residual_rhs = split
+    # every perspective term is gone from the residual row
+    assert residual_coeffs[0] == pytest.approx(0.0, abs=1e-12)
+    assert residual_coeffs[2] == pytest.approx(0.0, abs=1e-12)
+    assert residual_rhs == pytest.approx(0.0, abs=1e-12)
+    assert residual_coeffs[n] == -1.0, "the eta column must survive the split"
+    # and both terms got a row at their own reference
+    assert sorted(ep.rows) == [(0, 1.5), (1, 3.0)]
+
+
+def test_a_non_finite_reference_drops_the_cut_entirely():
+    ep = _epigraph([(0, 1, 2.0), (2, 3, 1.0)])
+    x_star = np.zeros(8)
+    x_star[2] = np.inf
+    before = oa._PERSPECTIVE_DISAGG_REFUSED[0]
+    assert oa._disaggregate_objective_cut(np.zeros(9), 0.0, x_star, ep) is None
+    assert oa._PERSPECTIVE_DISAGG_REFUSED[0] == before + 1
+    assert ep.rows == [], "a refused cut must not leave half its terms split out"
+
+
+def test_esh_hyperplanes_refuse_a_disaggregated_master():
+    """Refuse loudly rather than write an aggregate objective row into a master
+    whose epigraph has already been split (CLAUDE.md §3)."""
+    source = open(oa.__file__).read()
+    assert "ESH objective hyperplanes cannot be generated into a master" in source

--- a/python/tests/test_issue_1066_perspective_disaggregation.py
+++ b/python/tests/test_issue_1066_perspective_disaggregation.py
@@ -13,7 +13,9 @@ closure of the master LP with binaries relaxed to [0, 1] on ``squfl015-060``
 still climbing after 250 rounds -- disaggregated **362.941 (99.0%)**, converged
 in 41 rounds.
 
-Default OFF pending the §5 graduation panel; ``DISCOPT_PERSPECTIVE_DISAGG=1``.
+Default ON since the §5 graduation panel of 2026-08-29 (111 instances, ON vs
+OFF interleaved: 99 vs 98 solved, 1348.9 s vs 1398.5 s total wall, 438 executed
+checks, 0 violations); ``DISCOPT_PERSPECTIVE_DISAGG=0`` is the opt-out.
 """
 
 import numpy as np
@@ -28,9 +30,10 @@ def _epigraph(terms):
     return ep
 
 
-def test_flag_defaults_off_and_reads_the_environment(monkeypatch):
+def test_flag_defaults_on_and_the_opt_out_still_works(monkeypatch):
+    """Graduated default-ON, with the ``=0`` opt-out kept intact (CLAUDE.md §5)."""
     monkeypatch.delenv("DISCOPT_PERSPECTIVE_DISAGG", raising=False)
-    assert perspective_disaggregation_enabled() is False
+    assert perspective_disaggregation_enabled() is True
     monkeypatch.setenv("DISCOPT_PERSPECTIVE_DISAGG", "0")
     assert perspective_disaggregation_enabled() is False
     monkeypatch.setenv("DISCOPT_PERSPECTIVE_DISAGG", "1")


### PR DESCRIPTION
## What this changes

The single-tree master's objective epigraph is disaggregated: each perspective
term gets its own epigraph column `s_k` instead of sharing one aggregate row.

An aggregate row makes the master's LP relaxation see `sup_z sum_i g_i(z)` — every
term's perspective cut taken at one *common* reference point. One column per term
lets the LP combine each term's best reference independently, so it sees
`sum_i sup_z g_i(z)` — the full perspective closure, which is never weaker.

Mechanically: `_disaggregate_objective_cut` removes each term's tangent
contribution from the aggregate cut exactly (`2*q*z` off `coeffs[x_col]`,
`q*z**2` off `rhs`) and emits a row `2*q*z*x - q*z^2*y - s_k <= 0` for it. The
`s_k` block is appended last with objective coefficient `1.0` and bounds
`(0, 1e20)`, so the master minimizes `eta + sum_k s_k`, where `eta` now
underestimates only the residual objective. The split is all-or-nothing: a term
the split cannot carry refuses the whole disaggregation, because removing a term
from one aggregate row and not another leaves the master double-counting it —
an over-estimate of `f`, i.e. an invalid bound.

## Entry experiment (CLAUDE.md §4)

Run before implementing, on the real instance, as the cutting-plane closure of
the master LP with binaries relaxed to `[0, 1]`. `squfl015-060`, optimum
366.6218167:

| arm | closure | % of optimum | rounds |
| --- | --- | --- | --- |
| plain | 129.998 | 35.5% | still climbing at 250 |
| aggregate perspective | 173.401 | 47.3% | still climbing at 250 |
| **disaggregated** | **362.941** | **99.0%** | converged in 41 |

## Graduation panel (CLAUDE.md §5)

111 instances — the 104 that reach the convex auto-route plus the seven rows the
#1066 report names that the route panel did not already carry — ON vs OFF, arms
interleaved back to back per instance, 60 s limit, otherwise default settings.

| metric | OFF | ON |
| --- | --- | --- |
| solved to optimality | 98 | **99** |
| total wall, all instances | 1398.5 s | **1348.9 s** |
| total nodes | 298 840 | **292 065** |
| status regressions | — | **0** |

**Cert-clean**: 438 executed checks, 0 violations — no bound above its reference
optimum, no incumbent below one, no certifying instance losing its certificate,
no solve error on either arm.

**Net-positive**: `squfl025-040` gains a certificate (dual bound 143.83 → 197.33
against a 197.334 optimum, 32.5 s instead of exhausting the limit) and both
aggregate wall and node counts fall. The only material single-instance slowdown
is `slay07h`, 23.9 → 27.5 s, still optimal.

So the flag graduates default-ON. `DISCOPT_PERSPECTIVE_DISAGG=0` remains the
opt-out and keeps the aggregate path exactly as it was.

## Falsified and not shipped

Gating the *freshly split* perspective rows on violation (rather than emitting
them unconditionally) was measured on the three `squfl` rows, on the theory that
3000 rows per OA iteration is what starves `squfl020-150` of nodes. It is not:
`squfl020-150` was unchanged (74.3 s vs 77.0 s, `feasible` in both arms, same
incumbent), `squfl015-060` improved and `squfl025-040` got worse. Hypothesis
dead; the probe was removed rather than left in as a flag.

## Effect on the issue's reported set

Measured on this branch at default settings, 60 s, the 15 rows #1066 names:
**13/15 optimal**, against the 8/15 the report recorded. `squfl015-060` and
`squfl025-040` are the two rows this PR moves; `squfl015-060` also needs the
certificate fix merged in #1133 (its bound closes to 4.5e-14 of the incumbent,
which the old exit path still labelled `feasible`).

## Verification

- `pytest -m smoke` — 1137 passed, 1 skipped, 2 xpassed
- `pytest -m slow python/tests/test_adversarial_recent_fixes.py` — 19 passed
- `pytest python/tests/test_issue_1066_perspective_disaggregation.py` — 8 passed
- No Rust touched, so `cargo test -p discopt-core` was not run.

Contributes to #1066 (two of the three rows still open when it was filed; see the
issue for what remains).
