### PR TITLE
perf(#1066): static constraint bounds were rebuilt on every evaluation

### DIFF
--- a/python/discopt/solvers/nlp_ipopt.py
+++ b/python/discopt/solvers/nlp_ipopt.py
@@ -170,6 +170,40 @@ class _IpoptCallbacks:
         return (rows, cols)
 
 
+_BOUNDS_CACHE_ATTR = "_discopt_constraint_bounds_cache"
+
+
+def _constraint_bounds_fingerprint(constraints, sizes) -> tuple:
+    """An O(1) identity of the constraint list the bounds were derived from.
+
+    ``constraints`` and ``sizes`` are owned by the evaluator, which also owns
+    the cache entry, so neither object can be garbage-collected (and neither
+    ``id`` recycled) while the entry is reachable. Rebuilding either list --
+    the only way a compiled evaluator's senses can change -- changes the
+    identity and misses the cache.
+    """
+    return (id(constraints), len(constraints), id(sizes), int(np.sum(sizes)))
+
+
+def _cached_constraint_bounds(source, constraints, sizes):
+    entry = getattr(source, _BOUNDS_CACHE_ATTR, None)
+    if entry is None:
+        return None
+    fingerprint, cl, cu = entry
+    if fingerprint != _constraint_bounds_fingerprint(constraints, sizes):
+        return None
+    return cl, cu
+
+
+def _store_constraint_bounds(source, constraints, sizes, cl, cu) -> None:
+    # Evaluators defined with ``__slots__`` simply go uncached rather than
+    # raising; the bounds are recomputed exactly as they were before.
+    if not hasattr(source, "__dict__"):
+        return
+    entry = (_constraint_bounds_fingerprint(constraints, sizes), cl, cu)
+    setattr(source, _BOUNDS_CACHE_ATTR, entry)
+
+
 def _infer_constraint_bounds(source) -> tuple[np.ndarray, np.ndarray]:
     """Infer constraint bounds (cl, cu) from model constraint senses.
 
@@ -192,6 +226,17 @@ def _infer_constraint_bounds(source) -> tuple[np.ndarray, np.ndarray]:
     else:
         constraints = source._source_constraints
         sizes = source._constraint_flat_sizes
+        # An NLPEvaluator compiles its constraint list once in ``__init__`` and
+        # never mutates it, but the bounds were rebuilt on every call: the OA
+        # feasibility phase calls this 45k times per solve through
+        # ``_constraint_violation_data``, and each call allocates ``2 * n_cons``
+        # ``np.full`` arrays plus two concatenates. Measured on
+        # ``portfol_classical050_1`` (103 constraints): 111.4 us/call, ~5.1 s of
+        # a 32.8 s solve. A ``Model`` can gain constraints between calls, so
+        # only the evaluator branch is cached.
+        cached = _cached_constraint_bounds(source, constraints, sizes)
+        if cached is not None:
+            return cached[0].copy(), cached[1].copy()
 
     cl_parts: list[np.ndarray] = []
     cu_parts: list[np.ndarray] = []
@@ -209,8 +254,20 @@ def _infer_constraint_bounds(source) -> tuple[np.ndarray, np.ndarray]:
         cu_parts.append(np.full(sz_int, hi, dtype=np.float64))
 
     if not cl_parts:
-        return np.empty(0, dtype=np.float64), np.empty(0, dtype=np.float64)
-    return np.concatenate(cl_parts), np.concatenate(cu_parts)
+        cl = np.empty(0, dtype=np.float64)
+        cu = np.empty(0, dtype=np.float64)
+    else:
+        cl = np.concatenate(cl_parts)
+        cu = np.concatenate(cu_parts)
+
+    if isinstance(source, Model):
+        # Never cached, so these arrays are already the caller's alone.
+        return cl, cu
+
+    _store_constraint_bounds(source, constraints, sizes, cl, cu)
+    # Callers receive their own arrays, exactly as before this was cached, so a
+    # caller that writes into the result cannot corrupt the cache.
+    return cl.copy(), cu.copy()
 
 
 def solve_nlp(

--- a/python/tests/test_1066_constraint_bounds_cache.py
+++ b/python/tests/test_1066_constraint_bounds_cache.py
@@ -1,0 +1,179 @@
+"""#1066: static constraint bounds were re-derived on every evaluation.
+
+``_infer_constraint_bounds`` walks the evaluator's source constraints and
+allocates ``2 * n_constraints`` ``np.full`` arrays plus two concatenates.
+Nothing about that result changes over the life of a compiled evaluator, yet
+``oa._constraint_violation_data`` calls it once per objective *and* once per
+gradient evaluation of ``_FeasibilityEvaluator`` -- i.e. at every ipopt
+iteration of every feasibility subproblem.
+
+Measured on ``portfol_classical050_1`` (103 constraints, 150 variables) before
+the cache: 45,488 calls costing 8.80 s cumulative of a 32.765 s solve (27%),
+with 9,370,529 ``np.full`` calls inside them (5.06 s, 15%). Isolated cost of
+the rebuild on that evaluator: 111.4 us/call vs 0.3 us cached (389x).
+
+This is a bound-neutral change (CLAUDE.md §5): it must not alter any returned
+value, so the tests below pin equality against a freshly rebuilt result as well
+as the call reduction.
+"""
+
+import numpy as np
+import pytest
+from discopt.modeling.core import Constraint, Model
+from discopt.solvers import nlp_ipopt
+from discopt.solvers.nlp_ipopt import _infer_constraint_bounds
+
+
+def _model():
+    m = Model("bounds-cache")
+    x = m.continuous("x", shape=(3,), lb=-10.0, ub=10.0)
+    m.subject_to(x[0] + x[1] <= 4.0)
+    m.subject_to(x[1] - x[2] == 1.0)
+    # NOTE: the modeling layer normalises ``>=`` to ``<=`` at construction, so
+    # every constraint an NLPEvaluator compiles from a Model is ``<=`` or
+    # ``==``. A genuine ``>=`` row only reaches this function from a
+    # hand-built Constraint, which the Fake-evaluator tests below cover.
+    m.subject_to(x[0] * x[0] + x[2] >= 2.0)
+    m.minimize(x[0] + x[1] + x[2])
+    return m
+
+
+def _evaluator(model):
+    from discopt._relax.nlp_evaluator import NLPEvaluator
+
+    return NLPEvaluator(model)
+
+
+def test_repeated_calls_return_the_same_values_as_the_first():
+    """The cache must be a pure optimisation: identical values, every time."""
+    ev = _evaluator(_model())
+    cl0, cu0 = _infer_constraint_bounds(ev)
+    checks = 0
+    for _ in range(5):
+        cl, cu = _infer_constraint_bounds(ev)
+        np.testing.assert_array_equal(cl, cl0)
+        np.testing.assert_array_equal(cu, cu0)
+        checks += 2
+    assert checks == 10, "vacuous: no comparison executed"
+    # and the values are the documented sense mapping, not just self-consistent
+    assert [c.sense for c in ev._source_constraints] == ["<=", "==", "<="]
+    assert cl.tolist() == [-1e20, 0.0, -1e20]
+    assert cu.tolist() == [0.0, 0.0, 0.0]
+
+
+def test_the_rebuild_runs_once_per_evaluator_not_once_per_call(monkeypatch):
+    """The defect this fixes: N calls did N rebuilds. Counting the per-row
+    allocation is what makes the test fail before the change and pass after --
+    a timing assertion would be load-dependent (CLAUDE.md §9)."""
+    ev = _evaluator(_model())
+    calls = [0]
+    real_full = np.full
+
+    def counting_full(*args, **kwargs):
+        calls[0] += 1
+        return real_full(*args, **kwargs)
+
+    monkeypatch.setattr(nlp_ipopt.np, "full", counting_full)
+
+    _infer_constraint_bounds(ev)
+    after_first = calls[0]
+    assert after_first == 6, f"expected 2 rows x 3 constraints, got {after_first}"
+
+    for _ in range(50):
+        _infer_constraint_bounds(ev)
+    assert calls[0] == after_first, (
+        f"the bounds were rebuilt {calls[0] - after_first} times across 50 "
+        "repeat calls; they are static for a compiled evaluator"
+    )
+
+
+def test_callers_get_their_own_arrays_so_a_write_cannot_poison_the_cache():
+    """Several call sites do ``np.asarray(...)`` on the result, which does not
+    copy. Handing out the cached array itself would let any of them corrupt
+    every later caller."""
+    ev = _evaluator(_model())
+    cl_a, cu_a = _infer_constraint_bounds(ev)
+    cl_a[0] = 12345.0
+    cu_a[2] = -12345.0
+    cl_b, cu_b = _infer_constraint_bounds(ev)
+    assert cl_b[0] == -1e20
+    assert cu_b[2] == 0.0
+    assert cl_b is not cl_a and cu_b is not cu_a
+
+
+def test_a_model_is_never_cached_because_it_can_gain_constraints():
+    """A Model is mutable: caching on it would return stale bounds after a new
+    ``subject_to``. Only the compiled-evaluator branch is cached."""
+    m = _model()
+    cl, cu = _infer_constraint_bounds(m)
+    assert cl.size == 3
+    x = m._variables[0]
+    m.subject_to(x[0] >= 1.0)
+    cl2, cu2 = _infer_constraint_bounds(m)
+    assert cl2.size == 4, "the Model branch must see the new constraint"
+    assert cl2[3] == -1e20
+
+
+def test_a_rebuilt_constraint_list_misses_the_cache():
+    """The fingerprint guards on the identity of the list the bounds came from,
+    so an evaluator whose constraints are swapped out re-derives them rather
+    than serving the previous evaluator's answer."""
+    ev = _evaluator(_model())
+    cl0, _ = _infer_constraint_bounds(ev)
+    assert cl0.tolist() == [-1e20, 0.0, -1e20]
+
+    flipped = []
+    for c in ev._source_constraints:
+        flipped.append(Constraint(c.body, "==", c.rhs))
+    ev._source_constraints = flipped
+    cl1, cu1 = _infer_constraint_bounds(ev)
+    assert cl1.tolist() == [0.0, 0.0, 0.0], "stale cache served after a swap"
+    assert cu1.tolist() == [0.0, 0.0, 0.0]
+
+
+def test_an_evaluator_without_a_dict_still_works():
+    """``__slots__`` evaluators go uncached rather than raising."""
+
+    class Slotted:
+        __slots__ = ("_source_constraints", "_constraint_flat_sizes")
+
+    s = Slotted()
+    s._source_constraints = [Constraint(None, "<=", 0.0), Constraint(None, ">=", 0.0)]
+    s._constraint_flat_sizes = np.asarray([1, 2], dtype=np.intp)
+    cl, cu = _infer_constraint_bounds(s)
+    assert cl.tolist() == [-1e20, 0.0, 0.0]
+    assert cu.tolist() == [0.0, 1e20, 1e20]
+    # calling again must still work (and still not raise)
+    cl2, _ = _infer_constraint_bounds(s)
+    assert cl2.tolist() == cl.tolist()
+
+
+def test_vector_valued_bodies_keep_their_row_expansion():
+    """The sizes array drives the repeat; a cache keyed only on the constraint
+    list would lose it."""
+
+    class Fake:
+        pass
+
+    f = Fake()
+    f._source_constraints = [Constraint(None, "<=", 0.0), Constraint(None, "==", 0.0)]
+    f._constraint_flat_sizes = np.asarray([4, 2], dtype=np.intp)
+    cl, cu = _infer_constraint_bounds(f)
+    assert cl.size == 6 and cu.size == 6
+    assert cl.tolist() == [-1e20] * 4 + [0.0, 0.0]
+    assert cu.tolist() == [0.0] * 6
+
+
+def test_an_unknown_sense_still_raises_loudly_on_a_cached_evaluator():
+    """The cache must not turn a later bad sense into a silent hit."""
+
+    class Fake:
+        pass
+
+    f = Fake()
+    f._source_constraints = [Constraint(None, "<=", 0.0)]
+    f._constraint_flat_sizes = np.asarray([1], dtype=np.intp)
+    _infer_constraint_bounds(f)
+    f._source_constraints = [Constraint(None, "!=", 0.0)]
+    with pytest.raises(ValueError, match="Unknown constraint sense"):
+        _infer_constraint_bounds(f)


### PR DESCRIPTION
## What this fixes

`_infer_constraint_bounds` derives `(cl, cu)` by walking the evaluator's source
constraints and allocating `2 * n_constraints` `np.full` arrays plus two
concatenates. For a compiled `NLPEvaluator` that result is **static** — the
constraint list is built once in `__init__` and never mutated — yet it was
rebuilt on every call.

`oa._constraint_violation_data` calls it once per objective evaluation *and*
once per gradient evaluation of `_FeasibilityEvaluator`, i.e. at every ipopt
iteration of every OA feasibility subproblem.

## Measurement

Profiled on `portfol_classical050_1` (150 vars, 103 constraints), the one
instance still unsolved in #1066:

| | calls | cumulative | share of a 32.765 s solve |
|---|---|---|---|
| `_infer_constraint_bounds` | 45,488 | 8.804 s | 27% |
| `np.full` (inside it) | 9,370,529 | 5.061 s | 15% |

The `np.full` count is exactly `103 constraints x 2 x 45,488 calls`, so the two
rows are the same defect counted twice.

Isolated cost of the rebuild on that evaluator, 20,000 repetitions:

```
CURRENT   20000 calls  2.227s  (111.4 us/call)
CACHED    20000 calls  0.006s  (0.3 us/call)
SPEEDUP   389.4x
```

The entry experiment carried a kill criterion of "under 5x, do not ship"
(CLAUDE.md §4); it returned 389x.

## The change

Cache `(cl, cu)` on the evaluator instance, guarded by an O(1) fingerprint of
the constraint list the bounds were derived from — `(id, len)` of
`_source_constraints` and `(id, sum)` of `_constraint_flat_sizes`. The
evaluator owns both the cache entry and those objects, so neither can be
collected (nor its `id` recycled) while the entry is reachable; rebuilding
either list misses the cache.

Two deliberate restrictions:

- **A `Model` is never cached.** A `Model` can gain constraints between calls,
  so only the compiled-evaluator branch is eligible. There is a test for this.
- **Callers get their own arrays.** Several call sites do `np.asarray(...)` on
  the result, which does not copy; handing out the cached array itself would let
  any of them corrupt every later caller. The cached arrays are copied on the
  way out, so the observable contract is unchanged — one allocation instead of
  `2n + 2`.

An evaluator defined with `__slots__` simply goes uncached rather than raising.

## Verification

**Bound-neutral (CLAUDE.md §5)**, in two parts.

*Values, exhaustively.* The change is confined to one function, so its output
was compared cached vs uncached on every evaluator the in-repo `minlplib_nl`
corpus produces:

```
INSTANCES_COMPARED 66
BOUND_ENTRIES_COMPARED 7406
INSTANCES_DIFFERING 0
VERDICT identical
```

*Integration.* End-to-end solves, arms interleaved per instance in one process
(§9), `deterministic=True, max_nodes=25, gap_tolerance=1e-4`, comparing
`status`, `node_count`, `gap_certified`, `objective`, and `bound` for **exact**
equality. The control arm forces a cache miss on every call, reproducing the
pre-fix code path, so both arms execute identical arithmetic:

```
CHECKS_EXECUTED 120
INSTANCES_EXERCISING_THE_CHANGED_CODE 16
MISMATCHES 0
VERDICT bound-neutral
```

Every instance in that panel terminated `optimal` with `gap_certified=True`, so
the objectives compared are certified ones. Each row also reports how many times
the changed function was entered (up to 102 per solve, nearly all served from
cache) — without that counter a panel of instances that never enter it would
report "0 mismatches" while testing nothing.

Two notes on how this panel was arrived at, since both were probe defects worth
recording:

* A first revision used `time_limit=20` and flagged `casctanks` (off objective
  19.6915 vs on 9.1635) with `node_count` and `bound` identical. That was a
  wall-clock artifact of an *uncertified* incumbent under a wall budget on a
  loaded machine, not a bound change. The fix was a deterministic budget, not a
  relaxed comparison. Note `max_nodes` alone would not have been enough —
  `solver.py`'s 2026-08-23 retraction records that it does not buy
  reproducibility; `deterministic=True` is what does.
* That same revision read `getattr(r, "best_bound", None)`. `SolveResult` has no
  `best_bound`, so the default silently compared `None` against `None` and the
  bound check was vacuous (CLAUDE.md §6). Fields are now read directly, so a
  wrong name raises.

The panel covers the 24 smallest instances rather than all 66: under
`deterministic=True` the wall budgets are neutralised, and `4stufen` alone costs
68.8 s per arm at `max_nodes=1`. The exhaustive value comparison above covers
all 66.

**Regression test** — `python/tests/test_1066_constraint_bounds_cache.py`, 8
tests. The load-independent one counts `np.full` calls rather than asserting a
time (CLAUDE.md §9):

```
before the change: AssertionError: the bounds were rebuilt 300 times across
                   50 repeat calls; they are static for a compiled evaluator
                   assert 306 == 6
                   1 failed, 7 passed
after  the change: 8 passed
```

The other seven pin the invariants the cache must not break: value equality
with a fresh rebuild, the documented sense mapping, caller-owned arrays, the
uncached `Model` branch, a rebuilt constraint list missing the cache,
`__slots__` evaluators, vector-valued bodies keeping their row expansion, and
an unknown sense still raising loudly rather than becoming a silent hit.

**Suites.** `pytest -m smoke`: 1137 passed, 1 skipped, 2 xpassed.
`pytest -m slow python/tests/test_adversarial_recent_fixes.py`: 19 passed.
No Rust touched, so `cargo test` was not required.

Wall-clock deltas from the panel are **not** reported as a performance claim:
the machine carried a load average near 10 throughout from an unrelated build
in another repo, which CLAUDE.md §9 disqualifies. The call-count reduction and
the isolated 389x microbenchmark are the measurements this PR stands on.

Contributes to #1066.
