### PR TITLE
perf(#1066): the MIP-NLP cut-provenance ledger cost more than generating the cuts

### DIFF
--- a/python/discopt/solvers/oa.py
+++ b/python/discopt/solvers/oa.py
@@ -368,7 +368,20 @@ def _validate_external_termination(
 
 
 def _float_tuple(values) -> tuple[float, ...]:
-    return tuple(float(v) for v in np.asarray(values, dtype=np.float64).reshape(-1))
+    """The row as a tuple of Python floats.
+
+    ``ndarray.tolist()`` is the same conversion the element-wise ``float(v)``
+    generator did -- a ``float64`` becomes a Python ``float``, with identical
+    value, equality and hash -- but it runs in C over the whole buffer instead of
+    building one generator frame per element. That matters because this is the
+    per-cut cost of the provenance ledger, paid on the FULL master width for every
+    row: profiled on ``squfl020-150`` (3020 columns) at a 60 s limit, the
+    generator alone was 159.5 M calls and 11.5 s, and ``add_row`` 20.8 s
+    cumulative -- 31% of the solve spent recording cuts rather than generating
+    them. The values are unchanged, so this is bound-neutral by construction
+    (CLAUDE.md §5): same coefficients, same dedup keys, same tree.
+    """
+    return tuple(np.asarray(values, dtype=np.float64).reshape(-1).tolist())
 
 
 def _row_violation(

--- a/python/tests/test_issue_1066_cut_provenance_row_conversion.py
+++ b/python/tests/test_issue_1066_cut_provenance_row_conversion.py
@@ -1,0 +1,104 @@
+"""#1066: the MIP-NLP cut-provenance ledger must not do per-element Python work.
+
+Every generated master cut is recorded with its full coefficient row, and the row
+is the FULL master width. Converting it one element at a time made recording the
+cuts cost more than generating them: profiled on ``squfl020-150`` (3020 columns)
+at the default 60 s limit, the element-wise generator alone accounted for
+159,557,152 calls / 11.5 s tottime and ``add_row`` 20.8 s cumulative -- 31% of a
+67 s solve.
+
+The conversion itself is unchanged (``float64 -> float``), so this is
+bound-neutral by construction (CLAUDE.md §5). These tests pin both halves: that
+the values, types and hashes are identical to the element-wise conversion, and
+that the per-element Python frame is gone -- the property that a future
+"tidy-up" back to a comprehension would silently undo.
+"""
+
+import sys
+
+import numpy as np
+from discopt.solvers.oa import MIPNLPCutRecord, _float_tuple
+
+
+def _elementwise(values) -> tuple[float, ...]:
+    """The conversion this replaced. The reference for both value and cost."""
+    return tuple(float(v) for v in values)
+
+
+def _genexpr_frames(fn, arg) -> int:
+    """Python generator frames entered while ``fn(arg)`` runs.
+
+    ``sys.setprofile`` reports a ``call`` event every time a generator frame is
+    entered or resumed, so this counts exactly the per-element Python work the
+    fix removes. Counting frames -- not wall time -- keeps the assertion
+    deterministic under load (CLAUDE.md §9).
+    """
+    seen = [0]
+
+    def _hook(frame, event, _arg):
+        if event == "call" and frame.f_code.co_name == "<genexpr>":
+            seen[0] += 1
+
+    sys.setprofile(_hook)
+    try:
+        fn(arg)
+    finally:
+        sys.setprofile(None)
+    return seen[0]
+
+
+def test_conversion_is_indistinguishable_from_the_elementwise_one():
+    """Same values, same types, same hashes -- so same dedup keys, same tree."""
+    rng = np.random.default_rng(1066)
+    cases = [
+        np.array([]),
+        np.array([0.0]),
+        np.array([1.0, 2.5, -3.0]),
+        np.array([1e20, -0.0, 3.0, -1e-18]),
+        rng.normal(size=257),
+        rng.normal(size=(1, 64)),  # a 2-D row: reshape(-1) must flatten it
+        [1, 2, 3],  # ints must widen to float, as float(v) did
+        np.float64(7.0),  # a 0-d value is a one-element row
+    ]
+    checks = 0
+    for case in cases:
+        got = _float_tuple(case)
+        want = _elementwise(np.asarray(case, dtype=np.float64).reshape(-1))
+        assert got == want, case
+        assert all(type(x) is float for x in got), case
+        assert hash(got) == hash(want), case
+        checks += 1
+    assert checks == len(cases), "vacuous: not every shape was converted"
+
+
+def test_no_python_frame_per_element():
+    """The regression guard: the row is converted in C, not one element at a time.
+
+    Before the fix this counted 3021 frames on a 3020-column row -- the shape of
+    ``squfl020-150``'s master.
+    """
+    row = np.arange(3020, dtype=np.float64)
+    reference = _genexpr_frames(_elementwise, row)
+    assert reference > len(row), (
+        "the counter measured nothing -- it must see the element-wise generator "
+        f"it is the control for (saw {reference})"
+    )
+    assert _genexpr_frames(_float_tuple, row) == 0
+
+
+def test_the_record_still_keys_and_dedups_on_the_row():
+    """The ledger's dedup key is the converted row, so it must stay hashable and
+    compare equal for two spellings of the same cut."""
+    coeffs = np.array([1.5, -2.0, 0.0, 3.25])
+    point = np.array([0.5, 0.25, 0.0, 1.0])
+    a = MIPNLPCutRecord.from_row(
+        "objective", coeffs, 4.0, global_valid=True, supporting_point=point
+    )
+    b = MIPNLPCutRecord.from_row(
+        "objective", list(coeffs), 4.0, global_valid=True, supporting_point=list(point)
+    )
+    assert a.dedup_key == b.dedup_key
+    assert len({a.dedup_key, b.dedup_key}) == 1
+    assert a.coefficients == _elementwise(coeffs)
+    assert a.supporting_point == _elementwise(point)
+    assert a.violation == b.violation


### PR DESCRIPTION
## What

`_float_tuple` converts a master cut's coefficient row into a tuple of Python
floats for the MIP-NLP provenance ledger's dedup key. It did so one element at a
time, and every recorded cut pays it twice (coefficients + supporting point) on
the **full master width**.

Profiling a default 60 s solve of `squfl020-150` (3020 master columns) — the row
#1066 reports as finding the exact optimum and never certifying:

| function | ncalls | tottime | cumtime |
|---|---:|---:|---:|
| `oa.py:371(<genexpr>)` (inside `_float_tuple`) | 159,557,152 | 11.464 s | — |
| `_float_tuple` | 52,816 | 0.812 s | 17.274 s |
| `add_row` | 26,408 | 0.183 s | **20.805 s** |

**20.8 s of a 67.1 s solve — 31% — went to recording cuts rather than generating
them.**

`ndarray.tolist()` is the same conversion (a `float64` becomes a Python `float`
with identical value, equality and hash), run in C over the whole buffer.

## Why this is bound-neutral, and the evidence

The values are unchanged, so the coefficients, the dedup keys and the search tree
are unchanged by construction (CLAUDE.md §5, bound-neutral regime).

Measured anyway, patched tree vs a detached worktree at `eb0edefe`, **interleaved
per instance**, 60 s, default settings, one solve per subprocess with the §8
marker asserted **present** in the patched arm and **absent** in the control:

| instance | status p/c | nodes p/c | objective identical | wall p | wall c |
|---|---|---|---|---|---:|---:|
| batchs101006m | optimal/optimal | 2694/2694 | yes | 14.7 | 15.3 |
| clay0203m | optimal/optimal | 156/156 | yes | 7.9 | 7.9 |
| clay0303m | optimal/optimal | 241/241 | yes | 12.1 | 12.2 |
| cvxnonsep_normcon20 | optimal/optimal | 2243/2243 | yes | 6.8 | 6.5 |
| fac2 | optimal/optimal | 6/6 | yes | 0.4 | 0.3 |
| flay04h | optimal/optimal | 20299/20299 | yes | 17.6 | 17.9 |
| m7_ar2_1 | optimal/optimal | 14666/14666 | yes | 6.6 | 6.6 |
| ravempb | optimal/optimal | 26/26 | yes | 2.9 | 2.9 |
| rsyn0830m02m | optimal/optimal | 2615/2615 | yes | 13.4 | 21.0 |
| slay07m | optimal/optimal | 205/205 | yes | 18.1 | 16.5 |
| syn40m03m | optimal/optimal | 315/315 | yes | 22.5 | 25.4 |
| tls2 | optimal/optimal | 3/3 | yes | 24.1 | 26.6 |
| procurement2mot | optimal/optimal | 75/75 | yes | 13.2 | 14.7 |
| squfl015-060 | optimal/optimal | 13/13 | yes | 34.3 | 35.5 |
| squfl025-040 | **optimal**/feasible | 59/56 | — | 57.0 | 60.8 |
| squfl020-150 | feasible/feasible | 9/9 | yes | 79.3 | 78.0 |

**14 of 14 rows that certified in both arms have exactly identical `node_count`
and exactly identical `objective`.** `CHECKS_EXECUTED 32`.

The two rows that differ are the two that hit the wall clock, where a node count
is a function of how far the solve got, not of the search: `squfl025-040`
certified `optimal` in 57.0 s on the patched arm and timed out at `feasible` on
the control.

Timing caveat (CLAUDE.md §9): the panel ran interleaved, but an unrelated `cargo`
build on this box drove load from ~6 to ~30+ partway through, so the wall column
is directional only. The node/objective equality is unaffected by load.

## Regression guard

`test_no_python_frame_per_element` counts, with `sys.setprofile`, the Python
generator frames entered during the conversion — deterministic under load, unlike
a timing assertion. It counts **3021 on a 3020-column row before this change and
0 after**, and asserts the counter actually sees the element-wise reference it is
the control for, so it cannot pass vacuously (CLAUDE.md §6).

`test_conversion_is_indistinguishable_from_the_elementwise_one` pins value, type
and `hash()` equality across 8 shapes (empty, 0-d, 2-D, int input, ±0.0, 1e20),
and `test_the_record_still_keys_and_dedups_on_the_row` pins the ledger's dedup
key itself.

## Verification run

- `pytest -m smoke` — see comment below
- `pytest -m slow python/tests/test_adversarial_recent_fixes.py` — see comment below
- `pytest python/tests/test_issue_1066_cut_provenance_row_conversion.py` — 3 passed
- No Rust touched, so no `cargo test`.

Contributes to #1066.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019GYp9wAZ2Xt1Mz9rEvLdry
