### PR TITLE
perf(milp): root cut cleanup + profile reset guard; retract the cut-budget claim

### DIFF
--- a/crates/discopt-core/examples/milp_bench.rs
+++ b/crates/discopt-core/examples/milp_bench.rs
@@ -162,6 +162,8 @@ fn opts(n_struct: usize, integer_cols: Vec<usize>, tl: f64) -> MilpOptions {
         initial_incumbent: None,
         node_hook_rounds: 0,
         node_hook_cut_cap: 0,
+        root_cut_time_s: None,
+        root_cut_prune: true,
         simplex: SimplexOptions {
             tol: 1e-9,
             max_iter: 100_000,

--- a/crates/discopt-core/examples/par_bench.rs
+++ b/crates/discopt-core/examples/par_bench.rs
@@ -126,6 +126,8 @@ fn opts(inst: &Instance) -> MilpOptions {
         initial_incumbent: None,
         node_hook_rounds: 0,
         node_hook_cut_cap: 0,
+        root_cut_time_s: None,
+        root_cut_prune: true,
         simplex: SimplexOptions {
             tol: 1e-9,
             max_iter: 100_000,

--- a/crates/discopt-core/src/bnb/milp_driver.rs
+++ b/crates/discopt-core/src/bnb/milp_driver.rs
@@ -447,6 +447,47 @@ pub struct MilpOptions {
     /// the budget is spent the hook stops being called and the search runs on the
     /// relaxation it has.
     pub node_hook_cut_cap: usize,
+    /// Wall-clock ceiling for the ROOT CUT LOOP alone, in seconds.
+    ///
+    /// `None` (the value at every existing call site) leaves the loop bounded
+    /// only by `root_cuts` / `cut_rounds` / tailing-off, exactly as before.
+    ///
+    /// A value makes a many-round configuration safe to ask for. Raising
+    /// `cut_rounds` is how a weak root relaxation gets closed — on a lot-sizing
+    /// model the default single pass leaves the root bound at a fraction of the
+    /// optimum — but the separation phase is worth several seconds only if it
+    /// still leaves time to branch. This is the knob that says how much of the
+    /// budget the root may spend, so the round cap can be set by what the model
+    /// needs rather than by what a worst case can afford.
+    ///
+    /// Checked at the top of each round, so a round already in flight always
+    /// completes and the loop never abandons a partially augmented matrix. It
+    /// therefore bounds *entry* into rounds, not the duration of one round; a
+    /// single very slow round can still overrun it, bounded in turn by
+    /// `time_limit_s` through the LP's own deadline.
+    ///
+    /// This is not the ceiling on the whole solve -- that stays `time_limit_s`,
+    /// which the loop also honors (see the guard at the top of the round).
+    pub root_cut_time_s: Option<f64>,
+
+    /// Drop root cuts that are slack at the final root LP before the tree starts.
+    ///
+    /// Every root cut rides in every node LP for the rest of the solve. A cut that
+    /// is not tight at the root optimum has a zero dual multiplier there, so
+    /// removing it leaves the root bound and its certificate untouched while
+    /// taking a row out of every node — the measured cost of NOT doing this is
+    /// severe (30-instance MILP panel, `root_cuts=500, cut_rounds=50`: node counts
+    /// fell 2.4x but total wall rose from 103 s to 145 s, and `cflp_s101` went
+    /// from 0.04 s to 5.85 s at an unchanged node count).
+    ///
+    /// Deeper nodes may get a weaker bound than they would with the full set —
+    /// this is bound-CHANGING under CLAUDE.md §5, never bound-INVALIDATING, since
+    /// what remains is a subset of globally valid cuts. Kept as a switch so the
+    /// two can be measured against each other in one interleaved process.
+    ///
+    /// Inert unless `cut_rounds > 1`: with a single round every cut was separated
+    /// off the one root solve and is violated there, so nothing is ever slack.
+    pub root_cut_prune: bool,
     /// LP solver options.
     pub simplex: SimplexOptions,
 }
@@ -610,8 +651,7 @@ pub fn solve_milp_node_hooked(
     } else {
         node
     };
-    crate::profile::init_from_env();
-    crate::profile::reset();
+    crate::profile::begin_solve();
     let ns = opts.n_struct;
     let is_int = {
         let mut v = vec![false; ns];
@@ -876,13 +916,54 @@ pub fn solve_milp_node_hooked(
     // (`n_w`) it was computed at. Reused to warm-start the root B&B node so it does
     // not re-derive the augmented LP from a cold slack basis. See `root_warm_basis`.
     let mut root_basis: Option<(Basis, usize)> = None;
+    // Snapshot of the matrix as it stood before any root cut, kept so the cut
+    // cleanup after the loop can rebuild from it with a subset of the cuts. Only
+    // taken when more than one round can run: with `cut_rounds == 1` every cut is
+    // separated off the single root solve and is violated there by construction,
+    // so the cleanup below provably keeps all of them and the clone would be pure
+    // cost. (`cut_rounds == 1` is the shipped default.)
+    let prune_base: Option<(SparseCols, usize, usize)> =
+        if opts.root_cut_prune && opts.root_cuts > 0 && opts.cut_rounds > 1 {
+            Some((csc_w.clone(), m_w, n_w))
+        } else {
+            None
+        };
+    let mut all_root_cuts: Vec<GomoryCut> = Vec::new();
+    let mut last_root_x: Option<Vec<f64>> = None;
     if opts.root_cuts > 0 {
         let _t = crate::profile::Timer::new(crate::profile::Phase::RootCutLoop);
         let mut total_cuts = 0usize;
         let mut prev_obj = f64::NEG_INFINITY;
+        // Wall bound for the separation phase: the earlier of the caller's own
+        // deadline and the (optional) root-cut sub-budget. Checked at the top of
+        // each round -- a round in flight always finishes, so the loop never
+        // leaves a half-augmented matrix behind.
+        //
+        // `root_cut_time_s` is the substantive half: it is the only thing that
+        // stops a high `cut_rounds` from spending the whole budget separating.
+        //
+        // The `deadline` half is a cheap early exit, NOT a fix for an overrun.
+        // The loop already stopped at the caller's deadline indirectly: each
+        // round's root LP carries `node_simplex.deadline`, and a deadline-aborted
+        // LP comes back non-`Optimal`, which breaks the loop below. Testing the
+        // clock here just skips mounting a round whose LP would abort anyway,
+        // along with the separation work that would follow it.
+        let root_cut_deadline: Option<std::time::Instant> = match (deadline, opts.root_cut_time_s) {
+            (Some(dl), Some(rc)) => {
+                Some(dl.min(t_start + std::time::Duration::from_secs_f64(rc.max(0.0))))
+            }
+            (Some(dl), None) => Some(dl),
+            (None, Some(rc)) => Some(t_start + std::time::Duration::from_secs_f64(rc.max(0.0))),
+            (None, None) => None,
+        };
         for _round in 0..opts.cut_rounds {
             if total_cuts >= opts.root_cuts {
                 break;
+            }
+            if let Some(dl) = root_cut_deadline {
+                if std::time::Instant::now() >= dl {
+                    break;
+                }
             }
             crate::profile::incr(crate::profile::Ctr::RootCutRounds);
             let root = {
@@ -962,6 +1043,9 @@ pub fn solve_milp_node_hooked(
             // if more cuts are appended below it is extended to the new size after
             // the loop. The clone is cheap next to the solve it came from.
             root_basis = Some((root.basis.clone(), n_w));
+            if prune_base.is_some() {
+                last_root_x = Some(root.x.clone());
+            }
             // Tailing off: stop once added cuts barely move the bound.
             if root.obj <= prev_obj + 1e-7 * (1.0 + prev_obj.abs()) && prev_obj > f64::NEG_INFINITY
             {
@@ -1030,8 +1114,123 @@ pub fn solve_milp_node_hooked(
             csc_w = nw_csc;
             m_w = nm;
             n_w = nn;
+            if prune_base.is_some() {
+                all_root_cuts.extend(new_cuts);
+            }
         }
     }
+
+    // --- Root cut cleanup: keep only the cuts the root LP actually leans on ---
+    //
+    // Every cut generated above rides in *every* node LP for the rest of the
+    // solve. Across 50 rounds that is hundreds of extra rows, and the measured
+    // cost is severe: on the cflp family the 500-cut budget turned a 0.04 s solve
+    // into 31 s while the bound was no better. But a cut that is *slack* at the
+    // final root solution contributed nothing to the root bound, and dropping it
+    // is provably bound-neutral there: its dual multiplier is zero, so the root
+    // optimum and its KKT certificate survive the row's removal unchanged. Deeper
+    // in the tree a dropped cut could have become tight, so the node bounds may
+    // differ — weaker, never invalid, since the remaining rows are still globally
+    // valid cuts. This is a bound-CHANGING change under CLAUDE.md #5.
+    //
+    // A GMI cut's coefficients span the slack columns of the cuts before it, so a
+    // cut can only be dropped if nothing kept depends on it; the reverse sweep
+    // closes that dependency set before anything is removed.
+    if let (Some((csc_base, m_base, n_base)), Some(x)) = (prune_base.as_ref(), last_root_x.as_ref())
+    {
+        let (m_base, n_base) = (*m_base, *n_base);
+        let mut keep = vec![false; all_root_cuts.len()];
+        for ci in (0..all_root_cuts.len()).rev() {
+            let cut = &all_root_cuts[ci];
+            // `coeffs · x >= rhs`; the surplus is the amount by which the final
+            // root solution over-satisfies the cut. Cuts separated after the last
+            // solve have a negative surplus there (they were violated, which is
+            // why they were separated) and are always kept.
+            let act: f64 = cut
+                .coeffs
+                .iter()
+                .enumerate()
+                .take(x.len())
+                .map(|(j, &a)| a * x[j])
+                .sum();
+            let tight = act - cut.rhs <= 1e-6 * (1.0 + cut.rhs.abs());
+            if tight || keep[ci] {
+                keep[ci] = true;
+                for (j, &a) in cut.coeffs.iter().enumerate() {
+                    if a != 0.0 && j >= n_base {
+                        let dep = j - n_base;
+                        // A cut only ever sees the slacks of cuts before it, so
+                        // `dep < ci` and the reverse sweep still has it ahead.
+                        if dep < ci {
+                            keep[dep] = true;
+                        }
+                    }
+                }
+            }
+        }
+        let n_keep = keep.iter().filter(|&&k| k).count();
+        crate::profile::incr_by(
+            crate::profile::Ctr::RootCutsGenerated,
+            all_root_cuts.len() as u64,
+        );
+        crate::profile::incr_by(crate::profile::Ctr::RootCutsKept, n_keep as u64);
+        if n_keep < all_root_cuts.len() {
+            let mut newidx = vec![usize::MAX; all_root_cuts.len()];
+            let mut next = 0usize;
+            for (c, &k) in keep.iter().enumerate() {
+                if k {
+                    newidx[c] = next;
+                    next += 1;
+                }
+            }
+            let kept: Vec<GomoryCut> = all_root_cuts
+                .iter()
+                .enumerate()
+                .filter(|(c, _)| keep[*c])
+                .map(|(_, cut)| {
+                    let mut coeffs = vec![0.0; n_base + n_keep];
+                    for (j, &a) in cut.coeffs.iter().enumerate() {
+                        if a == 0.0 {
+                            continue;
+                        }
+                        if j < n_base {
+                            coeffs[j] = a;
+                        } else {
+                            // Kept by the dependency closure above; indexing a
+                            // `usize::MAX` here would panic rather than corrupt.
+                            coeffs[n_base + newidx[j - n_base]] = a;
+                        }
+                    }
+                    GomoryCut {
+                        coeffs,
+                        rhs: cut.rhs,
+                    }
+                })
+                .collect();
+            b_w.truncate(m_base);
+            c_w.truncate(n_base);
+            l_w.truncate(n_base);
+            u_w.truncate(n_base);
+            is_int_full.truncate(n_base);
+            for cut in &kept {
+                b_w.push(cut.rhs);
+                c_w.push(0.0);
+                l_w.push(0.0);
+                u_w.push(INF);
+                is_int_full.push(false);
+            }
+            csc_w = rebuild_csc_with_cuts(csc_base, m_base, n_base, &kept);
+            m_w = m_base + kept.len();
+            n_w = n_base + kept.len();
+            // The stored basis indexes the pre-cleanup matrix (dropped rows'
+            // slacks are basic in it, by definition of being slack), so it cannot
+            // be extended onto the smaller one. The root node cold-solves the
+            // reduced LP instead -- cheaper than the solve that produced the
+            // basis, and far cheaper than carrying the dropped rows all tree.
+            root_basis = None;
+        }
+    }
+
     let mut slack_l = l_w[ns..].to_vec();
     let mut slack_u = u_w[ns..].to_vec();
 
@@ -2749,6 +2948,73 @@ fn augment_cols_with_cuts(sp: &SparseCols, m: usize, n: usize, cuts: &[GomoryCut
     SparseCols::from_csc(new_col_ptr, new_row_idx, new_vals)
 }
 
+/// Rebuild the pre-cut matrix with an explicit, ordered subset of root cuts.
+///
+/// [`augment_cols_with_cuts`] appends a *batch* of cuts to a matrix whose column
+/// count already covers every column those cuts reference; it scans `j in 0..n`
+/// and therefore cannot place a coefficient that lands on a slack column the same
+/// call is creating. That is sound for the root loop, where a round's cuts are
+/// separated off the matrix as it stood *before* the round. It is not sound for a
+/// rebuild: a GMI cut's coefficient vector spans all columns of the LP it was read
+/// off, cut slacks included, so replaying round 7's cuts onto the original matrix
+/// would silently drop their coefficients on rounds 1-6's slack columns and leave
+/// a *different, unjustified* row in the LP.
+///
+/// This builds the whole augmented matrix in one pass instead. `cuts[i].coeffs`
+/// may reference any column `< n_base + i` — the original columns plus the slacks
+/// of the cuts before it — and every such coefficient is placed. Cuts referencing
+/// a *dropped* cut's slack are the caller's problem: it must have closed the
+/// dependency set first (see the cleanup in `solve_milp`).
+fn rebuild_csc_with_cuts(
+    base: &SparseCols,
+    m_base: usize,
+    n_base: usize,
+    cuts: &[GomoryCut],
+) -> SparseCols {
+    let k = cuts.len();
+    if k == 0 {
+        return base.clone();
+    }
+    let (col_ptr, row_idx, vals) = base.raw();
+    let mut new_col_ptr: Vec<usize> = Vec::with_capacity(n_base + k + 1);
+    let mut new_row_idx: Vec<usize> = Vec::with_capacity(row_idx.len() + n_base * k + k);
+    let mut new_vals: Vec<f64> = Vec::with_capacity(vals.len() + n_base * k + k);
+    new_col_ptr.push(0);
+    // Original columns: their base entries (rows 0..m_base) then their coefficient
+    // in each cut row (rows m_base.., strictly greater, so rows stay sorted).
+    for j in 0..n_base {
+        for idx in col_ptr[j]..col_ptr[j + 1] {
+            new_row_idx.push(row_idx[idx]);
+            new_vals.push(vals[idx]);
+        }
+        for (ci, cut) in cuts.iter().enumerate() {
+            if let Some(&v) = cut.coeffs.get(j) {
+                if v != 0.0 {
+                    new_row_idx.push(m_base + ci);
+                    new_vals.push(v);
+                }
+            }
+        }
+        new_col_ptr.push(new_row_idx.len());
+    }
+    // Cut slack columns: the surplus `-1` on the cut's own row, then any later
+    // cut's coefficient on this slack (again a strictly greater row index).
+    for c in 0..k {
+        new_row_idx.push(m_base + c);
+        new_vals.push(-1.0);
+        for (ci, cut) in cuts.iter().enumerate().skip(c + 1) {
+            if let Some(&v) = cut.coeffs.get(n_base + c) {
+                if v != 0.0 {
+                    new_row_idx.push(m_base + ci);
+                    new_vals.push(v);
+                }
+            }
+        }
+        new_col_ptr.push(new_row_idx.len());
+    }
+    SparseCols::from_csc(new_col_ptr, new_row_idx, new_vals)
+}
+
 /// Full CSC analogue of [`augment_with_cuts`] (T3b5): augment the matrix via
 /// [`augment_cols_with_cuts`] AND append the `k` surplus rows/cols to
 /// `b/c/l/u/is_int` exactly as the dense version does. Returns the grown CSC and new
@@ -3574,6 +3840,8 @@ mod tests {
             initial_incumbent: None,
             node_hook_rounds: 0,
             node_hook_cut_cap: 0,
+            root_cut_time_s: None,
+            root_cut_prune: true,
             simplex: SimplexOptions::default(),
         }
     }
@@ -3934,6 +4202,8 @@ mod tests {
             initial_incumbent: None,
             node_hook_rounds: 0,
             node_hook_cut_cap: 0,
+            root_cut_time_s: None,
+            root_cut_prune: true,
             simplex: SimplexOptions::default(),
         }
     }
@@ -4337,15 +4607,16 @@ mod tests {
         let r_ref = solve_milp(&lp, &b, 0.0, &o_ref);
         assert_eq!(r_ref.status, MilpStatus::Optimal);
 
-        // The driver calls `profile::init_from_env()` on entry, which overwrites a
-        // bare `set_enabled(true)` with "is DISCOPT_PROFILE set?" -- so arming the
-        // counters here means arming the env var, under TEST_LOCK.
-        std::env::set_var("DISCOPT_PROFILE", "1");
+        // `set_enabled(true)` raises the test override, which keeps both halves of
+        // the driver's `profile::begin_solve()` -- the env re-arm and the per-solve
+        // counter reset -- from touching this measurement, on this thread or a
+        // sibling's. Setting `DISCOPT_PROFILE` process-wide from a threaded test
+        // (the old way here) armed every concurrent solve as well.
+        crate::profile::set_enabled(true);
         crate::profile::reset();
         let r = solve_milp(&lp, &b, 0.0, &o);
         let rounds = crate::profile::counter(crate::profile::Ctr::RootCutRounds);
         let warm_reopt = crate::profile::counter(crate::profile::Ctr::RootCutWarmReopt);
-        std::env::remove_var("DISCOPT_PROFILE");
         crate::profile::set_enabled(false);
         assert_eq!(r.status, MilpStatus::Optimal);
         assert!(
@@ -4554,6 +4825,8 @@ mod tests {
             initial_incumbent: None,
             node_hook_rounds: 0,
             node_hook_cut_cap: 0,
+            root_cut_time_s: None,
+            root_cut_prune: true,
             simplex: SimplexOptions::default(),
         };
         let r = solve_milp(&lp, &b, 0.0, &o);
@@ -4684,6 +4957,8 @@ mod sparse_milp_diff {
                 initial_incumbent: None,
                 node_hook_rounds: 0,
                 node_hook_cut_cap: 0,
+                root_cut_time_s: None,
+                root_cut_prune: true,
                 simplex: SimplexOptions::default(),
             }
         }
@@ -4979,6 +5254,8 @@ mod sparse_milp_diff {
             initial_incumbent: None,
             node_hook_rounds: 0,
             node_hook_cut_cap: 0,
+            root_cut_time_s: None,
+            root_cut_prune: true,
             simplex: SimplexOptions::default(),
         };
         let r = solve_milp(&lp, &[10.0, 9.0], 0.0, &o);
@@ -5269,6 +5546,8 @@ mod lazy_separation {
                 initial_incumbent: None,
                 node_hook_rounds: 0,
                 node_hook_cut_cap: 0,
+                root_cut_time_s: None,
+                root_cut_prune: true,
                 simplex: SimplexOptions::default(),
             }
         }
@@ -5562,6 +5841,8 @@ mod node_separation {
                 initial_incumbent: None,
                 node_hook_rounds: rounds,
                 node_hook_cut_cap: cap,
+                root_cut_time_s: None,
+                root_cut_prune: true,
                 simplex: SimplexOptions::default(),
             }
         }
@@ -5838,6 +6119,8 @@ mod lazy_infeasible_node {
             initial_incumbent: None,
             node_hook_rounds: 0,
             node_hook_cut_cap: 0,
+            root_cut_time_s: None,
+            root_cut_prune: true,
             simplex: SimplexOptions::default(),
         }
     }
@@ -5906,5 +6189,282 @@ mod lazy_infeasible_node {
             "separator never ran on a FEASIBLE model; the guard above proves nothing"
         );
         let _ = r;
+    }
+}
+
+/// Tests for the root-cut wall bound (`MilpOptions::root_cut_time_s`) and for the
+/// root cut loop's newly-honored `time_limit_s` deadline.
+#[cfg(test)]
+mod root_cut_budget_tests {
+    use super::*;
+
+    /// A 0/1 knapsack big enough that cover/GMI cuts at the root measurably
+    /// shrink the tree — the differential the tests below read.
+    ///
+    /// `max Σ p_j x_j  s.t.  Σ w_j x_j ≤ cap`, written in the driver's minimize
+    /// form with one surplus column.
+    fn knapsack(
+        n: usize,
+    ) -> (
+        SparseCols,
+        usize,
+        usize,
+        Vec<f64>,
+        Vec<f64>,
+        Vec<f64>,
+        Vec<f64>,
+    ) {
+        // Deterministic pseudo-random weights/profits (no rng dependency): the
+        // pattern is arbitrary but fixed, so node counts are reproducible.
+        let w: Vec<f64> = (0..n).map(|j| (7 * j % 23 + 11) as f64).collect();
+        let p: Vec<f64> = (0..n).map(|j| (13 * j % 29 + 17) as f64).collect();
+        let cap: f64 = w.iter().sum::<f64>() / 2.0;
+        let mut dense = vec![0.0; n + 1];
+        dense[..n].copy_from_slice(&w);
+        dense[n] = 1.0; // slack:  Σ w x + s = cap,  s ≥ 0
+        let sp = SparseCols::from_dense(&dense, 1, n + 1);
+        let c: Vec<f64> = p.iter().map(|v| -v).chain(std::iter::once(0.0)).collect();
+        let l = vec![0.0; n + 1];
+        let mut u = vec![1.0; n + 1];
+        u[n] = INF;
+        (sp, 1, n, c, vec![cap], l, u)
+    }
+
+    fn budget_opts(ns: usize, root_cut_time_s: Option<f64>) -> MilpOptions {
+        MilpOptions {
+            n_struct: ns,
+            integer_cols: (0..ns).collect(),
+            max_nodes: 200_000,
+            time_limit_s: None,
+            gap_tol: 1e-9,
+            root_cuts: 200,
+            cut_rounds: 30,
+            gmi_cuts: true,
+            cut_select: true,
+            node_cuts: false,
+            max_pool_cuts: 500,
+            heuristics: true,
+            presolve: true,
+            strong_branch: true,
+            node_propagation: false,
+            reduced_cost_fixing: true,
+            sb_max_cands: 8,
+            sb_node_budget: 1024,
+            initial_incumbent: None,
+            node_hook_rounds: 0,
+            node_hook_cut_cap: 0,
+            root_cut_time_s,
+            root_cut_prune: true,
+            simplex: SimplexOptions::default(),
+        }
+    }
+
+    /// The budget really gates the separation phase, and gating it is visible.
+    ///
+    /// Same instance, same everything else: `root_cut_time_s: Some(0.0)` expires
+    /// before the first round is entered, so no root cuts are separated. The
+    /// cut-strengthened arm closes the 40-item knapsack at the root (1 node); the
+    /// budgeted-out arm has to branch (9 nodes). That strict inequality is the
+    /// anti-vacuity check (CLAUDE.md §6) -- if the budget were ignored both arms
+    /// would separate cuts and the node counts would be equal.
+    #[test]
+    fn a_zero_root_cut_budget_skips_the_separation_phase() {
+        let (sp, m, ns, c, b, l, u) = knapsack(40);
+        let n = l.len();
+        let full = solve_milp_csc(&sp, m, n, &c, &l, &u, &b, 0.0, &budget_opts(ns, None));
+        let zero = solve_milp_csc(&sp, m, n, &c, &l, &u, &b, 0.0, &budget_opts(ns, Some(0.0)));
+
+        assert_eq!(
+            full.status,
+            MilpStatus::Optimal,
+            "unbudgeted arm must certify"
+        );
+        assert_eq!(
+            zero.status,
+            MilpStatus::Optimal,
+            "budgeted arm must certify"
+        );
+        assert!(
+            zero.nodes > full.nodes,
+            "the root-cut budget did not gate the loop: {} nodes with cuts, {} without \
+             -- an equal count means both arms separated and the test proves nothing",
+            full.nodes,
+            zero.nodes
+        );
+    }
+
+    /// Gating the cuts must not change the ANSWER. The budget trades search
+    /// effort for wall time; a different optimum, or a dual bound above it, would
+    /// mean the loop is load-bearing for correctness rather than for speed
+    /// (CLAUDE.md §1).
+    #[test]
+    fn the_root_cut_budget_never_changes_the_certified_optimum() {
+        for n_items in [40usize, 300] {
+            let (sp, m, ns, c, b, l, u) = knapsack(n_items);
+            let n = l.len();
+            let full = solve_milp_csc(&sp, m, n, &c, &l, &u, &b, 0.0, &budget_opts(ns, None));
+            let zero = solve_milp_csc(&sp, m, n, &c, &l, &u, &b, 0.0, &budget_opts(ns, Some(0.0)));
+            assert_eq!(full.status, MilpStatus::Optimal, "n={n_items}");
+            assert_eq!(zero.status, MilpStatus::Optimal, "n={n_items}");
+            assert!(
+                (full.obj - zero.obj).abs() < 1e-6,
+                "n={n_items}: budgeted arm found {} but unbudgeted found {}",
+                zero.obj,
+                full.obj
+            );
+            for (name, r) in [("unbudgeted", &full), ("budgeted", &zero)] {
+                assert!(
+                    r.bound <= r.obj + 1e-6,
+                    "n={n_items} {name}: dual bound {} above incumbent {} -- false \
+                     certificate",
+                    r.bound,
+                    r.obj
+                );
+            }
+        }
+    }
+
+    /// A budget larger than the separation phase needs is a no-op: the loop runs
+    /// to its natural stop (cut cap / tailing off) and the tree is the same size
+    /// as with no budget at all. Without this the test above could pass with a
+    /// budget that always expires, which would make the option useless rather
+    /// than working.
+    #[test]
+    fn a_generous_root_cut_budget_is_indistinguishable_from_none() {
+        let (sp, m, ns, c, b, l, u) = knapsack(300);
+        let n = l.len();
+        let none = solve_milp_csc(&sp, m, n, &c, &l, &u, &b, 0.0, &budget_opts(ns, None));
+        let generous = solve_milp_csc(
+            &sp,
+            m,
+            n,
+            &c,
+            &l,
+            &u,
+            &b,
+            0.0,
+            &budget_opts(ns, Some(600.0)),
+        );
+        assert_eq!(none.status, generous.status);
+        assert_eq!(
+            none.nodes, generous.nodes,
+            "a 600 s budget must not perturb a separation phase that takes \
+             milliseconds"
+        );
+        assert!((none.obj - generous.obj).abs() < 1e-12);
+    }
+
+    /// Densify a CSC for element-wise comparison in the tests below.
+    fn dense_of(sp: &SparseCols, m: usize, n: usize) -> Vec<f64> {
+        let mut d = vec![0.0; m * n];
+        for j in 0..n {
+            let (rows, vals) = sp.col(j);
+            for (&r, &v) in rows.iter().zip(vals) {
+                d[r * n + j] = v;
+            }
+        }
+        d
+    }
+
+    /// The whole reason `rebuild_csc_with_cuts` exists: a GMI cut's coefficient
+    /// vector spans the slack columns of the cuts before it, and the batch
+    /// appender cannot place those.
+    ///
+    /// Two cuts on a 1x2 base; the second has a coefficient on the FIRST cut's
+    /// surplus column (`n_base + 0`). The rebuild must carry it. The assertion
+    /// against `augment_cols_with_cuts` on the same input is the anti-vacuity
+    /// half (CLAUDE.md §6): it pins that the two functions genuinely differ here,
+    /// so a future "simplification" back to the batch appender fails loudly
+    /// instead of silently installing a different row.
+    #[test]
+    fn the_rebuild_places_a_cut_coefficient_on_an_earlier_cuts_slack() {
+        let base = SparseCols::from_dense(&[2.0, 3.0], 1, 2);
+        let (m_base, n_base) = (1usize, 2usize);
+        let cuts = vec![
+            GomoryCut {
+                coeffs: vec![1.0, 1.0],
+                rhs: 1.0,
+            },
+            GomoryCut {
+                // ... plus 0.5 * (cut 0's surplus), column n_base + 0 == 2.
+                coeffs: vec![1.0, 0.0, 0.5],
+                rhs: 0.25,
+            },
+        ];
+        let m_new = m_base + 2;
+        let n_new = n_base + 2;
+
+        let rebuilt = dense_of(
+            &rebuild_csc_with_cuts(&base, m_base, n_base, &cuts),
+            m_new,
+            n_new,
+        );
+        // row 0: the base row, no surplus columns
+        assert_eq!(&rebuilt[0..4], &[2.0, 3.0, 0.0, 0.0]);
+        // row 1: cut 0 with its own -1 surplus
+        assert_eq!(&rebuilt[4..8], &[1.0, 1.0, -1.0, 0.0]);
+        // row 2: cut 1, including the 0.5 on cut 0's surplus column
+        assert_eq!(&rebuilt[8..12], &[1.0, 0.0, 0.5, -1.0]);
+
+        let batched = dense_of(
+            &augment_cols_with_cuts(&base, m_base, n_base, &cuts),
+            m_new,
+            n_new,
+        );
+        assert_eq!(
+            batched[8 + 2],
+            0.0,
+            "augment_cols_with_cuts is expected to DROP the cross-slack coefficient \
+             (it only scans j < n_base); if it now keeps it, rebuild_csc_with_cuts \
+             is redundant and this test is no longer proving anything"
+        );
+    }
+
+    /// The cleanup must remove cuts, and removing them must not move the answer.
+    ///
+    /// A 300-item knapsack under a 200-cut / 30-round budget separates far more
+    /// cuts than the final root LP leans on. The counters make the drop visible
+    /// (CLAUDE.md §6 -- without the strict `kept < generated` this test would pass
+    /// on a cleanup that never fired), and the certified optimum is compared
+    /// against the same solve with the separation phase budgeted out entirely.
+    #[test]
+    fn the_root_cut_cleanup_drops_slack_cuts_without_moving_the_optimum() {
+        let _g = crate::profile::test_guard();
+        let (sp, m, ns, c, b, l, u) = knapsack(300);
+        let n = l.len();
+
+        let reference = solve_milp_csc(&sp, m, n, &c, &l, &u, &b, 0.0, &budget_opts(ns, Some(0.0)));
+
+        crate::profile::set_enabled(true);
+        crate::profile::reset();
+        let cut = solve_milp_csc(&sp, m, n, &c, &l, &u, &b, 0.0, &budget_opts(ns, None));
+        let generated = crate::profile::counter(crate::profile::Ctr::RootCutsGenerated);
+        let kept = crate::profile::counter(crate::profile::Ctr::RootCutsKept);
+        crate::profile::set_enabled(false);
+
+        assert!(
+            generated > 0,
+            "no root cuts were separated -- the cleanup had nothing to act on and \
+             this test is vacuous"
+        );
+        assert!(
+            kept < generated,
+            "cleanup kept all {generated} root cuts; it never removed a row, so the \
+             per-node cost it exists to avoid is still being paid"
+        );
+        assert_eq!(cut.status, MilpStatus::Optimal);
+        assert_eq!(reference.status, MilpStatus::Optimal);
+        assert!(
+            (cut.obj - reference.obj).abs() < 1e-6,
+            "cleanup changed the optimum: {} vs {}",
+            cut.obj,
+            reference.obj
+        );
+        assert!(
+            cut.bound <= cut.obj + 1e-6,
+            "dual bound {} above incumbent {} after cleanup -- false certificate",
+            cut.bound,
+            cut.obj
+        );
     }
 }

--- a/crates/discopt-core/src/profile.rs
+++ b/crates/discopt-core/src/profile.rs
@@ -20,11 +20,42 @@ static ENABLED: AtomicBool = AtomicBool::new(false);
 
 /// Enable profiling iff `DISCOPT_PROFILE` is present in the environment. Cheap to
 /// call repeatedly; the first call per process fixes the flag.
+///
+/// In a **test** build this yields to an explicit [`set_enabled(true)`] override
+/// (see [`TEST_OVERRIDE`]). Every MILP solve calls this on entry, and `cargo test`
+/// runs the suite on a thread pool, so without that yield a driver test on a
+/// sibling thread disarms a counter-based probe mid-measurement and it reads 0 —
+/// the CLAUDE.md §6 failure mode of an instrument that silently measures nothing.
+/// `TEST_LOCK` cannot cover this: the clobbering test never touches the profile
+/// API, it just runs a solve.
 pub fn init_from_env() {
+    #[cfg(test)]
+    if TEST_OVERRIDE.load(Ordering::Relaxed) {
+        return;
+    }
     ENABLED.store(
         std::env::var_os("DISCOPT_PROFILE").is_some(),
         Ordering::Relaxed,
     );
+}
+
+/// The profiling side of entering a MILP solve: arm from the environment, then
+/// clear the per-run counters so the numbers belong to this solve.
+///
+/// Both halves yield to [`TEST_OVERRIDE`]. The reset half matters as much as the
+/// arm half: `cargo test` runs the suite on a thread pool and *every* MILP solve
+/// passes through here, so a sibling test that merely calls the driver used to
+/// zero the counters of a test that had already armed them and started measuring —
+/// which reads as "this path never executed" rather than as interference
+/// (CLAUDE.md §6). A test that owns the measurement calls [`reset`] itself; that
+/// entry point stays unconditional.
+pub fn begin_solve() {
+    init_from_env();
+    #[cfg(test)]
+    if TEST_OVERRIDE.load(Ordering::Relaxed) {
+        return;
+    }
+    reset();
 }
 
 /// Whether profiling is currently active.
@@ -353,6 +384,13 @@ counters!(
     // `rsyn0840m` OA master: 14 cold root solves = 23.1 s of a 24.2 s cut loop).
     RootCutRounds,
     RootCutWarmReopt,
+    // Root cut cleanup: cuts separated at the root vs. cuts still in the LP after
+    // the slack ones are dropped. `Kept == Generated` means the cleanup found
+    // nothing to remove -- either every cut is tight at the final root solution or
+    // the dependency closure held them all -- and the per-node row count is the
+    // full separation output.
+    RootCutsGenerated,
+    RootCutsKept,
     // Why a warm DUAL re-optimize was refused, forcing the primal fallback. On the
     // `rsyn0840m` OA master with a real root cut pool, 588 of 589 node LPs took the
     // primal path at 556 pivots each -- these separate "the shape is wrong" from
@@ -495,11 +533,27 @@ pub fn counter_snapshot() -> Vec<(&'static str, u64)> {
         .collect()
 }
 
+/// Set while a test holds profiling on via [`set_enabled`]. While it is set,
+/// [`init_from_env`] leaves `ENABLED` alone, so a solve running on a sibling test
+/// thread cannot switch the measurement off underneath the test that armed it.
+///
+/// Deliberately one-directional: `set_enabled(true)` raises it, `set_enabled(false)`
+/// clears it. A test that arms the counters through the env var instead (the
+/// `DISCOPT_PROFILE` route, which some driver tests need because they measure the
+/// driver's own `init_from_env` path) is therefore unaffected.
+#[cfg(test)]
+static TEST_OVERRIDE: AtomicBool = AtomicBool::new(false);
+
 /// Force the profiling flag on/off. Test-only: production toggles it exactly once
 /// via [`init_from_env`]. Exposed so a Rust test can deterministically observe a
 /// [`counter`] without setting the `DISCOPT_PROFILE` env var process-wide.
+///
+/// `true` also raises [`TEST_OVERRIDE`], which keeps a concurrent solve's
+/// `init_from_env` from disarming the measurement; `false` clears it and restores
+/// the ordinary env-driven behaviour.
 #[cfg(test)]
 pub fn set_enabled(on: bool) {
+    TEST_OVERRIDE.store(on, Ordering::Relaxed);
     ENABLED.store(on, Ordering::Relaxed);
 }
 
@@ -544,5 +598,95 @@ pub fn dump() {
     for i in 0..NC {
         let v = CVALS[i].swap(0, Ordering::Relaxed);
         eprintln!("  {:<18} {:>10}", CNAMES[i], v);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `init_from_env` must not disarm a measurement a test explicitly armed.
+    ///
+    /// Every MILP solve calls `init_from_env` on entry and `cargo test` runs the
+    /// suite on a thread pool, so before the `TEST_OVERRIDE` yield an unrelated
+    /// driver test on a sibling thread would switch `ENABLED` back off in the
+    /// middle of a counter-based probe, which then read 0 and failed as "this
+    /// path never executed" (CLAUDE.md §6). `TEST_LOCK` cannot cover that: the
+    /// clobbering test never touches the profile API, it just runs a solve.
+    ///
+    /// Asserted deterministically rather than by racing threads: the clobber is a
+    /// plain `init_from_env` call, so calling it directly is the same event.
+    #[test]
+    fn init_from_env_does_not_disarm_an_explicit_test_override() {
+        let _guard = test_guard();
+        // Precondition, or the test proves nothing: with the override cleared,
+        // `init_from_env` really does drive the flag from the (unset) env var.
+        set_enabled(false);
+        assert!(
+            std::env::var_os("DISCOPT_PROFILE").is_none(),
+            "this test reads the unset-env behaviour; DISCOPT_PROFILE is set"
+        );
+        ENABLED.store(true, Ordering::Relaxed);
+        init_from_env();
+        assert!(
+            !enabled(),
+            "without an override, init_from_env must follow the env var"
+        );
+
+        set_enabled(true);
+        init_from_env();
+        assert!(
+            enabled(),
+            "init_from_env disarmed an explicit set_enabled(true) -- a concurrent \
+             solve would silently zero a counter-based probe"
+        );
+        set_enabled(false);
+        assert!(!enabled(), "set_enabled(false) must clear the override");
+    }
+
+    /// The other half of the same hazard: `begin_solve` must not CLEAR the
+    /// counters of a measurement a test armed.
+    ///
+    /// The driver resets the per-run counters on entry to every solve. Under the
+    /// test thread pool that meant a sibling test's solve zeroed an armed probe
+    /// mid-measurement, and the probe read 0 -- indistinguishable from "the code
+    /// under test never ran". Observed as a ~2-in-3 flake on the root-cut cleanup
+    /// test, whose `RootCutsGenerated` came back 0 while `RootCutRounds` was
+    /// non-zero.
+    #[test]
+    fn begin_solve_does_not_clear_counters_under_a_test_override() {
+        let _guard = test_guard();
+        assert!(
+            std::env::var_os("DISCOPT_PROFILE").is_none(),
+            "this test reads the unset-env behaviour; DISCOPT_PROFILE is set"
+        );
+
+        // Precondition: with no override, `begin_solve` really does clear.
+        set_enabled(false);
+        set_enabled(true);
+        incr_by(Ctr::RootCutRounds, 7);
+        assert_eq!(counter(Ctr::RootCutRounds), 7, "counter did not record");
+        set_enabled(false);
+        // `set_enabled(false)` dropped the override but also `ENABLED`; the value
+        // stays in CVALS, which is what `begin_solve` clears.
+        begin_solve();
+        assert_eq!(
+            counter(Ctr::RootCutRounds),
+            0,
+            "without an override, begin_solve must clear the run counters"
+        );
+
+        set_enabled(true);
+        incr_by(Ctr::RootCutRounds, 5);
+        assert_eq!(counter(Ctr::RootCutRounds), 5);
+        begin_solve();
+        assert_eq!(
+            counter(Ctr::RootCutRounds),
+            5,
+            "begin_solve cleared an armed test's counters -- a concurrent solve \
+             would make the probe read 0 and look like dead code"
+        );
+        set_enabled(false);
+        reset();
     }
 }

--- a/crates/discopt-core/tests/dive_schedule_default_off.rs
+++ b/crates/discopt-core/tests/dive_schedule_default_off.rs
@@ -54,6 +54,8 @@ fn stride_unset_never_dives_away_from_the_root() {
         initial_incumbent: None,
         node_hook_rounds: 0,
         node_hook_cut_cap: 0,
+        root_cut_time_s: None,
+        root_cut_prune: true,
         simplex: SimplexOptions::default(),
     };
     let res = solve_milp(&lp, &b, 0.0, &opts);

--- a/crates/discopt-core/tests/dive_schedule_off_root.rs
+++ b/crates/discopt-core/tests/dive_schedule_off_root.rs
@@ -69,6 +69,8 @@ fn options() -> MilpOptions {
         initial_incumbent: None,
         node_hook_rounds: 0,
         node_hook_cut_cap: 0,
+        root_cut_time_s: None,
+        root_cut_prune: true,
         simplex: SimplexOptions::default(),
     }
 }

--- a/crates/discopt-python/src/lp_bindings.rs
+++ b/crates/discopt-python/src/lp_bindings.rs
@@ -1100,7 +1100,9 @@ impl MilpNodeHook for PyMilpNodeHook {
                     max_pool_cuts=128, heuristics=true, presolve=true, strong_branch=true,
                     node_propagation=false, reduced_cost_fixing=true,
                     sb_max_cands=6, sb_node_budget=48,
-                    initial_incumbent=None, time_limit_s=None, debug_hook=None))]
+                    initial_incumbent=None, time_limit_s=None, root_cut_time_s=None,
+                    root_cut_prune=true,
+                    debug_hook=None))]
 pub fn solve_milp_py<'py>(
     py: Python<'py>,
     c: PyReadonlyArray1<'py, f64>,
@@ -1129,6 +1131,8 @@ pub fn solve_milp_py<'py>(
     sb_node_budget: usize,
     initial_incumbent: Option<PyReadonlyArray1<'py, f64>>,
     time_limit_s: Option<f64>,
+    root_cut_time_s: Option<f64>,
+    root_cut_prune: bool,
     debug_hook: Option<Py<PyAny>>,
 ) -> PyResult<(String, Bound<'py, PyArray1<f64>>, f64, f64, usize, usize)> {
     let dims = a.shape();
@@ -1197,6 +1201,8 @@ pub fn solve_milp_py<'py>(
         sb_node_budget,
         initial_incumbent,
         time_limit_s,
+        root_cut_time_s,
+        root_cut_prune,
         debug_hook,
         // No lazy separator on this entry point: it keeps the historical
         // 6-tuple return and the driver's untouched path. `solve_milp_lazy_csc_py`
@@ -1222,7 +1228,9 @@ pub fn solve_milp_py<'py>(
                     max_pool_cuts=128, heuristics=true, presolve=true, strong_branch=true,
                     node_propagation=false, reduced_cost_fixing=true,
                     sb_max_cands=6, sb_node_budget=48,
-                    initial_incumbent=None, time_limit_s=None, debug_hook=None))]
+                    initial_incumbent=None, time_limit_s=None, root_cut_time_s=None,
+                    root_cut_prune=true,
+                    debug_hook=None))]
 #[allow(clippy::too_many_arguments)]
 pub fn solve_milp_csc_py<'py>(
     py: Python<'py>,
@@ -1256,6 +1264,8 @@ pub fn solve_milp_csc_py<'py>(
     sb_node_budget: usize,
     initial_incumbent: Option<PyReadonlyArray1<'py, f64>>,
     time_limit_s: Option<f64>,
+    root_cut_time_s: Option<f64>,
+    root_cut_prune: bool,
     debug_hook: Option<Py<PyAny>>,
 ) -> PyResult<(String, Bound<'py, PyArray1<f64>>, f64, f64, usize, usize)> {
     let col_ptr_v: Vec<usize> = col_ptr.as_slice()?.iter().map(|&x| x as usize).collect();
@@ -1313,6 +1323,8 @@ pub fn solve_milp_csc_py<'py>(
         sb_node_budget,
         initial_incumbent,
         time_limit_s,
+        root_cut_time_s,
+        root_cut_prune,
         debug_hook,
         // No lazy separator on this entry point: it keeps the historical
         // 6-tuple return and the driver's untouched path. `solve_milp_lazy_csc_py`
@@ -1375,7 +1387,9 @@ pub fn solve_milp_csc_py<'py>(
                     max_pool_cuts=128, heuristics=true, presolve=true, strong_branch=true,
                     node_propagation=false, reduced_cost_fixing=true,
                     sb_max_cands=6, sb_node_budget=48,
-                    initial_incumbent=None, time_limit_s=None, debug_hook=None,
+                    initial_incumbent=None, time_limit_s=None, root_cut_time_s=None,
+                    root_cut_prune=true,
+                    debug_hook=None,
                     node_callback=None, node_hook_rounds=0, node_hook_cut_cap=0))]
 #[allow(clippy::too_many_arguments)]
 pub fn solve_milp_lazy_csc_py<'py>(
@@ -1411,6 +1425,8 @@ pub fn solve_milp_lazy_csc_py<'py>(
     sb_node_budget: usize,
     initial_incumbent: Option<PyReadonlyArray1<'py, f64>>,
     time_limit_s: Option<f64>,
+    root_cut_time_s: Option<f64>,
+    root_cut_prune: bool,
     debug_hook: Option<Py<PyAny>>,
     node_callback: Option<Py<PyAny>>,
     node_hook_rounds: usize,
@@ -1493,6 +1509,8 @@ pub fn solve_milp_lazy_csc_py<'py>(
         sb_node_budget,
         initial_incumbent,
         time_limit_s,
+        root_cut_time_s,
+        root_cut_prune,
         debug_hook,
         Some(lazy_callback),
         node_callback,
@@ -1536,6 +1554,8 @@ fn run_milp_hooked<'py>(
     sb_node_budget: usize,
     initial_incumbent: Option<PyReadonlyArray1<'py, f64>>,
     time_limit_s: Option<f64>,
+    root_cut_time_s: Option<f64>,
+    root_cut_prune: bool,
     debug_hook: Option<Py<PyAny>>,
     lazy_callback: Option<Py<PyAny>>,
     node_callback: Option<Py<PyAny>>,
@@ -1577,6 +1597,8 @@ fn run_milp_hooked<'py>(
         initial_incumbent: initial_incumbent
             .map(|arr| arr.as_slice().map(|s| s.to_vec()))
             .transpose()?,
+        root_cut_time_s: parse_budget_secs(root_cut_time_s)?,
+        root_cut_prune,
         simplex: SimplexOptions {
             tol,
             max_iter: 100_000,

--- a/docs/dev/milp-competitiveness-plan.md
+++ b/docs/dev/milp-competitiveness-plan.md
@@ -1,0 +1,357 @@
+# Closing the MILP gap to HiGHS/SCIP — measured plan
+
+Status: entry measurements done 2026-09-05; source review against HiGHS 1.14 and
+SCIP 10.0.2 done 2026-09-05. **No stage below has been started.**
+Goal: discopt competitive with HiGHS/SCIP on pure MILP.
+
+## 0. The measurement this plan replaces
+
+The prior plan was "raise the root cut budget and clean up slack cuts". It looked
+net-positive on a 30-instance synthetic lattice panel (26/30 vs base 25/30).
+**On a real corpus it is net-negative and the claim is retracted** (CLAUDE.md §11).
+
+38 MIPLIB 2017 "easy" instances (size-filtered, and every one validated by having
+HiGHS reproduce the published optimum from *the converted arrays discopt
+receives*), TL = 20 s, arms interleaved per instance, 190/190 runs, no
+certification abort:
+
+| arm | solved | wall | med(solved) | nodes | kept/gen |
+|---|---|---|---|---|---|
+| base_16x1 | **18**/38 | 444.93 s | 0.139 s | 8,312,044 | 0/0 |
+| cut200_noprune | 11/38 | 573.62 s | 0.235 s | 1,964,690 | 0/0 |
+| cut200_prune | 11/38 | 529.55 s | 0.160 s | 1,327,506 | 2544/5720 |
+| cut500_prune | 11/38 | 541.52 s | 0.196 s | 694,144 | 3709/12671 |
+| **highs** | **36**/38 | **76.77 s** | 0.802 s | 15,073 | 0/0 |
+
+`DISCOPT_MILP_ROOT_CUTS` therefore **stays default-OFF**. The cleanup
+(`root_cut_prune`) is retained only because it is strictly better *within* the
+cut path (529 s / 1.33 M nodes vs 573 s / 1.96 M); it does not rescue the budget.
+
+**Both source reviews independently read that row as a lifecycle failure, not a
+cut-quality failure**: cuts added under a fixed budget and then carried in every
+node LP forever. See §2.1.
+
+### 0.1 Methodology corrections carried into every later panel
+
+- **Matched gap tolerance.** That run gave discopt `gap_tol = 1e-6` (relative —
+  `tree_manager.rs:992`) against HiGHS's default `mip_rel_gap = 1e-4`, a 100×
+  tighter stopping rule. I first estimated this at "exactly one instance". That
+  understated it: at matched 1e-4, `neos-1425699` goes from **640,669 nodes,
+  unsolved** to **29 nodes, 0.00 s**. No comparison number may be published at
+  mismatched tolerances again.
+- **Nodes, not wall, is the diagnostic.** Twelve of the twenty instances discopt
+  fails, HiGHS finishes in **one node**.
+
+### 0.2 The sharpest single fact on the panel
+
+HiGHS closes `b-ball`, `sp150x300d`, `beavma`, `nexp-50-20-1-1`,
+`nexp-50-20-4-2`, `khb05250`, `gen`, `dcmulti`, `app2-2`, `f2gap40400`, `gr4x6`,
+`supportcase14` and `supportcase16` in **one node**. One node means the root LP —
+after presolve, root cuts and root heuristics — both *produces* the optimum and
+*proves* it. discopt spends 350 k–870 k nodes on several of those same instances.
+
+This is a **root-strength** problem, not a tree-search problem. It is why Stage
+0's search-side flips move zero instances, and it is the reason the stage order
+below puts root cut control and cMIR ahead of everything on the search side.
+Almost everything that matters happens before the first branch.
+
+## 1. Where the gap is
+
+### 1a. The failures present as primal-short
+
+Decomposing base's 20 failures into primal gap `(inc − opt)/(1+|opt|)` and dual
+gap `(opt − bound)/(1+|opt|)`: **15/20 are primal-short**, and two
+(`enlight_hard`, `neos-2624317-amur`) never find a feasible point at all. Worst
+primal gaps: `neos-911970` 208.5 %, `fiber` 57.7 %, `nexp-50-20-1-1` 56.7 %,
+`beavma` 42.2 %, `sp150x300d` 34.3 %. Six have a dual gap ≤ 3 % (`obra` 0.46,
+`kaihu` 0.80, `iskar` 1.40, `istra` 2.56, `neos17` 2.56, `fiber` 3.02) — a decent
+incumbent alone would close those trees.
+
+§1c argues this is largely a *symptom*: a weak dual bound upstream of the missing
+incumbents. It is not, however, dismissed — see Stage 3.
+
+### 1b. The four `mik-250-20-75-*` are a pure dual failure
+
+They already hold the **optimum as incumbent** (primal gap ≈ 0) and still carry a
+7–10 % dual gap after ~700 k nodes. HiGHS: 558–1055 nodes, 3.6–5.2 s. `mik` is
+the textbook mixed-integer-knapsack (cMIR) family.
+
+discopt's MILP driver separates **cover + Gomory only** (`milp_driver.rs:1065`,
+`:1081`; in-tree at `:2300`, cover only), with `cut_select=false` and
+`node_cuts=false` as shipped defaults (`lp_bindings.rs:1099`).
+
+### 1c. Presolve, heuristics and symmetry are NOT the difference
+
+Ablation of HiGHS itself over the whole panel, HiGHS alone on the machine,
+TL = 20 s, 190 comparisons:
+
+| HiGHS arm | solved | wall | nodes |
+|---|---|---|---|
+| full | 38/38 | 66.85 s | 15,417 |
+| no_presolve | 36/38 | 114.38 s | 36,261 |
+| no_heur | 37/38 | 80.12 s | 41,521 |
+| no_sym | 38/38 | 71.79 s | 16,368 |
+| **bare** (all three off) | **37/38** | **119.93 s** | 54,420 |
+
+Presolve is worth ≤2 instances and ~1.7× wall; symmetry is 0. discopt's own MILP
+presolve is dimension-preserving FBBT (`milp_driver.rs:677`) and HiGHS's really
+does reduce (`nexp-50-20-1-1` 1030×540 → 728×280) — but the reduction is not what
+closes these instances.
+
+**Correction (CLAUDE.md §11).** An earlier draft of this document said HiGHS
+"reaches 37/38 with zero heuristic effort". That is wrong.
+`mip_heuristic_effort=0` does **not** disable HiGHS's heuristics: feasibility
+jump, rounding, shifting and RENS are gated by separate `mip_heuristic_run_*`
+booleans (`HighsOptions.h:490-495`, registered **default `true`** at
+`:1213-1215`), and `moreHeuristicsAllowed`
+(`HighsMipSolverData.cpp:611-673`) grants an unconditional 10,000-iteration
+heuristic LP budget even at effort 0 (`:627-629`); incumbents also arrive from
+integral node LPs (`HighsSearch.cpp:966-971`) and strong-branch LPs (`:601-606`).
+The `bare` arm still had a small primal side. The *direction* survives — cuts +
+LP + branching + propagation dominate — but the absolute claim does not.
+
+## 2. What the two source reviews established
+
+Reviews of this plan against `ref/HiGHS/` and `ref/scipoptsuite-10.0.2/`. They
+were run independently and **converge on the same reordering**: the plan's target
+(cuts) was right, its first action was wrong, and it omitted the two things that
+make aggressive root cutting affordable at all.
+
+### 2.1 Cut lifecycle is the missing prerequisite, not a refinement
+
+Neither solver carries root cuts forever, and neither budgets the root by rounds.
+
+- HiGHS: `HighsLpRelaxation::performAging` (`HighsLpRelaxation.cpp:595-642`) ages
+  basic cut rows at every node LP and deletes at `mip_lp_age_limit` = 10;
+  `removeObsoleteRows` (`:522-539`) drops basic cut rows after the root; the pool
+  re-separates by violation with score `viol/(nActiveNzs·sqrt(norm))` and a 0.1
+  parallelism cap (`HighsCutPool.cpp:168-364`), pool age limit 30.
+- SCIP: `separating/maxroundsroot = -1` (`set.c:471`) — no round budget at all.
+  It stops on **stalling**: `maxstallroundsroot` 10 (`:475`), stall test at
+  `solve.c:2965-2975` (objreldiff ≤ 1e-4 **and** a fractionality test). Cuts are
+  dynamic rows removed after `lp/rowagelimit` = 10 LPs nonbasic (`set.c:263`),
+  pool age limit 80. And directly on point for the `root_cut_prune` work on this
+  branch: `SCIP_DEFAULT_LP_CLEANUPROWSROOT = TRUE` (`set.c:268`) — SCIP removes
+  new **basic** rows after the root LP *by default*, on the same argument;
+  `CLEANUPROWS = TRUE` (`:267`) does it after every LP, which is Stage 1's aging
+  half. Selection is `cutsel_hybrid` (efficacy 1.0, objparal 0.1,
+  intsupport 0.1, minortho root 0.90 — `cutsel_hybrid.c:46-57`).
+
+discopt appends cuts to the matrix permanently (`augment_csc_with_cuts`,
+`rebuild_csc_with_cuts`) and budgets by fixed round/cut counts. That is the exact
+shape of the §0 regression.
+
+### 2.2 The plan's original Stage 1 would have re-run an experiment already killed
+
+`docs/dev/certification-gap-plan.md` records **CUT-1** and **CUTS-1** as NO-GO,
+re-confirmed 2026-07-10 on HEAD `059165fc`: oracle injection of SCIP's *actual*
+cMIR cut coefficients closed ≤1.8 % (nvs17) and 0 % (nvs19/24), and
+`DISCOPT_CMIR_AGGREGATION` ON/OFF gave **0× node reduction**, bit-identical bound
+and node count. `lp/aggregation.rs:1-46` carries the same finding in its header.
+
+**Why this does not settle the MILP case, stated as a precondition rather than
+assumed away.** That NO-GO was measured on the MINLP lifted-McCormick class,
+where *discopt's default root already closes 99.9 % of the gap* — the separator
+was inert because there was nothing left to cut. On `mik` the root leaves 7–10 %.
+The premise that made cMIR inert does not hold here. **But that is a hypothesis,
+and it is the first thing Stage 2 must test** (§3, Stage 2 entry experiment). If
+HiGHS's own root bound on `mik` is also 7–10 % and it wins on nodes instead, then
+cuts are not the `mik` lever and Stage 2 is re-scoped to search.
+
+### 2.3 What `separate_mir` actually has, verified in-tree
+
+Not taken on the reviewers' word — read directly:
+
+- deltas = `{1} ∪ {1/|a_j| : j integer}` (`mir.rs:226-232`) — **no** best/2, /4, /8
+  refinement (SCIP: `SCIPcutGenerationHeuristicCMIR`, `cuts.c:8339`).
+- complementation: two fixed patterns, all-lower and near-upper
+  (`mir.rs:236-254`) — **no** per-integer post-hoc flips.
+- simple bounds only — **no** VUB/VLB substitution (HiGHS:
+  `HighsTransformedLp.cpp:127-330`; SCIP: `VARTYPEUSEVBDS 2`). This is what makes
+  cMIR behave like flow cover on fixed-charge structure — i.e. `nexp`,
+  `sp150x300d`, `fiber`, `beavma`.
+- one cut per row, ranked by raw violation, with no lifted-cover competition
+  (HiGHS: `HighsCutGeneration.cpp:1391-1491`).
+- **discopt's slack columns are continuous**, so every pure-integer row is
+  weakened; SCIP adds integral row slacks to the δ/complementation set.
+
+So "call the existing MIR" is not a small step to HiGHS parity. It is most of
+`HighsCutGeneration`.
+
+### 2.4 Divergence between the two reviews, unresolved
+
+HiGHS's reviewer says row-by-row MIR on raw rows is the shape HiGHS deliberately
+avoids (separation is on tableau rows or *tight* rows only — `HighsPathSeparator`
+types a row with both slacks above feastol as unusable). SCIP's reviewer says
+single-row MIR is not intrinsically wrong — SCIP tries the un-aggregated row
+first (`sepa_aggregation.c` Step 1 at `naggrs=0`) — and that the real defect is
+§2.3's feature list. **Both agree the current `separate_mir` fed raw equality
+rows in both orientations would read as "MIR does nothing".** The tight-row
+filter is cheap and is adopted; the disagreement does not change Stage 2.
+
+## 3. Stages
+
+Reordered from the first draft per §2. Every bound-changing piece goes behind a
+default-off flag with the §5 double bar (cert-clean AND net-positive) over the 38
+panel *and* the in-repo MINLP corpus. Propagation, aging, restarts and node
+selection are contractions or reorderings and need only the bound-neutral or
+cert-clean check.
+
+### Stage 0 — flips of things already built (zero code)
+
+Ranked first because the code exists and shipping it off is the whole defect.
+
+1. **`node_propagation=true`** — FBBT per node with children inheriting tightened
+   bounds (`milp_driver.rs:2007`), which is HiGHS's `localdom.propagate()`
+   (`HighsSearch.cpp:875`) and SCIP's `PROPFREQ 1` (`cons_linear.c:155`).
+   Defaults **false** in the PyO3 signature at all three call sites
+   (`lp_bindings.rs:1101, :1229, :1388`). Pure contraction ⇒ cert-clean is
+   automatic. 
+
+   **MEASURED 2026-09-05, 38 instances, matched `gap_tol=1e-4`, TL = 20 s,
+   114/114 runs, zero certification aborts:**
+
+   | arm | solved | wall | med(solved) | nodes |
+   |---|---|---|---|---|
+   | base | 19/38 | 413.62 s | 0.101 s | 8,969,820 |
+   | nodeprop | 19/38 | 395.90 s | 0.081 s | 7,838,764 |
+   | highs | 38/38 | 66.35 s | 0.959 s | 15,417 |
+
+   **The HiGHS review predicted "~3-6 instances" from this flag. That is
+   falsified: it gains zero.** What it does deliver is −12.6 % nodes, −20 %
+   median solve time, and large per-instance wins — `flugpl` 11.0×, `enlight8`
+   9.8×, `gt2` 4.8×, `bppc8-02` 1.9× (10.55 s → 2.44 s). On timed-out instances
+   the dual bound is better on 8 and worse on 5; the standouts are
+   `enlight_hard` 28.95 % → **10.53 %** and `beavma` 28.94 % → 22.33 %, against a
+   real regression on `fiber` (2.92 % → 6.28 %). `neos-3610051-istra` newly
+   *finds* the optimum (primal 12.00 % → 0.00 %) and ends 1.35 % from proving it.
+
+   Verdict: cert-clean and mildly net-positive, so it graduates ON — but it is
+   **not a lever on the gap**, and nothing downstream should be planned as if
+   Stage 0 buys instances. Caveat (CLAUDE.md §9): machine load rose from 2.85 to
+   13.84 during the run, so the *wall* column is soft; node counts are
+   load-independent and carry the conclusion, and arms rotated per instance so
+   load hit all three alike. `base` is 19/38 here vs 18/38 in §0 — that one
+   instance is the §0.1 tolerance correction, now paid for.
+
+   **The `mik` family is untouched** (1.25–1.30× nodes, still ~600 k against
+   HiGHS's 558–1055). Propagation is not the `mik` mechanism; §1b stands.
+2. **`cut_select=true`** — `lp/cut_select.rs` exists and ships off
+   (`lp_bindings.rs:1099`).
+3. **Best-estimate node selection with plunging** — discopt uses
+   `SelectionStrategy::BestFirst` (`tree_manager.rs`) and has a best-estimate
+   field that is not the driver. SCIP's default is `nodesel_estimate` (verified: `STDPRIORITY 200000` at
+   `nodesel_estimate.c:48`, the highest of the five selectors — `bfs` 100000,
+   `hybridestim` 50000) with
+   plunging; HiGHS alternates best-estimate plunges with a forced best-bound pop
+   every 10 leaves (`HighsMipSolver.cpp:504-516`). Improves early incumbents,
+   which is §1a.
+
+*Kill criterion:* each flip measured alone on the 38 panel at matched tolerance;
+anything that does not improve solved-count or nodes stays off.
+
+### Stage 1 — root cut-loop control (the §0 prerequisite)
+
+Replace fixed round/cut budgets with stall-based termination, cut aging, and
+efficacy+orthogonality selection; move root cuts into a pool rather than the
+matrix.
+
+- Stall rule to replace `root.obj <= prev_obj + 1e-7*(1+|prev_obj|)`, which is
+  far tighter than either reference (HiGHS `stall < 3` with a 1.001 test against
+  *cumulative* gain; SCIP `objreldiff ≤ 1e-4` plus a fractionality test).
+- Delete cut rows that are basic/slack after the root (the `root_cut_prune` work
+  already on this branch is the first half of this), then age basic cut rows
+  in-tree with a ~10-LP limit, with deleted cuts held in a pool re-checked for
+  violation.
+- Row deletion must fix up the warm basis (HiGHS falls back to `firstrootbasis`,
+  `HighsMipSolver.cpp:635-639`).
+
+*Entry experiment:* re-run the cut200 arm with (a) `cut_select` on, (b) slack-cut
+drop, (c) both. *Kill:* if (b) alone does not recover a substantial share of the
+7 instances the cut budget lost, aging is not the mechanism and Stage 1 re-scopes.
+
+### Stage 2 — cMIR done properly
+
+*Attribution first, before any code:* compare discopt's post-cut root bound
+against HiGHS's root bound on the four `mik` plus the six ≤3 %-dual instances.
+**This is the test of §2.2's precondition.** If HiGHS's root gap on `mik` is also
+7–10 %, cuts are not the lever there and this stage is re-scoped to search.
+
+If confirmed, build in fidelity order, measuring after each: (1) integral row
+slacks treated as integer in the δ/complementation set; (2) separate on the
+current LP *including* previously added cuts, scored by efficacy `viol/‖α‖` not
+raw violation; (3) VUB/VLB substitution; (4) the full δ set incl. best/2,/4,/8
+and per-integer complementation flips; (5) tight-row filtering; (6) aggregation
+depth ≥3.
+
+*Kill:* root gap on `mik` fails to close ≥3 pp after (1)–(4).
+
+### Stage 3 — primal
+
+Reordered from FJ-first. SCIP has no feasibility-jump at all and still gets first
+incumbents; RENS is the cheapest for us because it reuses `milp_driver.rs`
+recursively.
+
+1. RENS on the root LP. 2. Propagation-backed rounding (needs Stage 0.1 anyway).
+3. Rounding/shifting after *every* root separation round — HiGHS's
+`rootSeparationRound` (`HighsMipSolverData.cpp:1783-1790`) is what produces the
+one-node solves. 4. Feasibility jump **only if** `enlight_hard` and
+`neos-2624317-amur` still lack an incumbent.
+
+### Stage 4 — restarts
+
+Root restart when reduced-cost fixing + propagation has fixed ≥5 % of integers
+(SCIP `restartfac` 0.025 / `immrestartfac` 0.05, `solve.c:4601-4603`). discopt
+already has `reduced_cost_fix` (`:2766`). Cert-neutral contraction. Also: root
+reduced-cost "lurking bounds" (`HighsRedcostFixing.cpp:36-71, :194+`) fire free
+tightenings every time the incumbent improves.
+
+### Stage 5 — conflict analysis; Stage 6 — clique/implication tables
+
+Both default-ON in SCIP (`set.c:108-172`). Conflict analysis needs a per-node
+bound-change log — a real build. Clique extraction feeds propagation, knapsack
+separation and heuristics; `presolve/cliques.rs` and `implied_bounds.rs` exist
+and are unwired on the MILP path.
+
+### Stage 7 — dimension-reducing presolve with postsolve
+
+Last, per §1c (≤2 instances, large build — the matrix path has no postsolve
+chain). Note restarts (Stage 4) want re-presolve, so there is a coupling.
+
+### Explicitly dropped
+
+Symmetry on this panel (0 instances, both reviews agree); GUB and superadditive
+cover lifting (OFF by default in SCIP — `cons_knapsack.c:127, :146`); more raw
+Gomory budget (measured negative, §0); CSC-native MIR before a dense root-gap
+gain is shown; oddcycle/cgmip/closecuts/lagromory (freq −1 in SCIP); local
+branching/DINS as first-incumbent tools.
+
+Sequentially-lifted knapsack cover (upgrading `lp/cover.rs` from unlifted) is
+*not* dropped but is low priority: ~0.5–1 instance, low risk, and irrelevant to
+`mik` (cover fires only on binary rows).
+
+## 4. Success metric
+
+The §0 panel at matched `mip_rel_gap = 1e-4`, TL = 20 s. Base is **18/38 at
+444.93 s** (19/38 once the tolerance is matched); HiGHS **36/38 at 76.77 s**
+interleaved, 38/38 at 66.85 s alone. "Competitive" is solved-count within a few
+instances of HiGHS's with total wall within ~2×. Every stage reports against this
+same table.
+
+## 5. Licensing note for the owner
+
+discopt is **EPL-2.0**. HiGHS is MIT (compatible inbound). SCIP 10 is Apache-2.0,
+which can be combined but not relicensed. Both reviews were instructed to
+describe algorithms, not paste source, and neither returned code. If the cMIR δ
+and complementation loop in Stage 2 ends up a close derivation of
+`SCIPcutGenerationHeuristicCMIR`, or the transform step of
+`HighsTransformedLp::transform`, that is an attribution decision for the owner
+before merge, not something to settle in a PR.
+
+## 6. Reproduction
+
+`scratchpad/miplib/` holds `loader.py` (MPS → engine arrays via highspy, so both
+solvers see byte-identical matrices), `hs.py` (the shared HiGHS arm), `screen.py`
+(the fidelity + tractability gate that built `panel.json`), `miplib_ab.py` (the
+§0 arm panel), `attribute.py` (the §1c ablation), `switches_ab.py` (Stage 0) and
+`pathology.py` (the `khb05250` 3-nodes-in-20 s probe).

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -21473,6 +21473,43 @@ def _milp_engine_default_on() -> bool:
     return os.environ.get("DISCOPT_MILP_ENGINE", "1").lower() not in ("0", "false", "no")
 
 
+def _milp_root_cut_budget(engine_budget: float) -> Optional[dict]:
+    """Root cut options for the pure-MILP engine, or ``None`` to keep the
+    binding's historical ``root_cuts=16, cut_rounds=1`` single pass.
+
+    Measured motivation (30-instance MILP panel, 20 s/instance): on the
+    lot-sizing / production-planning family the root dual bound the engine
+    proves is **18.9%** of the optimum, while HiGHS closes the same instances at
+    **100%** of theirs at its own root. That is not a missing cut *class* -- the
+    engine already separates cover and GMI cuts -- it is the budget: one round of
+    at most 16 cuts. Raising the same separator to 500 cuts over 50 rounds with
+    efficacy/orthogonality selection takes the prodplan root bound to **89.3%**
+    in 4.7 s.
+
+    Bound-CHANGING (CLAUDE.md §5), so it ships default-OFF behind
+    ``DISCOPT_MILP_ROOT_CUTS=1`` until a corpus-wide differential panel is
+    cert-clean AND net-positive. Nothing here can make a bound unsound -- a
+    Gomory/cover cut is valid for the integer hull either way -- but "sound" is
+    not the bar; "measurably helpful broadly" is (the ``DISCOPT_CUT_INHERIT``
+    lesson).
+
+    ``root_cut_time_s`` is what makes 50 rounds safe to ask for: without it a
+    long separation phase on a large root LP would spend the engine's whole slice
+    proving a bound with no time left to branch.
+    """
+    if os.environ.get("DISCOPT_MILP_ROOT_CUTS", "0").lower() in ("0", "false", "no"):
+        return None
+    return {
+        "root_cuts": 500,
+        "cut_rounds": 50,
+        "cut_select": True,
+        # Half the engine's slice, floored so a very short budget still gets one
+        # useful pass. The loop stops early on tailing off, so on an instance
+        # whose root closes in two rounds this ceiling is never reached.
+        "root_cut_time_s": max(0.5, 0.5 * float(engine_budget)),
+    }
+
+
 def _one_hot_swap_reseed(model: Model, x_lifted: np.ndarray, budget: float) -> Optional[np.ndarray]:
     """A lifted-space seed built by improving *x_lifted* with an assignment-aware
     swap over the ORIGINAL variables, or ``None`` when unavailable.
@@ -21646,6 +21683,12 @@ def _solve_milp_simplex(
     if initial_point is not None and np.asarray(initial_point).size == n_orig:
         _seed = np.ascontiguousarray(np.asarray(initial_point, dtype=np.float64).ravel())
 
+    # Root cut budget (default-off; see ``_milp_root_cut_budget``). Passed as
+    # keywords so the binding's own defaults stand when the flag is off -- these
+    # same defaults also serve the MINLP per-node relaxer, which is why the
+    # budget is raised HERE and not by changing them.
+    _cut_opts = _milp_root_cut_budget(_milp_budget) or {}
+
     status, x_struct, obj, bound, nodes, _lp_iters = solve_milp_py(
         np.ascontiguousarray(lp_data.c, dtype=np.float64),
         A,
@@ -21660,6 +21703,7 @@ def _solve_milp_simplex(
         initial_incumbent=_seed,
         time_limit_s=float(_milp_budget),
         debug_hook=_debug.rust_hook(),
+        **_cut_opts,
     )
 
     # Feasibility gate (shared by the return path below and the #698 re-entry


### PR DESCRIPTION
## What this changes

Two things in the MILP engine's root phase, plus the measurement that says the
feature they were built for does **not** ship on.

**1. Root cut cleanup (`MilpOptions::root_cut_prune`).** Every cut separated at
the root previously stayed in `csc_w` for the rest of the solve, so each one rode
in *every* node LP. This drops the cuts that are slack at the final root LP
before the tree starts.

Soundness: a slack cut has a zero dual multiplier at the root optimum, so the
root bound and its KKT certificate survive its removal exactly. Deeper nodes may
get a *weaker* bound than they would with the full set — never an invalid one,
since what remains is a subset of globally valid cuts. Bound-CHANGING under
CLAUDE.md §5, never bound-invalidating.

The non-obvious part: `separate_gomory_cols` returns coefficients over **all**
columns, including the surplus columns of earlier cuts. So (a) a cut may only be
dropped once nothing kept references its surplus column — hence the reverse
dependency-closure sweep — and (b) `augment_cols_with_cuts` cannot be reused for
the rebuild, because it only scans `j in 0..n_base` and would silently install a
*different* row. `rebuild_csc_with_cuts` exists for exactly that, and
`the_rebuild_places_a_cut_coefficient_on_an_earlier_cuts_slack` pins the
difference so a future simplification back to the batch appender fails loudly.

**2. `profile::begin_solve()`.** Every MILP solve called `init_from_env();
reset();` on entry. Under `cargo test`'s thread pool a sibling test's solve
zeroed an armed probe's counters mid-measurement, so it read 0 and looked like
dead code — the CLAUDE.md §6 failure mode. `begin_solve` yields to
`TEST_OVERRIDE` on both halves; this is the reset half of the hazard the earlier
`TEST_OVERRIDE` change fixed for the arm half. Regression test included.

## Why the root cut budget does NOT graduate — retraction

I previously reported the raised root cut budget as net-positive and said it met
CLAUDE.md §5's bar: 26/30 solved at 93.81 s vs base 25/30 at 103.77 s. **I am
retracting that** (CLAUDE.md §11). That panel was 30 *synthetic lattice families*
— exactly the §2 trap of measuring a class by proxy.

On 38 real MIPLIB 2017 "easy" instances (each one validated by having HiGHS
reproduce the published optimum from the same converted arrays discopt receives;
fidelity failures: 0), TL = 20 s, arms interleaved per instance, 190/190 runs, no
certification abort:

| arm | solved | wall | med(solved) | nodes | kept/gen |
|---|---|---|---|---|---|
| base_16x1 | **18**/38 | 444.93 s | 0.139 s | 8,312,044 | (not counted) |
| cut200_noprune | 11/38 | 573.62 s | 0.235 s | 1,964,690 | (not counted) |
| cut200_prune | 11/38 | 529.55 s | 0.160 s | 1,327,506 | 2544/5720 |
| cut500_prune | 11/38 | 541.52 s | 0.196 s | 694,144 | 3709/12671 |
| highs (reference) | 36/38 | 76.77 s | 0.802 s | 15,073 | n/a |

> **Correction (2026-09-05).** Those two cells previously read `0/0`. That was an
> **instrument artifact and I am retracting it** (CLAUDE.md §11). `RootCutsGenerated`
> and `RootCutsKept` increment only inside the cut-cleanup block
> (`milp_driver.rs:1226-1229`), which is gated by `prune_base` (`:934-939`) —
> `Some(..)` only when `root_cut_prune && root_cuts > 0 && cut_rounds > 1`. At
> `cut_rounds = 1` they never fire, so `0/0` meant *not counted*, not *no cuts*.
> The base arm does generate and keep cuts: `b-ball`'s root bound is −1.705882 at
> `root_cuts=16` against −1.818182 at `root_cuts=0`, and `enlight_hard` goes
> 21 → 23. This is precisely the CLAUDE.md §6 failure mode — a counter that
> measured nothing and was read as a measurement. It does not change any
> conclusion in this section (the solved/wall/node columns are independent of it),
> but the cells were being read as evidence that the base arm cuts nothing.

The budget **loses 7 of base's 18 solves and adds ~85 s of wall.** So
`DISCOPT_MILP_ROOT_CUTS` stays default-OFF and this PR does not propose flipping
it. Nothing here changes any default: `root_cut_prune` only takes effect inside
the cut path, which is itself off by default.

What the cleanup buys, stated carefully: in **aggregate** over the cut path it
beats not pruning — 529.55 s / 1.33 M nodes vs 573.62 s / 1.96 M nodes at the
same 11 solves. I earlier wrote that as "strictly better than not pruning";
**that phrasing is wrong and I retract it** (CLAUDE.md §11). Per instance the
prune is often much *worse*. On `sp150x300d` at a 200-cut budget, removing the
prune reaches the **identical** root bound (60) at 22.3 iterations/node instead
of 2079.6 and 0.38 s instead of 13.64 s; `fiber` and `blend2` show the same sign.

That per-instance split is the thread that led to the root cause, which is not
about pruning at all: `separate_gomory_cols` returns coefficients over the
slack-extended column space, so a cut puts a second nonzero into a base slack
column. That column stops being a singleton, `solve_lp_cols_warm`'s basis
reconstruction can no longer substitute for it, the returned basis is short,
`PreparedDual::prepare` refuses it on shape, and every node cold-solves — which
returns another short basis, so the state is self-sustaining. The prune looked
like a win in aggregate because its dependency-closure sweep keeps a cut
precisely *because* something references its slack, so it retains the
cross-referencing cuts and discards the clean ones, concentrating the pathology
onto fewer instances rather than causing it.

The fix is to rewrite each cut into structural space before it is appended. That
is a **separate PR** — #1167, which stacks on this one and is now open. This PR's
cleanup stands on its own soundness argument and stays default-inert.

**Post-fix update (2026-09-05).** With #1167's structural-space rewrite in the
tree, the same panel re-run at matched `gap_tol = 1e-4` inverts the result above:
`cut500_prune` reaches **21/38 at 4,693,240 nodes** against base's **19/38 at
8,853,388** — cert-clean *and* net-positive, 190/190 runs, zero certification
aborts. The budget's net-negativity measured here was caused entirely by the
warm-start breakage, exactly as this section's root-cause paragraph predicted.
Graduating the budget is therefore back on the table, but in its own PR with its
own panel — nothing in *this* PR changes a default.

Two source reviews (against `ref/HiGHS/` and `ref/scipoptsuite-10.0.2/`) read
that regression the same way and independently: it is a cut **lifecycle**
failure, not a cut **quality** failure. Neither reference solver carries root
cuts forever — HiGHS ages basic cut rows out at `mip_lp_age_limit`
(`HighsLpRelaxation.cpp:595-642`) and drops basic cut rows after the root
(`:522-539`); SCIP has no root round budget at all (`maxroundsroot = -1`,
`set.c:471`) and stops on stalling instead, with dynamic rows removed after
`rowagelimit` LPs nonbasic (`set.c:263`).

SCIP in fact does precisely what this PR adds, by default:
`SCIP_DEFAULT_LP_CLEANUPROWSROOT = TRUE` (`set.c:268`) removes new **basic** rows
after the root LP — the same rows this cleanup drops, on the same argument. That
is prior art for the soundness claim above. `CLEANUPROWS = TRUE` (`:267`) extends
it to every LP; that half is Stage 1 of
`docs/dev/milp-competitiveness-plan.md`, added here, and is not in this PR.

### Methodology note carried forward

That panel gave discopt `gap_tol = 1e-6` against HiGHS's default
`mip_rel_gap = 1e-4` — a 100× tighter stopping rule. It does not change the
conclusion above (all four discopt arms ran at the same tolerance), but it does
inflate the discopt-vs-HiGHS column: at matched 1e-4, `neos-1425699` goes from
640,669 nodes unsolved to **29 nodes / 0.00 s**. Later panels run matched.

## Also in this PR

`docs/dev/milp-competitiveness-plan.md` — the evidence-grounded roadmap that
replaces "raise the cut budget", including the primal/dual decomposition of
base's 20 failures, a HiGHS self-ablation showing presolve ≤2 instances and
symmetry 0 on this panel, and the argument for why the prior CUT-1/CUTS-1 NO-GO
(`certification-gap-plan.md`) does not automatically transfer from the MINLP
class to pure MILP — stated as a precondition to test, not an assumption.

It also carries the plan's first measurement, run before this PR opened. Stage 0
is "flip the switches that already exist and ship off"; the HiGHS review expected
`node_propagation=true` to be worth 3-6 instances. Measured over the same 38
instances at matched `gap_tol=1e-4`, TL = 20 s, 114/114 runs, zero certification
aborts:

| arm | solved | wall | med(solved) | nodes |
|---|---|---|---|---|
| base | 19/38 | 413.62 s | 0.101 s | 8,969,820 |
| nodeprop | 19/38 | 395.90 s | 0.081 s | 7,838,764 |
| highs | 38/38 | 66.35 s | 0.959 s | 15,417 |

**It gains zero instances** — that prediction is falsified and recorded as such.
It is still worth −12.6 % nodes and −20 % median time, with 5-11× wins on
`flugpl`, `enlight8`, `gt2` and `bppc8-02`, so it graduates ON in a separate,
one-line PR with this panel behind it. Not flipped here. (Machine load rose 2.85
→ 13.84 mid-run, so the wall column is soft; node counts are load-independent and
carry the conclusion, and arms rotated per instance.)

The useful part is what it rules *out*. Sixteen of the 38 instances HiGHS closes
in **one node** — root LP plus root cuts plus root heuristics both producing the
optimum and proving it, where discopt spends 350 k-870 k nodes.

### Correction to an earlier retraction in this body

This section previously retracted the phrase "the gap is a **root-strength**
problem" and replaced it with a primal/dual/proof split claiming "8 of 17 failures
already hold a dual bound within ~5 % and still cannot close." **That replacement
was wrong and is itself retracted** (CLAUDE.md §11). It classified failures with an
arbitrary 5 % threshold that has nothing to do with the solver's actual stopping
rule, and I published it without checking it against that rule.

Re-derived against the real tolerance (`gap_tol = 1e-4`), over the 17 instances
still unsolved at the strongest arm of the successor panel:

| class | count | meaning |
|---|---|---|
| dual gap already within `gap_tol` | **0** | no pruning/mechanics failure exists |
| PURE-BOUND (incumbent optimal, only bound missing) | 3 | `b-ball` 4.5e-4, `istra` 9.0e-3, `iskar` 1.0e-2 |
| BOTH SHORT (bound and incumbent) | 14 | dual 4.6e-3 … 1.0; primal 22 % … no feasible point |

**The bound is short on 17 of 17. The incumbent is additionally short on 14 of 17.**

The specific claim I made about `b-ball` — "dual gap 0.045 %, optimal incumbent in
hand, 200,839 nodes vs HiGHS's 1, therefore bounding/pruning mechanics" — is false.
Its bound is `-1.500672636` against an optimum of `-1.5`, a relative dual gap of
`4.484e-4` against a `1e-4` tolerance. The solver has *not* converged; it is
behaving correctly and is short by a factor of ~4.5 in bound. Nothing about
pruning is implicated, on that instance or any other on this panel.

So the original "root-strength" framing was substantially right and my first
retraction over-corrected. The accurate statement is narrower than either: this is
a **bound-strength** problem — root or in-tree — on every failing instance, with a
primal-heuristic problem layered on top of 14 of them. Bound work is necessary
everywhere; primal work is necessary on 14 and sufficient on none, since no
instance closes without the bound arriving too.

## Verification

- `cargo test -p discopt-core` — 677 passed, 0 failed.
- New tests: `the_root_cut_cleanup_drops_slack_cuts_without_moving_the_optimum`,
  `the_rebuild_places_a_cut_coefficient_on_an_earlier_cuts_slack`, and the
  `profile::begin_solve` reset-hazard regression test. Each fails before the
  corresponding change.
- Full CI on this PR is green: Rust, Python fast, Python correctness (fast
  subset), Python AMP coverage, claim-boundary, lint + typecheck, codecov
  patch/project.
- `pytest -m smoke` (1165 passed, 1 skipped, 2 xpassed) and `pytest -m slow
  python/tests/test_adversarial_recent_fixes.py` (19 passed) were run locally on
  the **successor branch** `fix/milp-cuts-structural-space`, which contains this
  PR's commit plus the structural-space fix — so they cover this change but are
  not an isolated measurement of it. This PR's own isolated evidence is the CI
  run above.
- Corpus gate: the 38-instance MIPLIB panel above, 190/190 runs, no false bound
  and no wrong optimal on any arm.

Contributes to the MILP competitiveness work; closes nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014E81XM1j2J5sydzj9nFFFp
