### PR TITLE
docs(gdp): #1124 truth semantics excludes the overlap's boundary, so 0.25 is an infimum

### DIFF
--- a/docs/disjunction_semantics.md
+++ b/docs/disjunction_semantics.md
@@ -42,7 +42,7 @@ lowering.
 |---|---|---|
 | `SELECT_ONE` | `(ONE_WAY, EXACTLY_ONE)` | **implemented** — the meaning of `either_or` |
 | `OR` | `(ONE_WAY, AT_LEAST_ONE)` | declared, not implemented |
-| `EXACTLY_ONE_TRUE` | `(REIFIED, EXACTLY_ONE)` | declared, not implemented |
+| `EXACTLY_ONE_TRUE` | `(REIFIED, EXACTLY_ONE)` | declared, not implemented — owes a boundary policy, §2 |
 
 ## 2. `either_or` is `SELECT_ONE`
 
@@ -62,6 +62,34 @@ true there. The same holds verbatim for nonconvex `S_k`; convexity governs
 relaxation strength and whether a hull formulation is ideal, not the Boolean
 meaning. Both cases are pinned in
 `python/tests/test_1124_disjunction_semantics.py`.
+
+### Truth semantics owes a boundary policy
+
+`EXACTLY_ONE_TRUE` over **closed** predicates that overlap does not merely exclude
+the interior of the overlap — it excludes the overlap's *boundary* too, and that
+can leave a problem with no optimum at all.
+
+Take the discriminator above, `min (x - 1/2)^2` over `[x <= 1] v [x >= 0]` with
+`x in [-2, 3]`. Both predicates hold on all of `[0, 1]`, endpoints included, so
+"exactly one true" admits only the **open** set `[-2, 0) u (1, 3]`. On it the
+objective approaches `0.25` at either boundary and never reaches it: `0.25` is an
+**infimum, not an attained optimum**, and writing "the optimum is 0.25 at
+`x in {0, 1}`" locates it at two points the semantics has just excluded.
+
+This is not a defect in `SELECT_ONE` — every lowering this repo ships is
+select-one, and the select-one optimum `0` at `x = 1/2` is attained and asserted.
+It is a constraint on work not yet written: **before `EXACTLY_ONE_TRUE` is
+implemented it needs an explicit strict-complement/boundary policy**, deciding
+what a lowering does when the complement of a closed predicate is open. Candidates
+are refusing such a disjunction, requiring strict predicates, or introducing an
+epsilon-margin — each with different soundness consequences, none of them free,
+and the choice must be made deliberately rather than falling out of whichever
+big-M happens to be emitted.
+
+Until then the value is useful only as a bound to compare against, which is how
+the test module uses it (`TRUTH_INF`, never `TRUTH_OPT`).
+
+*Raised in the #1128 review, after merge.*
 
 ### The indicator trap
 

--- a/python/tests/test_1124_disjunction_semantics.py
+++ b/python/tests/test_1124_disjunction_semantics.py
@@ -12,10 +12,21 @@ The discriminator throughout is
 
     min (x - 1/2)^2   s.t.   [x <= 1]  or  [x >= 0],   x in [-2, 3]
 
-whose optimum is ``0`` at ``x = 1/2`` under union/select-one and ``0.25`` (at
-``x in {0, 1}``) under truth semantics, since ``x = 1/2`` satisfies *both*
-predicates. Note that the pre-existing ``test_hull_overlapping_disjuncts`` does
-**not** discriminate: its ``min x`` objective is ``0`` under either reading.
+whose optimum is ``0`` at ``x = 1/2`` under union/select-one, since ``x = 1/2``
+satisfies *both* predicates and select-one only requires one to be *selected*.
+
+Under truth semantics the same problem has **infimum 0.25, not attained**. The
+predicates are closed and overlap on ``[0, 1]``, so "exactly one true" excludes
+every point of that interval — including its endpoints, where *both* predicates
+hold. The feasible set is the open ``[-2, 0) u (1, 3]``, on which ``(x - 1/2)^2``
+approaches ``0.25`` at either boundary without reaching it. So ``0.25`` is a bound
+to compare against, never a value to assert as an optimum, and a future
+``EXACTLY_ONE_TRUE`` lowering owes an explicit strict-complement/boundary policy
+before this problem has a solution at all (see ``docs/disjunction_semantics.md``
+§2). Raised by the #1128 review; it does not affect any select-one assertion here.
+
+Note that the pre-existing ``test_hull_overlapping_disjuncts`` does **not**
+discriminate: its ``min x`` objective is ``0`` under either reading.
 """
 
 import discopt.modeling as dm
@@ -38,9 +49,12 @@ from discopt.modeling.core import (
     _semantics_supported_by,
 )
 
-# Objective value under union / select-one semantics vs. under truth semantics.
+#: Objective value under union / select-one semantics -- an attained optimum.
 SELECT_ONE_OPT = 0.0
-TRUTH_OPT = 0.25
+#: The truth-semantics INFIMUM, deliberately not named ``_OPT``: it is approached
+#: at the boundary of the open feasible set and never attained (see the module
+#: docstring). It is only ever used as a value the select-one answer must NOT be.
+TRUTH_INF = 0.25
 
 ALL_METHODS = ["big-m", "mbigm", "hull", "auto"]
 
@@ -153,12 +167,15 @@ class TestSelectOneIsTheDefault:
     def test_overlap_point_stays_feasible(self, method):
         """AC-1/AC-2: a point in the overlap is feasible — the projection is the union.
 
-        Under EXACTLY_ONE_TRUE, x=1/2 would be infeasible and the optimum 0.25.
+        Under EXACTLY_ONE_TRUE, x=1/2 would be infeasible and the objective could
+        only approach 0.25 without attaining it -- both predicates hold at x=0 and
+        x=1, so the truth-semantics feasible set is open. The assertion below is a
+        select-one one; 0.25 appears only as a value this answer must not equal.
         """
         r = _overlap_model().solve(gdp_method=method)
         assert r.status == "optimal"
         assert r.objective == pytest.approx(SELECT_ONE_OPT, abs=1e-4)
-        assert r.objective != pytest.approx(TRUTH_OPT, abs=1e-2)
+        assert r.objective != pytest.approx(TRUTH_INF, abs=1e-2)
         assert float(r.x["x"]) == pytest.approx(0.5, abs=1e-3)
 
     @pytest.mark.parametrize("method", ["big-m", "hull"])
@@ -462,3 +479,58 @@ class TestIdentitiesVersusAuxiliaries:
         generated = [n for n in names if n.startswith(GDP_AUX_PREFIX)]
         assert len(generated) == 4  # 2 pre-existing + 2 freshly allocated
         assert len(set(generated)) == 4
+
+
+class TestTruthSemanticsBoundary:
+    """The overlap's BOUNDARY is excluded too, which is why 0.25 is an infimum.
+
+    Prose asserting "the optimum is 0.25 at ``x in {0, 1}``" shipped in #1128 and
+    was corrected after review. These tests make the correction executable: the
+    claim is arithmetic about the predicates, so it can be checked exactly rather
+    than restated, and it will fail if the docstring drifts back.
+
+    This constrains unwritten code. Nothing here exercises a lowering — discopt
+    ships no ``EXACTLY_ONE_TRUE`` lowering, and §5 of the contract says one that
+    cannot honor the declared semantics must raise rather than approximate.
+    """
+
+    @staticmethod
+    def _exactly_one_true(x: float) -> bool:
+        """The declared predicate pair of the module discriminator, evaluated."""
+        return (x <= 1.0) != (x >= 0.0)
+
+    def test_both_predicates_hold_on_the_whole_closed_overlap(self):
+        for x in (0.0, 0.25, 0.5, 0.75, 1.0):
+            assert (x <= 1.0) and (x >= 0.0), x
+            assert not self._exactly_one_true(x), x
+
+    def test_the_overlap_endpoints_are_excluded_not_optimal(self):
+        """The specific error: x=0 and x=1 are where the prose located the optimum,
+        and they are exactly the points where BOTH predicates hold."""
+        for x in (0.0, 1.0):
+            assert not self._exactly_one_true(x), x
+
+    def test_the_truth_feasible_set_is_open_at_the_overlap(self):
+        """Feasible arbitrarily close to the boundary, never at it — so the
+        infimum is approached and not attained."""
+        for eps in (1e-3, 1e-6, 1e-9):
+            assert self._exactly_one_true(0.0 - eps), eps
+            assert self._exactly_one_true(1.0 + eps), eps
+        assert not self._exactly_one_true(0.0)
+        assert not self._exactly_one_true(1.0)
+
+    def test_the_infimum_is_approached_but_never_attained(self):
+        """`(x - 1/2)^2` tends to TRUTH_INF at either boundary and always exceeds it."""
+        for eps in (1e-2, 1e-4, 1e-8):
+            for x in (0.0 - eps, 1.0 + eps):
+                assert self._exactly_one_true(x), x
+                assert (x - 0.5) ** 2 > TRUTH_INF, (x, (x - 0.5) ** 2)
+        assert (1e-12 - 0.5) ** 2 == pytest.approx(TRUTH_INF, abs=1e-9)
+
+    def test_select_one_by_contrast_attains_its_optimum(self):
+        """The discriminator's other half: x=1/2 IS feasible under select-one and
+        the optimum is attained there, which is what the rest of this module
+        asserts against a real solve."""
+        x = 0.5
+        assert (x <= 1.0) or (x >= 0.0)
+        assert (x - 0.5) ** 2 == pytest.approx(SELECT_ONE_OPT)


### PR DESCRIPTION
## Summary

Acts on the post-merge review of #1128 ([comment 5486657365](https://github.com/jkitchin/discopt/pull/1128#issuecomment-5486657365)), which landed **3h06m after** that PR was merged and so could not have been addressed in it. The comment clears the merge — every review-round finding was verified addressed at head `cd3b1c3f` — but carries one substantive item that is now on `main`: a mathematical error in prose, and a design constraint on unwritten code recorded nowhere.

I verified the reviewer's point independently before acting on it.

## The error

The discriminator is `min (x - 1/2)^2` over `[x <= 1] v [x >= 0]`, `x in [-2, 3]`. The module docstring said its truth-semantics optimum is **"0.25 (at `x in {0, 1}`)"**.

Both predicates are **closed** and hold on all of `[0, 1]` — endpoints included. So "exactly one true" excludes the endpoints as well as the interior, and the feasible set is the **open** `[-2, 0) u (1, 3]`. On it the objective approaches `0.25` at either boundary and never reaches it:

```
x=0 exactly-one-true?  False        # both predicates hold
x=1 exactly-one-true?  False        # both predicates hold
feasible set: [-2, 0) u (1, 3]
inf = 0.250000, approached at a boundary that is not in the set
```

`0.25` is an **infimum**, and the old prose located an optimum at the two points the semantics had just excluded.

## Nothing merged is broken by this

Every lowering this repo ships is select-one, whose optimum `0` at `x = 1/2` **is** attained and is what the module asserts against real solves on all four methods. The only assertion touching the constant is the negative `assert r.objective != pytest.approx(...)`, which holds either way. This is a docs/naming defect, not a behavioral one — which is why it is a separate small PR rather than a revert.

## What changed

- The module docstring and `test_overlap_point_stays_feasible`'s docstring now say **infimum**, and say *why* the endpoints are excluded.
- `TRUTH_OPT` → **`TRUTH_INF`**, with a comment that it is only ever a value the select-one answer must *not* be, never a target to assert.
- `docs/disjunction_semantics.md` §2 gains **"Truth semantics owes a boundary policy"**, and the status table's `EXACTLY_ONE_TRUE` row points at it.

That last item is the part worth keeping. Before `EXACTLY_ONE_TRUE` is implemented it needs an explicit **strict-complement/boundary policy** — refuse such a disjunction, require strict predicates, or introduce an epsilon margin — each with different soundness consequences, none free, and the choice must be made deliberately rather than falling out of whichever big-M happens to be emitted. §5 already says a lowering that cannot honor the declared semantics must raise rather than approximate; this names the specific thing it must not approximate.

## Regression test

`TestTruthSemanticsBoundary` — **5 cases**, making the correction executable rather than prose, since the claim is arithmetic about the predicates and can be checked exactly:

- both predicates hold across the whole closed overlap, so no point of `[0, 1]` is exactly-one-true;
- the endpoints specifically — the two points the old prose named — are excluded;
- the feasible set is open: feasible at `0-eps` and `1+eps` for eps down to `1e-9`, infeasible **at** 0 and 1;
- the objective strictly exceeds `TRUTH_INF` at every feasible point while tending to it;
- select-one by contrast attains its optimum at `x = 1/2`.

It will fail if the docstring drifts back. Nothing here exercises a lowering — discopt ships no `EXACTLY_ONE_TRUE` lowering, and the contract says one that cannot honor the semantics must raise.

## Correctness

- [x] Cannot produce a false certificate — **N/A**, no solver-math change. Docstrings, one constant rename, one docs section, and pure-arithmetic tests. No relaxation, bound, cut, reduction, or lowering is touched.
- [x] No validation, fallback, or safety guard was weakened. The change is additive: a refusal-side design constraint is written down that was previously unrecorded.

## Tests run (state the result — numbers, not adjectives)

- [x] `python/tests/test_1124_disjunction_semantics.py` → **45 passed** (was 40)
- [x] GDP selection (`test_gdp`, `test_gdp1_gdp2_bigm_soundness`, `test_issue1043_hull_perspective`, + the module) → **176 passed**, 21 deselected
- [x] `pytest -m smoke python/tests/` → **1165 passed, 1 skipped, 2 xpassed** (135 s)
- [x] The `Python fast` lane's own marker selection, locally → **8932 passed, 58 skipped, 5 xfailed, 2 xpassed**
- [x] `ruff check python/` → All checks passed
- [x] `cargo test -p discopt-core` → **N/A**, no Rust changed

*(The one local failure in that last run, `test_relax_package_name.py::test_the_old_package_name_is_not_importable`, is a pre-existing artifact of an untracked `python/discopt/_jax` directory in my checkout; it reproduces on `main` and CI never sees it, since the directory is not tracked.)*

Contributes to #1124.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UpPqh6w3WA62ud4jT8wDTS
