### PR TITLE
perf(#1066): cache the bound-independent half of the nonlinear row scan

### DIFF
--- a/python/discopt/_relax/nonlinear_bound_tightening.py
+++ b/python/discopt/_relax/nonlinear_bound_tightening.py
@@ -12,6 +12,7 @@ import inspect
 import logging
 import time
 from dataclasses import dataclass
+from types import MappingProxyType
 from typing import Callable, NoReturn, Optional, Sequence, TypeVar
 
 import numpy as np
@@ -135,6 +136,7 @@ def _get_struct_cache(model: Model) -> dict:
         cache = {
             "token": token,
             "flatten": {},
+            "rowstruct": {},
             "metadata": build_flat_variable_metadata(model),
         }
         try:
@@ -174,6 +176,54 @@ def _cached_flat_terms(model: Model, expr) -> list[tuple[float, object]]:
     return terms
 
 
+_ROWSTRUCT_MISS = object()
+
+
+def _cached_row_structure(model: Model, rule_name: str, constraint, metadata, build):
+    """Memoize a rule's *bound-independent* decomposition of one constraint row.
+
+    A rule's row scan splits into two halves: deriving the row's algebraic
+    shape (which terms are squares, which are linear, their coefficients) and
+    then intersecting that shape against the current box. Only the second half
+    reads ``flat_lb``/``flat_ub``; the first depends solely on the expression
+    DAG and the flat-variable metadata, both invariant across B&B nodes -- the
+    same invariant ``_cached_flat_terms`` already relies on.
+
+    Measured on portfol_classical050_1 (#1066), that first half dominated:
+    10.5M ``_constant_value`` calls and 55.6M ``isinstance`` calls, 15.9 s of a
+    46.6 s solve, redone identically at every one of 160 tightening passes.
+
+    The whole decomposition is cached rather than the individual term matches,
+    because a per-term cache would have to re-apply each term's scale *after*
+    the lookup. Threading the scale through the recursion computes
+    ``(s * c1) * c2`` while a unit-scale cache would compute ``s * (c1 * c2)``;
+    those differ in the last ulp, which would move a bound and violate the
+    CLAUDE.md 5 bound-neutrality requirement. Caching the finished dicts
+    reproduces the original arithmetic bit-for-bit.
+
+    ``build`` must return the decomposition, or ``None`` when the row does not
+    match the rule -- a non-match is cached too, since it is just as invariant.
+
+    The decomposition depends on ``metadata`` as well as on the row, and
+    ``metadata`` reaches a rule as a *parameter*. The production driver always
+    passes ``_cached_flat_metadata(model)`` -- the very object this cache is
+    stored beside, invalidated by the same structural token -- but a caller that
+    builds its own metadata (a test exercising a rule directly) would otherwise
+    read entries derived from a different one. Such a caller bypasses the cache
+    rather than being trusted to match it.
+    """
+    cache = _get_struct_cache(model)
+    if metadata is not cache["metadata"]:
+        return build()
+    rowstruct = cache["rowstruct"]
+    key = (rule_name, id(constraint.body))
+    value = rowstruct.get(key, _ROWSTRUCT_MISS)
+    if value is _ROWSTRUCT_MISS:
+        value = build()
+        rowstruct[key] = value
+    return value
+
+
 @dataclass(frozen=True)
 class NonlinearBoundTighteningStats:
     """Summary of a nonlinear tightening pass."""
@@ -196,6 +246,28 @@ class NonlinearBoundTighteningStats:
 # its deadline once per binary on an instance with 7 binaries and 107k constraints,
 # which is a poll that never fires in time.
 _DEADLINE_POLL_STRIDE = 64
+
+
+def _cached_model_structure(model: Model, key: str, metadata, build):
+    """Memoize a rule's *bound-independent* scan of the whole model.
+
+    The row-level sibling :func:`_cached_row_structure` keys on one constraint
+    body; a rule whose conclusion depends on what the model does *not* contain
+    (``PeriodicVariableBoundRule``) must scan the objective and every row before
+    it can conclude anything, so its unit of caching is the model.
+
+    Same metadata guard, for the same reason: the scan resolves expressions to
+    flat indices through ``metadata``, so a caller supplying its own bypasses the
+    cache rather than being trusted to match it.
+    """
+    cache = _get_struct_cache(model)
+    if metadata is not cache["metadata"]:
+        return build()
+    value = cache.get(key, _ROWSTRUCT_MISS)
+    if value is _ROWSTRUCT_MISS:
+        value = build()
+        cache[key] = value
+    return value
 
 
 def _rows_until(model: Model, deadline: Optional[float]):
@@ -977,6 +1049,58 @@ class SeparableQuadraticUpperBoundRule(NonlinearBoundTighteningRule):
     ) -> Optional[tuple[int, float]]:
         return _match_scaled_square_var(expr, scale, metadata)
 
+    def _decompose_row(
+        self,
+        model: Model,
+        constraint,
+        metadata: FlatVariableMetadata,
+    ) -> Optional[tuple[float, dict[int, tuple[float, float]]]]:
+        """Bound-independent half of the row scan; see ``_cached_row_structure``.
+
+        Returns ``(constant_term, {flat_idx: (quad_coeff, linear_coeff)})``, or
+        ``None`` when the row is not a separable convex quadratic this rule can
+        use. The arithmetic is exactly the loop this replaced, in the same order.
+        """
+        terms = _cached_flat_terms(model, constraint.body)
+
+        constant_term = 0.0
+        quad_coeffs: dict[int, float] = {}
+        linear_coeffs: dict[int, float] = {}
+
+        for scale, term in terms:
+            const_val = _constant_value(term)
+            if const_val is not None:
+                constant_term += scale * const_val
+                continue
+
+            square_match = self._match_scaled_square(term, scale, metadata)
+            if square_match is not None:
+                flat_idx, coeff = square_match
+                quad_coeffs[flat_idx] = quad_coeffs.get(flat_idx, 0.0) + coeff
+                continue
+
+            linear_match = _match_scaled_linear_var(term, scale, metadata)
+            if linear_match is not None:
+                flat_idx, coeff = linear_match
+                linear_coeffs[flat_idx] = linear_coeffs.get(flat_idx, 0.0) + coeff
+                continue
+
+            return None
+
+        if not quad_coeffs and not linear_coeffs:
+            return None
+
+        coeffs = {
+            flat_idx: (
+                quad_coeffs.get(flat_idx, 0.0),
+                linear_coeffs.get(flat_idx, 0.0),
+            )
+            for flat_idx in set(quad_coeffs) | set(linear_coeffs)
+        }
+        if any(a < -1e-12 for a, _ in coeffs.values()):
+            return None
+        return constant_term, coeffs
+
     def tighten(
         self,
         model: Model,
@@ -992,46 +1116,16 @@ class SeparableQuadraticUpperBoundRule(NonlinearBoundTighteningRule):
             if getattr(constraint, "sense", None) not in ("<=", "=="):
                 continue
 
-            terms = _cached_flat_terms(model, constraint.body)
-
-            constant_term = 0.0
-            quad_coeffs: dict[int, float] = {}
-            linear_coeffs: dict[int, float] = {}
-            matches_pattern = True
-
-            for scale, term in terms:
-                const_val = _constant_value(term)
-                if const_val is not None:
-                    constant_term += scale * const_val
-                    continue
-
-                square_match = self._match_scaled_square(term, scale, metadata)
-                if square_match is not None:
-                    flat_idx, coeff = square_match
-                    quad_coeffs[flat_idx] = quad_coeffs.get(flat_idx, 0.0) + coeff
-                    continue
-
-                linear_match = _match_scaled_linear_var(term, scale, metadata)
-                if linear_match is not None:
-                    flat_idx, coeff = linear_match
-                    linear_coeffs[flat_idx] = linear_coeffs.get(flat_idx, 0.0) + coeff
-                    continue
-
-                matches_pattern = False
-                break
-
-            if not matches_pattern or (not quad_coeffs and not linear_coeffs):
+            structure = _cached_row_structure(
+                model,
+                self.name,
+                constraint,
+                metadata,
+                lambda c=constraint: self._decompose_row(model, c, metadata),
+            )
+            if structure is None:
                 continue
-
-            coeffs = {
-                flat_idx: (
-                    quad_coeffs.get(flat_idx, 0.0),
-                    linear_coeffs.get(flat_idx, 0.0),
-                )
-                for flat_idx in set(quad_coeffs) | set(linear_coeffs)
-            }
-            if any(a < -1e-12 for a, _ in coeffs.values()):
-                continue
+            constant_term, coeffs = structure
 
             min_contribs: dict[int, float] = {}
             for flat_idx, (a, b) in coeffs.items():
@@ -1747,6 +1841,38 @@ class SquareDifferenceLowerBoundRule(NonlinearBoundTighteningRule):
 
         return None
 
+    def _decompose_row(
+        self,
+        constraint,
+        metadata: FlatVariableMetadata,
+    ) -> Optional[tuple[float, int, float, list[tuple[int, float]]]]:
+        """Bound-independent half of the row scan; see ``_cached_row_structure``.
+
+        Returns ``(constant_term, target_idx, target_scale, positive)`` -- the
+        negative square this rule tightens and the positive squares whose box
+        activity bounds it -- or ``None`` when the row is not of that shape. The
+        arithmetic is exactly the prologue this replaced, in the same order, and
+        ``positive`` keeps its original list order because the caller sums over
+        it in floating point.
+        """
+        if getattr(constraint, "sense", None) != "==":
+            return None
+
+        square_coeffs: dict[int, float] = {}
+        constant = self._collect_square_sum(constraint.body, 1.0, metadata, square_coeffs)
+        if constant is None:
+            return None
+        constant_term = float(constant)
+
+        square_coeffs = {idx: coeff for idx, coeff in square_coeffs.items() if abs(coeff) > 1e-12}
+        negative = [(idx, coeff) for idx, coeff in square_coeffs.items() if coeff < -1e-12]
+        positive = [(idx, coeff) for idx, coeff in square_coeffs.items() if coeff > 1e-12]
+        if len(negative) != 1 or not positive:
+            return None
+
+        target_idx, target_coeff = negative[0]
+        return constant_term, target_idx, -target_coeff, positive
+
     def tighten(
         self,
         model: Model,
@@ -1759,25 +1885,17 @@ class SquareDifferenceLowerBoundRule(NonlinearBoundTighteningRule):
         tightened_ub = flat_ub.copy()
 
         for constraint in _rows_until(model, deadline):
-            if getattr(constraint, "sense", None) != "==":
+            structure = _cached_row_structure(
+                model,
+                self.name,
+                constraint,
+                metadata,
+                lambda c=constraint: self._decompose_row(c, metadata),
+            )
+            if structure is None:
                 continue
+            constant_term, target_idx, target_scale, positive = structure
 
-            square_coeffs: dict[int, float] = {}
-            constant = self._collect_square_sum(constraint.body, 1.0, metadata, square_coeffs)
-            if constant is None:
-                continue
-            constant_term = float(constant)
-
-            square_coeffs = {
-                idx: coeff for idx, coeff in square_coeffs.items() if abs(coeff) > 1e-12
-            }
-            negative = [(idx, coeff) for idx, coeff in square_coeffs.items() if coeff < -1e-12]
-            positive = [(idx, coeff) for idx, coeff in square_coeffs.items() if coeff > 1e-12]
-            if len(negative) != 1 or not positive:
-                continue
-
-            target_idx, target_coeff = negative[0]
-            target_scale = -target_coeff
             rhs_lb = constant_term
             rhs_ub = constant_term
             for flat_idx, coeff in positive:
@@ -1969,6 +2087,60 @@ class NegativePowerBoundsRule(NonlinearBoundTighteningRule):
     # tightening -- safe to stop at a deadline mid-scan (#875).
     row_scan_is_anytime = True
 
+    def _decompose_row(
+        self,
+        model: Model,
+        constraint,
+        metadata: FlatVariableMetadata,
+        n_vars: int,
+    ) -> Optional[tuple[np.ndarray, float, int, float, float]]:
+        """Bound-independent half of the row scan; see ``_cached_row_structure``.
+
+        Returns ``(affine_coeff, affine_const, base_idx, exponent, power_scale)``
+        for a row of the form ``power_scale * x**exponent + affine <= rhs`` with
+        ``exponent < 0``, or ``None``. The arithmetic is exactly the prologue this
+        replaced, in the same order.
+
+        ``affine_coeff`` is shared by every node that reads this row, so it is
+        marked read-only: a downstream in-place write would otherwise corrupt the
+        cached row silently, and the box it produced with it (CLAUDE.md 3 --
+        refuse loudly rather than approximate).
+        """
+        if getattr(constraint, "sense", None) not in ("<=", "=="):
+            return None
+
+        terms = _cached_flat_terms(model, constraint.body)
+
+        power_match: Optional[tuple[int, float, float]] = None
+        affine_coeff = np.zeros(n_vars, dtype=np.float64)
+        affine_const = 0.0
+
+        for scale, term in terms:
+            match = _match_scaled_negative_power(term, scale, metadata)
+            if match is not None:
+                if power_match is not None:
+                    return None
+                power_match = match
+                continue
+
+            affine = _linearize_affine_expr(term, scale, metadata, n_vars)
+            if affine is None:
+                return None
+            affine_coeff += affine[0]
+            affine_const += affine[1]
+
+        if power_match is None:
+            return None
+
+        base_idx, exponent, power_scale = power_match
+        if power_scale <= 0.0:
+            return None
+        if abs(float(affine_coeff[base_idx])) > 1e-12:
+            return None
+
+        affine_coeff.setflags(write=False)
+        return affine_coeff, affine_const, base_idx, exponent, power_scale
+
     def tighten(
         self,
         model: Model,
@@ -1982,40 +2154,17 @@ class NegativePowerBoundsRule(NonlinearBoundTighteningRule):
         n_vars = len(flat_lb)
 
         for constraint in _rows_until(model, deadline):
-            if getattr(constraint, "sense", None) not in ("<=", "=="):
+            structure = _cached_row_structure(
+                model,
+                self.name,
+                constraint,
+                metadata,
+                lambda c=constraint: self._decompose_row(model, c, metadata, n_vars),
+            )
+            if structure is None:
                 continue
+            affine_coeff, affine_const, base_idx, exponent, power_scale = structure
 
-            terms = _cached_flat_terms(model, constraint.body)
-
-            power_match: Optional[tuple[int, float, float]] = None
-            affine_coeff = np.zeros(n_vars, dtype=np.float64)
-            affine_const = 0.0
-            matches_pattern = True
-
-            for scale, term in terms:
-                match = _match_scaled_negative_power(term, scale, metadata)
-                if match is not None:
-                    if power_match is not None:
-                        matches_pattern = False
-                        break
-                    power_match = match
-                    continue
-
-                affine = _linearize_affine_expr(term, scale, metadata, n_vars)
-                if affine is None:
-                    matches_pattern = False
-                    break
-                affine_coeff += affine[0]
-                affine_const += affine[1]
-
-            if not matches_pattern or power_match is None:
-                continue
-
-            base_idx, exponent, power_scale = power_match
-            if power_scale <= 0.0:
-                continue
-            if abs(float(affine_coeff[base_idx])) > 1e-12:
-                continue
             if tightened_lb[base_idx] < -1e-12 or tightened_ub[base_idx] <= 0.0:
                 continue
 
@@ -2337,6 +2486,64 @@ class BilinearProductEqualityRule(NonlinearBoundTighteningRule):
             return scale, v_idx, coeffs, const[0]
         return None
 
+    def _decompose_row(
+        self,
+        model: Model,
+        constraint,
+        metadata: FlatVariableMetadata,
+    ):
+        """Bound-independent half of the row scan; see ``_cached_row_structure``.
+
+        Returns ``(scale_p, v_idx, f_coeffs, f_const, rest_coeffs, rest_const)``
+        for a row ``s·(v·F) + R == 0``, or ``None``. The arithmetic is exactly the
+        prologue this replaced, in the same order.
+
+        The two coefficient maps are shared by every node that reads this row, so
+        they are wrapped read-only: ``_affine_box_interval`` only iterates them,
+        and a future in-place write would otherwise corrupt the cached row and
+        every box derived from it silently (CLAUDE.md 3 -- refuse loudly).
+        """
+        if getattr(constraint, "sense", None) != "==":
+            return None
+
+        terms = _cached_flat_terms(model, constraint.body)
+        product: Optional[tuple[float, int, dict[int, float], float]] = None
+        rest_coeffs: dict[int, float] = {}
+        rest_const = [0.0]
+
+        for scale, term in terms:
+            const_val = _constant_value(term)
+            if const_val is not None:
+                rest_const[0] += scale * const_val
+                continue
+            match = self._match_product_term(term, metadata)
+            if match is not None:
+                if product is not None:
+                    return None  # more than one bilinear product: not this pattern
+                p_scale, v_idx, f_coeffs, f_const = match
+                product = (scale * p_scale, v_idx, f_coeffs, f_const)
+                continue
+            if not _accumulate_affine(term, scale, metadata, rest_coeffs, rest_const):
+                return None  # a second nonlinear term: bail
+
+        if product is None:
+            return None
+
+        scale_p, v_idx, f_coeffs, f_const = product
+        # v must appear nowhere else (its presence in the remainder would make
+        # the isolation ``v = -R/(s·F)`` circular/unsound).
+        if abs(rest_coeffs.get(v_idx, 0.0)) > 1e-12:
+            return None
+
+        return (
+            scale_p,
+            v_idx,
+            MappingProxyType(f_coeffs),
+            f_const,
+            MappingProxyType(rest_coeffs),
+            rest_const[0],
+        )
+
     def tighten(
         self,
         model: Model,
@@ -2350,47 +2557,23 @@ class BilinearProductEqualityRule(NonlinearBoundTighteningRule):
         eps = 1e-9
 
         for constraint in _rows_until(model, deadline):
-            if getattr(constraint, "sense", None) != "==":
+            structure = _cached_row_structure(
+                model,
+                self.name,
+                constraint,
+                metadata,
+                lambda c=constraint: self._decompose_row(model, c, metadata),
+            )
+            if structure is None:
                 continue
-
-            terms = _cached_flat_terms(model, constraint.body)
-            product: Optional[tuple[float, int, dict[int, float], float]] = None
-            rest_coeffs: dict[int, float] = {}
-            rest_const = [0.0]
-            ok = True
-
-            for scale, term in terms:
-                const_val = _constant_value(term)
-                if const_val is not None:
-                    rest_const[0] += scale * const_val
-                    continue
-                match = self._match_product_term(term, metadata)
-                if match is not None:
-                    if product is not None:
-                        ok = False  # more than one bilinear product: not this pattern
-                        break
-                    p_scale, v_idx, f_coeffs, f_const = match
-                    product = (scale * p_scale, v_idx, f_coeffs, f_const)
-                    continue
-                if not _accumulate_affine(term, scale, metadata, rest_coeffs, rest_const):
-                    ok = False  # a second nonlinear term: bail
-                    break
-
-            if not ok or product is None:
-                continue
-
-            scale_p, v_idx, f_coeffs, f_const = product
-            # v must appear nowhere else (its presence in the remainder would make
-            # the isolation ``v = -R/(s·F)`` circular/unsound).
-            if abs(rest_coeffs.get(v_idx, 0.0)) > 1e-12:
-                continue
+            scale_p, v_idx, f_coeffs, f_const, rest_coeffs, rest_const_val = structure
 
             f_lo, f_hi = _affine_box_interval(f_coeffs, f_const, tightened_lb, tightened_ub)
             if not (f_lo > eps or f_hi < -eps):
                 continue  # F not sign-stable: division by an interval straddling 0
 
             r_lo, r_hi = _affine_box_interval(
-                rest_coeffs, rest_const[0], tightened_lb, tightened_ub
+                rest_coeffs, rest_const_val, tightened_lb, tightened_ub
             )
             # s·(v·F) + R == 0  ->  v·F == -R/s. Build the numerator box P.
             num_endpoints = [-r_hi / scale_p, -r_lo / scale_p]
@@ -2599,15 +2782,23 @@ class PeriodicVariableBoundRule(NonlinearBoundTighteningRule):
                 for sub in subs:
                     walk(sub)
 
-            if model._objective is not None:
-                walk(model._objective.expression)
-            for c in model._constraints:  # must be complete; see row_scan_is_anytime
-                walk(c.body)
+            def _scan():
+                """The whole bound-independent scan: which variables are
+                periodic-only, or ``None`` if an unrecognized node forbids the
+                conclusion. Depends on the expression graph, never on the box."""
+                if model._objective is not None:
+                    walk(model._objective.expression)
+                for c in model._constraints:  # must be complete; see row_scan_is_anytime
+                    walk(c.body)
+                if not complete[0]:
+                    return None
+                return frozenset(periodic - disqualified)
 
-            if not complete[0]:
+            periodic_only = _cached_model_structure(model, "periodic_only", metadata, _scan)
+            if periodic_only is None:
                 return lb, ub  # saw an unrecognized node -> change nothing
 
-            for idx in periodic - disqualified:
+            for idx in periodic_only:
                 if idx >= len(metadata.flat_var_types):
                     continue
                 if metadata.flat_var_types[idx] != VarType.CONTINUOUS:

--- a/python/tests/test_issue_1066_rowstruct_cache.py
+++ b/python/tests/test_issue_1066_rowstruct_cache.py
@@ -1,0 +1,113 @@
+"""#1066: the nonlinear row scan re-derived its bound-independent half per node.
+
+A rule's row scan splits in two: deriving the row's algebraic shape, then
+intersecting that shape against the current box. Only the second half reads the
+box, yet both halves ran at every tightening pass. Measured on
+``portfol_classical050_1`` after the linear-FBBT fix of the same issue, the first
+half was 15.9 s of a 46.6 s solve -- 10.5M ``_constant_value`` calls and 55.6M
+``isinstance`` calls, redone identically at every one of 160 passes.
+
+These tests pin the two properties that make caching that half legitimate: the
+cached path returns **bit-identical** bounds to the uncached scan (CLAUDE.md 5
+bound-neutrality), and the cache is genuinely exercised rather than silently
+bypassed -- otherwise the differential test would pass by comparing the uncached
+scan against itself (CLAUDE.md 6).
+"""
+
+from __future__ import annotations
+
+import discopt.modeling as dm
+import numpy as np
+import pytest
+from discopt._relax import nonlinear_bound_tightening as nbt
+from discopt._relax.model_utils import flat_variable_bounds
+from discopt.modeling.core import Model
+
+pytestmark = pytest.mark.unit
+
+
+def _model(name: str = "sepquad") -> Model:
+    """Rows the separable-quadratic rule accepts, plus one it must reject."""
+    m = Model(name)
+    x = m.continuous("x", lb=-5.0, ub=5.0)
+    y = m.continuous("y", lb=-4.0, ub=6.0)
+    z = m.continuous("z", lb=-3.0, ub=3.0)
+    m.subject_to(x**2 + 2.0 * y**2 + 3.0 * z <= 9.0)
+    m.subject_to(2.0 * x + y**2 <= 7.0)
+    m.subject_to(-x + 0.5 * z**2 + 1.5 <= 4.0)
+    m.subject_to(dm.exp(x) + y <= 20.0)  # not separable quadratic
+    m.minimize(x + y + z)
+    return m
+
+
+def _tighten(model: Model):
+    lb, ub = flat_variable_bounds(model)
+    return nbt.tighten_nonlinear_bounds(model, lb, ub)
+
+
+def test_cached_rows_give_bit_identical_bounds_to_the_uncached_scan(monkeypatch):
+    """The cache is an optimisation of the scan, not a different scan."""
+    cached_lb, cached_ub, cached_stats = _tighten(_model("cached"))
+
+    bypassed = {"n": 0}
+
+    def no_cache(model, rule_name, constraint, metadata, build):
+        bypassed["n"] += 1
+        return build()
+
+    monkeypatch.setattr(nbt, "_cached_row_structure", no_cache)
+    plain_lb, plain_ub, plain_stats = _tighten(_model("plain"))
+
+    # CLAUDE.md 6: a differential that never ran the control arm proves nothing.
+    assert bypassed["n"] > 0, "control arm never reached the cache seam"
+    assert "separable_quadratic_upper_bound" in cached_stats.applied_rules
+    np.testing.assert_array_equal(cached_lb, plain_lb)
+    np.testing.assert_array_equal(cached_ub, plain_ub)
+    assert cached_stats.applied_rules == plain_stats.applied_rules
+
+
+def test_the_cache_is_populated_and_reused_across_passes():
+    """Guards the differential above from passing because the cache is dead."""
+    m = _model()
+    _tighten(m)
+
+    cache = getattr(m, "_nl_struct_cache", None)
+    assert cache is not None, "structural cache was never attached to the model"
+    assert cache["rowstruct"], "no row decomposition was cached -- the fix is a no-op"
+    n_first = len(cache["rowstruct"])
+
+    # A second pass over the same model must reuse the entries, not re-add them.
+    lb, ub = flat_variable_bounds(m)
+    nbt.tighten_nonlinear_bounds(m, lb * 0.5, ub * 0.5)
+    assert len(cache["rowstruct"]) == n_first, "second pass re-derived cached rows"
+
+
+def test_a_row_the_rule_rejects_is_cached_as_a_rejection():
+    """A non-match is as bound-independent as a match, and on a real instance
+    most rows are non-matches -- caching only the matches would leave the cost."""
+    m = _model()
+    _tighten(m)
+    values = m._nl_struct_cache["rowstruct"].values()
+    assert any(v is None for v in values), "a rejected row was not cached as a rejection"
+    assert any(v is not None for v in values), "no row was accepted; the model is wrong"
+
+
+def test_a_caller_with_its_own_metadata_bypasses_the_cache():
+    """The decomposition depends on ``metadata``, which arrives as a parameter
+    and is therefore not covered by the model-structural cache token."""
+    m = _model()
+    _tighten(m)
+    cache = m._nl_struct_cache
+    n_before = len(cache["rowstruct"])
+
+    foreign = nbt.build_flat_variable_metadata(m)
+    assert foreign is not cache["metadata"]
+
+    built = []
+    rule = nbt.SeparableQuadraticUpperBoundRule()
+    out = nbt._cached_row_structure(
+        m, rule.name, m._constraints[0], foreign, lambda: built.append(1) or "rebuilt"
+    )
+    assert built == [1], "foreign metadata must rebuild rather than read the cache"
+    assert out == "rebuilt"
+    assert len(cache["rowstruct"]) == n_before, "a bypassed call must not write the cache"


### PR DESCRIPTION
## What

The nonlinear bound-tightening pass re-derives, on every call, the part of each
row's structure that does not depend on the current bounds: which rule matches,
which variables it involves, and the coefficients it extracts. Only the bounds
arithmetic that follows actually changes between passes.

This caches that bound-independent decomposition per `(rule, row)` and keeps the
arithmetic untouched.

Profiled on a default 60 s solve of `portfol_classical050_1` (150 vars, 103 rows),
nonlinear bound tightening was **15.9 s of a 46.6 s solve — 34% of the budget —
across 160 passes**, with 10.5M `_constant_value` calls and 2.4M
`_match_scaled_square_var` calls, nearly all of it re-deriving the same
decompositions.

Five rules are split into a cached `_decompose_row` plus the bounds arithmetic:
`SeparableQuadraticUpperBound`, `SquareDifferenceLowerBound`, `NegativePowerBounds`,
`BilinearProductEquality`, and `PeriodicVariableBound` (whose unit of caching is the
model, not the row).

## Why it is safe

The cache stores the *whole* decomposition rather than per-term matches. That is
deliberate: a unit-scale term cache would compute `s*(c1*c2)` where the recursion
computes `(s*c1)*c2` — an ulp difference that would move a bound. Storing the
decomposition keeps the arithmetic bit-identical.

It is keyed on `(rule_name, id(constraint.body))` and guarded by the existing
structural token, the same lifetime assumption `_cached_flat_terms` already makes.
A caller supplying its own `metadata` bypasses the cache rather than being trusted
to match it.

## Verification

**Differential against git HEAD** — 400 randomized models covering all five rule
shapes plus rows every rule rejects, asserting `module.__file__` in the worktree,
the marker present in the arm and **absent** in the control, and bit-identical
bounds via `assert_array_equal` (not `approx`):

```
CHECKS 6460   MODELS_TIGHTENED 245   ROWS_ACCEPTED 1600   ROWS_REJECTED 8454
EQUIV OK: 400 randomized models, bit-identical to HEAD
```

Every refactored rule is asserted to have both gone through the cache and
tightened something, so the differential cannot pass vacuously.

**Bound-neutral A/B**, interleaved, 2 reps x 6 instances x 2 arms, both arms
sharing one Rust `.so` (sha asserted equal) and each asserting its own marker:

| instance | | nodes old/new | obj | wall old | wall new | nodes/s |
|---|---|---|---|---|---|---|
| portfol_classical050_1 | timeout | 448 / 764,765 | identical | 60.40±0.07 | 60.33±0.03 | 7.42→12.67 (**1.71x**) |
| rsyn0830m | optimal | 377 / 377 | identical | 3.72±0.05 | 3.76±0.06 | |
| rsyn0840m | optimal | 317 / 317 | identical | 2.62±0.01 | 2.60±0.01 | |
| squfl015-080 | optimal | 21 / 21 | identical | 16.89±0.05 | 17.01±0.01 | |
| squfl020-150 | optimal | 11 / 11 | identical | 45.79±0.31 | 45.71±0.20 | |
| syn30m04m | optimal | 32 / 32 | identical | 6.62±0.00 | 6.69±0.11 | |

On every instance that terminates, `node_count` and the certified objective are
**exactly unchanged** — the §5 bound-neutral criterion. `portfol_classical050_1`
is excluded from that test on purpose: it stops at the time limit, so its node
count is not a property of the tree but the throughput being measured. There it
runs **1.71x more nodes in the same 60 s**, with an identical objective.

Total wall across the panel is flat (+0.0%): the cache pays where the nonlinear
tightening path is hot and costs nothing where it is not.

## Tests

`python/tests/test_issue_1066_rowstruct_cache.py` — 4 tests: bit-identical bounds
against a monkeypatched cache bypass (asserting the bypass actually fired), cache
populated and reused across passes, a rejected row cached as a rejection, and a
caller with foreign metadata bypassing the cache without writing to it.

Run: `pytest -m smoke` (1137 passed, 1 skipped, 2 xpassed) and
`pytest -m slow python/tests/test_adversarial_recent_fixes.py` (19 passed).
Rust untouched, so `cargo test` was not required.

## Scope

Contributes to #1066. This does not close it: the reported set is at 14/15 at
default settings, and `portfol_classical050_1` needs roughly 12.7x to finish
inside the 60 s default (it solves to `optimal` in 763.5 s). This is one factor
of that, not the whole of it.

Stacked on #1139.
