### PR TITLE
perf(presolve): restrict forward_propagate to the constraint's own subtree (5.2x presolve)

### DIFF
--- a/crates/discopt-core/src/presolve/fbbt.rs
+++ b/crates/discopt-core/src/presolve/fbbt.rs
@@ -1436,7 +1436,7 @@ pub fn fbbt_with_cutoff_until(
                 &model.arena,
                 constr.body,
                 output_bound,
-                &node_bounds,
+                node_bounds,
                 &mut var_bounds,
             );
         }
@@ -1456,7 +1456,7 @@ pub fn fbbt_with_cutoff_until(
                 &model.arena,
                 obj_expr,
                 *cutoff_bound,
-                &node_bounds,
+                node_bounds,
                 &mut var_bounds,
             );
         }
@@ -1548,7 +1548,7 @@ pub fn fbbt_until(
                 &model.arena,
                 constr.body,
                 output_bound,
-                &node_bounds,
+                node_bounds,
                 &mut var_bounds,
             );
         }

--- a/crates/discopt-core/src/presolve/fbbt.rs
+++ b/crates/discopt-core/src/presolve/fbbt.rs
@@ -408,20 +408,130 @@ fn contains_angle(lo_norm: f64, hi_norm: f64, target: f64) -> bool {
 // Forward propagation
 // ─────────────────────────────────────────────────────────────
 
+/// Push the direct children of `id` onto `out`.
+fn push_children(arena: &ExprArena, id: ExprId, out: &mut Vec<ExprId>) {
+    match arena.get(id) {
+        ExprNode::BinaryOp { left, right, .. } | ExprNode::MatMul { left, right } => {
+            out.push(*left);
+            out.push(*right);
+        }
+        ExprNode::UnaryOp { operand, .. } | ExprNode::Sum { operand, .. } => out.push(*operand),
+        ExprNode::FunctionCall { args, .. } => out.extend(args.iter().copied()),
+        ExprNode::Index { base, .. } => out.push(*base),
+        ExprNode::SumOver { terms } => out.extend(terms.iter().copied()),
+        ExprNode::Variable { .. }
+        | ExprNode::Constant(_)
+        | ExprNode::ConstantArray(_, _)
+        | ExprNode::Parameter { .. } => {}
+    }
+}
+
+/// Reusable buffers for [`forward_propagate_into`], allocated once per FBBT
+/// pass instead of once per constraint.
+///
+/// This type exists because forward propagation used to evaluate **every node
+/// in the arena** for **every constraint**, making one FBBT sweep
+/// `O(n_constraints x arena_len)` rather than `O(sum of constraint sizes)`.
+/// On a set-covering model with ~900 rows that is ~1e8 interval evaluations
+/// per sweep, which is why root probing — five sweeps per probe, two probes
+/// per binary — consumed its entire time budget and tightened nothing
+/// (measured: probing 60,362 ms, 27,900 work units, 0 bounds tightened).
+///
+/// The `seen`/`epoch` stamp is what keeps the per-call cost proportional to
+/// the subtree: clearing an `O(arena_len)` visited array per constraint would
+/// re-introduce the same quadratic, just with a cheaper constant.
+#[derive(Debug, Default)]
+pub struct FwdScratch {
+    bounds: Vec<Interval>,
+    seen: Vec<u32>,
+    epoch: u32,
+    stack: Vec<ExprId>,
+    order: Vec<usize>,
+}
+
+impl FwdScratch {
+    /// An empty scratch buffer; it sizes itself on first use.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Prepare for a propagation over an arena of `n` nodes.
+    fn begin(&mut self, n: usize) {
+        if self.bounds.len() != n {
+            self.bounds = vec![Interval::entire(); n];
+            self.seen = vec![0u32; n];
+            self.epoch = 0;
+        }
+        self.epoch = match self.epoch.checked_add(1) {
+            Some(e) => e,
+            None => {
+                // Wrapped. A stale stamp could alias the new epoch and make a
+                // node look already-evaluated, so clear before reusing 1.
+                self.seen.iter_mut().for_each(|s| *s = 0);
+                1
+            }
+        };
+    }
+}
+
+/// Forward-propagate interval bounds over the subtree rooted at `id`, reusing
+/// `scratch`.
+///
+/// Returns the whole node-bounds slice, but **only the slots reachable from
+/// `id` are written by this call**; every other slot holds whatever the
+/// previous call left there. That is sound for the one thing these bounds are
+/// used for — [`backward_propagate`] descends from the same `id`, so it reads
+/// only that subtree — and it is the difference between `O(arena_len)` and
+/// `O(subtree)` per constraint.
+///
+/// **Do not read a slot outside the subtree of `id`.** If you need bounds for
+/// two unrelated expressions, propagate twice; forward propagation is a pure
+/// function of `var_bounds`, so the second call cannot disagree with the
+/// first. (`polynomial.rs` did read across subtrees, relying on the old
+/// whole-arena behaviour, and now calls twice.)
+pub fn forward_propagate_into<'a>(
+    arena: &ExprArena,
+    id: ExprId,
+    var_bounds: &[Interval],
+    scratch: &'a mut FwdScratch,
+) -> &'a [Interval] {
+    scratch.begin(arena.len());
+
+    // Collect the reachable node set. The arena appends children before
+    // parents, so ascending index order over that set is a valid topological
+    // order — the same order the whole-arena walk used.
+    scratch.order.clear();
+    scratch.stack.clear();
+    scratch.stack.push(id);
+    while let Some(nid) = scratch.stack.pop() {
+        let i = nid.0;
+        if scratch.seen[i] == scratch.epoch {
+            continue;
+        }
+        scratch.seen[i] = scratch.epoch;
+        scratch.order.push(i);
+        push_children(arena, nid, &mut scratch.stack);
+    }
+    scratch.order.sort_unstable();
+
+    for k in 0..scratch.order.len() {
+        let i = scratch.order[k];
+        let v = eval_node_interval(arena, ExprId(i), var_bounds, &scratch.bounds);
+        scratch.bounds[i] = v;
+    }
+    &scratch.bounds
+}
+
 /// Forward-propagate interval bounds from leaves to root.
 ///
-/// Returns a vector of intervals, one per arena node.
-pub fn forward_propagate(arena: &ExprArena, _id: ExprId, var_bounds: &[Interval]) -> Vec<Interval> {
-    let n = arena.len();
-    let mut bounds = vec![Interval::entire(); n];
-
-    // Walk nodes in topological order (0..n). Because the arena adds
-    // children before parents, indices 0..n are already topologically sorted.
-    for i in 0..n {
-        let eid = ExprId(i);
-        bounds[i] = eval_node_interval(arena, eid, var_bounds, &bounds);
-    }
-    bounds
+/// Returns a vector of intervals, one per arena node. Nodes outside the
+/// subtree rooted at `id` are left at [`Interval::entire`] — see
+/// [`forward_propagate_into`], which this wraps, for why that is sound and
+/// for the one call site that had to change.
+pub fn forward_propagate(arena: &ExprArena, id: ExprId, var_bounds: &[Interval]) -> Vec<Interval> {
+    let mut scratch = FwdScratch::new();
+    forward_propagate_into(arena, id, var_bounds, &mut scratch);
+    scratch.bounds
 }
 
 /// Compute the interval for a single node given its children's intervals.
@@ -1275,6 +1385,9 @@ pub fn fbbt_with_cutoff_until(
     let mut var_bounds: Vec<Interval> = model.variables.iter().map(seed_block_interval).collect();
 
     // Determine the objective cutoff constraint (if any).
+    // One buffer for the whole call, not one per constraint per sweep.
+    let mut scratch = FwdScratch::new();
+
     let obj_cutoff: Option<(ExprId, Interval)> = incumbent_bound.map(|bound| {
         let output_bound = match model.objective_sense {
             ObjectiveSense::Minimize => Interval::new(f64::NEG_INFINITY, bound),
@@ -1299,7 +1412,8 @@ pub fn fbbt_with_cutoff_until(
                     return var_bounds;
                 }
             }
-            let node_bounds = forward_propagate(&model.arena, constr.body, &var_bounds);
+            let node_bounds =
+                forward_propagate_into(&model.arena, constr.body, &var_bounds, &mut scratch);
 
             let output_bound = match constr.sense {
                 ConstraintSense::Le => Interval::new(f64::NEG_INFINITY, constr.rhs),
@@ -1329,7 +1443,8 @@ pub fn fbbt_with_cutoff_until(
 
         // Propagate the objective cutoff constraint.
         if let Some((obj_expr, ref cutoff_bound)) = obj_cutoff {
-            let node_bounds = forward_propagate(&model.arena, obj_expr, &var_bounds);
+            let node_bounds =
+                forward_propagate_into(&model.arena, obj_expr, &var_bounds, &mut scratch);
             let obj_bound = node_bounds[obj_expr.0];
             if obj_bound.intersect(cutoff_bound).is_empty_beyond(FEAS_TOL) {
                 for b in &mut var_bounds {
@@ -1386,6 +1501,8 @@ pub fn fbbt_until(
     // C-31: seed each block from the element-wise union of its bounds (a valid
     // outer bound for every element), NOT element 0 — see `seed_block_interval`.
     let mut var_bounds: Vec<Interval> = model.variables.iter().map(seed_block_interval).collect();
+    // One buffer for the whole call, not one per constraint per sweep.
+    let mut scratch = FwdScratch::new();
 
     for _ in 0..max_iter {
         if let Some(dl) = deadline {
@@ -1402,7 +1519,8 @@ pub fn fbbt_until(
                 }
             }
             // Forward propagation.
-            let node_bounds = forward_propagate(&model.arena, constr.body, &var_bounds);
+            let node_bounds =
+                forward_propagate_into(&model.arena, constr.body, &var_bounds, &mut scratch);
 
             // Determine the output bound from the constraint sense and rhs.
             let output_bound = match constr.sense {
@@ -1809,6 +1927,164 @@ mod tests {
         let result = bounds[exp_x.0];
         assert!((result.lo - 1.0).abs() < 1e-14);
         assert!((result.hi - 1.0_f64.exp()).abs() < 1e-14);
+    }
+
+    // -- subtree-restricted forward propagation (the O(rows x arena) fix) --
+
+    /// Reference implementation: the whole-arena walk that `forward_propagate`
+    /// used to be. Every subtree-restricted result must agree with this on the
+    /// subtree it evaluated.
+    fn forward_propagate_whole_arena(arena: &ExprArena, var_bounds: &[Interval]) -> Vec<Interval> {
+        let n = arena.len();
+        let mut bounds = vec![Interval::entire(); n];
+        for i in 0..n {
+            bounds[i] = eval_node_interval(arena, ExprId(i), var_bounds, &bounds);
+        }
+        bounds
+    }
+
+    /// Three unrelated expressions in one arena, so a subtree walk provably
+    /// skips work: `x*y`, `exp(z)`, `x + z`.
+    fn make_three_tree_arena() -> (ExprArena, Vec<ExprId>) {
+        let mut arena = ExprArena::new();
+        let mut v = |a: &mut ExprArena, name: &str, index: usize| {
+            a.add(ExprNode::Variable {
+                name: name.into(),
+                index,
+                size: 1,
+                shape: vec![],
+            })
+        };
+        let x = v(&mut arena, "x", 0);
+        let y = v(&mut arena, "y", 1);
+        let z = v(&mut arena, "z", 2);
+        let prod = arena.add(ExprNode::BinaryOp {
+            op: BinOp::Mul,
+            left: x,
+            right: y,
+        });
+        let expz = arena.add(ExprNode::FunctionCall {
+            func: MathFunc::Exp,
+            args: vec![z],
+        });
+        let sum = arena.add(ExprNode::BinaryOp {
+            op: BinOp::Add,
+            left: x,
+            right: z,
+        });
+        (arena, vec![prod, expz, sum])
+    }
+
+    #[test]
+    fn subtree_propagation_agrees_with_the_whole_arena_walk() {
+        let (arena, roots) = make_three_tree_arena();
+        let var_bounds = vec![
+            Interval::new(1.0, 3.0),
+            Interval::new(2.0, 5.0),
+            Interval::new(0.0, 1.0),
+        ];
+        let reference = forward_propagate_whole_arena(&arena, &var_bounds);
+
+        let mut checked = 0usize;
+        let mut scratch = FwdScratch::new();
+        for &root in &roots {
+            let got = forward_propagate_into(&arena, root, &var_bounds, &mut scratch);
+            // Every node reachable from `root` must match the reference exactly.
+            let mut stack = vec![root];
+            let mut seen = std::collections::HashSet::new();
+            while let Some(nid) = stack.pop() {
+                if !seen.insert(nid.0) {
+                    continue;
+                }
+                assert_eq!(
+                    got[nid.0].lo, reference[nid.0].lo,
+                    "lo differs at node {} under root {}",
+                    nid.0, root.0
+                );
+                assert_eq!(
+                    got[nid.0].hi, reference[nid.0].hi,
+                    "hi differs at node {} under root {}",
+                    nid.0, root.0
+                );
+                checked += 1;
+                push_children(&arena, nid, &mut stack);
+            }
+        }
+        // Anti-vacuity (CLAUDE.md section 6): a walk that visited nothing would
+        // pass every assertion above.
+        // 3 nodes under x*y + 2 under exp(z) + 3 under x+z.
+        assert!(checked >= 8, "comparisons executed: {checked}");
+    }
+
+    #[test]
+    fn the_fresh_vec_wrapper_leaves_other_subtrees_entire() {
+        let (arena, roots) = make_three_tree_arena();
+        let var_bounds = vec![
+            Interval::new(1.0, 3.0),
+            Interval::new(2.0, 5.0),
+            Interval::new(0.0, 1.0),
+        ];
+        // Propagate only `exp(z)`. `x*y` shares no node with it.
+        let bounds = forward_propagate(&arena, roots[1], &var_bounds);
+        assert_eq!(bounds[roots[1].0].lo, 1.0);
+        let prod = bounds[roots[0].0];
+        assert!(
+            prod.lo == f64::NEG_INFINITY && prod.hi == f64::INFINITY,
+            "an unvisited root must stay entire, got {prod:?}"
+        );
+    }
+
+    #[test]
+    fn propagation_evaluates_only_the_subtree() {
+        // The whole point of the change. `exp(z)` is 2 nodes out of 6; the old
+        // implementation evaluated all 6 for it, and did so once per
+        // constraint per sweep.
+        let (arena, roots) = make_three_tree_arena();
+        assert_eq!(arena.len(), 6, "arena shape changed; update this test");
+        let var_bounds = vec![
+            Interval::new(1.0, 3.0),
+            Interval::new(2.0, 5.0),
+            Interval::new(0.0, 1.0),
+        ];
+        let mut scratch = FwdScratch::new();
+        forward_propagate_into(&arena, roots[1], &var_bounds, &mut scratch);
+        assert_eq!(
+            scratch.order.len(),
+            2,
+            "expected exp(z) and z, evaluated {:?}",
+            scratch.order
+        );
+        forward_propagate_into(&arena, roots[0], &var_bounds, &mut scratch);
+        assert_eq!(scratch.order.len(), 3, "expected x*y, x, y");
+    }
+
+    #[test]
+    fn a_reused_scratch_does_not_leak_a_stale_epoch() {
+        // The stamp is what keeps the per-call cost proportional to the
+        // subtree. If a stale stamp aliased the current epoch, nodes would be
+        // silently skipped and read back at their previous values.
+        let (arena, roots) = make_three_tree_arena();
+        let mut scratch = FwdScratch::new();
+        let tight = vec![
+            Interval::new(1.0, 1.0),
+            Interval::new(2.0, 2.0),
+            Interval::new(0.0, 0.0),
+        ];
+        let loose = vec![
+            Interval::new(1.0, 3.0),
+            Interval::new(2.0, 5.0),
+            Interval::new(0.0, 1.0),
+        ];
+        let mut checked = 0usize;
+        for _ in 0..3 {
+            let b = forward_propagate_into(&arena, roots[0], &tight, &mut scratch);
+            assert_eq!((b[roots[0].0].lo, b[roots[0].0].hi), (2.0, 2.0));
+            checked += 1;
+            let b = forward_propagate_into(&arena, roots[0], &loose, &mut scratch);
+            assert_eq!((b[roots[0].0].lo, b[roots[0].0].hi), (2.0, 15.0));
+            checked += 1;
+        }
+        assert_eq!(checked, 6, "assertions executed: {checked}");
     }
 
     // -- FBBT tests --

--- a/crates/discopt-core/src/presolve/fbbt_fp.rs
+++ b/crates/discopt-core/src/presolve/fbbt_fp.rs
@@ -45,7 +45,8 @@
 use std::collections::VecDeque;
 
 use super::fbbt::{
-    backward_propagate, forward_propagate, snap_integral_interval, Interval, FEAS_TOL,
+    backward_propagate, forward_propagate_into, snap_integral_interval, FwdScratch, Interval,
+    FEAS_TOL,
 };
 use crate::expr::{ConstraintSense, ExprArena, ExprId, ExprNode, ModelRepr, VarType};
 
@@ -130,6 +131,9 @@ pub fn fbbt_fixed_point(
         *slot = true;
     }
 
+    // One buffer for the whole pass, not one per constraint visit.
+    let mut scratch = FwdScratch::new();
+
     while let Some(ci) = queue.pop_front() {
         in_queue[ci] = false;
         stats.constraint_visits += 1;
@@ -139,7 +143,7 @@ pub fn fbbt_fixed_point(
         }
 
         let constr = &model.constraints[ci];
-        let node_bounds = forward_propagate(&model.arena, constr.body, bounds);
+        let node_bounds = forward_propagate_into(&model.arena, constr.body, bounds, &mut scratch);
 
         let output_bound = match constr.sense {
             ConstraintSense::Le => Interval::new(f64::NEG_INFINITY, constr.rhs),

--- a/crates/discopt-core/src/presolve/fbbt_fp.rs
+++ b/crates/discopt-core/src/presolve/fbbt_fp.rs
@@ -176,13 +176,7 @@ pub fn fbbt_fixed_point(
             .filter_map(|&v| bounds.get(v).map(|b| (v, *b)))
             .collect();
 
-        backward_propagate(
-            &model.arena,
-            constr.body,
-            output_bound,
-            &node_bounds,
-            bounds,
-        );
+        backward_propagate(&model.arena, constr.body, output_bound, node_bounds, bounds);
 
         // Detect changes; queue downstream constraints. Integer/binary vars
         // are snapped inward to integrality first, so an indicator fixing

--- a/crates/discopt-core/src/presolve/polynomial.rs
+++ b/crates/discopt-core/src/presolve/polynomial.rs
@@ -562,9 +562,16 @@ fn get_or_make_aux(
     }
 
     // Compute M5 derived bounds on a · b via forward interval propagation.
-    let node_bounds = forward_propagate(&model.arena, a, var_bounds);
-    let a_iv = node_bounds[a.0];
-    let b_iv = node_bounds[b.0];
+    //
+    // Two calls, not one: `b` is not in general reachable from `a`, and
+    // `forward_propagate` evaluates only the subtree of the root it is given.
+    // Reading `node_bounds[b.0]` off the `a` propagation used to work only
+    // because the old implementation evaluated the entire arena for every
+    // call — the quadratic that made root FBBT unusable on large models.
+    let bounds_a = forward_propagate(&model.arena, a, var_bounds);
+    let a_iv = bounds_a[a.0];
+    let bounds_b = forward_propagate(&model.arena, b, var_bounds);
+    let b_iv = bounds_b[b.0];
     let prod = interval_mul(&a_iv, &b_iv);
     let derived_finite = prod.lo.is_finite() && prod.hi.is_finite();
     if derived_finite {

--- a/crates/discopt-core/src/presolve/simplify.rs
+++ b/crates/discopt-core/src/presolve/simplify.rs
@@ -3,7 +3,7 @@
 
 use std::time::Instant;
 
-use super::fbbt::{forward_propagate, Interval};
+use super::fbbt::{forward_propagate, forward_propagate_into, FwdScratch, Interval};
 use crate::expr::{BinOp, ConstraintSense, ExprArena, ExprId, ExprNode, ModelRepr, UnOp, VarType};
 
 /// Result of simplification.
@@ -117,6 +117,8 @@ pub fn simplify_until(
     }
 
     // 3. Redundant constraint removal.
+    // One buffer for the whole scan, not one per constraint.
+    let mut scratch = FwdScratch::new();
     for (ci, constr) in model.constraints.iter().enumerate() {
         if let Some(dl) = deadline {
             if ci % SIMPLIFY_DEADLINE_POLL_STRIDE == 0 && Instant::now() >= dl {
@@ -124,7 +126,8 @@ pub fn simplify_until(
                 return result;
             }
         }
-        let node_bounds = forward_propagate(&model.arena, constr.body, var_bounds);
+        let node_bounds =
+            forward_propagate_into(&model.arena, constr.body, var_bounds, &mut scratch);
         let body_interval = node_bounds[constr.body.0];
 
         let redundant = match constr.sense {


### PR DESCRIPTION
## What

`forward_propagate` evaluated interval bounds for **every node in the shared expression arena** on every call, then returned the whole `Vec<Interval>` so the caller could read one entry out of it. With N constraints sharing an arena of M nodes, an FBBT sweep is O(N·M) even though each constraint touches only its own subtree — and each call allocates a fresh M-length `Vec`.

This restricts the evaluation to the nodes actually reachable from the root being propagated:

- `push_children` + an explicit stack collect the subtree in post-order.
- `FwdScratch { bounds, seen, epoch, stack, order }` is **epoch-stamped**, so a reused scratch needs no clearing pass over the arena between calls — a stale entry is detected by its epoch rather than by zeroing M slots.
- `forward_propagate_into(arena, id, var_bounds, scratch) -> &[Interval]` is the new working entry point; `forward_propagate` remains as a fresh-`Vec` wrapper, so every existing caller is source-compatible.
- The scratch is hoisted out of the loops in `fbbt_until`, `fbbt_with_cutoff_until`, the `fbbt_fp.rs` watch-list loop, and the `simplify.rs` redundant-constraint loop, so a sweep allocates once instead of once per constraint.

`polynomial.rs` now propagates **twice** at its degree-check site: `b` is not reachable from `a`, so a single subtree-restricted call no longer covers both roots. That is the one place where the old whole-arena behavior was being relied on implicitly, and it is now explicit rather than incidental.

## Why this is bound-neutral

Pure evaluation-*scope* change. The interval arithmetic per node is untouched, so the bounds computed for any node reachable from the requested root are bit-identical to before. Per CLAUDE.md §5 this is the bound-neutral regime, and it is verified as such below (`node_count` and certified `objective` exactly unchanged).

## Motivation (measured)

On a 30-instance MILP panel, presolve was **42.9% of total wall** (31.2 s of 72.8 s), dominated by this quadratic sweep. After the change: presolve **31.2 s → 6.0 s (5.2×)**, total **72.8 s → 53.3 s**.

## Verification

| gate | result |
|---|---|
| `cargo test -p discopt-core` | **658 passed, 0 failed** |
| `pytest -m smoke -q -n 8` | **1165 passed**, 1 skipped, 2 xpassed |
| `pytest -m slow python/tests/test_adversarial_recent_fixes.py` | **19 passed** |

**Bound-neutrality panel** — 62 MINLP corpus instances × 3 arms, run pre- and post-change (186 pairs, 0 crashes):

- solved counts unchanged per arm (55 / 56 / 56);
- **0** certification, objective, or bound problems;
- **0** node-count differences on any pair that reached `optimal`;
- wall improved on every arm: 416.0 → 404.5 s, 323.2 → 311.8 s, 323.5 → 315.3 s.

The 3 rows carrying a residual violation are `nvs05` on all three arms, byte-identical before and after (a pre-existing ~1.3e-4 equality residual on a `feasible` result) — not a regression introduced here.

## New tests

4 Rust tests in `fbbt.rs`, including a reference test that compares `forward_propagate_into` against a whole-arena evaluation node by node, with an `assert!(checked >= 8)` **executed-assertion counter** so the comparison cannot silently degrade to a no-op (CLAUDE.md §6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014E81XM1j2J5sydzj9nFFFp
