### PR TITLE
fix(#1066): a closed gap at the wall is a certificate, not "feasible"

### DIFF
--- a/python/discopt/solvers/oa.py
+++ b/python/discopt/solvers/oa.py
@@ -45,6 +45,7 @@ from discopt.solvers.mip_nlp_options import (
 
 if TYPE_CHECKING:
     from discopt._relax.nlp_evaluator import NLPEvaluator
+    from discopt.solvers import SolveStatus
 
 logger = logging.getLogger(__name__)
 
@@ -3890,6 +3891,79 @@ def _compute_gap(lb: float, ub: float) -> float:
     return optimality_gap(lb, ub, denom_floor=1.0)
 
 
+def _lp_nlp_bb_exit_status(
+    *,
+    converged_early: bool,
+    callback_terminated: bool,
+    master_status: "SolveStatus",
+    has_incumbent: bool,
+    master_bound_valid: bool,
+    gap: Optional[float],
+    gap_tolerance: float,
+    hook_stopped_before_wall: bool,
+) -> tuple[str, Optional[str]]:
+    """The status and termination reason :func:`solve_lp_nlp_bb` exits with.
+
+    Split out of the driver so the decision can be tested at every combination of
+    its inputs rather than only at whichever ones a 60-second solve happens to
+    produce.
+
+    The last clause is the one with teeth. A certificate the driver already holds
+    does not stop being a certificate because the *clock* -- rather than the gap
+    test -- is what ended the search. ``master_bound_valid`` says the master is a
+    relaxation of the MINLP, and a MIP tree's dual bound bounds its own optimum
+    whether the tree finished or was cut off mid-search, so ``gap <=
+    gap_tolerance`` on that bound is the same certificate a converged run reports.
+    Before this, a run that ended on the wall was reported ``feasible`` even with
+    the gap closed: ``squfl015-060`` at default settings finished with dual bound
+    366.6218167383147 against incumbent 366.62181673996474 -- a relative gap of
+    4.5e-14 against a 1e-4 tolerance -- and reported ``feasible``.
+
+    ``termination_reason`` is deliberately NOT rewritten to ``gap_tolerance`` when
+    that clause fires: the search really did stop on the clock, and the trace
+    should keep saying so. Status answers "is the answer proven"; the reason
+    answers "why did the loop end". They are different questions.
+    """
+    from discopt.solvers import SolveStatus
+
+    status = "feasible"
+    termination_reason: Optional[str] = None
+    if converged_early and has_incumbent:
+        # Stopped on the certificate, not on the clock or the caller's option.
+        termination_reason = "gap_tolerance"
+        status = "optimal" if gap is not None and gap <= gap_tolerance else "feasible"
+    elif callback_terminated:
+        # The clock and the hook both come back through the same callback, so name
+        # whichever one it was rather than reporting a time limit that may not have
+        # been reached.
+        termination_reason = "termination_hook" if hook_stopped_before_wall else "time_limit"
+        status = "time_limit" if not has_incumbent else "feasible"
+    elif master_status == SolveStatus.INFEASIBLE:
+        status = "infeasible"
+    elif master_status == SolveStatus.TIME_LIMIT:
+        status = "time_limit" if not has_incumbent else "feasible"
+    elif master_status == SolveStatus.ITERATION_LIMIT:
+        status = "iteration_limit" if not has_incumbent else "feasible"
+    elif master_status == SolveStatus.OPTIMAL and has_incumbent:
+        status = "optimal" if gap is not None and gap <= gap_tolerance else "feasible"
+    elif not has_incumbent:
+        status = "no_feasible_point"
+    if (
+        status == "feasible"
+        and has_incumbent
+        and master_bound_valid
+        and gap is not None
+        and gap <= gap_tolerance
+    ):
+        # ``gap`` comes from :func:`_compute_gap`, which reports 1.0 -- never a
+        # small number -- when the bound ordering is materially inverted, so a
+        # broken certificate cannot reach this branch (see ``solvers._gap``).
+        status = "optimal"
+    if termination_reason is None:
+        termination_reason = status
+    return status, termination_reason
+
+
 def solve_feasibility_pump(
     model: Model,
     time_limit: float = 3600.0,
@@ -4606,7 +4680,7 @@ def solve_lp_nlp_bb(
         )
         return rows
 
-    from discopt.solvers import MILPResult, SolveStatus
+    from discopt.solvers import MILPResult
 
     solve_milp_with_lazy_cuts: Callable[..., MILPResult]
     if lazy_backend == "gurobi":
@@ -4749,34 +4823,18 @@ def solve_lp_nlp_bb(
     callback_stats["dual_bound_observations"] = int(bound_observations[0])
     callback_stats["converged_early"] = bool(converged_at[0] is not None)
     callback_terminated = bool(callback_stats.get("terminated"))
-    status = "feasible"
-    termination_reason: Optional[str] = None
-    if converged_at[0] is not None and incumbent is not None:
-        # Stopped on the certificate, not on the clock or the caller's option.
-        termination_reason = "gap_tolerance"
-        status = "optimal" if gap is not None and gap <= gap_tolerance else "feasible"
-    elif callback_terminated:
-        # The clock and the hook both come back through the same callback, so name
-        # whichever one it was rather than reporting a time limit that may not have
-        # been reached.
-        termination_reason = (
-            "termination_hook"
-            if hook is not None and (time.perf_counter() - t_start) < float(time_limit)
-            else "time_limit"
-        )
-        status = "time_limit" if incumbent is None else "feasible"
-    elif master_result.status == SolveStatus.INFEASIBLE:
-        status = "infeasible"
-    elif master_result.status == SolveStatus.TIME_LIMIT:
-        status = "time_limit" if incumbent is None else "feasible"
-    elif master_result.status == SolveStatus.ITERATION_LIMIT:
-        status = "iteration_limit" if incumbent is None else "feasible"
-    elif master_result.status == SolveStatus.OPTIMAL and incumbent is not None:
-        status = "optimal" if gap is not None and gap <= gap_tolerance else "feasible"
-    elif incumbent is None:
-        status = "no_feasible_point"
-    if termination_reason is None:
-        termination_reason = status
+    status, termination_reason = _lp_nlp_bb_exit_status(
+        converged_early=converged_at[0] is not None,
+        callback_terminated=callback_terminated,
+        master_status=master_result.status,
+        has_incumbent=incumbent is not None,
+        master_bound_valid=bool(master_bound_valid),
+        gap=gap,
+        gap_tolerance=gap_tolerance,
+        hook_stopped_before_wall=(
+            hook is not None and (time.perf_counter() - t_start) < float(time_limit)
+        ),
+    )
 
     trace_bound_validity = (
         "global"

--- a/python/tests/test_912_wall_budget_inventory.py
+++ b/python/tests/test_912_wall_budget_inventory.py
@@ -409,7 +409,15 @@ KNOWN: tuple[tuple[str, str, str], ...] = (
     ),
     (
         "solvers/oa.py",
-        "return (time.perf_counter() - t_start) >= float(time_limit)",
+        "if (time.perf_counter() - t_start) >= float(time_limit):",
+        "contract",
+    ),
+    (
+        # The single-tree driver asks whether the wall or the termination hook is
+        # what stopped it, so the exit status can name the right reason. Reads the
+        # caller's own ``time_limit``; decides nothing about how much work to do.
+        "solvers/oa.py",
+        "hook is not None and (time.perf_counter() - t_start) < float(time_limit)",
         "contract",
     ),
     (

--- a/python/tests/test_issue_1066_certificate_at_time_limit.py
+++ b/python/tests/test_issue_1066_certificate_at_time_limit.py
@@ -1,0 +1,137 @@
+"""#1066: a closed gap on a valid bound is a certificate even at the wall.
+
+``solve_lp_nlp_bb`` decided its exit status from *how the loop ended* and only
+then, on two of the branches, looked at the gap. A run cut off by the clock was
+reported ``feasible`` even when the master's own dual bound already certified the
+incumbent -- measured on ``squfl015-060`` at default settings: dual bound
+366.6218167383147 against incumbent 366.62181673996474, a relative gap of 4.5e-14
+against the 1e-4 default, reported ``feasible``.
+
+The decision now lives in :func:`_lp_nlp_bb_exit_status`, which these tests drive
+directly at every combination its inputs can take.
+"""
+
+from __future__ import annotations
+
+import discopt.modeling as dm
+import pytest
+from discopt.solvers import SolveStatus
+from discopt.solvers.oa import _lp_nlp_bb_exit_status, solve_lp_nlp_bb
+
+TOL = 1e-4
+
+
+def _status(**over):
+    kw = dict(
+        converged_early=False,
+        callback_terminated=False,
+        master_status=SolveStatus.OPTIMAL,
+        has_incumbent=True,
+        master_bound_valid=True,
+        gap=0.5,
+        gap_tolerance=TOL,
+        hook_stopped_before_wall=False,
+    )
+    kw.update(over)
+    return _lp_nlp_bb_exit_status(**kw)
+
+
+def test_a_closed_gap_at_the_wall_is_optimal():
+    """The regression: the clock ended the loop, but the certificate stands."""
+    status, reason = _status(callback_terminated=True, gap=4.5e-14)
+    assert status == "optimal"
+    # The search really did stop on the clock and the trace keeps saying so --
+    # status answers "is it proven", the reason answers "why did the loop end".
+    assert reason == "time_limit"
+
+
+def test_an_open_gap_at_the_wall_is_still_feasible():
+    """The kill criterion: the upgrade must not fire on an unconverged run."""
+    status, reason = _status(callback_terminated=True, gap=0.5)
+    assert status == "feasible"
+    assert reason == "time_limit"
+
+
+def test_a_closed_gap_on_an_invalid_bound_is_not_a_certificate():
+    """``master_bound_valid`` is the whole warrant for the upgrade."""
+    assert _status(callback_terminated=True, gap=0.0, master_bound_valid=False)[0] == "feasible"
+
+
+def test_no_bound_at_all_is_not_a_certificate():
+    assert _status(callback_terminated=True, gap=None)[0] == "feasible"
+
+
+def test_no_incumbent_at_the_wall_stays_time_limit():
+    status, reason = _status(callback_terminated=True, has_incumbent=False, gap=None)
+    assert status == "time_limit"
+    assert reason == "time_limit"
+
+
+def test_the_hook_is_named_when_it_stopped_before_the_wall():
+    status, reason = _status(callback_terminated=True, hook_stopped_before_wall=True, gap=0.5)
+    assert (status, reason) == ("feasible", "termination_hook")
+
+
+def test_the_early_exit_keeps_its_own_reason():
+    status, reason = _status(converged_early=True, gap=0.0)
+    assert (status, reason) == ("optimal", "gap_tolerance")
+
+
+@pytest.mark.parametrize(
+    "master_status,expected",
+    [
+        (SolveStatus.INFEASIBLE, "infeasible"),
+        (SolveStatus.TIME_LIMIT, "feasible"),
+        (SolveStatus.ITERATION_LIMIT, "feasible"),
+        (SolveStatus.OPTIMAL, "feasible"),
+    ],
+)
+def test_master_status_branches_with_an_open_gap(master_status, expected):
+    """Every non-callback branch keeps the meaning it had before the split."""
+    assert _status(master_status=master_status, gap=0.5)[0] == expected
+
+
+def test_an_iteration_limit_without_an_incumbent_is_reported_as_such():
+    assert (
+        _status(master_status=SolveStatus.ITERATION_LIMIT, has_incumbent=False, gap=None)[0]
+        == "iteration_limit"
+    )
+
+
+def test_no_feasible_point_when_nothing_ended_the_loop():
+    assert (
+        _status(master_status=SolveStatus.ERROR, has_incumbent=False, gap=None)[0]
+        == "no_feasible_point"
+    )
+
+
+def test_the_driver_actually_consults_the_helper(monkeypatch):
+    """Anti-vacuity (CLAUDE.md §6): a helper nothing calls proves nothing.
+
+    Every assertion above is on a pure function. This one solves a real convex
+    MINLP through ``solve_lp_nlp_bb`` and fails if the driver reached its exit
+    without asking.
+    """
+    calls: list[dict] = []
+    import discopt.solvers.oa as oa
+
+    real = oa._lp_nlp_bb_exit_status
+
+    def spy(**kw):
+        calls.append(dict(kw))
+        return real(**kw)
+
+    monkeypatch.setattr(oa, "_lp_nlp_bb_exit_status", spy)
+
+    m = dm.Model("convex_minlp")
+    x = m.continuous("x", lb=0.0, ub=10.0)
+    y = m.binary("y")
+    m.subject_to(x >= 2 * y)
+    m.subject_to(x + y >= 1.5)
+    m.minimize((x - 3) ** 2 + y)
+    result = solve_lp_nlp_bb(m, time_limit=30.0, gap_tolerance=TOL)
+
+    assert len(calls) == 1, f"the driver exited without consulting the helper: {calls}"
+    assert calls[0]["gap_tolerance"] == TOL
+    assert result.status == "optimal"
+    assert result.objective == pytest.approx(0.0, abs=1e-6)


### PR DESCRIPTION

`solve_lp_nlp_bb` decided its exit status from *how the loop ended* and only then,
on two of the six branches, looked at the gap. The branch that fires when the
callback stops the search -- the clock, or a caller's termination hook -- set
`status = "feasible"` unconditionally whenever an incumbent existed, without ever
consulting the bound sitting right next to it.

5be6b0ce fixed the adjacent half of this: it made the driver *stop* when its own
bound certifies the incumbent. This is the other half -- what to report when the
driver did not get to stop on its own. The bound is the same object in both cases.
`master_bound_valid` says the master is a relaxation of the MINLP, and a MIP tree's
dual bound bounds its own optimum whether the tree finished or was cut off
mid-search, so `gap <= gap_tolerance` on that bound is the same certificate a
converged run reports. Reporting it as `feasible` is not conservative, it is wrong:
it throws away a proof the solver holds.

Measured, `squfl015-060` at default settings (60 s, `gap_tolerance=1e-4`, with the
disaggregated perspective epigraph of #1066 supplying the tight bound):

    dual bound  366.6218167383147
    incumbent   366.62181673996474
    relative gap 4.5e-14          reported status: feasible

The gap is ten orders of magnitude inside the tolerance. Without the tight bound
the clause is inert -- on the 104-instance route panel of PR #1131, 0 of the 7
`feasible` rows that carried both a bound and an incumbent had a closed gap -- so
this changes no status that was previously correct.

`termination_reason` is deliberately NOT rewritten to `gap_tolerance` when the new
clause fires. The search really did stop on the clock and the trace should keep
saying so: status answers "is the answer proven", the reason answers "why did the
loop end". Two different questions, two fields.

The decision moved out of the driver into `_lp_nlp_bb_exit_status`, a pure
function, so it can be tested at every combination of its inputs rather than only
at whichever ones a 60-second solve happens to produce. The extraction is
behaviour-preserving except for the one new clause.

Verification: 14 tests in
`python/tests/test_issue_1066_certificate_at_time_limit.py` -- the new clause, its
kill criteria (an open gap, an invalid bound, no bound, no incumbent), the
preserved meaning of every other branch, and an anti-vacuity test (CLAUDE.md §6)
that solves a real convex MINLP through `solve_lp_nlp_bb` and fails if the driver
reached its exit without consulting the helper. ruff, ruff format and mypy clean
on `oa.py`. Rust untouched.

Contributes to #1066.
