### PR TITLE
perf(#1066): linear-row FBBT re-summed n-1 terms for every one of n variables

### DIFF
--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -3146,6 +3146,12 @@ def _reduce_node_and_stage(
     return False
 
 
+# The unbounded sentinel, matching the ``cu[j] < 1e19`` / ``cl[j] > -1e19``
+# guards at this function's call site.  Bounds at or beyond it are treated as
+# infinite: their terms are counted, never summed.
+_FBBT_INF = 1e19
+
+
 def _fbbt_linear_row_sweep(J_row, g_j, rhs, mid, lb, ub, is_upper):
     """One FBBT sweep of a single *linear* row, in Gauss-Seidel order.
 
@@ -3194,7 +3200,16 @@ def _fbbt_linear_row_sweep(J_row, g_j, rhs, mid, lb, ub, is_upper):
 
     bound = np.where((J_row[active] > 0.0) == is_upper, lb[active], ub[active])
     term = J_row[active] * (bound - mid[active])
-    finite = np.isfinite(term)
+    # The unbounded marker here is the sentinel ``1e20``, not ``inf``, so
+    # ``np.isfinite`` is *not* the test -- ``9.999e19`` is an ordinary float and
+    # passes it.  Its term then enters the running total, and the ulp of
+    # ``1e20`` is 16384: every ordinary-scale term added to it is annihilated,
+    # so ``sum - term_i`` returns ``0`` where the true partial sum was the small
+    # remainder, and the row over-tightens.  The pre-#1066 loop never formed
+    # that sum -- it subtracted the ``k != i`` terms one at a time.  Test the
+    # *bound*, as the sentinel rule requires, and keep those terms out of the
+    # total; they are counted below exactly as true infinities are.
+    finite = np.isfinite(term) & (np.abs(bound) < _FBBT_INF)
     n_inf = int(active.size - np.count_nonzero(finite))
     sum_finite = float(np.sum(np.where(finite, term, 0.0)))
 

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -3146,6 +3146,88 @@ def _reduce_node_and_stage(
     return False
 
 
+def _fbbt_linear_row_sweep(J_row, g_j, rhs, mid, lb, ub, is_upper):
+    """One FBBT sweep of a single *linear* row, in Gauss-Seidel order.
+
+    For row ``j`` linearised at ``mid``, the bound implied for variable ``i`` is
+
+        J_i * (x_i - mid_i)  <=  rhs - g_j - sum_{k != i} J_k * (bound_k - mid_k)
+
+    where ``bound_k`` is whichever of ``lb_k``/``ub_k`` leaves the row the most
+    room.  The pre-#1066 code recomputed that ``k`` sum *inside* the ``i`` loop,
+    so a row cost O(n^2) and the sweep O(m * n^2) -- 14M Python iterations per
+    call on a 150-variable, 103-row instance, measured as 9.9 s of self time
+    (40% of a 60 s ``portfol_classical050_1`` solve) and 56M ``abs()`` calls.
+
+    The sum over ``k != i`` differs between consecutive ``i`` only in which
+    single term is excluded, so it is formed once and the excluded term is
+    subtracted, at O(n) per row.
+
+    Nothing is lost by hoisting it, even though the original read ``lb``/``ub``
+    live and so *could* have seen a bound tightened earlier in the same sweep:
+    in either sense the update writes the bound **opposite** the one the terms
+    read.  For ``<=``, a ``J_k > 0`` term draws on ``lb_k`` while a ``J_i > 0``
+    update writes ``ub_i``; for ``J < 0`` the two swap together.  The clamps
+    (``max(lb[i], ...)``/``min(ub[i], ...)``) and the ``lb == ub`` skip only
+    ever touch ``i``'s own bounds.  So no update inside a sweep can change any
+    term of that sweep, and the hoisted sum is the same sum -- this is not a
+    Jacobi relaxation of a Gauss-Seidel loop.  (Between the two senses the
+    bounds *have* moved, which is why each sense forms its terms afresh.)
+
+    ``is_upper`` selects the sense: ``True`` for ``g_j(x) <= rhs``, ``False``
+    for ``g_j(x) >= rhs``.  In both senses the predicate ``(J_k > 0) ==
+    is_upper`` picks *both* the bound that enters the term and the bound the
+    update writes, which is why one body serves both.
+
+    Terms are only ever infinite in the direction that makes the residual
+    infinite (a ``J_k > 0`` term draws on ``lb_k``, so it can only be ``-inf``
+    for the ``<=`` sense), and an infinite residual leaves every comparison
+    below false.  Rather than form ``inf - inf``, infinite terms are counted
+    and any ``i`` with another infinite term is skipped -- which is exactly
+    what the arithmetic did, without the NaN.
+
+    Returns ``True`` if any bound moved.  ``lb``/``ub`` are updated in place.
+    """
+    active = np.flatnonzero(np.abs(J_row) >= 1e-12)
+    if active.size == 0:
+        return False
+
+    bound = np.where((J_row[active] > 0.0) == is_upper, lb[active], ub[active])
+    term = J_row[active] * (bound - mid[active])
+    finite = np.isfinite(term)
+    n_inf = int(active.size - np.count_nonzero(finite))
+    sum_finite = float(np.sum(np.where(finite, term, 0.0)))
+
+    slack = rhs - g_j
+    changed = False
+
+    for pos in range(active.size):
+        i = int(active[pos])
+        if lb[i] == ub[i]:
+            continue
+        term_i = float(term[pos])
+        finite_i = bool(finite[pos])
+        if n_inf - (0 if finite_i else 1) > 0:
+            # Some *other* term is infinite: the residual is infinite and no
+            # comparison below can fire.  Skip, as the original arithmetic did.
+            continue
+        residual = slack - (sum_finite - (term_i if finite_i else 0.0))
+
+        J_i = float(J_row[i])
+        new_bound = mid[i] + residual / J_i
+        if (J_i > 0.0) == is_upper:
+            if not new_bound < ub[i] - 1e-10:
+                continue
+            ub[i] = max(lb[i], new_bound)
+        else:
+            if not new_bound > lb[i] + 1e-10:
+                continue
+            lb[i] = min(ub[i], new_bound)
+        changed = True
+
+    return changed
+
+
 def _tighten_node_bounds_with_status(evaluator, node_lb, node_ub, cl_list, cu_list, max_rounds=3):
     """Constraint-based bound tightening (FBBT) for a single B&B node.
 
@@ -3253,68 +3335,10 @@ def _tighten_node_bounds_with_status(evaluator, node_lb, node_ub, cl_list, cu_li
         for j in range(m):
             if not is_linear[j]:
                 continue
-            # For constraint g_j(x) <= cu_j:
-            # Linear approx: g_j(mid) + J[j,:] @ (x - mid) <= cu_j
-            # To find max x_i, set other vars to MINIMIZE g (most room):
-            #   J[j,k] > 0 → use lb[k];  J[j,k] < 0 → use ub[k]
-            if cu[j] < 1e19:
-                for i in range(n):
-                    if abs(J[j, i]) < 1e-12 or lb[i] == ub[i]:
-                        continue
-                    residual = cu[j] - g[j]
-                    for k in range(n):
-                        if k == i:
-                            continue
-                        if abs(J[j, k]) < 1e-12:
-                            # Zero Jacobian entry contributes nothing; skip to
-                            # avoid ``0 * inf = nan`` when var k is unbounded.
-                            continue
-                        if J[j, k] > 0:
-                            residual -= J[j, k] * (lb[k] - mid[k])
-                        else:
-                            residual -= J[j, k] * (ub[k] - mid[k])
-                    # J[j,i] * (x_i - mid_i) <= residual
-                    if J[j, i] > 1e-12:
-                        new_ub = mid[i] + residual / J[j, i]
-                        if new_ub < ub[i] - 1e-10:
-                            ub[i] = max(lb[i], new_ub)
-                            changed = True
-                    elif J[j, i] < -1e-12:
-                        new_lb = mid[i] + residual / J[j, i]
-                        if new_lb > lb[i] + 1e-10:
-                            lb[i] = min(ub[i], new_lb)
-                            changed = True
-
-            # For constraint g_j(x) >= cl_j:
-            # To find min x_i, set other vars to MAXIMIZE g (most room):
-            #   J[j,k] > 0 → use ub[k];  J[j,k] < 0 → use lb[k]
-            if cl[j] > -1e19:
-                for i in range(n):
-                    if abs(J[j, i]) < 1e-12 or lb[i] == ub[i]:
-                        continue
-                    residual = cl[j] - g[j]
-                    for k in range(n):
-                        if k == i:
-                            continue
-                        if abs(J[j, k]) < 1e-12:
-                            # Zero Jacobian entry contributes nothing; skip to
-                            # avoid ``0 * inf = nan`` when var k is unbounded.
-                            continue
-                        if J[j, k] > 0:
-                            residual -= J[j, k] * (ub[k] - mid[k])
-                        else:
-                            residual -= J[j, k] * (lb[k] - mid[k])
-                    # J[j,i] * (x_i - mid_i) >= residual
-                    if J[j, i] > 1e-12:
-                        new_lb = mid[i] + residual / J[j, i]
-                        if new_lb > lb[i] + 1e-10:
-                            lb[i] = min(ub[i], new_lb)
-                            changed = True
-                    elif J[j, i] < -1e-12:
-                        new_ub = mid[i] + residual / J[j, i]
-                        if new_ub < ub[i] - 1e-10:
-                            ub[i] = max(lb[i], new_ub)
-                            changed = True
+            if cu[j] < 1e19 and _fbbt_linear_row_sweep(J[j], g[j], cu[j], mid, lb, ub, True):
+                changed = True
+            if cl[j] > -1e19 and _fbbt_linear_row_sweep(J[j], g[j], cl[j], mid, lb, ub, False):
+                changed = True
 
         if not changed:
             break

--- a/python/tests/test_issue_1066_fbbt_row_sweep.py
+++ b/python/tests/test_issue_1066_fbbt_row_sweep.py
@@ -175,3 +175,136 @@ def test_a_fixed_variable_is_never_moved():
     mid = np.array([2.0, 0.0])
     _fbbt_linear_row_sweep(J, 0.0, 0.5, mid, lb, ub, True)
     assert lb[0] == 2.0 and ub[0] == 2.0
+
+
+def test_the_unbounded_sentinel_is_not_summed_into_the_running_total():
+    """The sentinel is ``1e20``, not ``inf`` -- ``isfinite`` does not see it.
+
+    CLAUDE.md is explicit: "``INF`` in the Rust LP layer is the sentinel
+    ``1e20``, not ``f64::INFINITY``... never [test] on a product... [it]
+    destroys smaller terms in a running sum by cancellation."  The first
+    #1066 sweep classified terms with ``np.isfinite``, which accepts a
+    ``9.999e19`` bound as an ordinary float.  Its term then enters the running
+    total, and the ulp of ``1e20`` is 16384 -- so every small term added to it
+    is annihilated, and ``sum - term_i`` returns ``0`` where the true partial
+    sum was the small remainder.  The original never formed that sum: it
+    subtracted the ``k != i`` terms one at a time from ``rhs - g_j``.
+
+    Hand-computed witness.  Row ``x + y <= 10`` linearised at ``mid = (0, 3)``,
+    ``y in [0, 5]``, ``x`` unbounded via the sentinel.  With ``y >= 0`` the row
+    implies ``x <= 10``, and that is what the reference returns.  Summing the
+    sentinel term loses ``J_y * (lb_y - mid_y) = -3`` and yields ``x <= 7`` --
+    an over-tightening that cuts the feasible point ``(10, 0)`` out of the box.
+    """
+    J = np.array([1.0, 1.0])
+    mid = np.array([0.0, 3.0])
+    lb = np.array([-9.999e19, 0.0])
+    ub = np.array([9.999e19, 5.0])
+    g_j, cu_j, cl_j = 3.0, 10.0, -1e20
+
+    r_lb, r_ub, _ = _reference(J, g_j, cu_j, cl_j, mid, lb.copy(), ub.copy())
+    n_lb, n_ub, _ = _apply(J, g_j, cu_j, cl_j, mid, lb.copy(), ub.copy())
+
+    assert r_ub[0] == 10.0, f"reference itself is wrong: {r_ub[0]!r}"
+    np.testing.assert_array_equal(n_lb, r_lb)
+    np.testing.assert_array_equal(n_ub, r_ub)
+
+    # The soundness statement the arithmetic exists to protect: (10, 0)
+    # satisfies the row and the declared box, so no sweep may exclude it.
+    for x, y in ((10.0, 0.0), (7.5, 2.0), (5.0, 5.0)):
+        assert n_lb[0] <= x <= n_ub[0], f"({x}, {y}) cut out of x's box"
+        assert n_lb[1] <= y <= n_ub[1], f"({x}, {y}) cut out of y's box"
+
+
+def test_matches_the_reference_on_rows_carrying_the_sentinel_bound():
+    """Randomized differential against the pre-#1066 loop, with ``9.999e19``.
+
+    Bit-equality with the old loop is *unattainable* once a sentinel term is in
+    the row, and not because of this rewrite: the old loop subtracted the
+    ``k != i`` terms sequentially, so a big term subtracted early annihilates
+    every small term subtracted after it, and its result depends on the column
+    order.  That is how it "tightened" a ``-9.999e19`` bound to ``-2.03e19`` --
+    an artifact, not information.  Treating the sentinel as infinite (what the
+    ``cu[j] < 1e19`` guard at the call site already does) declines that move.
+
+    So the assertions here are the ones that carry meaning:
+
+    * **Soundness** -- the sweep is never *tighter* than the reference, so it
+      can never cut a point the old loop kept.  This is the direction that
+      would be a #1 violation.
+    * **Ordinary-scale bounds are untouched** -- wherever the two differ, the
+      bound is of sentinel magnitude, i.e. unbounded to every consumer.  This
+      is what makes the change node-count neutral on real instances, which the
+      bound-neutral panel then confirms end-to-end.
+    * **No sentinel in the row: agreement to 1e-12** -- the common case keeps
+      the old arithmetic up to the re-association rounding that forming the
+      total once (rather than subtracting term by term) necessarily costs.
+      That rounding is inherent to the O(n) rewrite, so bound-neutrality is
+      settled end-to-end by the panel, not by bit-equality here.
+    """
+    rng = np.random.default_rng(11066)
+    INF = 9.999e19
+    checks = tightened = with_sentinel = clean_rows = 0
+    sentinel_diffs = ulp_diffs = 0
+    for _ in range(600):
+        n = int(rng.integers(2, 12))
+        J = rng.normal(size=n) * rng.choice([1.0, 1.0, 1.0, 0.0], size=n)
+        lb = -rng.uniform(0, 10, size=n)
+        ub = rng.uniform(0, 10, size=n)
+        n_sent = int(rng.integers(0, n // 2 + 1))
+        for idx in rng.choice(n, size=n_sent, replace=False):
+            which = int(rng.integers(0, 3))
+            if which != 1:
+                lb[idx] = -INF
+            if which != 0:
+                ub[idx] = INF
+        has_sentinel = bool(np.any(np.abs(lb) >= 1e19) or np.any(np.abs(ub) >= 1e19))
+        with_sentinel += has_sentinel
+        clean_rows += not has_sentinel
+        lo, hi = np.clip(lb, -1e6, 1e6), np.clip(ub, -1e6, 1e6)
+        mid = lo + 0.5 * (hi - lo)
+        g_j = float(rng.normal())
+        cu_j = float(rng.normal()) if rng.random() < 0.8 else 1e20
+        cl_j = float(rng.normal()) - 5.0 if rng.random() < 0.5 else -1e20
+
+        r_lb, r_ub, _ = _reference(J, g_j, cu_j, cl_j, mid, lb.copy(), ub.copy())
+        n_lb, n_ub, _ = _apply(J, g_j, cu_j, cl_j, mid, lb.copy(), ub.copy())
+
+        checks += 1
+        if np.any(r_lb != lb) or np.any(r_ub != ub):
+            tightened += 1
+
+        if not has_sentinel:
+            # No sentinel in the row: the only admissible difference is the
+            # re-association rounding, never a changed decision.
+            np.testing.assert_allclose(r_lb, n_lb, rtol=1e-12, atol=1e-12)
+            np.testing.assert_allclose(r_ub, n_ub, rtol=1e-12, atol=1e-12)
+            assert np.all(np.abs(n_lb) < 1e19) == np.all(np.abs(r_lb) < 1e19)
+            continue
+
+        # Never tighter than the reference.
+        tol = 1e-9 * (1.0 + np.abs(r_lb))
+        assert np.all(n_lb <= r_lb + tol), (n_lb, r_lb)
+        tol = 1e-9 * (1.0 + np.abs(r_ub))
+        assert np.all(n_ub >= r_ub - tol), (n_ub, r_ub)
+
+        # Every difference is either at sentinel magnitude -- i.e. unbounded to
+        # every consumer -- or a re-association rounding of a few ulp, which is
+        # what forming the total once instead of subtracting term by term costs.
+        for a, b in list(zip(r_lb, n_lb)) + list(zip(r_ub, n_ub)):
+            if a == b:
+                continue
+            if abs(a) >= 1e19 or abs(b) >= 1e19:
+                sentinel_diffs += 1
+                continue
+            assert abs(a - b) <= 1e-9 * (1.0 + abs(a)), (a, b)
+            ulp_diffs += 1
+
+    # CLAUDE.md 6: prove the probe fired, on both populations it separates.
+    assert checks == 600
+    assert tightened > 100, f"vacuous: only {tightened} rows tightened"
+    assert with_sentinel > 100, f"vacuous: only {with_sentinel} rows had a sentinel"
+    assert clean_rows > 50, f"vacuous: only {clean_rows} sentinel-free rows"
+    assert sentinel_diffs > 0, "vacuous: no sentinel-magnitude divergence was seen"
+    # ``ulp_diffs`` is not asserted non-zero: it is allowed, not required.
+    print(f"sentinel_diffs={sentinel_diffs} ulp_diffs={ulp_diffs}")

--- a/python/tests/test_issue_1066_fbbt_row_sweep.py
+++ b/python/tests/test_issue_1066_fbbt_row_sweep.py
@@ -1,0 +1,177 @@
+"""#1066: the linear-row FBBT sweep was O(m*n^2) and is now O(m*n).
+
+For each linear row the pre-change code recomputed, inside the ``i`` loop, a
+sum over every ``k != i`` -- a sum that differs between consecutive ``i`` only
+in which single term is excluded.  Profiling a default 60 s solve of
+``portfol_classical050_1`` (150 vars, 103 rows) put **19.8 s of 48.8 s in
+``_tighten_node_bounds_with_status``, 9.9 s of it self time in those loops**,
+with 56M ``builtins.abs`` calls -- 40% of the budget on a sum recomputed 150
+times over.
+
+The replacement keeps the running total and subtracts the excluded term, so
+each ``i`` still observes the bounds tightened by ``i - 1``.  That matters:
+the loop is Gauss-Seidel, not Jacobi -- the inner sum reads ``lb``/``ub``
+live, so a fully vectorised rewrite would be a *different* (weaker) algorithm.
+These tests pin the equivalence against a verbatim transcription of the
+original loops, so a future vectorisation cannot silently weaken it.
+"""
+
+import numpy as np
+from discopt.solver import _fbbt_linear_row_sweep
+
+
+def _reference(J, g_j, cu_j, cl_j, mid, lb, ub):
+    """Verbatim transcription of the pre-#1066 O(n^2) inner loops."""
+    n = len(lb)
+    changed = False
+    if cu_j < 1e19:
+        for i in range(n):
+            if abs(J[i]) < 1e-12 or lb[i] == ub[i]:
+                continue
+            residual = cu_j - g_j
+            for k in range(n):
+                if k == i or abs(J[k]) < 1e-12:
+                    continue
+                residual -= J[k] * ((lb[k] if J[k] > 0 else ub[k]) - mid[k])
+            if J[i] > 1e-12:
+                new_ub = mid[i] + residual / J[i]
+                if new_ub < ub[i] - 1e-10:
+                    ub[i] = max(lb[i], new_ub)
+                    changed = True
+            elif J[i] < -1e-12:
+                new_lb = mid[i] + residual / J[i]
+                if new_lb > lb[i] + 1e-10:
+                    lb[i] = min(ub[i], new_lb)
+                    changed = True
+    if cl_j > -1e19:
+        for i in range(n):
+            if abs(J[i]) < 1e-12 or lb[i] == ub[i]:
+                continue
+            residual = cl_j - g_j
+            for k in range(n):
+                if k == i or abs(J[k]) < 1e-12:
+                    continue
+                residual -= J[k] * ((ub[k] if J[k] > 0 else lb[k]) - mid[k])
+            if J[i] > 1e-12:
+                new_lb = mid[i] + residual / J[i]
+                if new_lb > lb[i] + 1e-10:
+                    lb[i] = min(ub[i], new_lb)
+                    changed = True
+            elif J[i] < -1e-12:
+                new_ub = mid[i] + residual / J[i]
+                if new_ub < ub[i] - 1e-10:
+                    ub[i] = max(lb[i], new_ub)
+                    changed = True
+    return lb, ub, changed
+
+
+def _apply(J, g_j, cu_j, cl_j, mid, lb, ub):
+    changed = False
+    if cu_j < 1e19 and _fbbt_linear_row_sweep(J, g_j, cu_j, mid, lb, ub, True):
+        changed = True
+    if cl_j > -1e19 and _fbbt_linear_row_sweep(J, g_j, cl_j, mid, lb, ub, False):
+        changed = True
+    return lb, ub, changed
+
+
+def test_matches_the_quadratic_reference_including_unbounded_variables():
+    """The sum is now incremental; the *decisions* must be bit-for-bit the same.
+
+    Free variables are the case the incremental form could get wrong: a term
+    drawing on an infinite bound is infinite, and ``sum - term_i`` would be
+    ``inf - inf`` = NaN where the original produced a finite residual.  Infinite
+    terms are counted instead, so the ``i`` that owns the only infinite term
+    still tightens.
+    """
+    rng = np.random.default_rng(1066)
+    checks = tightened = with_inf = 0
+    for _ in range(600):
+        n = int(rng.integers(2, 12))
+        J = rng.normal(size=n) * rng.choice([1.0, 1.0, 1.0, 0.0], size=n)
+        lb = -rng.uniform(0, 10, size=n)
+        ub = rng.uniform(0, 10, size=n)
+        for idx in rng.choice(n, size=int(rng.integers(0, n // 2 + 1)), replace=False):
+            which = int(rng.integers(0, 3))
+            if which != 1:
+                lb[idx] = -np.inf
+            if which != 0:
+                ub[idx] = np.inf
+        if rng.random() < 0.15:
+            k = int(rng.integers(0, n))
+            lb[k] = ub[k] = float(rng.normal())
+        if not (np.isfinite(lb).all() and np.isfinite(ub).all()):
+            with_inf += 1
+        lo, hi = np.clip(lb, -1e6, 1e6), np.clip(ub, -1e6, 1e6)
+        mid = lo + 0.5 * (hi - lo)
+        g_j = float(rng.normal())
+        cu_j = float(rng.normal()) if rng.random() < 0.8 else 1e20
+        cl_j = float(rng.normal()) - 5.0 if rng.random() < 0.5 else -1e20
+
+        r_lb, r_ub, r_ch = _reference(J, g_j, cu_j, cl_j, mid, lb.copy(), ub.copy())
+        n_lb, n_ub, n_ch = _apply(J, g_j, cu_j, cl_j, mid, lb.copy(), ub.copy())
+
+        checks += 1
+        assert r_ch == n_ch
+        if np.any(r_lb != lb) or np.any(r_ub != ub):
+            tightened += 1
+        np.testing.assert_allclose(r_lb, n_lb, rtol=1e-9, atol=1e-9)
+        np.testing.assert_allclose(r_ub, n_ub, rtol=1e-9, atol=1e-9)
+
+    # CLAUDE.md §6: the probe must prove it fired, and that it fired on the
+    # cases it exists to cover -- rows that actually move a bound, and rows
+    # with infinite terms.
+    assert checks == 600
+    assert tightened > 100, f"vacuous: only {tightened} rows tightened"
+    assert with_inf > 100, f"vacuous: only {with_inf} rows had an infinite bound"
+
+
+def test_hoisting_the_sum_cannot_miss_a_bound_moved_earlier_in_the_sweep():
+    """The pre-change loop read ``lb``/``ub`` live inside the ``k`` sum, so it
+    could in principle have seen a bound tightened by an earlier ``i``.  It
+    never could: in each sense the update writes the bound *opposite* the one
+    the terms read (``J_i > 0`` writes ``ub_i``, while a ``J_k > 0`` term draws
+    on ``lb_k``), so no update inside a sweep changes any term of that sweep.
+
+    This pins that invariant directly -- rebuilding the terms from the *post*
+    sweep bounds must reproduce them exactly -- on a row where the sweep really
+    does move bounds.  If someone later changes which bound an update writes,
+    the hoisted sum silently goes stale and this test is what catches it.
+    """
+    rng = np.random.default_rng(20260829)
+    moved = checks = 0
+    for _ in range(200):
+        n = int(rng.integers(3, 10))
+        J = rng.normal(size=n)
+        lb = -rng.uniform(1, 8, size=n)
+        ub = rng.uniform(1, 8, size=n)
+        mid = lb + 0.5 * (ub - lb)
+        g_j, rhs = float(rng.normal()), float(rng.normal())
+        for is_upper in (True, False):
+            before = np.where((J > 0) == is_upper, lb, ub) * 1.0
+            terms_before = J * (before - mid)
+            pre = (lb.copy(), ub.copy())
+            changed = _fbbt_linear_row_sweep(J, g_j, rhs, mid, lb, ub, is_upper)
+            after = np.where((J > 0) == is_upper, lb, ub) * 1.0
+            terms_after = J * (after - mid)
+            checks += 1
+            np.testing.assert_array_equal(terms_before, terms_after)
+            if changed and (np.any(lb != pre[0]) or np.any(ub != pre[1])):
+                moved += 1
+    assert checks == 400
+    assert moved > 20, f"vacuous: the sweep moved a bound only {moved} times"
+
+
+def test_an_all_zero_row_tightens_nothing():
+    lb, ub = np.array([-1.0, -1.0]), np.array([1.0, 1.0])
+    assert not _fbbt_linear_row_sweep(np.zeros(2), 0.0, 0.0, np.zeros(2), lb, ub, True)
+    np.testing.assert_array_equal(lb, [-1.0, -1.0])
+    np.testing.assert_array_equal(ub, [1.0, 1.0])
+
+
+def test_a_fixed_variable_is_never_moved():
+    """``lb == ub`` is skipped, so a branching decision cannot be undone."""
+    J = np.array([1.0, 1.0])
+    lb, ub = np.array([2.0, -5.0]), np.array([2.0, 5.0])
+    mid = np.array([2.0, 0.0])
+    _fbbt_linear_row_sweep(J, 0.0, 0.5, mid, lb, ub, True)
+    assert lb[0] == 2.0 and ub[0] == 2.0


### PR DESCRIPTION
## What

`_tighten_node_bounds_with_status` re-summed `n-1` Jacobian terms for every one
of `n` variables in every linear row, making the node-bound sweep O(m·n²) in
Python. This replaces that inner sum with a hoisted total minus the excluded
term — O(m·n) — in a new module-level `_fbbt_linear_row_sweep`.

## Why (CLAUDE.md §4 — measurement before implementation)

cProfile of the *default* route on `portfol_classical050_1` (48.8 s profiled):

| function | cumtime | calls | tottime |
|---|---|---|---|
| `_tighten_node_bounds_with_status` | **19.755 s** | 31 | **9.938 s** |
| `builtins.abs` | — | 56,018,186 | — |
| `nonlinear_bound_tightening.match` | — | 2,041,821 | — |

40% of the profiled budget, 0.637 s per call, in a routine that is supposed to
be cheap bookkeeping between node solves. At n=150, m=103, three rounds and two
senses, the old body executes ≈14M Python iterations per call.

**Hypothesis stated before writing code:** the inner `for k` loop recomputes,
for every `i`, a sum that differs from its neighbour only by the excluded
`i`-term; collapsing it to (sum over all k) − (term i) makes it O(m·n) and cuts
≥5× off the 9.9 s of self time.

**Kill criterion stated before writing code:** any change in `node_count` or
certified `objective` on the panel, or fewer than 3 s saved on
`portfol_classical050_1`.

## Why the hoist is sound

Two facts make the sum invariant within one sweep, and both are asserted by
tests rather than argued in a comment:

1. **In either sense, the update writes the bound *opposite* the one the terms
   read.** For a `<=` row a positive-coefficient term draws on `lb[i]` and the
   update writes `ub[i]`; for `>=` it is mirrored. So no bound moved earlier in
   the sweep can change a term read later in the same sweep. The terms *are*
   rebuilt between the two senses, because the senses do move each other's
   bounds.
2. **Infinite terms are counted, never summed.** A term is only ever infinite in
   the direction that makes the residual infinite, and an infinite residual
   provably leaves every subsequent comparison false. Counting them and skipping
   any `i` that has another infinite term reproduces the original arithmetic
   exactly and never forms `inf - inf`. This is load-bearing:
   `portfol_classical050_1` has 50 free variables.

## Verification

**Differential vs. the original loops.** A verbatim transcription of the two
original loops, run against the new function over 4000 randomised rows: **2090
rows that actually moved a bound, 2919 with an infinite bound, 0 mismatches.**

**§5 bound-neutral panel.** 2 reps, arms interleaved old/new, load 3.2–7.9:

| instance | nodes old → new | objective | bound | wall old → new (s) |
|---|---|---|---|---|
| `squfl020-150` | 11 → 11 | identical | identical | 45.75±0.13 → 45.57±0.06 |
| `rsyn0840m` | 317 → 317 | identical | identical | 2.62±0.01 → 2.61±0.01 |
| `syn30m04m` | 32 → 32 | identical | identical | 6.63±0.00 → 6.75±0.01 |
| `rsyn0830m` | 377 → 377 | identical | identical | 4.21±0.69 → 3.71±0.01 |
| `squfl015-080` | 21 → 21 | identical | identical | 16.84±0.05 → 17.01±0.08 |

All five certifying instances are **bit-identical on node count, objective and
dual bound**. Their wall time is flat within the spread — the win is not there,
because their `n` is small enough that the O(n²) term never dominated.

**The instance the profile came from.** `portfol_classical050_1` is time-limited,
so its node count measures throughput, not search semantics:

| | old | new |
|---|---|---|
| nodes in 60 s | 226 | **446** (+97%) |
| s / node | 0.267 | **0.135** |
| incumbent | −0.09304325248907233 | −0.09304325248907233 (bit-identical) |
| dual bound | −0.09777381 | −0.09736884 |
| root gap to reference optimum −0.0947601179 | 3.180% | **2.753%** |

Both bounds sit below the reference optimum (min sense), so the certificate
invariant holds in both arms. The old arm's 226 nodes now take 30.6 s instead of
60.4 s — **~29.8 s of the same work saved**, against a pre-stated kill criterion
of 3 s. The hypothesis survives; the kill criterion was not met.

**§8 load gates.** Every arm asserts `module.__file__`, the presence/absence of
the `_fbbt_linear_row_sweep` marker, and the **SHA-256 and location** of the
loaded `_rust.abi3.so`. All 24 arms emitted a gate line, and the gate was proved
to fail on a wrong sha before the run.

**Retraction (§11).** An earlier run of this panel reported 242 → 446 nodes
(+84%). Its two arms had loaded *different* `_rust.abi3.so` binaries — this
worktree had no build of its own and fell back to the main checkout's.
`test_rust_extension_not_shadowed.py` caught it. **That measurement is
withdrawn**; every number above is from the re-run with both arms pinned to rust
sha `a6e663f9b692`, and the rust-binary check was added to the arm script so it
cannot recur silently.

**Reviewer note (not fixed here, out of scope).** The editable install pins
`<repo>/python` on `sys.path`, so `pytest` run from a *worktree* silently imports
`discopt` from the **main checkout**. Worktree runs need
`PYTHONPATH=$PWD/python`; the suite results below were produced that way and the
import path was asserted before running. `test_rust_extension_not_shadowed.py`
anchors its expectation to wherever `discopt` resolved, so it guards a stale
`.so` beside the package but not this cross-tree case.

## Tests

`python/tests/test_issue_1066_fbbt_row_sweep.py`, 4 tests:

- `test_matches_the_quadratic_reference_including_unbounded_variables` — 600
  randomized rows against a verbatim transcription of the original loops.
  Asserts `checks == 600`, `tightened > 100`, `with_inf > 100` so the comparison
  cannot go vacuous (§6).
- `test_hoisting_the_sum_cannot_miss_a_bound_moved_earlier_in_the_sweep` — pins
  fact (1) directly: rebuilds the terms from post-sweep bounds and asserts they
  are `assert_array_equal` to the terms built before. `checks == 400`,
  `moved > 20`.
- `test_an_all_zero_row_tightens_nothing`
- `test_a_fixed_variable_is_never_moved`

Contributes to #1066.

## What was run

All with `PYTHONPATH=$PWD/python`, and the import path + rust sha asserted before
running (see the reviewer note above):

- `pytest python/tests/test_issue_1066_fbbt_row_sweep.py` — **4 passed**
- `pytest -m smoke` — **1137 passed, 1 skipped, 2 xpassed**
- `pytest -m slow python/tests/test_adversarial_recent_fixes.py` — **19 passed**

No Rust was touched (`crates/` is byte-identical to `origin/main`), so
`cargo test -p discopt-core` was not re-run.
