### PR TITLE
fix(#1066): refuse to publish a master dual bound that has crossed its own incumbent

### DIFF
--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -5746,7 +5746,31 @@ def _merge_route_and_fallback(route, fallback, is_maximize: bool):
         winner.bound = float(l_b)
     obj, bnd = winner.objective, winner.bound
     if obj is not None and bnd is not None and np.isfinite(obj) and np.isfinite(bnd):
-        winner.gap = abs(bnd - obj) / max(abs(obj), 1e-10)
+        # A bound past the incumbent is a broken certificate whichever side it
+        # came from -- the check above covers only the LOSER's bound, so a
+        # winner that arrives already inverted sailed through. Measured on
+        # ``squfl020-150`` at default settings: the OA route won with
+        # ``objective=557.848649973387`` and its own ``bound=557.9460019817818``
+        # (MINLPLib ``=best=`` 557.84865), and this merge published that bound.
+        #
+        # Note what the gap formula below does with such a pair on its own:
+        # ``abs(bnd - obj)`` turns an inversion of 0.097 into a 1.75e-4 gap
+        # that reads as nearly converged -- precisely backwards. The guard has
+        # to come first; the formula cannot detect this case at all.
+        if _bound_crosses_objective(float(bnd), obj, is_maximize):
+            logger.warning(
+                "#1059 merge: the %s side's dual bound %.12g crosses the incumbent "
+                "%.12g it is reported against; suppressing it rather than "
+                "publishing a bound known to be invalid.",
+                "route" if route_wins else "fallback",
+                float(bnd),
+                float(obj),
+            )
+            winner.bound = None
+            winner.gap = None
+            winner.gap_certified = False
+        else:
+            winner.gap = abs(bnd - obj) / max(abs(obj), 1e-10)
     # ``node_count`` is a WORK statistic, not part of the answer, so it belongs to
     # the solve rather than to whichever side won it. Reporting only the winner's
     # made a routed ``squfl025-040`` say ``nodes=0`` after 61 s in which the

--- a/python/discopt/solvers/oa.py
+++ b/python/discopt/solvers/oa.py
@@ -5135,6 +5135,10 @@ def solve_lp_nlp_bb(
     wall_time = time.perf_counter() - t_start
 
     bound = None
+    # The master bound as it stood before the inversion guard below, kept so the
+    # trace still carries the number a diagnosis needs after ``bound`` is
+    # suppressed. ``None`` means the guard did not fire.
+    inverted_master_bound: Optional[float] = None
     if master_bound_valid and master_result.bound is not None:
         bound = float(master_result.bound)
         if decomp.obj_is_linear and decomp.obj_coeffs is not None:
@@ -5145,6 +5149,42 @@ def solve_lp_nlp_bb(
         # if the post-hoc read came back weaker, reporting it would contradict the
         # very test that ended the search and turn a certificate into "feasible".
         bound = converged_at[0] if bound is None else max(bound, converged_at[0])
+    # The master's dual bound crossed the incumbent it is reported against.
+    # ``solve_oa`` has refused to publish that since ``fac2`` (see
+    # ``_certified_bound_inverted``); this path -- the single-tree LP/NLP-BB
+    # driver, a different function -- never got the same guard. Measured on
+    # ``squfl020-150`` (MINLPLib ``=best=`` 557.84865) at default settings: the
+    # HiGHS lazy master returned ``bound=557.9460019817818`` against this
+    # driver's own incumbent ``557.848649973387``, i.e. a *lower* bound 0.097
+    # ABOVE the true optimum, and the run reported it. ``_compute_gap`` already
+    # declines to call that converged (it returns 1.0, documented as "nothing
+    # proved"), but suppressing only the gap still hands the caller ``bound >
+    # objective``, and #1059's route merge republishes exactly that number.
+    #
+    # One of the two is wrong and this code cannot tell which, so neither is
+    # reported as proved. The incumbent survives -- it is an independently
+    # feasibility-checked point -- and the offending number is kept in the
+    # trace as ``inverted_master_bound``, where a diagnostic belongs and nothing
+    # reads it as a dual certificate (CLAUDE.md §1).
+    if (
+        bound is not None
+        and incumbent_obj is not None
+        and np.isfinite(bound)
+        and np.isfinite(incumbent_obj)
+        and float(bound) - float(incumbent_obj)
+        > bound_inversion_tolerance(float(bound), float(incumbent_obj))
+    ):
+        logger.warning(
+            "lp_nlp_bb: master dual bound %.12g is above the incumbent %.12g by "
+            "more than rounding -- one of the two is wrong, so neither the bound "
+            "nor the gap is reported. This is a bound-validity defect worth "
+            "investigating, not a tolerance to widen.",
+            float(bound),
+            float(incumbent_obj),
+        )
+        inverted_master_bound = float(bound)
+        bound = None
+        master_bound_valid = False
     gap = (
         _compute_gap(bound, incumbent_obj)
         if bound is not None and incumbent_obj is not None
@@ -5232,6 +5272,10 @@ def solve_lp_nlp_bb(
         "final_lb": _trace_value(bound),
         "final_ub": _trace_value(incumbent_obj),
         "final_gap": _trace_value(gap),
+        # Only set when the master handed back a bound past the incumbent and
+        # the guard above suppressed it -- the number to investigate, kept out
+        # of ``final_lb`` so nothing reads it as a dual certificate.
+        "inverted_master_bound": _trace_value(inverted_master_bound),
     }
 
     if incumbent is not None and incumbent_obj is not None:

--- a/python/tests/test_issue_1066_master_bound_inversion.py
+++ b/python/tests/test_issue_1066_master_bound_inversion.py
@@ -1,0 +1,157 @@
+"""#1066: neither the single-tree driver nor the #1059 merge may publish a dual
+bound that has crossed the incumbent it is reported against.
+
+Measured on ``squfl020-150`` (MINLPLib, ``=best= 557.84865``) at the issue's own
+defaults (``gap_tolerance=1e-4``, ``time_limit=60``). ``solve_lp_nlp_bb``
+returned ``objective=557.848649973387`` with ``bound=558.0440365723572`` -- a
+*lower* bound 0.0954 **above** its own incumbent -- and the #1059 merge then
+republished it.
+
+Where the 558.044 comes from is settled, and it is not a discopt cut. At the
+restart that produced it the master held 69,330 rows; evaluating the instance's
+true optimum against the matrix **HiGHS itself stored** (``h.getLp()``) gave
+0 violated rows, worst residual 8.35e-15, cost 557.84865. Handing that same
+model back to HiGHS from an MPS file, with no discopt in the loop, reproduces
+the contradiction in isolation:
+
+=========================================  ==============================
+what is fixed at the known optimum          HiGHS returns
+=========================================  ==============================
+all 6,021 columns                           ``kOptimal`` obj **557.84865**,
+                                            ``num_primal_infeasibilities=0``
+only the 20 integer columns (same values)   ``kOptimal`` obj **558.04404**
+=========================================  ==============================
+
+Fixing *more* variables cannot lower an optimum, so the second answer is
+invalid. Ruled out as causes, each by its own arm: retained solver state
+(``clearSolver()`` -- byte-identical trace), growing the instance with
+``addRow`` after ``run()`` (a fresh ``Highs`` per restart -- byte-identical
+558.0440365723572), presolve (same MPS, ``presolve=off`` -- identical
+558.0440365723573), and tolerances (``mip_feasibility_tolerance=1e-9`` moved it
+the wrong way, to 558.0653).
+
+So the master's dual bound cannot be trusted unconditionally, and discopt's
+obligation is the one CLAUDE.md §1 states: never publish a bound known to be
+invalid. ``solve_oa`` has refused this since the ``fac2`` incident (#1059) via
+``_certified_bound_inverted``; the single-tree path and the merge's *winner*
+had no such guard. These tests pin both.
+"""
+
+from __future__ import annotations
+
+import discopt.modeling as dm
+import discopt.solvers.milp_highs as milp_highs
+import discopt.solvers.oa as oa
+import numpy as np
+import pytest
+from discopt.modeling.core import SolveResult
+from discopt.solver import _merge_route_and_fallback
+
+SQUFL_OBJ = 557.848649973387
+# Two inverted bounds were observed on this instance across runs; both are used
+# below because they exercise different halves of the defect.
+SQUFL_BAD_BOUND = 558.0440365723572  # inversion 0.1954, naive gap 3.50e-4
+SQUFL_ROUTE_BOUND = 557.9460019817818  # inversion 0.0974, naive gap 1.75e-4
+
+
+def _sr(objective, bound, *, gap_certified=False, status="feasible", node_count=0):
+    return SolveResult(
+        status=status,
+        objective=objective,
+        bound=bound,
+        gap_certified=gap_certified,
+        gap=None,
+        node_count=node_count,
+        x={},
+    )
+
+
+@pytest.mark.unit
+class TestMergeGuardsTheWinnersBound:
+    """``_merge_route_and_fallback`` checked only the *loser's* bound."""
+
+    def test_the_squfl020_150_winner_bound_is_suppressed(self):
+        route = _sr(SQUFL_OBJ, SQUFL_BAD_BOUND)
+        fallback = _sr(1197.972555976441, 382.43)
+        merged = _merge_route_and_fallback(route, fallback, False)
+        assert merged.objective == pytest.approx(SQUFL_OBJ)
+        assert merged.bound is None, "a bound above the incumbent must not be published"
+        assert merged.gap is None
+        assert merged.gap_certified is False
+
+    def test_the_inversion_is_not_laundered_into_a_small_gap(self):
+        """The old ``abs(bnd - obj) / max(|obj|, 1e-10)`` read this pair as 1.75e-4.
+
+        That is *below* the issue's own 1e-4-scale tolerance band -- an
+        inversion of 0.0954 presented as "nearly converged", precisely
+        backwards. Whatever the merge reports, it must never be a small gap.
+        """
+        route = _sr(SQUFL_OBJ, SQUFL_ROUTE_BOUND)
+        merged = _merge_route_and_fallback(route, _sr(1197.97, None), False)
+        naive = abs(SQUFL_ROUTE_BOUND - SQUFL_OBJ) / max(abs(SQUFL_OBJ), 1e-10)
+        assert naive < 2e-4, "premise check: the naive formula really is this flattering"
+        assert merged.bound is None
+        assert merged.gap is None or merged.gap > naive
+
+    def test_maximize_direction_is_inverted(self):
+        """For a maximize model the bound is an UPPER bound; below is the crossing."""
+        merged = _merge_route_and_fallback(_sr(-70.0, -211.0), _sr(-500.0, None), True)
+        assert merged.objective == pytest.approx(-70.0)
+        assert merged.bound is None
+
+    def test_a_sound_winner_bound_still_reports_its_gap(self):
+        """Anti-vacuity (CLAUDE.md §6): the guard must not suppress everything."""
+        merged = _merge_route_and_fallback(_sr(100.0, 90.0), _sr(500.0, 10.0), False)
+        assert merged.bound == pytest.approx(90.0)
+        assert merged.gap == pytest.approx(0.1, rel=1e-9)
+
+    def test_rounding_at_scale_is_not_treated_as_a_crossing(self):
+        merged = _merge_route_and_fallback(
+            _sr(331837498.1769339, 331837498.1769349), _sr(4e8, None), False
+        )
+        assert merged.bound is not None, "1 ulp at |obj|~3e8 is noise, not a broken certificate"
+
+
+@pytest.mark.unit
+def test_lp_nlp_bb_refuses_a_master_bound_above_its_incumbent(monkeypatch):
+    """Drive the real driver with a master whose bound has been corrupted.
+
+    The corruption is applied to the *real* master result, so everything else
+    about the solve is genuine -- only the number under test is wrong. This is
+    the ``squfl020-150`` shape reproduced deterministically: without the guard
+    the driver publishes ``bound > objective``.
+    """
+    real = milp_highs.solve_milp_with_lazy_cuts
+    inflated: list[float] = []
+
+    def corrupt(*args, **kwargs):
+        res = real(*args, **kwargs)
+        if res.bound is not None and np.isfinite(res.bound):
+            res.bound = float(res.bound) + 50.0
+            inflated.append(res.bound)
+        return res
+
+    monkeypatch.setattr(milp_highs, "solve_milp_with_lazy_cuts", corrupt)
+
+    m = dm.Model("convex_minlp")
+    x = m.continuous("x", lb=0.0, ub=10.0)
+    y = m.binary("y")
+    m.subject_to(x >= 2 * y)
+    m.subject_to(x + y >= 1.5)
+    m.minimize((x - 3) ** 2 + y)
+    result = oa.solve_lp_nlp_bb(m, time_limit=30.0, gap_tolerance=1e-4, milp_solver="highs")
+
+    # CLAUDE.md §6: if the seam was never reached the rest asserts nothing.
+    assert inflated, "the master was never solved through the patched entry point"
+
+    assert result.objective is not None
+    if result.bound is not None:
+        assert result.bound <= result.objective + 1e-6, (
+            f"published an inverted certificate: bound={result.bound!r} "
+            f"objective={result.objective!r}"
+        )
+    trace = getattr(result, "mip_nlp_trace", None) or {}
+    assert trace.get("inverted_master_bound") is not None, (
+        "the guard fired but did not record the bound it suppressed"
+    )
+    assert result.gap_certified is False


### PR DESCRIPTION
## What was wrong

Measured on `squfl020-150` (MINLPLib, `=best= 557.84865`) at the issue's own
defaults (`gap_tolerance=1e-4`, `time_limit=60`), `solve_lp_nlp_bb` returned:

```
objective = 557.848649973387
bound     = 558.0440365723572     <- a LOWER bound 0.195 ABOVE its own incumbent
```

and the #1059 merge republished it.

`solve_oa` has refused exactly this since the `fac2` incident
(`_certified_bound_inverted`). The single-tree path never got the guard, and
`_merge_route_and_fallback` applied `_bound_crosses_objective` only to the
**loser's** bound — so a winner that arrived already inverted sailed straight
through.

The gap formula makes it worse rather than catching it. `abs(bnd - obj) /
max(abs(obj), 1e-10)` turns an inversion into a small *positive* gap: the
`557.9460019817818` bound seen on an earlier run of the same instance scores
**1.75e-4**, which reads as "nearly converged" at a 1e-4 tolerance. Precisely
backwards.

## Where 558.044 comes from — it is not a discopt cut

At the restart that produced it the master held 69,330 rows. Evaluating the
instance's true optimum against the matrix **HiGHS itself stored**
(`h.getLp()`, not our copy) gave 0 violated rows, worst residual 8.35e-15, cost
557.84865. That exonerates the perspective disaggregation rows, the initial
master, every recorded lazy cut, and `_prepare_cut_row`.

Handing that same model back to HiGHS from an MPS file, with no discopt in the
loop, reproduces the contradiction in isolation:

| what is fixed at the known optimum | HiGHS returns |
|---|---|
| all 6,021 columns | `kOptimal`, obj **557.84865**, `num_primal_infeasibilities=0` |
| only the 20 integer columns, at those same values | `kOptimal`, obj **558.04404** |

Fixing *more* variables cannot lower an optimum, so the second answer is
invalid. Column bounds and integrality of the reference point were both checked
explicitly (worst bound violation 0.0, worst fractionality 0.0 over 20 integer
columns) after an earlier version of the probe checked row activities only.

Each alternative explanation got its own arm and a stated kill criterion
(CLAUDE.md §4):

| hypothesis | arm | result |
|---|---|---|
| retained solver state | `clearSolver()` before each `run()` | byte-identical trace — **killed** |
| instance grown by `addRow` after `run()` | a fresh `Highs` per restart | byte-identical `558.0440365723572` — **killed** |
| presolve | same MPS, `presolve=off` | identical `558.0440365723573` — **killed** |
| tolerances | `mip_feasibility_tolerance=1e-9` | moved it the **wrong way**, to `558.0653` — **killed** |

## What this PR does

It does **not** fix HiGHS. It makes discopt refuse to publish a bound it can
see is invalid, which is what CLAUDE.md §1 requires.

- `oa.py`, `solve_lp_nlp_bb`: a bound above the incumbent by more than
  `bound_inversion_tolerance` is suppressed along with the gap and
  `gap_certified`, logged at WARNING as a bound-validity defect rather than a
  tolerance to widen, and recorded in the trace as `inverted_master_bound` so a
  diagnosis still has the number.
- `solver.py`, `_merge_route_and_fallback`: the same check now covers the
  **winner's** bound, and runs *before* the gap formula, which cannot detect
  this case at all.

On the real instance at default settings this turns

```
status=optimal-looking  obj=557.848649973387  bound=558.0440365723572
```

into

```
status=feasible  obj=557.848649973387  bound=None  gap=None  gap_certified=False
trace: inverted_master_bound=558.0440365723572, master_bound_valid=False
```

— honestly uncertified instead of falsely certified.

### Residual risk, stated plainly

This guard catches a corrupted master bound only when it *crosses the
incumbent*. A HiGHS bound that is wrong but still below the incumbent would not
be caught and could falsely close a gap. That is a real remaining exposure and
it is upstream; the MPS reproducer above is self-contained and suitable for a
HiGHS bug report.

## Retraction (CLAUDE.md §11)

Two runs earlier in this investigation reported `obj=1197.972555976441` and I
read them as "the false bound is not reproducing under load". **That reading
was wrong and is withdrawn.** My own trace patch called
`info.mip_primal_bound`, which does not exist on this highspy build; the
`AttributeError` was swallowed by the OA route's broad `except` and surfaced as
a silent fallback to the default path. The bug was never exercised in those
runs — an instrument that broke the code under test and reported the breakage
as a result (CLAUDE.md §7).

A separate `presolve=off` arm was also read as suggestive of presolve being the
cause. The same-model A/B above falsifies that, and it is withdrawn too.

## Verification

| suite | result |
|---|---|
| `pytest python/tests -m smoke` | **1137 passed**, 1 skipped, 2 xpassed (146.5 s) |
| `pytest -m slow python/tests/test_adversarial_recent_fixes.py` | **19 passed** (147.9 s) |
| #1059/#1066 neighbouring suites | **95 passed** |
| `ruff check` / `ruff format --check` | clean |

New test `python/tests/test_issue_1066_master_bound_inversion.py`: **4 of its 6
tests fail on the parent commit** — the OA test there publishes `bound=50.0`
against `objective=2.2e-18` — and all 6 pass here. The other 2 are anti-vacuity
and rounding-at-scale checks that must pass both ways. The `solve_lp_nlp_bb`
test asserts the patched master seam was actually reached before asserting
anything about the result (CLAUDE.md §6).

Baseline and fixed arms were each run with `PYTHONPATH` pinned to the worktree
and the version marker asserted **present** in the fixed arm and **absent** in
the baseline (CLAUDE.md §8) — this worktree's bare `pytest` otherwise imports
`discopt` from the main tree.

No Rust touched, so `cargo test -p discopt-core` was not run.

Contributes to #1066, which stays open — it closes when the reported set is
solved at default settings, not when its work items are individually merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019GYp9wAZ2Xt1Mz9rEvLdry
