### PR TITLE
fix(#1066): perspective rows at a numerically-zero reference wrecked the master

### DIFF
--- a/python/discopt/solvers/milp_highs.py
+++ b/python/discopt/solvers/milp_highs.py
@@ -134,14 +134,26 @@ def _prepare_cut_row(
     if nz.size == 0:
         return nz, coeffs[nz], rhs
 
-    a = coeffs[nz]
-    a_min = float(np.min(np.abs(a)))
-    a_max = float(np.max(np.abs(a)))
-    # Lift the small end a decade clear of the drop threshold, without bringing the
-    # large end within a decade of the value HiGHS refuses. Scale UP only: scaling
-    # down would push entries that fit today below the threshold. Both ends are
-    # strictly positive, so the logarithm is always defined.
-    room = min(10.0 * small_tol / a_min, large_tol / (10.0 * a_max))
+    a_abs = np.abs(coeffs[nz])
+    a_max = float(np.max(a_abs))
+    # The largest scale the big end tolerates, i.e. without bringing it within a
+    # decade of the value HiGHS refuses. Scale UP only: scaling down would push
+    # entries that fit today below the threshold.
+    scale_cap = large_tol / (10.0 * a_max)
+    # Only terms this scale can actually lift clear of the drop threshold get a
+    # say in how far to scale. A term too small to be rescued is dropped below no
+    # matter what, so letting it set the scale buys nothing and costs the whole
+    # row its conditioning -- measured on ``squfl020-150`` (#1066): a perspective
+    # row at reference ``z=1.2e-16`` spans 3e-32 (its ``q*z**2`` term) to 1, the
+    # 3e-32 drove ``headroom`` to 46, and ``2**46 * 3e-32 = 2.1e-18`` was still
+    # under ``small_matrix_value`` and dropped -- so the row was scaled by
+    # 7.04e13 to rescue a term it discarded, and what reached the master was a
+    # redundant ``s_k >= 0`` carrying a 7.04e13 coefficient.
+    liftable = a_abs[a_abs * scale_cap > small_tol]
+    # ``a_max`` itself always qualifies (``a_max * scale_cap`` is ``large_tol/10``,
+    # far above ``small_tol``), so this is never empty.
+    a_min = float(np.min(liftable))
+    room = min(10.0 * small_tol / a_min, scale_cap)
     headroom = math.floor(math.log2(room))
     if headroom > 0:
         scale = 2.0**headroom

--- a/python/discopt/solvers/oa.py
+++ b/python/discopt/solvers/oa.py
@@ -2379,6 +2379,25 @@ def _strengthen_objective_cut_perspective(coeffs, rhs, x_star, n_vars, terms):
 #: reporting zero rows ran the aggregate master whatever the flag said.
 _PERSPECTIVE_DISAGG_ROWS: list[int] = [0]
 _PERSPECTIVE_DISAGG_REFUSED: list[int] = [0]
+#: References dropped because their row carries no information (see
+#: ``_PERSPECTIVE_MIN_ROW_COEFF``). Counted so "none were dropped" is
+#: distinguishable from "the check never ran" (CLAUDE.md §6).
+_PERSPECTIVE_DISAGG_NEAR_ZERO: list[int] = [0]
+
+#: Smallest ``2*q*|z|`` worth a perspective row. The row is
+#: ``2*q*z*x_k - q*z**2*y_k - s_k <= 0`` against a ``-1`` on ``s_k``, so once
+#: ``2*q*|z|`` falls to the master backend's matrix floor the backend drops the
+#: ``x_k`` term outright and what lands is ``s_k >= 0`` -- which the column's own
+#: lower bound already says. This is HiGHS's default ``small_matrix_value``, the
+#: value at which that discard provably happens.
+#:
+#: Measured on ``squfl020-150`` (#1066): references at ``z ~ 1.2e-16`` produced
+#: 43 500 such rows, 63% of the master's 69 330. Because their ``q*z**2`` term
+#: (~3e-32) also drove the row-scaling in ``milp_highs._prepare_cut_row``, each
+#: reached HiGHS multiplied by ``2**46``, taking the master's coefficient range
+#: to 6.4e18 -- and HiGHS then reported dual bounds ABOVE the master's own
+#: provable optimum (558.044 against 557.84865).
+_PERSPECTIVE_MIN_ROW_COEFF = 1e-9
 
 
 def _perspective_disagg_enabled() -> bool:
@@ -2522,10 +2541,16 @@ def _disaggregate_objective_cut(coeffs, rhs, x_star, epigraph: _PerspectiveEpigr
         z = float(x_star[x_col])
         coeffs[x_col] -= 2.0 * q * z
         rhs -= q * z * z
-        if z != 0.0:
-            # z == 0 makes the row ``0 <= s_k``, which the column bound already
-            # says; the removal above still has to happen either way.
+        if 2.0 * q * abs(z) > _PERSPECTIVE_MIN_ROW_COEFF:
             epigraph.add(k, z)
+        else:
+            # The row would say ``s_k >= 0``, which the column bound already
+            # says -- exactly true at z == 0 and true to the master's own
+            # arithmetic below the floor. The removal above still has to happen
+            # either way; it subtracts ``2*q*z`` and ``q*z**2``, both negligible
+            # here, and dropping an underestimator row can only weaken the
+            # bound, never invalidate it.
+            _PERSPECTIVE_DISAGG_NEAR_ZERO[0] += 1
     return coeffs, rhs
 
 

--- a/python/tests/test_issue_1066_vacuous_perspective_rows.py
+++ b/python/tests/test_issue_1066_vacuous_perspective_rows.py
@@ -1,0 +1,177 @@
+"""#1066: perspective rows at a numerically-zero reference wrecked the master.
+
+``squfl020-150`` at the issue's defaults (``gap_tolerance=1e-4``,
+``time_limit=60``) returned ``feasible`` with **no dual bound at all**: the
+single-tree master's HiGHS solve reported ``mip_dual_bound = 558.0440365723572``
+for a master whose optimum is provably at most ``557.84865`` -- fixing all 6021
+columns at the lifted true optimum solves to ``kOptimal`` at 557.84865 with a
+max primal infeasibility of 8.35e-15, and fixing more variables cannot lower an
+optimum. The #1136 inversion guard caught it and suppressed the bound, which is
+correct but leaves the instance uncertified.
+
+The master was 69 330 rows against 6 021 columns, and **43 500 of those rows
+(63%) were the same vacuous row**, reaching HiGHS as
+
+    ``0.0174 * x_k  -  70368744177664 * s_k  <=  5.69e-20``
+
+Dividing by ``2**46 = 70368744177664`` recovers what was actually separated:
+``2.47e-16 * x_k - s_k <= 8.09e-34``, i.e. ``s_k >= ~0`` -- which ``s_k``'s own
+lower bound of 0 already says. Two independent defects compounded:
+
+1. ``_disaggregate_objective_cut`` emitted a perspective row for every reference
+   ``z != 0.0``, including ``z ~ 1.2e-16``, whose row carries no information.
+2. ``_prepare_cut_row`` chose its power-of-two scale from *every* coefficient,
+   including the ``q*z**2 ~ 3e-32`` term. That drove ``headroom`` to 46 -- and
+   ``2**46 * 3e-32 = 2.1e-18`` is still under ``small_matrix_value``, so the term
+   was dropped anyway. The row was scaled by 7.04e13 to rescue a term it then
+   discarded.
+
+Together they took the master's coefficient range to 1.1e-5 .. 7.04e13 (ratio
+6.4e18), with a median *per-row* range of 3.4e14 and 43 500 rows above 1e9. On a
+matrix like that HiGHS's dual bound is not trustworthy, and measurably was not.
+
+After both fixes ``squfl020-150`` solves to ``optimal``, certified, in 49.3 s:
+bound 557.848649960045 <= incumbent 557.848649973387 <= 557.84865. 61 650 of
+86 356 references (71%) are refused as vacuous.
+"""
+
+import numpy as np
+from discopt.solvers import oa
+from discopt.solvers.milp_highs import _prepare_cut_row
+from discopt.solvers.milp_simplex import _INF
+
+# HiGHS defaults, read here as plain numbers so the test states the window it
+# is reasoning about rather than depending on a live solver.
+SMALL, LARGE = 1e-9, 1e15
+
+
+def test_scale_ignores_terms_it_is_going_to_drop_anyway():
+    """The measured ``squfl020-150`` row must not be scaled by ``2**46``.
+
+    ``q*z**2`` is too small for ANY admissible scale to lift over
+    ``small_matrix_value``, so it is dropped either way; letting it choose the
+    scale only destroys the row's conditioning.
+    """
+    q, z = 1.0, 1.2e-16
+    coeffs = np.zeros(4)
+    coeffs[0] = 2.0 * q * z  # 2.4e-16 on x_k
+    coeffs[1] = -q * z * z  # -1.44e-32 on y_k -- unrescuable
+    coeffs[2] = -1.0  # s_k
+    lb = np.array([0.0, 0.0, 0.0, 0.0])
+    ub = np.array([_INF, 1.0, _INF, _INF])
+
+    _idx, vals, _rhs = _prepare_cut_row(coeffs.copy(), 0.0, lb, ub, SMALL, LARGE)
+
+    biggest = float(np.max(np.abs(vals)))
+    # Before the fix this was exactly 2**46 = 70368744177664.0.
+    assert biggest < 1e8, f"row still scaled into the danger zone: max|a| = {biggest!r}"
+    assert biggest != float(2**46)
+
+
+def test_scale_still_lifts_a_term_that_can_be_rescued():
+    """Anti-vacuity: the fix must not disable scaling for rows it should help.
+
+    ``squfl025-040``'s first cut spans 2.05e-19 to 114 -- 21 orders inside a
+    24-wide window -- and the docstring of ``_prepare_cut_row`` records that
+    failing to lift it killed every ``squfl`` instance under ``lp_nlp_bb``.
+    """
+    coeffs = np.zeros(3)
+    coeffs[0] = 2.05e-19
+    coeffs[1] = 114.0
+    lb = np.array([0.0, 0.0, 0.0])
+    ub = np.array([10.0, 10.0, 10.0])
+
+    _idx, vals, _rhs = _prepare_cut_row(coeffs.copy(), 1.0, lb, ub, SMALL, LARGE)
+
+    smallest = float(np.min(np.abs(vals)))
+    assert len(vals) == 2, "the liftable small term must survive, not be dropped"
+    assert smallest > SMALL, f"liftable term was not lifted clear: {smallest!r}"
+
+
+def _epigraph():
+    ep = oa._perspective_epigraph_for([(0, 1, 2.0), (2, 3, 1.0)], n_vars=8)
+    assert ep is not None
+    return ep
+
+
+def test_a_numerically_zero_reference_emits_no_row():
+    """``z ~ 1e-16`` must be refused exactly as ``z == 0.0`` already was.
+
+    The row would say ``s_k >= 0``, which the column bound already carries.
+    """
+    ep = _epigraph()
+    x_star = np.zeros(8)
+    x_star[0] = 1.2e-16  # term 0: 2*q*z = 4.8e-16, far under the floor
+    x_star[2] = 3.0  # term 1: an ordinary reference, must still be taken
+
+    before = oa._PERSPECTIVE_DISAGG_NEAR_ZERO[0]
+    out = oa._disaggregate_objective_cut(np.zeros(9), 0.0, x_star, ep)
+
+    assert out is not None, "a near-zero reference must not kill the whole cut"
+    assert oa._PERSPECTIVE_DISAGG_NEAR_ZERO[0] == before + 1, "the guard did not fire"
+    # Only the real reference got a row; the vacuous one did not.
+    assert ep.rows == [(1, 3.0)]
+
+
+def test_the_removal_still_happens_for_a_refused_reference():
+    """Skipping the row must not skip the subtraction.
+
+    The term has to leave the aggregate row on every row or none (see
+    ``test_split_is_all_or_nothing``); what the guard drops is only the
+    *replacement* row, and dropping an underestimator can weaken a bound but
+    never invalidate it.
+    """
+    q0, q1 = 2.0, 1.0
+    ep = _epigraph()
+    n = 8
+    z0, z1 = 1.2e-16, 3.0
+    x_star = np.zeros(n)
+    x_star[0], x_star[2] = z0, z1
+
+    coeffs = np.zeros(n + 1)
+    coeffs[0] = 2.0 * q0 * z0
+    coeffs[2] = 2.0 * q1 * z1
+    coeffs[n] = -1.0
+    rhs = q0 * z0**2 + q1 * z1**2
+
+    out = oa._disaggregate_objective_cut(coeffs.copy(), rhs, x_star, ep)
+    assert out is not None
+    residual_coeffs, residual_rhs = out
+
+    # BOTH terms left the aggregate row, the refused one included.
+    assert residual_coeffs[0] == 0.0
+    assert residual_coeffs[2] == 0.0
+    assert residual_rhs == 0.0
+    assert residual_coeffs[n] == -1.0, "the eta column must survive the split"
+
+
+def test_an_ordinary_reference_is_still_taken():
+    """Anti-vacuity for the guard: normal references must be unaffected."""
+    ep = _epigraph()
+    x_star = np.zeros(8)
+    x_star[0], x_star[2] = 1.5, 3.0
+    before = oa._PERSPECTIVE_DISAGG_NEAR_ZERO[0]
+
+    assert oa._disaggregate_objective_cut(np.zeros(9), 0.0, x_star, ep) is not None
+
+    assert oa._PERSPECTIVE_DISAGG_NEAR_ZERO[0] == before, "guard fired on a good reference"
+    assert sorted(ep.rows) == [(0, 1.5), (1, 3.0)]
+
+
+def test_the_threshold_is_on_the_row_coefficient_not_the_reference():
+    """A tiny ``z`` with a large ``q`` still produces a usable row.
+
+    The floor is on ``2*q*|z|`` -- what actually reaches the master -- so a
+    curvature big enough to lift the coefficient clear keeps its row. Gating on
+    ``|z|`` alone would throw that away.
+    """
+    ep = oa._perspective_epigraph_for([(0, 1, 1e9)], n_vars=8)
+    assert ep is not None
+    x_star = np.zeros(8)
+    x_star[0] = 1e-8  # 2*q*z = 20.0, comfortably representable
+    before = oa._PERSPECTIVE_DISAGG_NEAR_ZERO[0]
+
+    assert oa._disaggregate_objective_cut(np.zeros(9), 0.0, x_star, ep) is not None
+
+    assert oa._PERSPECTIVE_DISAGG_NEAR_ZERO[0] == before
+    assert ep.rows == [(0, 1e-8)]


### PR DESCRIPTION
## What was wrong

`squfl020-150` at the issue's defaults (`gap_tolerance=1e-4`, `time_limit=60`)
returned `feasible` with **no dual bound at all**. The single-tree master's HiGHS
solve reported `mip_dual_bound = 558.0440365723572` for a master whose optimum is
provably at most **557.84865** — fixing all 6021 columns at the lifted true
optimum solves to `kOptimal` at 557.84865 with max primal infeasibility 8.35e-15,
and fixing more variables cannot lower an optimum. The #1136 inversion guard
caught it and suppressed the bound, which is correct but leaves the instance
uncertified.

The master was **69 330 rows against 6 021 columns**, and **43 500 of those rows
(63%) were the same vacuous row**, reaching HiGHS as

```
0.0174 * x_k  -  70368744177664 * s_k  <=  5.69e-20
```

`70368744177664` is exactly `2**46`. Dividing it out recovers what was actually
separated: `2.47e-16 * x_k - s_k <= 8.09e-34`, i.e. **`s_k >= ~0`** — which
`s_k`'s own lower bound of 0 already says.

## Two defects, compounding

**1. A row was emitted for a reference that carries no information.**
`_disaggregate_objective_cut` took every reference with `z != 0.0`, including
`z ~ 1.2e-16`. The guard is now on `2*q*|z|` — the coefficient that actually
reaches the master — against the backend's matrix floor. Gating on `|z|` alone
would have thrown away a tiny `z` paired with a large curvature; that case is
tested and kept.

**2. The row scaling rescued a term it then discarded.** `_prepare_cut_row` chose
its power-of-two scale from *every* coefficient, including `q*z**2 ~ 3e-32`. That
drove `headroom` to 46 — and `2**46 * 3e-32 = 2.1e-18` is still under
`small_matrix_value`, so the term was dropped anyway. The row was scaled by
7.04e13 to rescue a term it discarded. The scale is now chosen only from terms
that some admissible scale can actually lift clear of the floor.

Together they took the master's coefficient range to `1.1e-5 .. 7.04e13` (ratio
6.4e18), a median **per-row** range of 3.4e14, and 43 500 rows above 1e9. HiGHS's
dual bound on such a matrix is not trustworthy, and measurably was not.

## Why neither change can invalidate a bound

Dropping an underestimator row only weakens the master, never invalidates it. The
removal of a term from the aggregate row still happens on every term or none — the
invariant `test_split_is_all_or_nothing` guards — so nothing is double-counted.
This generalizes the `if z != 0.0` guard that was already there for the exactly-zero
case, which had already established that skipping the row while keeping the
subtraction is the safe combination.

## Measured

#1066 panel, all 15 instances, at the issue's defaults. `CHECKS_EXECUTED 30`,
`VIOLATIONS 0`.

| | before (#1136 head) | after |
|---|---|---|
| optimal | 12/15 | **14/15** |
| `squfl020-150` | `feasible`, bound suppressed as invalid | **`optimal`, certified, 56.8 s** |
| `squfl025-040` | `feasible`, 0.05% off, hit the 60 s limit | **`optimal`, 33.8 s** |
| `portfol_classical050_1` | `feasible`, 1.81% off | `feasible`, 1.81% off (unchanged) |

On `squfl020-150`, 61 650 of 86 356 references (71%) are now refused as vacuous,
and the certified bound is 557.848649960045 against an incumbent of
557.848649973387.

## A falsified hypothesis, recorded so it is not retried

Master **row accumulation is not the mechanism**. I built row purging down to a
budget and verified it fired (30 233 rows removed, counted directly, not
inferred). The bound was still wrong: 559.315 and 557.9198, both above the
optimum — and the first came from a strictly *smaller* master than the one that
gave 558.044, which a relaxation cannot do. That machinery is deliberately not in
this PR.

An earlier reading of the same experiment — that purging restored a valid bound —
was wrong twice over and is retracted: the first run purged against the known true
optimum, which is not available in production, and the run after that never
executed the purge at all (`point is None` at all ten restarts, because the
separator vetoes every incumbent on this instance). The numbers it produced were
run-to-run noise.

## Verification

- `python/tests/test_issue_1066_vacuous_perspective_rows.py` — 6 new tests, both
  directions: the vacuous row refused *and* an ordinary reference, a liftable
  small coefficient, and a tiny-`z`/large-`q` row all left alone.
- `pytest -m smoke` — 1137 passed, 1 skipped, 2 xpassed.
- `pytest -m slow python/tests/test_adversarial_recent_fixes.py` — 19 passed.
- No Rust touched, so no `cargo test`.

Contributes to #1066 — `portfol_classical050_1` is still short of the bar, so the
issue stays open.
