### PR TITLE
fix(tests): register row_filter/ in the solver_stats schema check (#1150 regression)

### DIFF
--- a/discopt_benchmarks/tests/test_cert_instrumentation.py
+++ b/discopt_benchmarks/tests/test_cert_instrumentation.py
@@ -171,7 +171,8 @@ def test_reduction_separation_timers_present_and_bounded():
     non-negative floats; the timers sum to no more than the wall time; at least one
     timer is strictly positive (cert:T0.3).
 
-    Plus per-decision cut-pool telemetry (``pool/gate_*``, cut-inheritance gating).
+    Plus per-decision cut-pool telemetry (``pool/gate_*``, cut-inheritance gating)
+    and the ``row_filter/`` counters (#1039/#1150).
 
     NOTE (schema, not a weakening): the ``sum(values) <= wall_time`` invariant is
     only meaningful for the *timer* families — ``cuts/`` values are counts and
@@ -192,7 +193,13 @@ def test_reduction_separation_timers_present_and_bounded():
     stats = result.solver_stats
     assert stats is not None and len(stats) > 0
     _TIMER_FAMILIES = ("reduce/", "separate/")
-    _NON_TIMER_FAMILIES = ("cuts/", "pool/")
+    # ``row_filter/`` (#1039/#1150) is COUNTS -- invocations and rows dropped by the
+    # candidate-A row filter -- so it belongs here and not above: it is not seconds,
+    # and admitting it to the timer families would corrupt the ``sum <= wall_time``
+    # invariant below. It is emitted unconditionally, zeros included, precisely so a
+    # dormant filter is distinguishable from an unwired counter, which is why it now
+    # reaches this schema check on every spatial solve.
+    _NON_TIMER_FAMILIES = ("cuts/", "pool/", "row_filter/")
     _KNOWN = _TIMER_FAMILIES + _NON_TIMER_FAMILIES
     # Every entry is a non-negative float in a known instrumentation family.
     assert all(isinstance(v, float) and v >= 0.0 for v in stats.values())


### PR DESCRIPTION
## What broke

#1150 made the `row_filter/*` counters emit unconditionally, zeros included, so
that a dormant filter is distinguishable from a counter that was never wired up
(present-and-zero and absent must not be the same observation — CLAUDE.md §6).
That was the intended change. What it also did was put two new keys into
`solver_stats` on every spatial solve, and
`test_reduction_separation_timers_present_and_bounded` pins the *schema* of that
dict against a whitelist of instrumentation families that nobody extended:

```
AssertionError: unexpected solver_stats keys:
  ['row_filter/invocations', 'row_filter/rows_dropped']
```

## The fix

Register the family under `_NON_TIMER_FAMILIES` — deliberately not
`_TIMER_FAMILIES`. These are counts, not seconds; admitting them to the timer
tuple would quietly corrupt the same test's `sum(timers) <= wall_time`
invariant, which is the assertion actually worth protecting here.

## Why it escaped

Mine, from #1150, and worth stating plainly (§11): I reported that PR's smoke
run as clean, but the run had only covered `python/tests/`. This test lives in
`discopt_benchmarks/tests/`, so nothing I ran touched it.

CI does not close that gap either, though not for the reason I first wrote here
(correcting my own claim, §11). It is not that CI skips `discopt_benchmarks/`
wholesale — #1034 fixed that — it is that `ci.yml` opts in **file by file**:

```
discopt_benchmarks/tests/test_1134_cert_baseline_shrink_guard.py
discopt_benchmarks/tests/test_correctness.py
discopt_benchmarks/tests/test_cert_neutrality_regime.py
```

`test_cert_instrumentation.py` is not on that list, so the failure is only
reachable from a local `-m smoke` over both trees. Worth noting on its own: an
enumerated allow-list means any *new* benchmark test file is uncovered by
default and nothing announces it. That is a live gap after #1034, but it is not
this PR's to close.

The failure surfaced while reviewing #1155, which is unrelated to it; I
confirmed it reproduces on `origin/main` with the #1155 code absent, so it is
not that PR's.

## Verification

* Fails on `origin/main`, passes with this change.
* Benchmark smoke tier: **51 passed**.
* The two pre-existing ruff findings in this file (`I001`, `N806`) are unchanged
  in count — measured before and after — and out of scope; the lint job checks
  `python/` only.

Regression from #1150; no separate issue was filed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014E81XM1j2J5sydzj9nFFFp
