### PR TITLE
fix(cert): #1134 root-cause the panel drift (two bisects); stop the reference shrinking silently

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -235,9 +235,11 @@ jobs:
     runs-on: ubuntu-latest
     needs: changes
     # `python-coverage` below runs the SAME pytest invocation as this job — same
-    # `-m` marker expression, same `--ignore`, same worker count — plus
-    # test_amp.py and the optional-extra deps, i.e. a strict superset, with
-    # coverage instrumentation on top. Whenever it runs (every push to main, and
+    # test paths, same `-m` marker expression, same `--ignore`, same worker
+    # count — plus test_amp.py and the optional-extra deps, i.e. a strict
+    # superset, with coverage instrumentation on top. Adding a test path to one
+    # of the two and not the other silently drops it from whichever event runs
+    # the other job, so change them together. Whenever it runs (every push to main, and
     # any PR carrying the `coverage` label) this job was re-running that superset
     # for a second time on the same tree, for ~15 min of runner time that bought
     # no signal. Skip here and let the superset be the signal; on an ordinary PR
@@ -307,7 +309,20 @@ jobs:
           # `python-coverage` job (main pushes + the `coverage` label) instead.
           # That parenthetical used to read "nightly + label-triggered";
           # `python-coverage` has never had a schedule trigger.
+          # The cert-tooling tests join this lane. `cert-baseline.jsonl` is the
+          # §0.2.5 bound-neutrality reference every solver change is judged
+          # against, and until #1134 NOTHING in CI exercised the code that
+          # generates, validates or reads it: ci.yml pulled exactly one file out
+          # of discopt_benchmarks/tests, so both cert modules could only ever be
+          # run by hand. This one is unmarked and lands here; its sibling
+          # `test_cert_neutrality_regime.py` is `pytest.mark.correctness` and
+          # would collect ZERO tests under this lane's `not correctness`, so it
+          # joins `python-correctness` instead. Both are pure functions over the
+          # committed reference — no solve, no .nl file, numpy their only
+          # third-party import — so they cost ~a second and cannot flake on a
+          # runner's wall clock.
           scripts/run_memory_capped_pytest.sh pytest python/tests/ \
+            discopt_benchmarks/tests/test_1134_cert_baseline_shrink_guard.py \
             -q --tb=short --timeout=120 \
             -m "not slow and not correctness and not integration and not amp_benchmark and not requires_cyipopt and not memory_heavy" \
             --ignore=python/tests/test_correctness.py \
@@ -401,8 +416,13 @@ jobs:
           # the consumer of #1116's `deterministic=`) and it lived its whole life
           # skipping. It resolves instances from python/tests/data/minlplib_nl/,
           # which is in the checkout, and skips the ones that are not.
+          # test_cert_neutrality_regime.py joins for the same reason as #1134's
+          # shrink-guard module joins python-fast: it is `correctness`-marked, so
+          # this is the only lane whose marker expression selects it, and until
+          # now nothing in CI ran it at all.
           scripts/run_memory_capped_pytest.sh pytest python/tests/ \
             discopt_benchmarks/tests/test_correctness.py \
+            discopt_benchmarks/tests/test_cert_neutrality_regime.py \
             -q --tb=short --timeout=120 -p no:cacheprovider \
             -m "correctness and not slow and not integration and not amp_benchmark and not requires_cyipopt and not memory_heavy" \
             --ignore=python/tests/test_amp.py \
@@ -660,7 +680,12 @@ jobs:
       - name: Run pytest with coverage
         run: |
           source .venv/bin/activate
+          # Kept a strict superset of `python-fast` (see that job's comment):
+          # the cert-tooling tests are added HERE TOO, or they would silently
+          # stop running on every push to main, which is the only event that
+          # skips python-fast.
           scripts/run_memory_capped_pytest.sh pytest python/tests/ \
+            discopt_benchmarks/tests/test_1134_cert_baseline_shrink_guard.py \
             -q --tb=short --timeout=120 \
             -m "not slow and not correctness and not integration and not amp_benchmark and not requires_cyipopt and not memory_heavy" \
             --ignore=python/tests/test_correctness.py \

--- a/crates/discopt-core/Cargo.toml
+++ b/crates/discopt-core/Cargo.toml
@@ -172,34 +172,43 @@ description = "Core MINLP solver: B&B engine, expression IR, presolve"
 # build; POUNCE 0.10.0 pins feral 0.15.1, so the shared-release alignment noted
 # above returns as soon as POUNCE follows to 0.16.0.
 #
-# RETRACTION (#1134, 2026-08-31, CLAUDE.md §11). The (b) paragraph above asserts
-# that "the certifying panel cannot" see an LU kernel bump's benefit, and so
-# measures net-positive only on the captured relaxation LPs. The panel cannot see
-# the benefit — that part stands — but it does see a COST that this record does
-# not carry, and two of the three certifications #1134 reports lost are it.
-# Measured on `main`, interleaved A/B, 3 reps, the two arms differing only in
+# RETRACTION (#1134, 2026-08-31, CLAUDE.md §11), narrow. The (b) paragraph above
+# asserts that "the certifying panel cannot" see an LU kernel bump, and so measures
+# net-positive only on the captured relaxation LPs. It cannot see the BENEFIT --
+# that part stands -- but it does see a per-node COST that this record does not
+# carry. Measured on `main`, interleaved A/B, 3 reps, arms differing only in
 # `LuParams::pivoting` and distinguished by a marker string baked into the
-# extension:
+# extension, restricted to instances that are NOT auto-routed and whose node count
+# is identical in both arms (so the comparison is per-node cost, not search) --
+# wall in seconds, Markowitz / GilbertPeierls:
 #
-#   cvxnonsep_nsig30   identical 165-node tree, identical objective.
-#                      GilbertPeierls 39.5 s (sd 1.05) vs Markowitz 59.4 s
-#                      (sd 0.80) — +49% wall, against a 60 s budget it used to
-#                      clear in 1.12 s on the reference machine.
-#   nvs05              identical 175-node tree. GilbertPeierls 57.0 s (sd 0.24)
-#                      certifies; Markowitz does not finish inside 60 s.
+#   nvs09  2.78/2.65   st_e29 2.07/2.03   ex1224 2.03/2.00   ex1225 1.88/1.84
+#   gkocis 1.35/1.39   ex1226 1.53/1.35   oaer   1.32/1.32   st_e36 6.83/7.03
+#   nvs22 15.35/12.11  nvs05 >=60.32/56.62  (the Markowitz arm censored at 60 s)
 #
-# Same trees, same answers: this is per-factorization overhead, not search. It is
-# the expected shape — Markowitz chooses its column order DURING factorization, and
-# on the panel's small, low-fill bases that search has nothing to amortize against,
-# while the 0.16.0 win (fill 8.32x -> 1.28x) is measured on large high-fill QPLIB
-# relaxation bases. The bump is NOT retracted: fill, `numerical` refusals and wall
-# on the LPs that dominate a real solve all improved, and no verdict was ever false.
-# What is retracted is the claim that this panel is blind to the change, and with it
-# the assumption that a kernel bump needs no wall measurement at panel scale.
+# Median ratio ~1.03. Two rows carry it: `nvs22` +27%, and `nvs05` >=+7%, which is
+# enough to lose a certification 3/3 reps that the GilbertPeierls arm holds at
+# 56.6 s (sd 1.35) -- one of the three #1134 reports lost. It is two-sided: on the
+# routed `m3` Markowitz is 2.4x FASTER (1.53 s vs 3.70 s). The shape is expected --
+# Markowitz chooses its column order DURING factorization, and on the panel's small
+# low-fill bases that search has little to amortize against, while the 0.16.0 win
+# (fill 8.32x -> 1.28x) is measured on large high-fill QPLIB relaxation bases.
+#
+# The bump is NOT retracted: fill, `numerical` refusals and wall on the LPs that
+# dominate a real solve all improved, and no verdict was ever false. What is
+# retracted is the claim that this panel is blind to the change, and with it the
+# assumption that a kernel bump needs no wall measurement at panel scale.
+#
+# WITHDRAWN from this evidence: `cvxnonsep_nsig30`, which a first pass under #1134
+# read as +49% from pivoting. It is auto-routed to the `oa` master on `main`, where
+# the route runs to a wall-clock budget checkpoint before abstaining, so a wall
+# difference there is not a per-factorization measurement. Its real regression
+# bisects to `533c05e1` (PR #1100), not to this bump -- see
+# docs/dev/certification-gap-plan.md §0.6.1, Cause 2.
 #
 # FOLLOW-UP: size-routed pivoting (GilbertPeierls below a basis-size/fill
 # threshold, Markowitz above) is the general fix and the numbers above are its
-# entry measurement. Not taken here — it is a bound-changing default and owes the
+# entry measurement. Not taken here -- it is a bound-changing default and owes the
 # CLAUDE.md §5 graduation pair on a machine that can run it.
 feral = "0.16.0"
 # rayon: data-parallel iterators. Used (behind the `parallel` feature) to solve

--- a/crates/discopt-core/Cargo.toml
+++ b/crates/discopt-core/Cargo.toml
@@ -171,6 +171,36 @@ description = "Core MINLP solver: B&B engine, expression IR, presolve"
 # previous paragraph carried (e00aa706, feral PR #162) and with it the two-copy
 # build; POUNCE 0.10.0 pins feral 0.15.1, so the shared-release alignment noted
 # above returns as soon as POUNCE follows to 0.16.0.
+#
+# RETRACTION (#1134, 2026-08-31, CLAUDE.md §11). The (b) paragraph above asserts
+# that "the certifying panel cannot" see an LU kernel bump's benefit, and so
+# measures net-positive only on the captured relaxation LPs. The panel cannot see
+# the benefit — that part stands — but it does see a COST that this record does
+# not carry, and two of the three certifications #1134 reports lost are it.
+# Measured on `main`, interleaved A/B, 3 reps, the two arms differing only in
+# `LuParams::pivoting` and distinguished by a marker string baked into the
+# extension:
+#
+#   cvxnonsep_nsig30   identical 165-node tree, identical objective.
+#                      GilbertPeierls 39.5 s (sd 1.05) vs Markowitz 59.4 s
+#                      (sd 0.80) — +49% wall, against a 60 s budget it used to
+#                      clear in 1.12 s on the reference machine.
+#   nvs05              identical 175-node tree. GilbertPeierls 57.0 s (sd 0.24)
+#                      certifies; Markowitz does not finish inside 60 s.
+#
+# Same trees, same answers: this is per-factorization overhead, not search. It is
+# the expected shape — Markowitz chooses its column order DURING factorization, and
+# on the panel's small, low-fill bases that search has nothing to amortize against,
+# while the 0.16.0 win (fill 8.32x -> 1.28x) is measured on large high-fill QPLIB
+# relaxation bases. The bump is NOT retracted: fill, `numerical` refusals and wall
+# on the LPs that dominate a real solve all improved, and no verdict was ever false.
+# What is retracted is the claim that this panel is blind to the change, and with it
+# the assumption that a kernel bump needs no wall measurement at panel scale.
+#
+# FOLLOW-UP: size-routed pivoting (GilbertPeierls below a basis-size/fill
+# threshold, Markowitz above) is the general fix and the numbers above are its
+# entry measurement. Not taken here — it is a bound-changing default and owes the
+# CLAUDE.md §5 graduation pair on a machine that can run it.
 feral = "0.16.0"
 # rayon: data-parallel iterators. Used (behind the `parallel` feature) to solve
 # the independent per-node LP relaxations of a B&B batch concurrently. Pinned to

--- a/discopt_benchmarks/benchmarks/metrics.py
+++ b/discopt_benchmarks/benchmarks/metrics.py
@@ -97,6 +97,20 @@ class SolveResult:
     # Iteration count (NLP solver iterations or B&B iterations)
     iterations: int = 0
 
+    # Why an algorithm other than the default B&B ran, when the solver's own
+    # router chose it (discopt SolveResult.algorithm_route). None when no
+    # automatic routing happened -- which is every row written before #1134.
+    #
+    # #1134: without this the panel could see that `cvxnonsep_nsig30` went 1.12 s
+    # -> 42.5 s on an IDENTICAL 165-node tree, and could not see that 39.6 s of it
+    # was an auto-routed `oa` master that abstained at its budget checkpoint before
+    # the default path solved the instance from scratch. A wall regression whose
+    # cause is a routing decision is invisible in a table of nodes and seconds, and
+    # it took a second bisect to recover something the solver already knew and was
+    # already reporting. Additive and optional: rows written before this default to
+    # None, so every existing report and the committed cert baseline still load.
+    algorithm_route: Optional[str] = None
+
     @property
     def is_solved(self) -> bool:
         return self.status == SolveStatus.OPTIMAL

--- a/discopt_benchmarks/benchmarks/runner.py
+++ b/discopt_benchmarks/benchmarks/runner.py
@@ -380,6 +380,10 @@ class BenchmarkRunner:
                 jax_time_fraction=jax_frac,
                 python_time_fraction=py_frac,
                 pounce_time_fraction=pounce_frac,
+                # #1134: carry the solver's own routing note. A wall regression
+                # caused by an auto-routed algorithm that then abstains is
+                # invisible in a table of nodes and seconds.
+                algorithm_route=getattr(result, "algorithm_route", None),
             )
         except Exception as e:
             elapsed = time.monotonic() - start_time

--- a/discopt_benchmarks/scripts/check_cert_neutrality.py
+++ b/discopt_benchmarks/scripts/check_cert_neutrality.py
@@ -5,12 +5,29 @@ each row against the committed baseline with the differential criteria
 (objective-to-tolerance, still-optimal, node_count one-directional). Prints any
 violations and exits non-zero if there are any.
 
+Two reporting-only aids, added by #1134 because their absence turned a
+one-lookup question into a bisect. Neither changes a verdict:
+
+  * the **reference's provenance** (generating commit and host, from
+    ``cert-baseline-meta.json``) is printed up front, so "is this reference stale
+    relative to the tree?" is answerable without archaeology; and
+  * a **host-speed calibration**, measured on the instances whose ``node_count``
+    reproduced *exactly* — identical node counts mean the two runs did the same
+    work, so their wall-time ratio is a clean speed proxy. ``status`` violations
+    are annotated with it because this panel's status verdicts are wall-clock
+    verdicts: an instance that certifies in 20 s of a 60 s budget on the reference
+    machine is ``time_limit`` on a box 3x slower, with nothing wrong in the tree.
+    The violation still stands (never weaken a guard to make a panel read green,
+    CLAUDE.md §1) — the annotation only stops it being misread.
+
 Usage:
     python discopt_benchmarks/scripts/check_cert_neutrality.py
 """
 
 from __future__ import annotations
 
+import json
+import statistics
 import sys
 from pathlib import Path
 
@@ -24,6 +41,13 @@ from scripts.gen_cert_baseline import _instance_budgets  # noqa: E402
 from utils.cert_neutrality import check_neutrality, load_baseline  # noqa: E402
 
 _CERT_BASELINE = _REPO_ROOT / "docs" / "dev" / "data" / "cert-baseline.jsonl"
+_CERT_BASELINE_META = _REPO_ROOT / "docs" / "dev" / "data" / "cert-baseline-meta.json"
+
+# Minimum number of exactly-reproducing instances before a host-speed ratio is
+# reported. Below this the median is noise, and a speed claim on a handful of
+# sub-second solves is exactly the kind of unfounded timing statement CLAUDE.md §9
+# exists to stop.
+_MIN_CALIBRATION_SAMPLES = 5
 
 # Documented performance-only regressions (soundness still enforced). T1.2's
 # monomial coverage moves nvs17 from the cold path to the incremental path, which
@@ -35,11 +59,63 @@ _KNOWN_PERF_GATED = {
 }
 
 
+def host_speed_ratio(
+    new_rows: dict[str, dict], baseline: dict[str, dict]
+) -> tuple[float | None, int]:
+    """Median ``wall_new / wall_baseline`` over instances with an identical node_count.
+
+    Returns ``(ratio, n_samples)``; ``ratio`` is None when fewer than
+    ``_MIN_CALIBRATION_SAMPLES`` instances qualify. Equal node counts are the
+    condition that makes this a *speed* measurement rather than a work measurement:
+    the two runs explored the same tree, so the wall ratio is the machines'.
+    Baseline walls at or below 0.05 s are excluded — at that scale the row is
+    process noise, not throughput.
+    """
+    ratios = []
+    for inst, base in baseline.items():
+        new = new_rows.get(inst)
+        if new is None or new.get("node_count") != base.get("node_count"):
+            continue
+        wb, wn = base.get("wall_time"), new.get("wall_time")
+        if wb is None or wn is None or wb <= 0.05:
+            continue
+        ratios.append(wn / wb)
+    if len(ratios) < _MIN_CALIBRATION_SAMPLES:
+        return None, len(ratios)
+    return statistics.median(ratios), len(ratios)
+
+
+def _print_reference_provenance() -> None:
+    """Print who generated the committed reference, so staleness is a lookup.
+
+    Absent for a reference generated before #1134 added the record; that absence is
+    itself the finding, and is reported rather than passed over.
+    """
+    if not _CERT_BASELINE_META.exists():
+        print(
+            f"  reference provenance: NONE ({_CERT_BASELINE_META.name} absent) — this "
+            "reference predates the\n    #1134 provenance record, so the commit it was "
+            "generated at is not recoverable from the tree."
+        )
+        return
+    meta = json.loads(_CERT_BASELINE_META.read_text())
+    host = meta.get("host") or {}
+    print(
+        f"  reference provenance: commit {meta.get('commit')} at {meta.get('generated_at')}, "
+        f"budget {meta.get('time_limit')}s, host {host.get('platform')} "
+        f"({host.get('cpu_count')} cpu)"
+    )
+    lost = meta.get("coverage_lost") or []
+    if lost:
+        print(f"  reference recorded {len(lost)} instance(s) of coverage loss: {', '.join(lost)}")
+
+
 def main() -> int:
     baseline = load_baseline(_CERT_BASELINE)
     budgets = _instance_budgets(60.0)
     solver = SolverConfig(name="discopt", command="", solver_type="internal")
     print(f"Neutrality check: {len(baseline)} certifying instances vs {_CERT_BASELINE.name}")
+    _print_reference_provenance()
 
     new_rows: dict[str, dict] = {}
     for i, name in enumerate(sorted(baseline), 1):
@@ -65,14 +141,31 @@ def main() -> int:
         if inst in baseline:
             print(f"  [perf-gated] {inst}: {why} (soundness still checked)")
     violations = check_neutrality(new_rows, baseline, known_perf_gated=_KNOWN_PERF_GATED)
+    ratio, n_cal = host_speed_ratio(new_rows, baseline)
     print("\n─── neutrality result ───")
+    if ratio is None:
+        print(
+            f"  host-speed calibration: unavailable ({n_cal} instance(s) reproduced their "
+            f"node_count exactly, need {_MIN_CALIBRATION_SAMPLES})"
+        )
+    else:
+        print(
+            f"  host-speed calibration: this box is {ratio:.2f}x the reference machine's "
+            f"wall on {n_cal} instance(s) that reproduced their node_count exactly"
+        )
     if not violations:
         print("  NEUTRAL — all certifying instances pass (objective to tol, still "
               "optimal, node_count not materially worse).")
         return 0
     print(f"  {len(violations)} VIOLATION(S):")
     for v in violations:
-        print(f"    {v.instance:20s} [{v.kind}] {v.detail}")
+        note = ""
+        if v.kind == "status" and ratio is not None and ratio > 1.0:
+            note = (
+                f"  [wall-clock verdict; this box runs {ratio:.2f}x the reference's "
+                "wall on equal-node work]"
+            )
+        print(f"    {v.instance:20s} [{v.kind}] {v.detail}{note}")
     return 1
 
 

--- a/discopt_benchmarks/scripts/check_cert_neutrality.py
+++ b/discopt_benchmarks/scripts/check_cert_neutrality.py
@@ -11,10 +11,13 @@ one-lookup question into a bisect. Neither changes a verdict:
   * the **reference's provenance** (generating commit and host, from
     ``cert-baseline-meta.json``) is printed up front, so "is this reference stale
     relative to the tree?" is answerable without archaeology; and
-  * a **host-speed calibration**, measured on the instances whose ``node_count``
-    reproduced *exactly* — identical node counts mean the two runs did the same
-    work, so their wall-time ratio is a clean speed proxy. ``status`` violations
-    are annotated with it because this panel's status verdicts are wall-clock
+  * a **host-speed calibration**, measured on the **unrouted** instances whose
+    ``node_count`` reproduced *exactly* — same tree and no time spent outside it
+    means the two runs did the same work, so their wall-time ratio is a clean speed
+    proxy. (Equal node counts alone are not enough: an auto-routed algorithm that
+    abstains at a budget checkpoint burns wall the tree does not account for. That
+    is #1134's Cause 2, and it is why the routed rows are dropped.) ``status``
+    violations are annotated with it because this panel's status verdicts are wall-clock
     verdicts: an instance that certifies in 20 s of a 60 s budget on the reference
     machine is ``time_limit`` on a box 3x slower, with nothing wrong in the tree.
     The violation still stands (never weaken a guard to make a panel read green,
@@ -62,12 +65,27 @@ _KNOWN_PERF_GATED = {
 def host_speed_ratio(
     new_rows: dict[str, dict], baseline: dict[str, dict]
 ) -> tuple[float | None, int]:
-    """Median ``wall_new / wall_baseline`` over instances with an identical node_count.
+    """Median ``wall_new / wall_baseline`` over **unrouted** instances with an
+    identical node_count.
 
     Returns ``(ratio, n_samples)``; ``ratio`` is None when fewer than
-    ``_MIN_CALIBRATION_SAMPLES`` instances qualify. Equal node counts are the
-    condition that makes this a *speed* measurement rather than a work measurement:
-    the two runs explored the same tree, so the wall ratio is the machines'.
+    ``_MIN_CALIBRATION_SAMPLES`` instances qualify. Equal node counts are *necessary*
+    for this to be a speed measurement rather than a work measurement — the two runs
+    explored the same tree, so the wall ratio is the machines'.
+
+    They are not *sufficient*, which #1134's own Cause 2 is the proof of: an
+    auto-routed algorithm that runs to a budget checkpoint and then abstains spends
+    wall outside the counted tree, so `cvxnonsep_nsig30` (165 → 165 nodes,
+    1.12 s → 49.6 s), `fac2` (39 → 39, 2.77 → 38.9) and `cvxnonsep_psig30` (89 → 89,
+    0.41 → 8.5) all clear the equal-node filter carrying a 14-44x inflation that is
+    not the box. Worse, the route's price is a *fraction of the wall-clock budget*
+    (`_CONVEX_ROUTE_BUDGET_FRACTION`), i.e. the same number of seconds on a fast box
+    and a slow one, so a row routed on **both** sides compresses the ratio toward 1
+    instead of inflating it. Either way the row measures the router, not the
+    machine, and is excluded — which is what `algorithm_route` (added by #1134 to
+    `SolveResult`) is here for. Reference rows predate the field and read as
+    unrouted, which is correct: they were generated before the route was reachable.
+
     Baseline walls at or below 0.05 s are excluded — at that scale the row is
     process noise, not throughput.
     """
@@ -75,6 +93,8 @@ def host_speed_ratio(
     for inst, base in baseline.items():
         new = new_rows.get(inst)
         if new is None or new.get("node_count") != base.get("node_count"):
+            continue
+        if new.get("algorithm_route") or base.get("algorithm_route"):
             continue
         wb, wn = base.get("wall_time"), new.get("wall_time")
         if wb is None or wn is None or wb <= 0.05:
@@ -85,29 +105,75 @@ def host_speed_ratio(
     return statistics.median(ratios), len(ratios)
 
 
+def meta_describes_the_committed_reference(meta: dict) -> bool:
+    """Whether ``meta`` is the provenance of the reference now on disk.
+
+    ``gen_cert_baseline`` writes the meta on **every** run, including one whose
+    write the shrink guard refused — deliberately, because a run that shrank
+    coverage is the run whose evidence matters. So the meta on disk is the
+    reference's provenance only when that run actually wrote the reference.
+    ``baseline_written`` records it; for a meta written before that field existed
+    it is re-derived from the guard's own condition (a run loses coverage and does
+    not pass ``--allow-shrink`` ⇒ the write was refused).
+    """
+    written = meta.get("baseline_written")
+    if written is not None:
+        return bool(written)
+    return not (meta.get("coverage_lost") or []) or bool(meta.get("allow_shrink"))
+
+
+def provenance_lines(meta: dict | None) -> list[str]:
+    """The provenance report for ``meta`` (None when the meta file is absent).
+
+    Pure so the *stale/refused* case is testable without touching the committed
+    ``docs/dev/data`` files. Reporting-only: nothing here decides a verdict.
+    """
+    if meta is None:
+        return [
+            f"  reference provenance: NONE ({_CERT_BASELINE_META.name} absent) — this "
+            "reference predates the\n    #1134 provenance record, so the commit it was "
+            "generated at is not recoverable from the tree."
+        ]
+    host = meta.get("host") or {}
+    stamp = (
+        f"commit {meta.get('commit')} at {meta.get('generated_at')}, "
+        f"budget {meta.get('time_limit')}s (default; perf-panel instances run at their "
+        f"own), host {host.get('platform')} ({host.get('cpu_count')} cpu)"
+    )
+    lost = meta.get("coverage_lost") or []
+    if not meta_describes_the_committed_reference(meta):
+        # The meta is a REFUSED run's. Attributing its commit and host to the
+        # reference on disk would be a confidently wrong answer to exactly the
+        # question #1134 exists to make answerable — worse than the missing answer
+        # the NONE branch above gives. Say what it is instead.
+        return [
+            f"  reference provenance: UNKNOWN — {_CERT_BASELINE_META.name} records a "
+            "REFUSED regeneration",
+            f"    ({stamp}),",
+            f"    which dropped {len(lost)} instance(s) the reference covered "
+            f"({', '.join(lost)}) and so did NOT",
+            "    overwrite cert-baseline.jsonl. The committed reference is OLDER than "
+            "this record and its",
+            "    own provenance is not recoverable from the tree.",
+        ]
+    out = [f"  reference provenance: {stamp}"]
+    if lost:
+        out.append(
+            f"  reference was written under --allow-shrink, deliberately losing "
+            f"{len(lost)} instance(s): {', '.join(lost)}"
+        )
+    return out
+
+
 def _print_reference_provenance() -> None:
     """Print who generated the committed reference, so staleness is a lookup.
 
     Absent for a reference generated before #1134 added the record; that absence is
     itself the finding, and is reported rather than passed over.
     """
-    if not _CERT_BASELINE_META.exists():
-        print(
-            f"  reference provenance: NONE ({_CERT_BASELINE_META.name} absent) — this "
-            "reference predates the\n    #1134 provenance record, so the commit it was "
-            "generated at is not recoverable from the tree."
-        )
-        return
-    meta = json.loads(_CERT_BASELINE_META.read_text())
-    host = meta.get("host") or {}
-    print(
-        f"  reference provenance: commit {meta.get('commit')} at {meta.get('generated_at')}, "
-        f"budget {meta.get('time_limit')}s, host {host.get('platform')} "
-        f"({host.get('cpu_count')} cpu)"
-    )
-    lost = meta.get("coverage_lost") or []
-    if lost:
-        print(f"  reference recorded {len(lost)} instance(s) of coverage loss: {', '.join(lost)}")
+    meta = json.loads(_CERT_BASELINE_META.read_text()) if _CERT_BASELINE_META.exists() else None
+    for line in provenance_lines(meta):
+        print(line)
 
 
 def main() -> int:
@@ -145,13 +211,14 @@ def main() -> int:
     print("\n─── neutrality result ───")
     if ratio is None:
         print(
-            f"  host-speed calibration: unavailable ({n_cal} instance(s) reproduced their "
-            f"node_count exactly, need {_MIN_CALIBRATION_SAMPLES})"
+            f"  host-speed calibration: unavailable ({n_cal} instance(s) qualified — "
+            f"node_count reproduced exactly, unrouted, baseline wall above noise; need "
+            f"{_MIN_CALIBRATION_SAMPLES})"
         )
     else:
         print(
             f"  host-speed calibration: this box is {ratio:.2f}x the reference machine's "
-            f"wall on {n_cal} instance(s) that reproduced their node_count exactly"
+            f"wall on {n_cal} unrouted instance(s) that reproduced their node_count exactly"
         )
     if not violations:
         print("  NEUTRAL — all certifying instances pass (objective to tol, still "
@@ -163,7 +230,7 @@ def main() -> int:
         if v.kind == "status" and ratio is not None and ratio > 1.0:
             note = (
                 f"  [wall-clock verdict; this box runs {ratio:.2f}x the reference's "
-                "wall on equal-node work]"
+                "wall on equal-node unrouted work]"
             )
         print(f"    {v.instance:20s} [{v.kind}] {v.detail}{note}")
     return 1

--- a/discopt_benchmarks/scripts/gen_cert_baseline.py
+++ b/discopt_benchmarks/scripts/gen_cert_baseline.py
@@ -128,6 +128,15 @@ def build_meta(
     the *previous* reference covered are marked ``in_previous_baseline`` and carry
     that row's status/nodes/objective, so the record says what was lost, not merely
     that something was.
+
+    ``baseline_written`` says whether this run's rows actually became
+    ``cert-baseline.jsonl``. The meta is written unconditionally — a refused run is
+    exactly the run whose evidence matters — so without this field a refused run
+    leaves a provenance record describing a reference that was never written, and a
+    reader (``check_cert_neutrality._print_reference_provenance``) reports this
+    run's commit and host as the committed reference's. That is a *confidently
+    wrong* answer to the question #1134 was opened to make answerable, which is
+    worse than the missing one it replaces.
     """
     lost = set(coverage_loss(previous, certifying))
     return {
@@ -139,6 +148,9 @@ def build_meta(
         "previous_instances_certifying": len(previous),
         "coverage_lost": sorted(lost),
         "allow_shrink": allow_shrink,
+        # The write condition, recorded rather than left to be re-derived: this
+        # must stay in lockstep with the guard in main() below.
+        "baseline_written": not lost or allow_shrink,
         "host": {
             "platform": platform.platform(),
             "processor": platform.processor(),
@@ -284,7 +296,10 @@ def main() -> int:
     )
     _CERT_BASELINE_META.write_text(json.dumps(meta, indent=2, sort_keys=True) + "\n")
 
-    if not lost or args.allow_shrink:
+    # The write is driven by the recorded flag, not by a second evaluation of the
+    # same condition: the meta's `baseline_written` is what every later reader
+    # trusts, so it cannot be allowed to drift from what actually happened.
+    if meta["baseline_written"]:
         with open(_CERT_BASELINE, "w") as fh:
             for r in cert_rows:
                 fh.write(json.dumps(r.to_dict(), sort_keys=True) + "\n")

--- a/discopt_benchmarks/scripts/gen_cert_baseline.py
+++ b/discopt_benchmarks/scripts/gen_cert_baseline.py
@@ -9,14 +9,29 @@ perf panel (``perf/panel.py``) with the T0.1–T0.3 instrumentation on, and writ
     reference, restricted to the **deterministic certifying** subset: each
     instance is solved twice and included only if both runs reach OPTIMAL with a
     bit-identical node_count and objective. Time-limited / non-deterministic rows
-    are excluded, so the reference is reproducible by construction.
+    are excluded, so the reference is reproducible by construction; and
+  * ``docs/dev/data/cert-baseline-meta.json`` — the reference's **provenance**
+    (generating commit, timestamp, budget, host) and the **drop record**: every
+    instance the run refused to admit, with the reason, and whether the previous
+    committed reference covered it.
 
 Per-instance time limits use the perf panel's own budgets where defined, else
 ``--time-limit``. The baseline is the frozen reference, so re-generate it
 deliberately (not in CI).
 
+**Coverage may not shrink silently** (issue #1134). The admission filter is
+machine-sensitive — it drops anything that does not certify inside
+``_MARGIN_FRAC`` of its budget — so a regeneration on a slower box quietly
+deletes rows rather than recording a regression, leaving a *smaller* panel that
+still reads as a green reference. A run that would drop an instance the previous
+committed reference covered therefore refuses to overwrite the baseline and exits
+non-zero; ``--allow-shrink`` performs the write, and the meta file records exactly
+what was lost either way. The full-panel ``reports/cert0_*.json`` and the meta
+file are always written, so a refused run still leaves its evidence behind.
+
 Usage:
     python discopt_benchmarks/scripts/gen_cert_baseline.py [--time-limit 60]
+                                                           [--allow-shrink]
 """
 
 from __future__ import annotations
@@ -24,7 +39,10 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import platform
+import subprocess
 import sys
+from collections.abc import Iterable  # noqa: TC003
 from datetime import datetime
 from pathlib import Path
 
@@ -44,9 +62,11 @@ from benchmarks.metrics import (  # noqa: E402
 )
 from benchmarks.runner import BenchmarkConfig, BenchmarkRunner, SolverConfig  # noqa: E402
 from perf.panel import PANEL  # noqa: E402
+from utils.cert_neutrality import load_baseline  # noqa: E402
 
 _GLOBAL50 = _BENCH_ROOT / "config" / "baron_global50.txt"
 _CERT_BASELINE = _REPO_ROOT / "docs" / "dev" / "data" / "cert-baseline.jsonl"
+_CERT_BASELINE_META = _REPO_ROOT / "docs" / "dev" / "data" / "cert-baseline-meta.json"
 _CERT_OPTIMA = _REPO_ROOT / "docs" / "dev" / "data" / "cert-optima.json"
 
 # Objective reproducibility tolerance (absolute + relative). A certified optimum
@@ -58,6 +78,90 @@ _OBJ_RTOL = 1e-9
 # certify within this fraction of its budget (margin against boundary-flakiness).
 _N_DET = 3
 _MARGIN_FRAC = 0.6
+
+
+def coverage_loss(previous: dict[str, dict], certifying: Iterable[str]) -> list[str]:
+    """Instances the previous committed reference covered that this run will not.
+
+    This is the quantity a regeneration must never lose silently (#1134): the
+    admission filter drops an instance for *any* of not-optimal / node drift /
+    objective drift / near-budget, and three of those four are properties of the
+    machine and the budget rather than of the tree. Dropping such a row shrinks the
+    panel that later changes are held against, which reads as a green reference
+    while covering less.
+    """
+    return sorted(set(previous) - set(certifying))
+
+
+def _generating_commit() -> str | None:
+    """Best-effort ``git rev-parse HEAD`` for the provenance record.
+
+    Deliberately narrow (`CalledProcessError`/`FileNotFoundError` only): a broad
+    ``except`` here would turn "this tree is not a checkout" into a silent null and
+    the provenance field is the whole point of the record (CLAUDE.md §7).
+    """
+    try:
+        out = subprocess.run(
+            ["git", "-C", str(_REPO_ROOT), "rev-parse", "HEAD"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+    except (subprocess.CalledProcessError, FileNotFoundError) as exc:
+        print(f"  provenance: git rev-parse failed ({exc}); commit recorded as null")
+        return None
+    return out.stdout.strip() or None
+
+
+def build_meta(
+    *,
+    certifying: list[str],
+    dropped: list[tuple[str, str]],
+    previous: dict[str, dict],
+    time_limit: float,
+    attempted: int,
+    allow_shrink: bool,
+) -> dict:
+    """The committed provenance + drop record for this regeneration.
+
+    ``dropped`` is ``(instance, reason)`` as the admission filter produced it. Rows
+    the *previous* reference covered are marked ``in_previous_baseline`` and carry
+    that row's status/nodes/objective, so the record says what was lost, not merely
+    that something was.
+    """
+    lost = set(coverage_loss(previous, certifying))
+    return {
+        "generated_at": datetime.now().isoformat(),
+        "commit": _generating_commit(),
+        "time_limit": time_limit,
+        "instances_attempted": attempted,
+        "instances_certifying": len(certifying),
+        "previous_instances_certifying": len(previous),
+        "coverage_lost": sorted(lost),
+        "allow_shrink": allow_shrink,
+        "host": {
+            "platform": platform.platform(),
+            "processor": platform.processor(),
+            "cpu_count": os.cpu_count(),
+        },
+        "dropped": [
+            {
+                "instance": name,
+                "reason": reason,
+                "in_previous_baseline": name in previous,
+                "previous": (
+                    {
+                        "status": previous[name].get("status"),
+                        "node_count": previous[name].get("node_count"),
+                        "objective": previous[name].get("objective"),
+                    }
+                    if name in previous
+                    else None
+                ),
+            }
+            for name, reason in dropped
+        ],
+    }
 
 
 def _instance_budgets(default_tl: float) -> dict[str, float]:
@@ -73,7 +177,20 @@ def _instance_budgets(default_tl: float) -> dict[str, float]:
 def main() -> int:
     ap = argparse.ArgumentParser()
     ap.add_argument("--time-limit", type=float, default=60.0, help="default per-instance seconds")
+    ap.add_argument(
+        "--allow-shrink",
+        action="store_true",
+        help=(
+            "overwrite cert-baseline.jsonl even when this run drops an instance the "
+            "committed reference covered (#1134). Without it such a run refuses the "
+            "write and exits non-zero; the drop record is written either way."
+        ),
+    )
     args = ap.parse_args()
+
+    # The reference this run would replace: read BEFORE the solves so the shrink
+    # guard has something to compare against even if the write is refused.
+    previous = load_baseline(_CERT_BASELINE) if _CERT_BASELINE.exists() else {}
 
     budgets = _instance_budgets(args.time_limit)
     order = sorted(budgets)
@@ -153,9 +270,24 @@ def main() -> int:
     # deterministic-certifying subset only.
     cert_rows = sorted(certifying, key=lambda r: r.instance)
     os.makedirs(_CERT_BASELINE.parent, exist_ok=True)
-    with open(_CERT_BASELINE, "w") as fh:
-        for r in cert_rows:
-            fh.write(json.dumps(r.to_dict(), sort_keys=True) + "\n")
+
+    # Provenance + drop record. Written unconditionally, including on a refused
+    # write: a run that shrank coverage is exactly the run whose evidence matters.
+    lost = coverage_loss(previous, [r.instance for r in cert_rows])
+    meta = build_meta(
+        certifying=[r.instance for r in cert_rows],
+        dropped=dropped,
+        previous=previous,
+        time_limit=float(args.time_limit),
+        attempted=len(order),
+        allow_shrink=bool(args.allow_shrink),
+    )
+    _CERT_BASELINE_META.write_text(json.dumps(meta, indent=2, sort_keys=True) + "\n")
+
+    if not lost or args.allow_shrink:
+        with open(_CERT_BASELINE, "w") as fh:
+            for r in cert_rows:
+                fh.write(json.dumps(r.to_dict(), sort_keys=True) + "\n")
 
     # Summary + self-check.
     full_rows = results.get_results("discopt")
@@ -169,8 +301,29 @@ def main() -> int:
     print(f"  deterministic-certifying subset: {len(cert_rows)}  (neutrality reference)")
     print(f"  dropped ({len(dropped)}): " + ", ".join(f"{n}[{r}]" for n, r in dropped))
     print(f"  results: {results_path}")
-    print(f"  baseline: {_CERT_BASELINE}")
-    return 0
+    print(f"  meta: {_CERT_BASELINE_META}")
+    if not lost:
+        print(f"  coverage: {len(previous)} -> {len(cert_rows)} instances, none lost")
+        print(f"  baseline: {_CERT_BASELINE} (written)")
+        return 0
+    reasons = dict(dropped)
+    print(
+        f"\n  COVERAGE LOSS: {len(lost)} instance(s) the committed reference covered "
+        "are not admitted by this run:"
+    )
+    for name in lost:
+        print(f"    {name:20s} {reasons.get(name, 'absent from this run')}")
+    if args.allow_shrink:
+        print(f"  baseline: {_CERT_BASELINE} (written under --allow-shrink)")
+        return 0
+    print(
+        f"  baseline: {_CERT_BASELINE} NOT overwritten. Refusing to shrink the panel\n"
+        "  silently (#1134): a smaller reference still reads as green while covering\n"
+        "  less. Establish why each instance above dropped -- a genuine regression, or\n"
+        "  a slower box than the one that generated the reference -- then re-run with\n"
+        "  --allow-shrink to record the loss deliberately."
+    )
+    return 1
 
 
 if __name__ == "__main__":

--- a/discopt_benchmarks/tests/test_1134_cert_baseline_shrink_guard.py
+++ b/discopt_benchmarks/tests/test_1134_cert_baseline_shrink_guard.py
@@ -19,11 +19,16 @@ Pinned here:
   new run does not admit;
 * `build_meta` records those, each drop's reason, and the previous row's verdict,
   plus the generating commit and host — the provenance whose absence forced the
-  bisect;
+  bisect — and `baseline_written`, without which a *refused* run's meta reads as the
+  provenance of a reference it never wrote;
+* `provenance_lines` refuses to attribute a refused run's commit and host to the
+  reference on disk, reporting `UNKNOWN` instead — a confidently wrong answer here
+  is worse than the missing one it replaces;
 * `host_speed_ratio` measures this box against the reference machine using only
-  instances whose `node_count` reproduced *exactly* (equal trees ⇒ the wall ratio is
-  the machines', not the work's), and abstains below a sample floor rather than
-  publishing a timing claim from a handful of sub-second solves (CLAUDE.md §9).
+  **unrouted** instances whose `node_count` reproduced *exactly* (equal trees *and*
+  no wall spent outside them ⇒ the ratio is the machines', not the work's), and
+  abstains below a sample floor rather than publishing a timing claim from a handful
+  of sub-second solves (CLAUDE.md §9).
 
 The guard these feed — refusing the overwrite without `--allow-shrink` — is asserted
 on the plan (`coverage_loss` non-empty) rather than by running a 56-instance solve.
@@ -43,6 +48,8 @@ for _p in (str(_BENCH_ROOT), str(_REPO_ROOT)):
 from scripts.check_cert_neutrality import (  # noqa: E402
     _MIN_CALIBRATION_SAMPLES,
     host_speed_ratio,
+    meta_describes_the_committed_reference,
+    provenance_lines,
 )
 from scripts.gen_cert_baseline import build_meta, coverage_loss  # noqa: E402
 
@@ -138,6 +145,85 @@ def test_meta_carries_the_provenance_the_bisect_had_to_recover():
     assert meta["host"]["cpu_count"]
 
 
+def test_meta_records_whether_the_reference_was_actually_written():
+    """The meta is written on EVERY run, including a refused one — so it must say
+    which kind of run it was, or a reader attributes a refused run's commit and host
+    to the reference on disk."""
+    previous = {n: _row(n) for n in ("nvs05", "nvs14")}
+    refused = build_meta(
+        certifying=["nvs14"], dropped=[("nvs05", "near-limit(wall 45s/60s)")],
+        previous=previous, time_limit=60.0, attempted=56, allow_shrink=False,
+    )
+    assert refused["baseline_written"] is False
+    accepted = build_meta(
+        certifying=["nvs14"], dropped=[("nvs05", "near-limit(wall 45s/60s)")],
+        previous=previous, time_limit=60.0, attempted=56, allow_shrink=True,
+    )
+    assert accepted["baseline_written"] is True
+    grew = build_meta(
+        certifying=["nvs05", "nvs14"], dropped=[], previous=previous,
+        time_limit=60.0, attempted=56, allow_shrink=False,
+    )
+    assert grew["baseline_written"] is True
+
+
+# --------------------------------------------------------------------------- #
+# provenance_lines — what the checker may claim about the reference on disk
+# --------------------------------------------------------------------------- #
+
+
+def test_provenance_of_a_refused_run_is_not_claimed_as_the_reference():
+    """A refused run's meta must NOT be reported as the committed reference's
+    provenance. That would be a confidently wrong answer to the one question #1134
+    exists to make answerable — worse than the missing answer it replaces."""
+    meta = build_meta(
+        certifying=["nvs14"], dropped=[("nvs05", "near-limit(wall 45s/60s)")],
+        previous={n: _row(n) for n in ("nvs05", "nvs14")},
+        time_limit=60.0, attempted=56, allow_shrink=False,
+    )
+    text = "\n".join(provenance_lines(meta))
+    assert meta_describes_the_committed_reference(meta) is False
+    assert "UNKNOWN" in text and "REFUSED" in text
+    assert "OLDER" in text
+    assert "nvs05" in text
+
+
+def test_provenance_of_a_written_run_is_reported_plainly():
+    meta = build_meta(
+        certifying=["nvs05", "nvs14"], dropped=[], previous={"nvs14": _row("nvs14")},
+        time_limit=60.0, attempted=56, allow_shrink=False,
+    )
+    text = "\n".join(provenance_lines(meta))
+    assert meta_describes_the_committed_reference(meta) is True
+    assert "UNKNOWN" not in text and "REFUSED" not in text
+    assert meta["commit"] in text
+
+
+def test_provenance_of_a_deliberate_shrink_says_so():
+    meta = build_meta(
+        certifying=["nvs14"], dropped=[("nvs05", "near-limit(wall 45s/60s)")],
+        previous={n: _row(n) for n in ("nvs05", "nvs14")},
+        time_limit=60.0, attempted=56, allow_shrink=True,
+    )
+    text = "\n".join(provenance_lines(meta))
+    assert meta_describes_the_committed_reference(meta) is True
+    assert "--allow-shrink" in text and "nvs05" in text
+
+
+def test_provenance_derives_the_verdict_for_a_meta_predating_the_field():
+    """A meta written before `baseline_written` existed is still classifiable from
+    the guard's own condition; it must not silently read as 'written'."""
+    refused_legacy = {"commit": "a" * 40, "coverage_lost": ["nvs05"], "allow_shrink": False}
+    written_legacy = {"commit": "b" * 40, "coverage_lost": [], "allow_shrink": False}
+    assert meta_describes_the_committed_reference(refused_legacy) is False
+    assert meta_describes_the_committed_reference(written_legacy) is True
+
+
+def test_provenance_reports_an_absent_meta_as_absent():
+    text = "\n".join(provenance_lines(None))
+    assert "NONE" in text
+
+
 # --------------------------------------------------------------------------- #
 # host_speed_ratio — reading a wall-clock verdict against the reference machine
 # --------------------------------------------------------------------------- #
@@ -183,6 +269,53 @@ def test_speed_ratio_of_the_reference_machine_against_itself_is_one():
     assert abs(ratio - 1.0) < 1e-9
 
 
+def test_speed_ratio_excludes_an_auto_routed_row():
+    """Equal node counts are necessary but NOT sufficient — #1134's own Cause 2.
+
+    An auto-routed algorithm that runs to a budget checkpoint and abstains spends
+    wall outside the counted tree, so its row clears the equal-node filter carrying
+    an inflation that is not the machine. These are §0.6.1's measured numbers:
+    identical trees, 14-44x wall. Admitting them would make the published host-speed
+    figure a measurement of the router.
+    """
+    # Six unrouted rows spanning ratios 1..6 — median 3.5, the machine's true figure.
+    baseline = {f"i{k}": _row(f"i{k}", nodes=k + 1, wall=1.0) for k in range(6)}
+    new = {f"i{k}": _row(f"i{k}", nodes=k + 1, wall=float(k + 1)) for k in range(6)}
+    # §0.6.1's three measured route-inflated rows: identical trees, 14-44x wall.
+    for tag, nodes, wb, wn in (
+        ("cvxnonsep_nsig30", 165, 1.12, 49.6),
+        ("fac2", 39, 2.77, 38.9),
+        ("cvxnonsep_psig30", 89, 0.41, 8.5),
+    ):
+        baseline[tag] = _row(tag, nodes=nodes, wall=wb)  # reference predates the field
+        new[tag] = {
+            **_row(tag, nodes=nodes, wall=wn),
+            "algorithm_route": "mip-nlp/oa: did not certify in 39.63s",
+        }
+    ratio, n = host_speed_ratio(new, baseline)
+    assert n == 6, n  # the 3 routed rows are not samples
+    # Admitting them drags the median from 3.5 to 5.0 — the size of the error the
+    # published figure carries, not merely a bookkeeping difference.
+    assert abs(ratio - 3.5) < 1e-9, ratio
+
+
+def test_speed_ratio_excludes_a_row_routed_on_both_sides():
+    """A row routed in BOTH arms is excluded too, and the reason is the opposite one.
+
+    The route's price is a fraction of the wall-clock BUDGET, i.e. the same seconds
+    on a fast box and a slow one, so a both-routed row compresses the ratio toward 1
+    and biases the estimate DOWN. Either direction, it measures the router.
+    """
+    routed = {"algorithm_route": "mip-nlp/oa: routed"}
+    baseline = {f"i{k}": _row(f"i{k}", nodes=k + 1, wall=1.0) for k in range(6)}
+    new = {f"i{k}": _row(f"i{k}", nodes=k + 1, wall=3.0) for k in range(6)}
+    baseline["r"] = {**_row("r", nodes=42, wall=31.0), **routed}
+    new["r"] = {**_row("r", nodes=42, wall=33.0), **routed}
+    ratio, n = host_speed_ratio(new, baseline)
+    assert n == 6, n
+    assert abs(ratio - 3.0) < 1e-9, ratio
+
+
 # --------------------------------------------------------------------------- #
 # The routing note the panel could not see (#1134, Cause 2)
 # --------------------------------------------------------------------------- #
@@ -212,9 +345,18 @@ def test_solve_result_round_trips_the_routing_note():
 
 
 def test_rows_written_before_the_field_still_load():
-    """Backward compatibility, and the reason the field is optional: every row of
-    the committed `cert-baseline.jsonl` predates it, and `load`/`from_dict` must
-    not start rejecting the reference the neutrality check is built on."""
+    """Backward compatibility, and the reason the field is optional: `load`/`from_dict`
+    must not start rejecting the reference the neutrality check is built on.
+
+    Asserted on the *value*, not on the key's absence. `to_dict` is `asdict`, so it
+    emits `"algorithm_route": null` on every row including unrouted ones — the next
+    regeneration on the reference machine (which §0.6.1 prescribes) therefore writes
+    the key into all 52 rows. A test keyed to `"algorithm_route" not in row` would
+    fail on that regeneration while nothing was wrong, i.e. it would pin the
+    accident of when the file was generated rather than the compatibility contract.
+    Every row must LOAD and read as unrouted, whichever side of the field it was
+    written on.
+    """
     from benchmarks.metrics import SolveResult  # noqa: PLC0415
     from scripts.check_cert_neutrality import _CERT_BASELINE  # noqa: PLC0415
     from utils.cert_neutrality import load_baseline  # noqa: PLC0415
@@ -223,7 +365,19 @@ def test_rows_written_before_the_field_still_load():
     assert baseline, "committed cert baseline is empty"
     loaded = 0
     for row in baseline.values():
-        assert "algorithm_route" not in row, "test premise: committed rows predate the field"
+        assert row.get("algorithm_route") is None, row.get("algorithm_route")
         assert SolveResult.from_dict(row).algorithm_route is None
         loaded += 1
     assert loaded == len(baseline), (loaded, len(baseline))
+
+
+def test_an_unrouted_result_still_serializes_the_field():
+    """The premise the test above is written against: `to_dict` emits the key with a
+    null value even when nothing routed, so a freshly generated baseline carries it."""
+    from benchmarks.metrics import SolveResult, SolveStatus  # noqa: PLC0415
+
+    d = SolveResult(instance="alan", solver="discopt", status=SolveStatus.OPTIMAL).to_dict()
+    assert "algorithm_route" in d
+    assert d["algorithm_route"] is None
+    # ...and such a row loads through the same path the committed reference uses.
+    assert SolveResult.from_dict(d).algorithm_route is None

--- a/discopt_benchmarks/tests/test_1134_cert_baseline_shrink_guard.py
+++ b/discopt_benchmarks/tests/test_1134_cert_baseline_shrink_guard.py
@@ -181,3 +181,49 @@ def test_speed_ratio_of_the_reference_machine_against_itself_is_one():
     ratio, n = host_speed_ratio(dict(baseline), baseline)
     assert n == 6
     assert abs(ratio - 1.0) < 1e-9
+
+
+# --------------------------------------------------------------------------- #
+# The routing note the panel could not see (#1134, Cause 2)
+# --------------------------------------------------------------------------- #
+
+
+def test_solve_result_round_trips_the_routing_note():
+    """`algorithm_route` survives `to_dict`/`from_dict`.
+
+    #1134's second cause — `cvxnonsep_nsig30` going 1.12 s → 42.5 s on an
+    *identical* 165-node tree because the auto-routed `oa` master burned 39.6 s and
+    abstained before the default path solved it — was invisible in a table of nodes
+    and seconds, and cost a second bisect to recover something the solver already
+    knew and was already reporting on `SolveResult.algorithm_route`.
+    """
+    from benchmarks.metrics import SolveResult, SolveStatus  # noqa: PLC0415
+
+    note = "mip-nlp/oa: minlp certified convex at the root; did not certify in 39.63s"
+    r = SolveResult(
+        instance="cvxnonsep_nsig30",
+        solver="discopt",
+        status=SolveStatus.OPTIMAL,
+        algorithm_route=note,
+    )
+    d = r.to_dict()
+    assert d["algorithm_route"] == note
+    assert SolveResult.from_dict(d).algorithm_route == note
+
+
+def test_rows_written_before_the_field_still_load():
+    """Backward compatibility, and the reason the field is optional: every row of
+    the committed `cert-baseline.jsonl` predates it, and `load`/`from_dict` must
+    not start rejecting the reference the neutrality check is built on."""
+    from benchmarks.metrics import SolveResult  # noqa: PLC0415
+    from scripts.check_cert_neutrality import _CERT_BASELINE  # noqa: PLC0415
+    from utils.cert_neutrality import load_baseline  # noqa: PLC0415
+
+    baseline = load_baseline(_CERT_BASELINE)
+    assert baseline, "committed cert baseline is empty"
+    loaded = 0
+    for row in baseline.values():
+        assert "algorithm_route" not in row, "test premise: committed rows predate the field"
+        assert SolveResult.from_dict(row).algorithm_route is None
+        loaded += 1
+    assert loaded == len(baseline), (loaded, len(baseline))

--- a/discopt_benchmarks/tests/test_1134_cert_baseline_shrink_guard.py
+++ b/discopt_benchmarks/tests/test_1134_cert_baseline_shrink_guard.py
@@ -1,0 +1,183 @@
+"""Regression (#1134): a baseline regeneration may not shrink the panel silently.
+
+`cert-baseline.jsonl` is the §0.2.5 bound-neutrality reference. `gen_cert_baseline`
+writes only the *deterministic certifying* subset, and three of that filter's four
+rejection reasons — not-optimal, near-budget, and (via a wall-clock exit) node
+drift — are properties of the **machine and the budget**, not of the search tree.
+So a regeneration on a slower box deletes rows rather than recording a regression,
+and the smaller reference that results still reads as green while covering less.
+
+#1134 is what that costs: `clay0303hfsg`, `nvs05` and `tanksize` stopped certifying
+inside their 60 s budgets, and regenerating would have dropped all three out of the
+panel instead of recording it. The same issue also cost a bisect to answer "when did
+this reference last match the tree?", because the committed reference carried no
+provenance at all.
+
+Pinned here:
+
+* `coverage_loss` names exactly the instances the previous reference covered that a
+  new run does not admit;
+* `build_meta` records those, each drop's reason, and the previous row's verdict,
+  plus the generating commit and host — the provenance whose absence forced the
+  bisect;
+* `host_speed_ratio` measures this box against the reference machine using only
+  instances whose `node_count` reproduced *exactly* (equal trees ⇒ the wall ratio is
+  the machines', not the work's), and abstains below a sample floor rather than
+  publishing a timing claim from a handful of sub-second solves (CLAUDE.md §9).
+
+The guard these feed — refusing the overwrite without `--allow-shrink` — is asserted
+on the plan (`coverage_loss` non-empty) rather than by running a 56-instance solve.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_BENCH_ROOT = Path(__file__).resolve().parents[1]
+_REPO_ROOT = _BENCH_ROOT.parent
+for _p in (str(_BENCH_ROOT), str(_REPO_ROOT)):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+from scripts.check_cert_neutrality import (  # noqa: E402
+    _MIN_CALIBRATION_SAMPLES,
+    host_speed_ratio,
+)
+from scripts.gen_cert_baseline import build_meta, coverage_loss  # noqa: E402
+
+
+def _row(name: str, *, nodes: int = 10, wall: float = 1.0, obj: float = 1.0) -> dict:
+    return {
+        "instance": name,
+        "status": "optimal",
+        "objective": obj,
+        "node_count": nodes,
+        "wall_time": wall,
+    }
+
+
+# --------------------------------------------------------------------------- #
+# coverage_loss — the quantity the guard is built on
+# --------------------------------------------------------------------------- #
+
+
+def test_coverage_loss_names_the_instances_the_reference_covered():
+    """The #1134 shape: three rows the reference had that the new run will not admit."""
+    previous = {n: _row(n) for n in ("clay0303hfsg", "nvs05", "tanksize", "nvs14", "gbd")}
+    lost = coverage_loss(previous, ["nvs14", "gbd"])
+    assert lost == ["clay0303hfsg", "nvs05", "tanksize"], lost
+
+
+def test_coverage_loss_is_empty_when_the_panel_only_grows():
+    previous = {n: _row(n) for n in ("nvs14", "gbd")}
+    assert coverage_loss(previous, ["nvs14", "gbd", "tanksize"]) == []
+
+
+def test_coverage_loss_ignores_a_reordered_panel():
+    previous = {n: _row(n) for n in ("gbd", "nvs14")}
+    assert coverage_loss(previous, ["nvs14", "gbd"]) == []
+
+
+# --------------------------------------------------------------------------- #
+# build_meta — the committed drop record + provenance
+# --------------------------------------------------------------------------- #
+
+
+def test_meta_records_each_drop_with_its_reason_and_the_lost_row():
+    previous = {n: _row(n, nodes=283, obj=41.5) for n in ("clay0303hfsg", "nvs14")}
+    meta = build_meta(
+        certifying=["nvs14"],
+        dropped=[("clay0303hfsg", "not-optimal(time_limit/time_limit/time_limit)")],
+        previous=previous,
+        time_limit=60.0,
+        attempted=56,
+        allow_shrink=False,
+    )
+    assert meta["coverage_lost"] == ["clay0303hfsg"]
+    (drop,) = meta["dropped"]
+    assert drop["instance"] == "clay0303hfsg"
+    assert "time_limit" in drop["reason"]
+    # The record must carry what was LOST, not merely that something was.
+    assert drop["in_previous_baseline"] is True
+    assert drop["previous"] == {"status": "optimal", "node_count": 283, "objective": 41.5}
+
+
+def test_meta_marks_a_drop_the_reference_never_covered():
+    """A never-admitted instance is a drop but not a coverage loss."""
+    meta = build_meta(
+        certifying=["nvs14"],
+        dropped=[("nvs17", "near-limit(wall 45s/60s)")],
+        previous={"nvs14": _row("nvs14")},
+        time_limit=60.0,
+        attempted=56,
+        allow_shrink=False,
+    )
+    assert meta["coverage_lost"] == []
+    (drop,) = meta["dropped"]
+    assert drop["in_previous_baseline"] is False
+    assert drop["previous"] is None
+
+
+def test_meta_carries_the_provenance_the_bisect_had_to_recover():
+    meta = build_meta(
+        certifying=["nvs14"],
+        dropped=[],
+        previous={},
+        time_limit=60.0,
+        attempted=56,
+        allow_shrink=False,
+    )
+    # This repo is a git checkout, so the generating commit must be recorded: a null
+    # here is the exact gap that turned "is the reference stale?" into a bisect.
+    assert isinstance(meta["commit"], str) and len(meta["commit"]) == 40, meta["commit"]
+    assert meta["generated_at"]
+    assert meta["time_limit"] == 60.0
+    assert meta["instances_attempted"] == 56
+    assert meta["instances_certifying"] == 1
+    assert meta["host"]["cpu_count"]
+
+
+# --------------------------------------------------------------------------- #
+# host_speed_ratio — reading a wall-clock verdict against the reference machine
+# --------------------------------------------------------------------------- #
+
+
+def test_speed_ratio_uses_only_instances_that_reproduced_their_node_count():
+    """Equal node counts ⇒ the two runs did the same work, so the wall ratio is the
+    machines'. A row whose tree changed carries a work difference and must not
+    contaminate the estimate."""
+    baseline = {f"i{k}": _row(f"i{k}", nodes=k + 1, wall=1.0) for k in range(6)}
+    new = {f"i{k}": _row(f"i{k}", nodes=k + 1, wall=3.0) for k in range(6)}
+    # One instance whose tree exploded: 100x the wall, and it must be excluded.
+    new["i0"] = _row("i0", nodes=999, wall=100.0)
+    ratio, n = host_speed_ratio(new, baseline)
+    assert n == 5, n
+    assert abs(ratio - 3.0) < 1e-9, ratio
+
+
+def test_speed_ratio_abstains_below_the_sample_floor():
+    """Fewer samples than the floor ⇒ no ratio at all, rather than a timing claim
+    published off a handful of solves (CLAUDE.md §9)."""
+    n_rows = _MIN_CALIBRATION_SAMPLES - 1
+    baseline = {f"i{k}": _row(f"i{k}", nodes=k + 1, wall=1.0) for k in range(n_rows)}
+    new = {f"i{k}": _row(f"i{k}", nodes=k + 1, wall=3.0) for k in range(n_rows)}
+    ratio, n = host_speed_ratio(new, baseline)
+    assert ratio is None
+    assert n == n_rows
+
+
+def test_speed_ratio_drops_sub_noise_baseline_walls():
+    """A 0.01 s baseline row is process noise, not throughput."""
+    baseline = {f"i{k}": _row(f"i{k}", nodes=k + 1, wall=0.01) for k in range(6)}
+    new = {f"i{k}": _row(f"i{k}", nodes=k + 1, wall=3.0) for k in range(6)}
+    ratio, n = host_speed_ratio(new, baseline)
+    assert ratio is None, ratio
+    assert n == 0
+
+
+def test_speed_ratio_of_the_reference_machine_against_itself_is_one():
+    baseline = {f"i{k}": _row(f"i{k}", nodes=k + 1, wall=1.0 + k) for k in range(6)}
+    ratio, n = host_speed_ratio(dict(baseline), baseline)
+    assert n == 6
+    assert abs(ratio - 1.0) < 1e-9

--- a/docs/dev/certification-gap-plan.md
+++ b/docs/dev/certification-gap-plan.md
@@ -100,77 +100,135 @@ Stop work and surface to the maintainer (do not improvise) when:
 
 ### 0.6.1 The reference's own drift (falsification, #1134, 2026-08-31)
 
-§0.6 makes "the baseline is stale relative to `main`" a stop-and-escalate condition,
-but nothing in the tooling could *detect* it, so it was never raised. #1134 is the
-bill: 7 rows of the committed reference read as regressions on `main`, the #1130
-graduation gate charged that drift to all 7 flags as `soundness=FAIL`, and answering
-"when did this reference last match the tree?" cost a bisect that the reference
-should have answered by inspection.
+§0.6 makes "the baseline is stale relative to `main`" a stop-and-escalate
+condition, but nothing in the tooling could *detect* it, so it was never raised.
+#1134 is the bill: 7 rows of the committed reference read as regressions on
+`main`, the #1130 graduation gate charged that drift to all 7 flags as
+`soundness=FAIL`, and answering "when did this reference last match the tree?"
+cost a bisect that the reference should have answered by inspection.
 
-**Root cause, bisected.** `git bisect --first-parent` on `nvs14`'s node count
-(deterministic, well inside its budget, so unconfounded by wall clock) over
-`23a64ab6` (2026-08-11, the reference's actual generating commit) → `main`, 104
-first-parent revisions, 7 steps, names **`bd9c4c5c` (PR #1025)** — the `feral`
-0.15.1 → 0.16.0 bump, whose one breaking item is `SparseLu::factor` defaulting to
-threshold Markowitz instead of AMD-on-AtA + Gilbert–Peierls. Confirmed forward by an
-A/B on `main` distinguished by a marker string baked into the extension: a
-`LuPivoting::GilbertPeierls` arm restores **`nvs02` 421 → 345** and **`tspn05` 51 →
-39**, i.e. *exactly* the committed reference's values, and takes **`nvs14` 839 →
-175**. The drift is a rounding-trajectory reshuffle of degenerate pivot choices, and
-it was already recorded as such by the bump itself (`crates/discopt-core/Cargo.toml`
-names nvs02, nvs14, nvs11, nvs12, tanksize under its regime-(b) acceptance). Nothing
-regressed since v0.8.0 — the reference simply predates v0.8.0 and was never
-refreshed after a deliberate, accepted bound-changing change.
+There are **two** independent causes, both found by `git bisect --first-parent`
+over `23a64ab6` (2026-08-11, the reference's actual last regeneration) → `main`.
 
-**The issue's window was wrong, and could not have been right.** #1134 placed the
-regression in 2026-08-17…08-24 because the reference was assumed to be the v0.8.0
-snapshot (`deba4ce`, 08-16). It is not: `git log --follow` puts its last
-regeneration at `23a64ab6`, 08-11, five days *before* v0.8.0 and three before the
-bump. `nvs14` measures 839 at `deba4ce` and at `1a0df198`, both inside the supposed
-window's "good" end. **A reference that does not carry its own provenance cannot be
-reasoned about, only bisected** — which is what #1134 fixed in the tooling.
+#### Cause 1 — the LU pivoting default (`bd9c4c5c`, PR #1025): the node drift
 
-**Not every row is the bump.** Measured on a 4-vCPU box, interleaved A/B, 3 reps,
-per-instance sd reported (CLAUDE.md §9):
+Bisected on `nvs14`'s node count (deterministic, well inside its budget, so
+unconfounded by wall clock), 104 first-parent revisions, 7 steps. The first bad
+commit is the `feral` 0.15.1 → 0.16.0 bump, whose one breaking item is
+`SparseLu::factor` defaulting to threshold Markowitz instead of AMD-on-AtA +
+Gilbert–Peierls. Confirmed forward on `main` by an A/B whose arms differ only in
+`LuParams::pivoting` and are distinguished by a marker string baked into the
+extension: the `GilbertPeierls` arm restores **`nvs02` 421 → 345** and **`tspn05`
+51 → 39**, i.e. *exactly* the committed values, and takes **`nvs14` 839 → 175**.
+The drift was already recorded and accepted by the bump itself
+(`crates/discopt-core/Cargo.toml`, regime (b)); the reference was simply never
+refreshed after it.
 
-| instance | issue's reading | measured |
+#### Cause 2 — the convex-MINLP route becoming reachable (`533c05e1`, PR #1100): the wall
+
+`cvxnonsep_nsig30` does not fit Cause 1: it certifies the *same* 165-node tree
+with the *same* objective and dual bound at every point measured, yet its wall
+went 1.12 s (reference) → 42.5 s, far past what the machine explains. Bisected on
+wall at a 60 s budget, **with both arms pinned to `GilbertPeierls` so the
+pivoting rule is not the variable**, it names `533c05e1` — "#1060 opt-in HiGHS
+master so `lp_nlp_bb` finishes without Gurobi". Measured at `533c05e1^1` vs
+`533c05e1`: **4.5 s → 38.9 s**, tree unchanged.
+
+The mechanism is not the HiGHS master. That PR also corrected
+`_convex_minlp_auto_route`'s availability gate, which used to be `import
+highspy` — a package `get_milp_solver("auto")` has not touched since #356, so the
+gate tested something the master would never load. Its own comment says it "refused
+on machines whose master was perfectly available and routed on machines whose
+master was not". The correction is right; what it exposed is that **on a
+highspy-free machine a large part of the cert panel now takes the `oa` route, and
+a route that abstains costs 50–66% of the budget before the default path starts
+from scratch**. Measured on `main` (`algorithm_route` quotes the solver's own note):
+
+| instance | reference | now | what the route did |
+|---|---|---|---|
+| `cvxnonsep_nsig30` | 165 nodes, 1.12 s | 165 nodes, 49.6 s | OA did not certify in **39.63 s** of 60; default path then solved the same tree |
+| `clay0303hfsg` | 283 nodes, 15.29 s | no certificate at 60 s | OA `unknown` after **30.64 s**; fallback left 29.36 s |
+| `fac2` | 39 nodes, 2.77 s | 39 nodes, 38.9 s | OA `feasible` after **30.13 s**; fallback certified in ~8.8 s |
+| `cvxnonsep_psig30` | 89 nodes, 0.41 s | 89 nodes, 8.5 s | routed |
+| `alan` | 21 nodes, 0.21 s | 13 nodes, 1.3 s | routed |
+
+The 30 s cut-offs are `_CONVEX_ROUTE_BUDGET_FRACTION` (0.5) and the 39.6 s one is
+the #1066 progress guard, whose `checkpoint` is that same 50% by construction.
+Nothing here is malfunctioning — this is the #1059/#1066 policy doing exactly what
+it specifies. The finding is that the policy's *price*, on instances the default
+path certifies in 4–9 s, is half the budget, and that price only became visible on
+highspy-free machines when #1100 fixed the gate. Re-tuning it is a bound-changing
+default and owes the CLAUDE.md §5 graduation pair; it is **not** taken under #1134.
+
+#### Row-by-row, and what is *not* a regression
+
+Measured on a 4-vCPU box, interleaved A/B, 3 reps, per-instance sd reported
+(CLAUDE.md §9). The host-speed calibration — median wall ratio over the **21**
+instances that reproduced their node count exactly — is **3.45x** the reference
+machine.
+
+| instance | issue's reading | measured cause |
 |---|---|---|
-| `nvs14` 129→839 | node regression | the bump (GP arm → 175) |
-| `nvs02` 345→421 | node regression | the bump (GP arm → 345, exact) |
-| `tspn05` 39→51 | node regression | the bump (GP arm → 39, exact) |
-| `nvs09` 5→31 | node regression | **does not reproduce** — 5 nodes in both arms, 3/3 reps |
-| `clay0303hfsg` → `time_limit` | lost certification | **the box**: non-certifying in *both* arms (ref 15.3 s / 283 nodes) |
-| `tanksize` → `time_limit` | lost certification | **the box**: non-certifying in *both* arms (ref 30.4 s / 16879 nodes) |
-| `nvs05` → `feasible` | lost certification | **per-node wall**: identical 175-node tree; GP 57.0 s (sd 0.24), Markowitz > 60 s |
-| `cvxnonsep_nsig30` marginal | budget cliff | **per-node wall**: identical 165-node tree; GP 39.5 s (sd 1.05) vs Markowitz 59.4 s (sd 0.80) |
+| `nvs14` 129→839 | node regression | Cause 1 (GP arm → 175) |
+| `nvs02` 345→421 | node regression | Cause 1 (GP arm → 345, exact) |
+| `tspn05` 39→51 | node regression | Cause 1 (GP arm → 39, exact) |
+| `nvs09` 5→31 | node regression | **does not reproduce** — 5 nodes, both arms, 3/3 reps |
+| `cvxnonsep_nsig30` marginal | budget cliff | **Cause 2** — route burns 39.6 s of 60 |
+| `clay0303hfsg` → `time_limit` | lost certification | **Cause 2 + the box** (15.29 s x 3.45 ≈ 53 s before the route's 30.6 s) |
+| `nvs05` → `feasible` | lost certification | **the box**: not routed, identical 175-node tree, 20.53 s x 3.45 ≈ 71 s > 60 s |
+| `tanksize` → `time_limit` | lost certification | **the box**: not routed, ~2.3x per node |
 
-The last two are the finding the #1025 acceptance does not cover. That record's
-net-positive arm was measured on captured *relaxation* LPs — large, high-fill bases,
-where Markowitz wins 8.32x → 1.28x fill — and it says outright that "the certifying
-panel cannot" see the change. It can: on this panel's small bases Markowitz's
-ordering search does not amortize, and it *costs* wall (`cvxnonsep_nsig30` +49%,
-same tree). Two of #1134's three "lost certifications" are that cost pushing an
-instance across a 60 s line it was already near. This does not retract the bump —
-`numerical` refusals and fill both improved, and no verdict was ever false — but it
-does retract "the certifying panel cannot see it", and it is the entry measurement
-for size-routed pivoting (Gilbert–Peierls on small bases, Markowitz on large).
+#### What the LU bump costs at panel scale (retraction, CLAUDE.md §11)
 
-**Do not regenerate the reference on an arbitrary box.** The admission filter drops
-anything not certifying inside `_MARGIN_FRAC` (0.6) of its budget, and three of its
-four rejection reasons are properties of the machine. The 4-vCPU box above runs
-**≈3x** the reference machine's wall on equal-node work (`nvs09` 0.82 → 2.8 s at 5
-nodes; `tspn05` 2.44 → 7.30 s at 39 nodes), which is enough on its own to drop
-`clay0303hfsg`, `nvs05` and `tanksize` — the exact silent shrink #1134 warned about.
-Regeneration belongs on the reference machine.
+The #1025 record asserts that "the certifying panel cannot" see an LU kernel bump
+and measures net-positive only on captured relaxation LPs. It cannot see the
+benefit — that stands — but it does see a cost. Measured mk-vs-gp on `main`, 3
+reps, restricted to **unrouted** instances whose node count is identical in both
+arms (so the comparison is per-node cost, not search):
 
-**Tooling fixed under #1134**, so this is a lookup next time, not a bisect:
+    nvs09 2.78/2.65   st_e29 2.07/2.03   ex1224 2.03/2.00   ex1225 1.88/1.84
+    gkocis 1.35/1.39  ex1226 1.53/1.35   oaer 1.32/1.32     st_e36 6.83/7.03
+    nvs22 15.35/12.11 nvs05 >=60.32/56.62 (mk censored at the limit)
+
+Median ratio ~1.03 — small. Two rows carry it: `nvs22` **+27%** and `nvs05`
+**>=+7%**, the latter enough to lose a certification 3/3 reps that the GP arm
+holds at 56.6 s (sd 1.35). It is two-sided: on the routed `m3` Markowitz is 2.4x
+*faster* (1.53 s vs 3.70 s). So the retraction is narrow — the panel sees a
+per-node cost of a few percent with a +27% tail, not the large regression the
+first reading of #1134 suggested. The bump stands. Size-routed pivoting
+(Gilbert–Peierls on small low-fill bases, Markowitz on large) is the general
+follow-up and these are its entry numbers.
+
+#### The issue's window was wrong, and could not have been right
+
+#1134 placed the regression in 2026-08-17…08-24 because the reference was assumed
+to be the v0.8.0 snapshot (`deba4ce`, 08-16). It is not: `git log --follow` puts
+its last regeneration at `23a64ab6`, 08-11, five days *before* v0.8.0 and three
+before Cause 1. `nvs14` measures 839 at `deba4ce` and at `1a0df198`, both inside
+the supposed window's "good" end. **A reference that does not carry its own
+provenance cannot be reasoned about, only bisected.**
+
+#### Do not regenerate the reference on an arbitrary box
+
+The admission filter drops anything not certifying inside `_MARGIN_FRAC` (0.6) of
+its budget, and three of its four rejection reasons are properties of the machine.
+Run on the 4-vCPU box above, `gen_cert_baseline.py` admitted **45** of the
+reference's 52 rows: it would have dropped `clay0303hfsg`, `cvxnonsep_nsig30`,
+`fac2`, `nvs05`, `nvs17`, `nvs22` and `tanksize` — four more than #1134
+anticipated — and the resulting 45-row reference would still have read as green.
+Regeneration belongs on the reference machine, and Cause 2 should be settled
+first: `cvxnonsep_nsig30`, `clay0303hfsg` and `fac2` will sit near their budgets
+*there* too, because the route flip is machine-independent.
+
+#### Tooling fixed under #1134, so this is a lookup next time
+
 `gen_cert_baseline.py` writes `docs/dev/data/cert-baseline-meta.json` (generating
 commit, timestamp, budget, host, and the full drop record with each dropped row's
 previous verdict) and **refuses to overwrite the reference when coverage would
-shrink** unless `--allow-shrink` is passed; `check_cert_neutrality.py` prints that
-provenance and a host-speed calibration measured only on instances whose
-`node_count` reproduced exactly, and annotates `status` violations with it. The
-calibration is reporting-only — no violation is ever suppressed by it (§0.3).
+shrink** unless `--allow-shrink` is passed — verified end-to-end on the 56-instance
+panel, where it refused and named all 7 losses. `check_cert_neutrality.py` prints
+that provenance and the host-speed calibration, and annotates `status` violations
+with it. The calibration is reporting-only: no violation is ever suppressed (§0.3).
 
 ### 0.7 Definition of done (per phase)
 

--- a/docs/dev/certification-gap-plan.md
+++ b/docs/dev/certification-gap-plan.md
@@ -178,8 +178,18 @@ machine.
 > (`clay0303hfsg`, `nvs05`) is correspondingly an upper bound, and it does not
 > change either row's attribution — both still exceed the budget at any ratio in
 > the plausible range. `host_speed_ratio` now excludes routed rows on either side,
-> so the next run's figure is the one to quote. Not re-measured here: it needs the
-> panel re-run, and no conclusion in this section turns on it.
+> so the next run's figure is the one to quote.
+>
+> **Re-measured (2026-08-31, same box, idle).** `check_cert_neutrality.py` over all
+> 52 reference instances at their budgets, with the corrected filter:
+> **3.46x on 17 unrouted instances** that reproduced their node count exactly. So
+> the contaminated figure was high by 0.01x — the three inflated samples all landed
+> above the median, which is exactly the ~1.5 rank positions predicted, and a median
+> absorbed them. The correction above stands as a method fix, not as a number that
+> moved: every conclusion drawn from 3.45x holds unchanged at 3.46x, and this is now
+> a measurement rather than an upper bound. The same run confirms the annotation
+> path end to end — `clay0303hfsg`, `nvs05` and `tanksize` each report their
+> `status` violation carrying the ratio, and none is suppressed by it.
 
 | instance | issue's reading | measured cause |
 |---|---|---|

--- a/docs/dev/certification-gap-plan.md
+++ b/docs/dev/certification-gap-plan.md
@@ -98,6 +98,80 @@ Stop work and surface to the maintainer (do not improvise) when:
 - the baseline (`cert-baseline.jsonl`) is missing or stale relative to `main` such
   that neutrality cannot be asserted.
 
+### 0.6.1 The reference's own drift (falsification, #1134, 2026-08-31)
+
+§0.6 makes "the baseline is stale relative to `main`" a stop-and-escalate condition,
+but nothing in the tooling could *detect* it, so it was never raised. #1134 is the
+bill: 7 rows of the committed reference read as regressions on `main`, the #1130
+graduation gate charged that drift to all 7 flags as `soundness=FAIL`, and answering
+"when did this reference last match the tree?" cost a bisect that the reference
+should have answered by inspection.
+
+**Root cause, bisected.** `git bisect --first-parent` on `nvs14`'s node count
+(deterministic, well inside its budget, so unconfounded by wall clock) over
+`23a64ab6` (2026-08-11, the reference's actual generating commit) → `main`, 104
+first-parent revisions, 7 steps, names **`bd9c4c5c` (PR #1025)** — the `feral`
+0.15.1 → 0.16.0 bump, whose one breaking item is `SparseLu::factor` defaulting to
+threshold Markowitz instead of AMD-on-AtA + Gilbert–Peierls. Confirmed forward by an
+A/B on `main` distinguished by a marker string baked into the extension: a
+`LuPivoting::GilbertPeierls` arm restores **`nvs02` 421 → 345** and **`tspn05` 51 →
+39**, i.e. *exactly* the committed reference's values, and takes **`nvs14` 839 →
+175**. The drift is a rounding-trajectory reshuffle of degenerate pivot choices, and
+it was already recorded as such by the bump itself (`crates/discopt-core/Cargo.toml`
+names nvs02, nvs14, nvs11, nvs12, tanksize under its regime-(b) acceptance). Nothing
+regressed since v0.8.0 — the reference simply predates v0.8.0 and was never
+refreshed after a deliberate, accepted bound-changing change.
+
+**The issue's window was wrong, and could not have been right.** #1134 placed the
+regression in 2026-08-17…08-24 because the reference was assumed to be the v0.8.0
+snapshot (`deba4ce`, 08-16). It is not: `git log --follow` puts its last
+regeneration at `23a64ab6`, 08-11, five days *before* v0.8.0 and three before the
+bump. `nvs14` measures 839 at `deba4ce` and at `1a0df198`, both inside the supposed
+window's "good" end. **A reference that does not carry its own provenance cannot be
+reasoned about, only bisected** — which is what #1134 fixed in the tooling.
+
+**Not every row is the bump.** Measured on a 4-vCPU box, interleaved A/B, 3 reps,
+per-instance sd reported (CLAUDE.md §9):
+
+| instance | issue's reading | measured |
+|---|---|---|
+| `nvs14` 129→839 | node regression | the bump (GP arm → 175) |
+| `nvs02` 345→421 | node regression | the bump (GP arm → 345, exact) |
+| `tspn05` 39→51 | node regression | the bump (GP arm → 39, exact) |
+| `nvs09` 5→31 | node regression | **does not reproduce** — 5 nodes in both arms, 3/3 reps |
+| `clay0303hfsg` → `time_limit` | lost certification | **the box**: non-certifying in *both* arms (ref 15.3 s / 283 nodes) |
+| `tanksize` → `time_limit` | lost certification | **the box**: non-certifying in *both* arms (ref 30.4 s / 16879 nodes) |
+| `nvs05` → `feasible` | lost certification | **per-node wall**: identical 175-node tree; GP 57.0 s (sd 0.24), Markowitz > 60 s |
+| `cvxnonsep_nsig30` marginal | budget cliff | **per-node wall**: identical 165-node tree; GP 39.5 s (sd 1.05) vs Markowitz 59.4 s (sd 0.80) |
+
+The last two are the finding the #1025 acceptance does not cover. That record's
+net-positive arm was measured on captured *relaxation* LPs — large, high-fill bases,
+where Markowitz wins 8.32x → 1.28x fill — and it says outright that "the certifying
+panel cannot" see the change. It can: on this panel's small bases Markowitz's
+ordering search does not amortize, and it *costs* wall (`cvxnonsep_nsig30` +49%,
+same tree). Two of #1134's three "lost certifications" are that cost pushing an
+instance across a 60 s line it was already near. This does not retract the bump —
+`numerical` refusals and fill both improved, and no verdict was ever false — but it
+does retract "the certifying panel cannot see it", and it is the entry measurement
+for size-routed pivoting (Gilbert–Peierls on small bases, Markowitz on large).
+
+**Do not regenerate the reference on an arbitrary box.** The admission filter drops
+anything not certifying inside `_MARGIN_FRAC` (0.6) of its budget, and three of its
+four rejection reasons are properties of the machine. The 4-vCPU box above runs
+**≈3x** the reference machine's wall on equal-node work (`nvs09` 0.82 → 2.8 s at 5
+nodes; `tspn05` 2.44 → 7.30 s at 39 nodes), which is enough on its own to drop
+`clay0303hfsg`, `nvs05` and `tanksize` — the exact silent shrink #1134 warned about.
+Regeneration belongs on the reference machine.
+
+**Tooling fixed under #1134**, so this is a lookup next time, not a bisect:
+`gen_cert_baseline.py` writes `docs/dev/data/cert-baseline-meta.json` (generating
+commit, timestamp, budget, host, and the full drop record with each dropped row's
+previous verdict) and **refuses to overwrite the reference when coverage would
+shrink** unless `--allow-shrink` is passed; `check_cert_neutrality.py` prints that
+provenance and a host-speed calibration measured only on instances whose
+`node_count` reproduced exactly, and annotates `status` violations with it. The
+calibration is reporting-only — no violation is ever suppressed by it (§0.3).
+
 ### 0.7 Definition of done (per phase)
 
 A phase is done when: its §4–§9 exit gate is green on the committed baseline's

--- a/docs/dev/certification-gap-plan.md
+++ b/docs/dev/certification-gap-plan.md
@@ -167,6 +167,20 @@ Measured on a 4-vCPU box, interleaved A/B, 3 reps, per-instance sd reported
 instances that reproduced their node count exactly — is **3.45x** the reference
 machine.
 
+> **Correction (review of PR #1144, CLAUDE.md §11).** That 3.45x admitted rows that
+> reproduce their node count but are **auto-routed**, which Cause 2 above is the
+> proof cannot be treated as equal work: `cvxnonsep_nsig30` (165 → 165 nodes,
+> 1.12 → 49.6 s), `fac2` (39 → 39, 2.77 → 38.9) and `cvxnonsep_psig30` (89 → 89,
+> 0.41 → 8.5) each clear the equal-node filter carrying a 14-44x inflation that is
+> the router, not the box. Three contaminated samples in a 21-row median move it by
+> ~1.5 rank positions, so **3.45x is an upper bound on the machine ratio, not the
+> measurement**; the arithmetic below that multiplies a reference wall by 3.45
+> (`clay0303hfsg`, `nvs05`) is correspondingly an upper bound, and it does not
+> change either row's attribution — both still exceed the budget at any ratio in
+> the plausible range. `host_speed_ratio` now excludes routed rows on either side,
+> so the next run's figure is the one to quote. Not re-measured here: it needs the
+> panel re-run, and no conclusion in this section turns on it.
+
 | instance | issue's reading | measured cause |
 |---|---|---|
 | `nvs14` 129→839 | node regression | Cause 1 (GP arm → 175) |
@@ -229,6 +243,21 @@ shrink** unless `--allow-shrink` is passed — verified end-to-end on the 56-ins
 panel, where it refused and named all 7 losses. `check_cert_neutrality.py` prints
 that provenance and the host-speed calibration, and annotates `status` violations
 with it. The calibration is reporting-only: no violation is ever suppressed (§0.3).
+
+Two corrections from the review of that PR, both about the tooling telling the
+truth about itself:
+
+* the meta is written on **every** run, a refused one included — so it records
+  `baseline_written`, and a refused run's meta is reported as
+  `provenance: UNKNOWN … records a REFUSED regeneration` rather than having its
+  commit and host attributed to the reference still on disk. Claiming a refused
+  run's provenance would be a *confidently wrong* answer to the one question this
+  section exists to make answerable, which is worse than the missing answer it
+  replaces; and
+* the calibration excludes **routed** rows on either side (see the correction
+  above). A row routed in both arms is excluded too, and for the opposite reason:
+  the route's price is a fraction of the wall-clock *budget*, i.e. the same seconds
+  on a fast box and a slow one, so it biases the ratio *down* toward 1.
 
 ### 0.7 Definition of done (per phase)
 

--- a/docs/dev/certification-gap-plan.md
+++ b/docs/dev/certification-gap-plan.md
@@ -244,6 +244,74 @@ Regeneration belongs on the reference machine, and Cause 2 should be settled
 first: `cvxnonsep_nsig30`, `clay0303hfsg` and `fac2` will sit near their budgets
 *there* too, because the route flip is machine-independent.
 
+#### Resolution (2026-08-31): the panel re-run on a verified-fresh build
+
+Everything above was measured on a 4-vCPU box. Re-run on a second machine
+(14-core, `highspy` installed, `_rust.abi3.so` rebuilt from the tree under test
+and asserted at import per §8 — the previous local build was a two-week-old
+`_rust.cpython-*.so` **shadowing** the real extension, which is its own lesson:
+`test_rust_extension_not_shadowed` was failing and saying so). Host-speed
+calibration on this box: **1.53x** the reference machine over 17 unrouted rows
+that reproduced their node count exactly.
+
+**The three lost certifications do not reproduce. All 52 rows certify
+`optimal`.** `clay0303hfsg`, `nvs05` and `tanksize` — the whole of #1134's
+"lost certification" table — come back `optimal`, as does `cvxnonsep_nsig30` and
+even the perf-gated `nvs17` (60451 nodes, exact). The losses were the reporting
+box's wall: at 3.45x, `nvs05` (20.53 s) and `tanksize` (30.39 s) exceed a 60 s
+budget arithmetically, and at 1.53x they do not.
+
+**No soundness fault.** `incorrect_count = 0` against 58 oracles. Eleven rows
+drift beyond the 1e-8 byte-reproducibility tolerance; every one was bracketed
+against `cert-optima.json` and **none** disagrees with the true optimum — and
+**eight of the eleven land closer to it than the committed reference does**
+(`st_test1` -1.65e-08 → exactly 0, `gbd` → 2.2000000009 vs 2.2, `m3` →
+37.80000007 vs 37.8, `st_miqp5` → -333.88888889 exact). On those rows the
+*reference* is the less accurate artifact.
+
+**The node regressions are real, and are Cause 1.** `nvs14` 129 → 839, `nvs02`
+345 → 421, `clay0303hfsg` 283 → 315, `tspn05` 39 → 43 (51 on the other box —
+this row is not machine-invariant), `nvs09` 5 → **31**.
+
+> **Retraction (CLAUDE.md §11).** The row-by-row table above records `nvs09`
+> 5 → 31 as "**does not reproduce** — 5 nodes, both arms, 3/3 reps". It
+> reproduces here: **31 nodes**, on current `main` with a build asserted fresh.
+> Read the "does not reproduce" as scoped to that box and that build, not to the
+> tree.
+
+**Why the reference still cannot be refreshed — and it is one row, one
+mechanism.** `gen_cert_baseline.py --time-limit 60` admitted **51 of the
+reference's 52** and the shrink guard refused the write, naming exactly one
+loss: `clay0303hfsg`, `near-limit(wall 49 s/60 s)` at 315 nodes against the
+reference's 283 at 15.29 s. An +11% tree cannot cost 3.2x wall, and
+`algorithm_route` — the field added by #1144 for this exact question — answers
+it without a bisect:
+
+    clay0303hfsg  48.74s  oa: ... did not certify in 30.27s (unknown)  -> fallback got 29.73s
+    fac2          35.45s  oa: ... did not certify in 30.08s (feasible) -> fallback got 29.92s
+    cvxnonsep_nsig30 28.89s oa: ... did not certify in 28.20s (feasible) -> fallback got 31.80s
+
+Strip the 30.27 s the abstaining route burns and `clay0303hfsg` finishes in
+~18.5 s, inside the 36 s margin, and the panel refreshes with **zero** coverage
+loss. So the sole blocker to a refreshed reference is **#1143**, quantified.
+
+> **Retraction (CLAUDE.md §11).** Cause 2 above frames the route cost as what
+> "#1100 exposed **on a highspy-free machine**". That framing is wrong. This box
+> has `highspy` installed and the route still fires on **23 of 56** panel
+> instances and abstains on **5** of them. The post-#1100 gate asks
+> `get_milp_solver()`, which succeeds with or without `highspy`; #1100 made the
+> route reachable *generally*, not on one class of machine. Likewise "admitted
+> 45 of the reference's 52 rows … four more than #1134 anticipated" is that
+> box's speed, not a property of the tree: here the same script admits **51**.
+
+**Disposition.** #1134 asked whether the panel regressed since v0.8.0. It did
+not: no soundness fault, no reproducible lost certification, and node drift that
+predates v0.8.0 and was accepted when it shipped (Cause 1). #1134 is closed on
+this evidence. Refreshing the reference is **an acceptance criterion on #1143**,
+not a separate task — the guard added here will refuse until #1143 is fixed, and
+that refusal is the correct behavior, not a blocker to route around with
+`--allow-shrink`.
+
 #### Tooling fixed under #1134, so this is a lookup next time
 
 `gen_cert_baseline.py` writes `docs/dev/data/cert-baseline-meta.json` (generating

--- a/docs/dev/certification-gap-plan.md
+++ b/docs/dev/certification-gap-plan.md
@@ -304,6 +304,31 @@ loss. So the sole blocker to a refreshed reference is **#1143**, quantified.
 > 45 of the reference's 52 rows … four more than #1134 anticipated" is that
 > box's speed, not a property of the tree: here the same script admits **51**.
 
+**Both framings were half right; the dated history is neither.** The retraction
+just above reads "#1100 made the route reachable *generally*, not on one class of
+machine", which over-corrects in the other direction. The pre-#1100 gate was
+`import highspy`, so it *succeeded* on a machine with `highspy` — that box was
+already routing before #1100, and observing that it routes after is consistent
+with the highspy-free framing rather than a counterexample to it. What #1100
+actually changed is routing on machines *without* `highspy`, which is why the
+bisect on such a box lands there. `git log -S` dates the whole sequence:
+
+| commit | date | what |
+|---|---|---|
+| `23a64ab6` | 08-11 | reference regenerated — **the route does not exist yet** |
+| `6442d7e3` | 08-17 | #1059 introduces the route, default-off |
+| `d9fec841` | 08-19 | #1059 graduates it **default-ON** — fires on `highspy` machines |
+| `533c05e1` | 08-20 | #1100 corrects the gate — fires everywhere |
+
+This also settles the loose end in Cause 2's evidence: the reference's
+`cvxnonsep_nsig30` row (165 nodes, 1.12 s) is unrouted not because that machine
+lacked `highspy` but because on 08-11 **there was no route to take**. And it
+re-scopes #1143: the abstain cost has been live since `d9fec841`, one day before
+#1100, so it is a property of the #1059 graduation that #1100 extended to the
+remaining machines — not a regression #1100 introduced. A bisect for it on a
+`highspy` box would name `d9fec841`; on a `highspy`-free box, `533c05e1`. Same
+mechanism, two different first-bad commits, and neither is wrong.
+
 **Disposition.** #1134 asked whether the panel regressed since v0.8.0. It did
 not: no soundness fault, no reproducible lost certification, and node drift that
 predates v0.8.0 and was accepted when it shipped (Cause 1). #1134 is closed on


### PR DESCRIPTION
## Summary

Closes #1134. The 7 rows the cert panel reports as regressions are **two independent causes**, both bisected, and the window in that issue could not have been right: `git log --follow` puts the reference's last regeneration at `23a64ab6` (2026-08-11), five days *before* v0.8.0, not at it — `nvs14` measures 839 nodes at both ends of the supposed "good" end of the window.

**Cause 1 — the node counts.** `git bisect --first-parent` on `nvs14`'s node count (deterministic, well inside its budget, so unconfounded by wall clock) over `23a64ab6` → `main`, 104 revisions, 7 steps → **`bd9c4c5c` (#1025)**, the feral 0.15.1 → 0.16.0 bump defaulting `SparseLu::factor` to threshold Markowitz. Confirmed forward on `main` by an A/B whose arms differ only in `LuParams::pivoting`: the `GilbertPeierls` arm restores `nvs02` 421 → **345** and `tspn05` 51 → **39**, exactly the committed values, and takes `nvs14` 839 → 175. Already recorded and accepted by that bump under its regime-(b) acceptance; the reference was simply never refreshed after it.

**Cause 2 — the wall.** `cvxnonsep_nsig30` certifies the *same* 165-node tree with the same objective and dual bound, yet went 1.12 s → 42.5 s. Bisecting on wall **with both arms pinned to `GilbertPeierls`** (so the pivoting rule is not the variable) names **`533c05e1` (#1100)**, which corrected `_convex_minlp_auto_route`'s availability gate. The route abstains at a budget checkpoint and the fallback then restarts, so it costs 50–66% of the budget. Split to **#1143**; not fixed here, because re-tuning it is a bound-changing default owing the CLAUDE.md §5 graduation pair. §0.6.1 dates the full sequence: the route is `d9fec841` (#1059, default-ON 08-19) and `533c05e1` (08-20) extended it to machines without `highspy` — a bisect names one or the other depending on the box, and the cost belongs to the #1059 graduation.

**Verdict on the issue's question — the panel did not regress since v0.8.0.** Re-run on a second machine with the extension rebuilt from the tree under test and asserted at import (§8): **all 52 rows certify `optimal`**, `incorrect_count = 0` against 58 oracles, and of the 11 rows drifting past the 1e-8 byte-reproducibility tolerance, none disagrees with the true optimum and **8 land closer to it than the committed reference does**. The three "lost certifications" were the reporting box's wall (3.46x the reference machine there, 1.53x on the fast box); the node drift is Cause 1 and predates v0.8.0. §0.6.1 carries the two retractions this produced (`nvs09` does reproduce, at 31 nodes; and the "45 of 52 rows" / highspy-free framings were box-scoped).

**What this PR changes** is the tooling that let a stale reference sit undetected and would have hidden the coverage loss on refresh:

- `gen_cert_baseline.py` writes `docs/dev/data/cert-baseline-meta.json` (generating commit, timestamp, budget, host, `baseline_written`, and the full drop record with each dropped row's previous verdict) and **refuses to overwrite the reference when coverage would shrink**, unless `--allow-shrink`. The meta and the full-panel report are written either way, so a refused run still leaves its evidence — and is reported as a *refused* regeneration rather than having its provenance attributed to the reference still on disk.
- `check_cert_neutrality.py` prints that provenance and a host-speed calibration measured only on **unrouted** instances whose `node_count` reproduced exactly, and annotates `status` violations with it.
- `benchmarks.metrics.SolveResult` gains an optional `algorithm_route`, populated by the runner. Its absence is why Cause 2 was invisible in a table of nodes and seconds and cost a second bisect; with it, the one row still blocking a refresh (`clay0303hfsg`, 49 s of 60) is explained in one line — 30.27 s of it is an abstaining OA route — instead of another bisect.
- `docs/dev/certification-gap-plan.md` §0.6.1 records the falsification per §0.4; `crates/discopt-core/Cargo.toml` carries a narrowed retraction per §11.
- `.github/workflows/ci.yml` runs the cert-baseline tooling tests, which no lane exercised — `ci.yml` pulled exactly one file out of `discopt_benchmarks/tests`, so the reference every solver change is judged against had no CI covering the code that generates or reads it.

**No baseline is committed.** On the fast box the generator admits 51 of 52 and the guard refuses on `clay0303hfsg` alone; strip the abstaining route and it finishes in ~18.5 s, inside the margin, with zero coverage loss. Refreshing the reference is therefore an acceptance criterion on **#1143**, and the refusal is the guard working, not something to route around with `--allow-shrink`.

## Correctness

- [x] Cannot produce a false certificate (**N/A — no solver-math change**). The diff touches the benchmark harness, two generator/checker scripts, CI config, docs, and TOML comments. The one field added to a solver-facing dataclass is a reporting string. No relaxation, bound, cut, or reduction is touched; `cargo build -p discopt-core` recompiles only because a comment moved. Independently, the fresh-build panel run reports `incorrect_count = 0` against 58 oracles with every drifting row bracketed against `cert-optima.json`.
- [x] No validation, fallback, or safety guard was weakened to make a check pass. The guard-adjacent additions are strictly one-directional: the shrink guard *adds* a refusal that did not exist, and the host-speed calibration is **reporting-only** — it annotates a `status` violation with the machine ratio and never suppresses one (§0.3), confirmed on a live 52-instance run where all 17 violations stand. Excluding routed rows removes samples from that statistic; it does not change any verdict. `test_cert_neutrality_regime.py` passes unchanged.

## Tests run (state the result — numbers, not adjectives)

- [x] `pytest -m smoke python/tests/` → **1119 passed, 21 skipped, 2 xpassed** (367 s)
- [x] `pytest -m slow python/tests/test_adversarial_recent_fixes.py` → **19 passed** (158 s)
- [x] `cargo test -p discopt-core` → **N/A** — no Rust source changed; `Cargo.toml` edit is comments only (`cargo metadata` parses, `cargo build --release -p discopt-core` clean)
- [x] `ruff check` / `ruff format --check python/` → **All checks passed / 957 files already formatted**
- [x] `pytest discopt_benchmarks/tests/ -m "not slow"` → **green**; the two cert modules on the merged head → **33 passed** (21 + 12)

## Regression test

`discopt_benchmarks/tests/test_1134_cert_baseline_shrink_guard.py` — **21 tests**. Fail-before/pass-after confirmed: on the pre-change tree the module **errors at collection** (`coverage_loss`, `build_meta`, `host_speed_ratio`, `provenance_lines`, `meta_describes_the_committed_reference` and `_MIN_CALIBRATION_SAMPLES` do not exist); after, 21 pass.

Covered: `coverage_loss` names exactly the rows the previous reference covered and a new run will not admit; `build_meta` records each drop's reason plus the lost row's previous verdict, distinguishes a never-admitted instance from a coverage loss, carries the generating commit, and records whether the reference was actually written; `provenance_lines` reports a refused run as `UNKNOWN` rather than claiming the reference's provenance, and re-derives that verdict for a meta written before the field existed; `host_speed_ratio` uses only unrouted instances whose node count reproduced exactly (a row whose tree exploded 100x is excluded, and so is a routed row on either side — both asserted), abstains below the sample floor, drops sub-noise baseline walls, and returns 1.0 for a machine against itself; and `algorithm_route` round-trips through `to_dict`/`from_dict` while all 52 rows of the committed baseline still load.

- [x] Added a regression test that fails before / passes after

**End-to-end validation on real panels, on two machines.** On the 4-vCPU box `gen_cert_baseline.py --time-limit 60` refused the write and named its losses; `check_cert_neutrality.py` over all 52 rows then exercised the reporting paths (provenance correctly `NONE`, calibration 3.46x on 17 unrouted rows, 17 violations with the three `status` rows annotated and none suppressed). On the 14-core box with a verified-fresh extension the same generator admits 51 of 52 and refuses on one row, and `algorithm_route` explains it. Runner wiring verified with a live solve: `alan` comes back carrying the OA route note, `nvs14` with `None`.

## Bound-changing / performance change?

Not a behavior change — the solver path is untouched — but the PR **retracts a published claim**, which CLAUDE.md §11 requires be recorded in writing, so the measurement is here.

The #1025 record asserts that "the certifying panel cannot" see an LU kernel bump, and measures net-positive only on captured relaxation LPs. It cannot see the *benefit* — that stands — but it does see a per-node cost. Measured on `main`, interleaved A/B, 3 reps, arms distinguished by a marker string baked into the extension, restricted to **unrouted** instances whose node count is identical in both arms (so the comparison is per-node cost, not search). Wall in seconds, Markowitz / GilbertPeierls:

```
nvs09  2.78/2.65   st_e29 2.07/2.03   ex1224 2.03/2.00   ex1225 1.88/1.84
gkocis 1.35/1.39   ex1226 1.53/1.35   oaer   1.32/1.32   st_e36 6.83/7.03
nvs22 15.35/12.11  nvs05 >=60.32/56.62  (Markowitz arm censored at the 60 s limit)
```

Median ratio **~1.03**, carried by `nvs22` **+27%** and `nvs05` **≥+7%**. It is two-sided: on the routed `m3` Markowitz is **2.4x faster** (1.53 s vs 3.70 s). The bump is **not** retracted — fill, `numerical` refusals and wall on the LPs that dominate a real solve all improved, and no verdict was ever false. What is retracted is that the panel is blind to it, at that smaller size. Size-routed pivoting (Gilbert–Peierls on small low-fill bases, Markowitz on large) is named as the follow-up lead in `Cargo.toml`, with these numbers as its entry measurement.

**Withdrawn from that evidence:** an earlier pass in this branch read `cvxnonsep_nsig30` as +49% from pivoting. It is auto-routed, so a wall difference there is not a per-factorization measurement; its real regression is Cause 2. Recorded in `Cargo.toml` alongside the retraction.

**Corrected in review:** the host-speed calibration was first published as 3.45x over 21 equal-node rows, which admitted three auto-routed rows carrying 14–44x inflation that is the router, not the box — Cause 2 in this same PR is the proof equal node counts are necessary but not sufficient. `host_speed_ratio` now excludes routed rows on either side, and the figure was re-measured on the same idle box: **3.46x over 17 unrouted rows**. The contaminated value was high by 0.01x and every conclusion drawn from it holds unchanged. §0.6.1 records the correction, the re-measurement, and the fast box's independent 1.53x.

*Measurement hygiene (CLAUDE.md §8/§9):* timing runs were load-gated on an idle box, run A/B interleaved rather than sequentially, and report a per-instance standard deviation over 3 reps. Every arm asserts both `module.__file__` and a marker string unique to the version under test, with the other arm's marker asserted absent. The extension-shadowing hazard the fresh-build re-run uncovered was checked against this container's builds: `_rust.abi3.so` is the only extension in the tree (fresh clone, `*.so` gitignored) and `discopt._rust.__file__` resolves to it, so the bisect attributions are against the tree under test.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011x5obMV6ZStxUyEe5WezGK