### PR TITLE
perf(milp): A0 graduate the root cut budget to default-ON

### DIFF
--- a/crates/discopt-core/examples/milp_bench.rs
+++ b/crates/discopt-core/examples/milp_bench.rs
@@ -162,6 +162,8 @@ fn opts(n_struct: usize, integer_cols: Vec<usize>, tl: f64) -> MilpOptions {
         initial_incumbent: None,
         node_hook_rounds: 0,
         node_hook_cut_cap: 0,
+        root_cut_time_s: None,
+        root_cut_prune: true,
         simplex: SimplexOptions {
             tol: 1e-9,
             max_iter: 100_000,

--- a/crates/discopt-core/examples/par_bench.rs
+++ b/crates/discopt-core/examples/par_bench.rs
@@ -126,6 +126,8 @@ fn opts(inst: &Instance) -> MilpOptions {
         initial_incumbent: None,
         node_hook_rounds: 0,
         node_hook_cut_cap: 0,
+        root_cut_time_s: None,
+        root_cut_prune: true,
         simplex: SimplexOptions {
             tol: 1e-9,
             max_iter: 100_000,

--- a/crates/discopt-core/src/bnb/milp_driver.rs
+++ b/crates/discopt-core/src/bnb/milp_driver.rs
@@ -447,6 +447,47 @@ pub struct MilpOptions {
     /// the budget is spent the hook stops being called and the search runs on the
     /// relaxation it has.
     pub node_hook_cut_cap: usize,
+    /// Wall-clock ceiling for the ROOT CUT LOOP alone, in seconds.
+    ///
+    /// `None` (the value at every existing call site) leaves the loop bounded
+    /// only by `root_cuts` / `cut_rounds` / tailing-off, exactly as before.
+    ///
+    /// A value makes a many-round configuration safe to ask for. Raising
+    /// `cut_rounds` is how a weak root relaxation gets closed — on a lot-sizing
+    /// model the default single pass leaves the root bound at a fraction of the
+    /// optimum — but the separation phase is worth several seconds only if it
+    /// still leaves time to branch. This is the knob that says how much of the
+    /// budget the root may spend, so the round cap can be set by what the model
+    /// needs rather than by what a worst case can afford.
+    ///
+    /// Checked at the top of each round, so a round already in flight always
+    /// completes and the loop never abandons a partially augmented matrix. It
+    /// therefore bounds *entry* into rounds, not the duration of one round; a
+    /// single very slow round can still overrun it, bounded in turn by
+    /// `time_limit_s` through the LP's own deadline.
+    ///
+    /// This is not the ceiling on the whole solve -- that stays `time_limit_s`,
+    /// which the loop also honors (see the guard at the top of the round).
+    pub root_cut_time_s: Option<f64>,
+
+    /// Drop root cuts that are slack at the final root LP before the tree starts.
+    ///
+    /// Every root cut rides in every node LP for the rest of the solve. A cut that
+    /// is not tight at the root optimum has a zero dual multiplier there, so
+    /// removing it leaves the root bound and its certificate untouched while
+    /// taking a row out of every node — the measured cost of NOT doing this is
+    /// severe (30-instance MILP panel, `root_cuts=500, cut_rounds=50`: node counts
+    /// fell 2.4x but total wall rose from 103 s to 145 s, and `cflp_s101` went
+    /// from 0.04 s to 5.85 s at an unchanged node count).
+    ///
+    /// Deeper nodes may get a weaker bound than they would with the full set —
+    /// this is bound-CHANGING under CLAUDE.md §5, never bound-INVALIDATING, since
+    /// what remains is a subset of globally valid cuts. Kept as a switch so the
+    /// two can be measured against each other in one interleaved process.
+    ///
+    /// Inert unless `cut_rounds > 1`: with a single round every cut was separated
+    /// off the one root solve and is violated there, so nothing is ever slack.
+    pub root_cut_prune: bool,
     /// LP solver options.
     pub simplex: SimplexOptions,
 }
@@ -610,8 +651,7 @@ pub fn solve_milp_node_hooked(
     } else {
         node
     };
-    crate::profile::init_from_env();
-    crate::profile::reset();
+    crate::profile::begin_solve();
     let ns = opts.n_struct;
     let is_int = {
         let mut v = vec![false; ns];
@@ -876,13 +916,54 @@ pub fn solve_milp_node_hooked(
     // (`n_w`) it was computed at. Reused to warm-start the root B&B node so it does
     // not re-derive the augmented LP from a cold slack basis. See `root_warm_basis`.
     let mut root_basis: Option<(Basis, usize)> = None;
+    // Snapshot of the matrix as it stood before any root cut, kept so the cut
+    // cleanup after the loop can rebuild from it with a subset of the cuts. Only
+    // taken when more than one round can run: with `cut_rounds == 1` every cut is
+    // separated off the single root solve and is violated there by construction,
+    // so the cleanup below provably keeps all of them and the clone would be pure
+    // cost. (`cut_rounds == 1` is the shipped default.)
+    let prune_base: Option<(SparseCols, usize, usize)> =
+        if opts.root_cut_prune && opts.root_cuts > 0 && opts.cut_rounds > 1 {
+            Some((csc_w.clone(), m_w, n_w))
+        } else {
+            None
+        };
+    let mut all_root_cuts: Vec<GomoryCut> = Vec::new();
+    let mut last_root_x: Option<Vec<f64>> = None;
     if opts.root_cuts > 0 {
         let _t = crate::profile::Timer::new(crate::profile::Phase::RootCutLoop);
         let mut total_cuts = 0usize;
         let mut prev_obj = f64::NEG_INFINITY;
+        // Wall bound for the separation phase: the earlier of the caller's own
+        // deadline and the (optional) root-cut sub-budget. Checked at the top of
+        // each round -- a round in flight always finishes, so the loop never
+        // leaves a half-augmented matrix behind.
+        //
+        // `root_cut_time_s` is the substantive half: it is the only thing that
+        // stops a high `cut_rounds` from spending the whole budget separating.
+        //
+        // The `deadline` half is a cheap early exit, NOT a fix for an overrun.
+        // The loop already stopped at the caller's deadline indirectly: each
+        // round's root LP carries `node_simplex.deadline`, and a deadline-aborted
+        // LP comes back non-`Optimal`, which breaks the loop below. Testing the
+        // clock here just skips mounting a round whose LP would abort anyway,
+        // along with the separation work that would follow it.
+        let root_cut_deadline: Option<std::time::Instant> = match (deadline, opts.root_cut_time_s) {
+            (Some(dl), Some(rc)) => {
+                Some(dl.min(t_start + std::time::Duration::from_secs_f64(rc.max(0.0))))
+            }
+            (Some(dl), None) => Some(dl),
+            (None, Some(rc)) => Some(t_start + std::time::Duration::from_secs_f64(rc.max(0.0))),
+            (None, None) => None,
+        };
         for _round in 0..opts.cut_rounds {
             if total_cuts >= opts.root_cuts {
                 break;
+            }
+            if let Some(dl) = root_cut_deadline {
+                if std::time::Instant::now() >= dl {
+                    break;
+                }
             }
             crate::profile::incr(crate::profile::Ctr::RootCutRounds);
             let root = {
@@ -962,6 +1043,9 @@ pub fn solve_milp_node_hooked(
             // if more cuts are appended below it is extended to the new size after
             // the loop. The clone is cheap next to the solve it came from.
             root_basis = Some((root.basis.clone(), n_w));
+            if prune_base.is_some() {
+                last_root_x = Some(root.x.clone());
+            }
             // Tailing off: stop once added cuts barely move the bound.
             if root.obj <= prev_obj + 1e-7 * (1.0 + prev_obj.abs()) && prev_obj > f64::NEG_INFINITY
             {
@@ -1030,8 +1114,123 @@ pub fn solve_milp_node_hooked(
             csc_w = nw_csc;
             m_w = nm;
             n_w = nn;
+            if prune_base.is_some() {
+                all_root_cuts.extend(new_cuts);
+            }
         }
     }
+
+    // --- Root cut cleanup: keep only the cuts the root LP actually leans on ---
+    //
+    // Every cut generated above rides in *every* node LP for the rest of the
+    // solve. Across 50 rounds that is hundreds of extra rows, and the measured
+    // cost is severe: on the cflp family the 500-cut budget turned a 0.04 s solve
+    // into 31 s while the bound was no better. But a cut that is *slack* at the
+    // final root solution contributed nothing to the root bound, and dropping it
+    // is provably bound-neutral there: its dual multiplier is zero, so the root
+    // optimum and its KKT certificate survive the row's removal unchanged. Deeper
+    // in the tree a dropped cut could have become tight, so the node bounds may
+    // differ — weaker, never invalid, since the remaining rows are still globally
+    // valid cuts. This is a bound-CHANGING change under CLAUDE.md #5.
+    //
+    // A GMI cut's coefficients span the slack columns of the cuts before it, so a
+    // cut can only be dropped if nothing kept depends on it; the reverse sweep
+    // closes that dependency set before anything is removed.
+    if let (Some((csc_base, m_base, n_base)), Some(x)) = (prune_base.as_ref(), last_root_x.as_ref())
+    {
+        let (m_base, n_base) = (*m_base, *n_base);
+        let mut keep = vec![false; all_root_cuts.len()];
+        for ci in (0..all_root_cuts.len()).rev() {
+            let cut = &all_root_cuts[ci];
+            // `coeffs · x >= rhs`; the surplus is the amount by which the final
+            // root solution over-satisfies the cut. Cuts separated after the last
+            // solve have a negative surplus there (they were violated, which is
+            // why they were separated) and are always kept.
+            let act: f64 = cut
+                .coeffs
+                .iter()
+                .enumerate()
+                .take(x.len())
+                .map(|(j, &a)| a * x[j])
+                .sum();
+            let tight = act - cut.rhs <= 1e-6 * (1.0 + cut.rhs.abs());
+            if tight || keep[ci] {
+                keep[ci] = true;
+                for (j, &a) in cut.coeffs.iter().enumerate() {
+                    if a != 0.0 && j >= n_base {
+                        let dep = j - n_base;
+                        // A cut only ever sees the slacks of cuts before it, so
+                        // `dep < ci` and the reverse sweep still has it ahead.
+                        if dep < ci {
+                            keep[dep] = true;
+                        }
+                    }
+                }
+            }
+        }
+        let n_keep = keep.iter().filter(|&&k| k).count();
+        crate::profile::incr_by(
+            crate::profile::Ctr::RootCutsGenerated,
+            all_root_cuts.len() as u64,
+        );
+        crate::profile::incr_by(crate::profile::Ctr::RootCutsKept, n_keep as u64);
+        if n_keep < all_root_cuts.len() {
+            let mut newidx = vec![usize::MAX; all_root_cuts.len()];
+            let mut next = 0usize;
+            for (c, &k) in keep.iter().enumerate() {
+                if k {
+                    newidx[c] = next;
+                    next += 1;
+                }
+            }
+            let kept: Vec<GomoryCut> = all_root_cuts
+                .iter()
+                .enumerate()
+                .filter(|(c, _)| keep[*c])
+                .map(|(_, cut)| {
+                    let mut coeffs = vec![0.0; n_base + n_keep];
+                    for (j, &a) in cut.coeffs.iter().enumerate() {
+                        if a == 0.0 {
+                            continue;
+                        }
+                        if j < n_base {
+                            coeffs[j] = a;
+                        } else {
+                            // Kept by the dependency closure above; indexing a
+                            // `usize::MAX` here would panic rather than corrupt.
+                            coeffs[n_base + newidx[j - n_base]] = a;
+                        }
+                    }
+                    GomoryCut {
+                        coeffs,
+                        rhs: cut.rhs,
+                    }
+                })
+                .collect();
+            b_w.truncate(m_base);
+            c_w.truncate(n_base);
+            l_w.truncate(n_base);
+            u_w.truncate(n_base);
+            is_int_full.truncate(n_base);
+            for cut in &kept {
+                b_w.push(cut.rhs);
+                c_w.push(0.0);
+                l_w.push(0.0);
+                u_w.push(INF);
+                is_int_full.push(false);
+            }
+            csc_w = rebuild_csc_with_cuts(csc_base, m_base, n_base, &kept);
+            m_w = m_base + kept.len();
+            n_w = n_base + kept.len();
+            // The stored basis indexes the pre-cleanup matrix (dropped rows'
+            // slacks are basic in it, by definition of being slack), so it cannot
+            // be extended onto the smaller one. The root node cold-solves the
+            // reduced LP instead -- cheaper than the solve that produced the
+            // basis, and far cheaper than carrying the dropped rows all tree.
+            root_basis = None;
+        }
+    }
+
     let mut slack_l = l_w[ns..].to_vec();
     let mut slack_u = u_w[ns..].to_vec();
 
@@ -2749,6 +2948,73 @@ fn augment_cols_with_cuts(sp: &SparseCols, m: usize, n: usize, cuts: &[GomoryCut
     SparseCols::from_csc(new_col_ptr, new_row_idx, new_vals)
 }
 
+/// Rebuild the pre-cut matrix with an explicit, ordered subset of root cuts.
+///
+/// [`augment_cols_with_cuts`] appends a *batch* of cuts to a matrix whose column
+/// count already covers every column those cuts reference; it scans `j in 0..n`
+/// and therefore cannot place a coefficient that lands on a slack column the same
+/// call is creating. That is sound for the root loop, where a round's cuts are
+/// separated off the matrix as it stood *before* the round. It is not sound for a
+/// rebuild: a GMI cut's coefficient vector spans all columns of the LP it was read
+/// off, cut slacks included, so replaying round 7's cuts onto the original matrix
+/// would silently drop their coefficients on rounds 1-6's slack columns and leave
+/// a *different, unjustified* row in the LP.
+///
+/// This builds the whole augmented matrix in one pass instead. `cuts[i].coeffs`
+/// may reference any column `< n_base + i` — the original columns plus the slacks
+/// of the cuts before it — and every such coefficient is placed. Cuts referencing
+/// a *dropped* cut's slack are the caller's problem: it must have closed the
+/// dependency set first (see the cleanup in `solve_milp`).
+fn rebuild_csc_with_cuts(
+    base: &SparseCols,
+    m_base: usize,
+    n_base: usize,
+    cuts: &[GomoryCut],
+) -> SparseCols {
+    let k = cuts.len();
+    if k == 0 {
+        return base.clone();
+    }
+    let (col_ptr, row_idx, vals) = base.raw();
+    let mut new_col_ptr: Vec<usize> = Vec::with_capacity(n_base + k + 1);
+    let mut new_row_idx: Vec<usize> = Vec::with_capacity(row_idx.len() + n_base * k + k);
+    let mut new_vals: Vec<f64> = Vec::with_capacity(vals.len() + n_base * k + k);
+    new_col_ptr.push(0);
+    // Original columns: their base entries (rows 0..m_base) then their coefficient
+    // in each cut row (rows m_base.., strictly greater, so rows stay sorted).
+    for j in 0..n_base {
+        for idx in col_ptr[j]..col_ptr[j + 1] {
+            new_row_idx.push(row_idx[idx]);
+            new_vals.push(vals[idx]);
+        }
+        for (ci, cut) in cuts.iter().enumerate() {
+            if let Some(&v) = cut.coeffs.get(j) {
+                if v != 0.0 {
+                    new_row_idx.push(m_base + ci);
+                    new_vals.push(v);
+                }
+            }
+        }
+        new_col_ptr.push(new_row_idx.len());
+    }
+    // Cut slack columns: the surplus `-1` on the cut's own row, then any later
+    // cut's coefficient on this slack (again a strictly greater row index).
+    for c in 0..k {
+        new_row_idx.push(m_base + c);
+        new_vals.push(-1.0);
+        for (ci, cut) in cuts.iter().enumerate().skip(c + 1) {
+            if let Some(&v) = cut.coeffs.get(n_base + c) {
+                if v != 0.0 {
+                    new_row_idx.push(m_base + ci);
+                    new_vals.push(v);
+                }
+            }
+        }
+        new_col_ptr.push(new_row_idx.len());
+    }
+    SparseCols::from_csc(new_col_ptr, new_row_idx, new_vals)
+}
+
 /// Full CSC analogue of [`augment_with_cuts`] (T3b5): augment the matrix via
 /// [`augment_cols_with_cuts`] AND append the `k` surplus rows/cols to
 /// `b/c/l/u/is_int` exactly as the dense version does. Returns the grown CSC and new
@@ -3574,6 +3840,8 @@ mod tests {
             initial_incumbent: None,
             node_hook_rounds: 0,
             node_hook_cut_cap: 0,
+            root_cut_time_s: None,
+            root_cut_prune: true,
             simplex: SimplexOptions::default(),
         }
     }
@@ -3934,6 +4202,8 @@ mod tests {
             initial_incumbent: None,
             node_hook_rounds: 0,
             node_hook_cut_cap: 0,
+            root_cut_time_s: None,
+            root_cut_prune: true,
             simplex: SimplexOptions::default(),
         }
     }
@@ -4337,15 +4607,16 @@ mod tests {
         let r_ref = solve_milp(&lp, &b, 0.0, &o_ref);
         assert_eq!(r_ref.status, MilpStatus::Optimal);
 
-        // The driver calls `profile::init_from_env()` on entry, which overwrites a
-        // bare `set_enabled(true)` with "is DISCOPT_PROFILE set?" -- so arming the
-        // counters here means arming the env var, under TEST_LOCK.
-        std::env::set_var("DISCOPT_PROFILE", "1");
+        // `set_enabled(true)` raises the test override, which keeps both halves of
+        // the driver's `profile::begin_solve()` -- the env re-arm and the per-solve
+        // counter reset -- from touching this measurement, on this thread or a
+        // sibling's. Setting `DISCOPT_PROFILE` process-wide from a threaded test
+        // (the old way here) armed every concurrent solve as well.
+        crate::profile::set_enabled(true);
         crate::profile::reset();
         let r = solve_milp(&lp, &b, 0.0, &o);
         let rounds = crate::profile::counter(crate::profile::Ctr::RootCutRounds);
         let warm_reopt = crate::profile::counter(crate::profile::Ctr::RootCutWarmReopt);
-        std::env::remove_var("DISCOPT_PROFILE");
         crate::profile::set_enabled(false);
         assert_eq!(r.status, MilpStatus::Optimal);
         assert!(
@@ -4554,6 +4825,8 @@ mod tests {
             initial_incumbent: None,
             node_hook_rounds: 0,
             node_hook_cut_cap: 0,
+            root_cut_time_s: None,
+            root_cut_prune: true,
             simplex: SimplexOptions::default(),
         };
         let r = solve_milp(&lp, &b, 0.0, &o);
@@ -4684,6 +4957,8 @@ mod sparse_milp_diff {
                 initial_incumbent: None,
                 node_hook_rounds: 0,
                 node_hook_cut_cap: 0,
+                root_cut_time_s: None,
+                root_cut_prune: true,
                 simplex: SimplexOptions::default(),
             }
         }
@@ -4979,6 +5254,8 @@ mod sparse_milp_diff {
             initial_incumbent: None,
             node_hook_rounds: 0,
             node_hook_cut_cap: 0,
+            root_cut_time_s: None,
+            root_cut_prune: true,
             simplex: SimplexOptions::default(),
         };
         let r = solve_milp(&lp, &[10.0, 9.0], 0.0, &o);
@@ -5269,6 +5546,8 @@ mod lazy_separation {
                 initial_incumbent: None,
                 node_hook_rounds: 0,
                 node_hook_cut_cap: 0,
+                root_cut_time_s: None,
+                root_cut_prune: true,
                 simplex: SimplexOptions::default(),
             }
         }
@@ -5562,6 +5841,8 @@ mod node_separation {
                 initial_incumbent: None,
                 node_hook_rounds: rounds,
                 node_hook_cut_cap: cap,
+                root_cut_time_s: None,
+                root_cut_prune: true,
                 simplex: SimplexOptions::default(),
             }
         }
@@ -5838,6 +6119,8 @@ mod lazy_infeasible_node {
             initial_incumbent: None,
             node_hook_rounds: 0,
             node_hook_cut_cap: 0,
+            root_cut_time_s: None,
+            root_cut_prune: true,
             simplex: SimplexOptions::default(),
         }
     }
@@ -5906,5 +6189,282 @@ mod lazy_infeasible_node {
             "separator never ran on a FEASIBLE model; the guard above proves nothing"
         );
         let _ = r;
+    }
+}
+
+/// Tests for the root-cut wall bound (`MilpOptions::root_cut_time_s`) and for the
+/// root cut loop's newly-honored `time_limit_s` deadline.
+#[cfg(test)]
+mod root_cut_budget_tests {
+    use super::*;
+
+    /// A 0/1 knapsack big enough that cover/GMI cuts at the root measurably
+    /// shrink the tree — the differential the tests below read.
+    ///
+    /// `max Σ p_j x_j  s.t.  Σ w_j x_j ≤ cap`, written in the driver's minimize
+    /// form with one surplus column.
+    fn knapsack(
+        n: usize,
+    ) -> (
+        SparseCols,
+        usize,
+        usize,
+        Vec<f64>,
+        Vec<f64>,
+        Vec<f64>,
+        Vec<f64>,
+    ) {
+        // Deterministic pseudo-random weights/profits (no rng dependency): the
+        // pattern is arbitrary but fixed, so node counts are reproducible.
+        let w: Vec<f64> = (0..n).map(|j| (7 * j % 23 + 11) as f64).collect();
+        let p: Vec<f64> = (0..n).map(|j| (13 * j % 29 + 17) as f64).collect();
+        let cap: f64 = w.iter().sum::<f64>() / 2.0;
+        let mut dense = vec![0.0; n + 1];
+        dense[..n].copy_from_slice(&w);
+        dense[n] = 1.0; // slack:  Σ w x + s = cap,  s ≥ 0
+        let sp = SparseCols::from_dense(&dense, 1, n + 1);
+        let c: Vec<f64> = p.iter().map(|v| -v).chain(std::iter::once(0.0)).collect();
+        let l = vec![0.0; n + 1];
+        let mut u = vec![1.0; n + 1];
+        u[n] = INF;
+        (sp, 1, n, c, vec![cap], l, u)
+    }
+
+    fn budget_opts(ns: usize, root_cut_time_s: Option<f64>) -> MilpOptions {
+        MilpOptions {
+            n_struct: ns,
+            integer_cols: (0..ns).collect(),
+            max_nodes: 200_000,
+            time_limit_s: None,
+            gap_tol: 1e-9,
+            root_cuts: 200,
+            cut_rounds: 30,
+            gmi_cuts: true,
+            cut_select: true,
+            node_cuts: false,
+            max_pool_cuts: 500,
+            heuristics: true,
+            presolve: true,
+            strong_branch: true,
+            node_propagation: false,
+            reduced_cost_fixing: true,
+            sb_max_cands: 8,
+            sb_node_budget: 1024,
+            initial_incumbent: None,
+            node_hook_rounds: 0,
+            node_hook_cut_cap: 0,
+            root_cut_time_s,
+            root_cut_prune: true,
+            simplex: SimplexOptions::default(),
+        }
+    }
+
+    /// The budget really gates the separation phase, and gating it is visible.
+    ///
+    /// Same instance, same everything else: `root_cut_time_s: Some(0.0)` expires
+    /// before the first round is entered, so no root cuts are separated. The
+    /// cut-strengthened arm closes the 40-item knapsack at the root (1 node); the
+    /// budgeted-out arm has to branch (9 nodes). That strict inequality is the
+    /// anti-vacuity check (CLAUDE.md §6) -- if the budget were ignored both arms
+    /// would separate cuts and the node counts would be equal.
+    #[test]
+    fn a_zero_root_cut_budget_skips_the_separation_phase() {
+        let (sp, m, ns, c, b, l, u) = knapsack(40);
+        let n = l.len();
+        let full = solve_milp_csc(&sp, m, n, &c, &l, &u, &b, 0.0, &budget_opts(ns, None));
+        let zero = solve_milp_csc(&sp, m, n, &c, &l, &u, &b, 0.0, &budget_opts(ns, Some(0.0)));
+
+        assert_eq!(
+            full.status,
+            MilpStatus::Optimal,
+            "unbudgeted arm must certify"
+        );
+        assert_eq!(
+            zero.status,
+            MilpStatus::Optimal,
+            "budgeted arm must certify"
+        );
+        assert!(
+            zero.nodes > full.nodes,
+            "the root-cut budget did not gate the loop: {} nodes with cuts, {} without \
+             -- an equal count means both arms separated and the test proves nothing",
+            full.nodes,
+            zero.nodes
+        );
+    }
+
+    /// Gating the cuts must not change the ANSWER. The budget trades search
+    /// effort for wall time; a different optimum, or a dual bound above it, would
+    /// mean the loop is load-bearing for correctness rather than for speed
+    /// (CLAUDE.md §1).
+    #[test]
+    fn the_root_cut_budget_never_changes_the_certified_optimum() {
+        for n_items in [40usize, 300] {
+            let (sp, m, ns, c, b, l, u) = knapsack(n_items);
+            let n = l.len();
+            let full = solve_milp_csc(&sp, m, n, &c, &l, &u, &b, 0.0, &budget_opts(ns, None));
+            let zero = solve_milp_csc(&sp, m, n, &c, &l, &u, &b, 0.0, &budget_opts(ns, Some(0.0)));
+            assert_eq!(full.status, MilpStatus::Optimal, "n={n_items}");
+            assert_eq!(zero.status, MilpStatus::Optimal, "n={n_items}");
+            assert!(
+                (full.obj - zero.obj).abs() < 1e-6,
+                "n={n_items}: budgeted arm found {} but unbudgeted found {}",
+                zero.obj,
+                full.obj
+            );
+            for (name, r) in [("unbudgeted", &full), ("budgeted", &zero)] {
+                assert!(
+                    r.bound <= r.obj + 1e-6,
+                    "n={n_items} {name}: dual bound {} above incumbent {} -- false \
+                     certificate",
+                    r.bound,
+                    r.obj
+                );
+            }
+        }
+    }
+
+    /// A budget larger than the separation phase needs is a no-op: the loop runs
+    /// to its natural stop (cut cap / tailing off) and the tree is the same size
+    /// as with no budget at all. Without this the test above could pass with a
+    /// budget that always expires, which would make the option useless rather
+    /// than working.
+    #[test]
+    fn a_generous_root_cut_budget_is_indistinguishable_from_none() {
+        let (sp, m, ns, c, b, l, u) = knapsack(300);
+        let n = l.len();
+        let none = solve_milp_csc(&sp, m, n, &c, &l, &u, &b, 0.0, &budget_opts(ns, None));
+        let generous = solve_milp_csc(
+            &sp,
+            m,
+            n,
+            &c,
+            &l,
+            &u,
+            &b,
+            0.0,
+            &budget_opts(ns, Some(600.0)),
+        );
+        assert_eq!(none.status, generous.status);
+        assert_eq!(
+            none.nodes, generous.nodes,
+            "a 600 s budget must not perturb a separation phase that takes \
+             milliseconds"
+        );
+        assert!((none.obj - generous.obj).abs() < 1e-12);
+    }
+
+    /// Densify a CSC for element-wise comparison in the tests below.
+    fn dense_of(sp: &SparseCols, m: usize, n: usize) -> Vec<f64> {
+        let mut d = vec![0.0; m * n];
+        for j in 0..n {
+            let (rows, vals) = sp.col(j);
+            for (&r, &v) in rows.iter().zip(vals) {
+                d[r * n + j] = v;
+            }
+        }
+        d
+    }
+
+    /// The whole reason `rebuild_csc_with_cuts` exists: a GMI cut's coefficient
+    /// vector spans the slack columns of the cuts before it, and the batch
+    /// appender cannot place those.
+    ///
+    /// Two cuts on a 1x2 base; the second has a coefficient on the FIRST cut's
+    /// surplus column (`n_base + 0`). The rebuild must carry it. The assertion
+    /// against `augment_cols_with_cuts` on the same input is the anti-vacuity
+    /// half (CLAUDE.md §6): it pins that the two functions genuinely differ here,
+    /// so a future "simplification" back to the batch appender fails loudly
+    /// instead of silently installing a different row.
+    #[test]
+    fn the_rebuild_places_a_cut_coefficient_on_an_earlier_cuts_slack() {
+        let base = SparseCols::from_dense(&[2.0, 3.0], 1, 2);
+        let (m_base, n_base) = (1usize, 2usize);
+        let cuts = vec![
+            GomoryCut {
+                coeffs: vec![1.0, 1.0],
+                rhs: 1.0,
+            },
+            GomoryCut {
+                // ... plus 0.5 * (cut 0's surplus), column n_base + 0 == 2.
+                coeffs: vec![1.0, 0.0, 0.5],
+                rhs: 0.25,
+            },
+        ];
+        let m_new = m_base + 2;
+        let n_new = n_base + 2;
+
+        let rebuilt = dense_of(
+            &rebuild_csc_with_cuts(&base, m_base, n_base, &cuts),
+            m_new,
+            n_new,
+        );
+        // row 0: the base row, no surplus columns
+        assert_eq!(&rebuilt[0..4], &[2.0, 3.0, 0.0, 0.0]);
+        // row 1: cut 0 with its own -1 surplus
+        assert_eq!(&rebuilt[4..8], &[1.0, 1.0, -1.0, 0.0]);
+        // row 2: cut 1, including the 0.5 on cut 0's surplus column
+        assert_eq!(&rebuilt[8..12], &[1.0, 0.0, 0.5, -1.0]);
+
+        let batched = dense_of(
+            &augment_cols_with_cuts(&base, m_base, n_base, &cuts),
+            m_new,
+            n_new,
+        );
+        assert_eq!(
+            batched[8 + 2],
+            0.0,
+            "augment_cols_with_cuts is expected to DROP the cross-slack coefficient \
+             (it only scans j < n_base); if it now keeps it, rebuild_csc_with_cuts \
+             is redundant and this test is no longer proving anything"
+        );
+    }
+
+    /// The cleanup must remove cuts, and removing them must not move the answer.
+    ///
+    /// A 300-item knapsack under a 200-cut / 30-round budget separates far more
+    /// cuts than the final root LP leans on. The counters make the drop visible
+    /// (CLAUDE.md §6 -- without the strict `kept < generated` this test would pass
+    /// on a cleanup that never fired), and the certified optimum is compared
+    /// against the same solve with the separation phase budgeted out entirely.
+    #[test]
+    fn the_root_cut_cleanup_drops_slack_cuts_without_moving_the_optimum() {
+        let _g = crate::profile::test_guard();
+        let (sp, m, ns, c, b, l, u) = knapsack(300);
+        let n = l.len();
+
+        let reference = solve_milp_csc(&sp, m, n, &c, &l, &u, &b, 0.0, &budget_opts(ns, Some(0.0)));
+
+        crate::profile::set_enabled(true);
+        crate::profile::reset();
+        let cut = solve_milp_csc(&sp, m, n, &c, &l, &u, &b, 0.0, &budget_opts(ns, None));
+        let generated = crate::profile::counter(crate::profile::Ctr::RootCutsGenerated);
+        let kept = crate::profile::counter(crate::profile::Ctr::RootCutsKept);
+        crate::profile::set_enabled(false);
+
+        assert!(
+            generated > 0,
+            "no root cuts were separated -- the cleanup had nothing to act on and \
+             this test is vacuous"
+        );
+        assert!(
+            kept < generated,
+            "cleanup kept all {generated} root cuts; it never removed a row, so the \
+             per-node cost it exists to avoid is still being paid"
+        );
+        assert_eq!(cut.status, MilpStatus::Optimal);
+        assert_eq!(reference.status, MilpStatus::Optimal);
+        assert!(
+            (cut.obj - reference.obj).abs() < 1e-6,
+            "cleanup changed the optimum: {} vs {}",
+            cut.obj,
+            reference.obj
+        );
+        assert!(
+            cut.bound <= cut.obj + 1e-6,
+            "dual bound {} above incumbent {} after cleanup -- false certificate",
+            cut.bound,
+            cut.obj
+        );
     }
 }

--- a/crates/discopt-core/src/bnb/milp_driver.rs
+++ b/crates/discopt-core/src/bnb/milp_driver.rs
@@ -39,6 +39,15 @@ const CUT_MIN_EFFICACY: f64 = 1e-4;
 /// Drop a candidate cut whose direction is more than this parallel (|cos|) to an
 /// already-selected cut — keeps the kept set spanning diverse faces.
 const CUT_MAX_PARALLEL: f64 = 0.99;
+/// Nonzero ceiling for a cut once its slack coefficients have been expanded into
+/// structural ones, as `CUT_LEN_BASE + CUT_LEN_FRAC * n_struct`. Expanding a slack
+/// pulls in that row's whole support, so the rewrite can inflate a short tableau
+/// cut into a long row that then rides in every node LP. Same shape and constants
+/// as HiGHS's post-`untransform` limit (`HighsCutGeneration.cpp:982`): a generous
+/// fixed allowance so small models are not over-constrained, plus a fraction that
+/// scales with the model.
+const CUT_LEN_BASE: usize = 100;
+const CUT_LEN_FRAC: f64 = 0.15;
 
 /// Terminal status of a MILP solve.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -930,6 +939,15 @@ pub fn solve_milp_node_hooked(
         };
     let mut all_root_cuts: Vec<GomoryCut> = Vec::new();
     let mut last_root_x: Option<Vec<f64>> = None;
+    // Row-major view of the pre-cut matrix, and the running list of cuts already
+    // appended (each already rewritten into structural space). Together these let
+    // every newly separated cut be expressed over structural columns only, which
+    // is what keeps each slack column a singleton and so keeps node warm starts
+    // usable. See `substitute_slacks_to_structural`.
+    let (m_base0, n_base0) = (m_w, n_w);
+    let base_rows = BaseRows::build(&csc_w, m_base0, n_base0, ns, &b_w);
+    let cut_max_len = CUT_LEN_BASE + (CUT_LEN_FRAC * ns as f64) as usize;
+    let mut structural_cuts: Vec<GomoryCut> = Vec::new();
     if opts.root_cuts > 0 {
         let _t = crate::profile::Timer::new(crate::profile::Phase::RootCutLoop);
         let mut total_cuts = 0usize;
@@ -1086,6 +1104,37 @@ pub fn solve_milp_node_hooked(
                     1e7,
                 ));
             }
+            // Rewrite every separated cut over structural columns only, before
+            // anything downstream looks at it. Doing it here (rather than at
+            // append time) means selection scores, dedup signatures and the
+            // cleanup's tightness test all see one consistent space, and no cut
+            // row ever references another row's slack.
+            {
+                let _t = crate::profile::Timer::new(crate::profile::Phase::SepGomory);
+                let before = cuts.len();
+                cuts = cuts
+                    .iter()
+                    .filter_map(|c| {
+                        substitute_slacks_to_structural(
+                            c,
+                            &base_rows,
+                            &structural_cuts,
+                            ns,
+                            n_base0,
+                            &root.x,
+                            &l_w,
+                            &u_w,
+                            cut_max_len,
+                            opts.simplex.tol,
+                            1e7,
+                        )
+                    })
+                    .collect();
+                crate::profile::incr_by(
+                    crate::profile::Ctr::RootCutsSubstDropped,
+                    (before - cuts.len()) as u64,
+                );
+            }
             // Keep the strongest, most diverse few (efficacy + orthogonality)
             // up to the remaining root-cut budget; otherwise add first-come.
             let remaining = opts.root_cuts - total_cuts;
@@ -1100,6 +1149,10 @@ pub fn solve_milp_node_hooked(
                 break;
             }
             total_cuts += new_cuts.len();
+            // Cut `i` occupies column `n_base0 + i`; later rounds expand a
+            // reference to that slack through this entry, so the order here must
+            // match the append order below exactly.
+            structural_cuts.extend(new_cuts.iter().cloned());
             let (nw_csc, nm, nn) = augment_csc_with_cuts(
                 &csc_w,
                 &mut b_w,
@@ -2947,24 +3000,343 @@ fn augment_cols_with_cuts(sp: &SparseCols, m: usize, n: usize, cuts: &[GomoryCut
     }
     SparseCols::from_csc(new_col_ptr, new_row_idx, new_vals)
 }
+/// Row-major structural block of the base matrix, plus each base row's rhs and
+/// the coefficient on that row's own slack column. Built once per solve and used
+/// to rewrite cut coefficients out of slack space (`substitute_slacks_to_structural`).
+struct BaseRows {
+    /// CSR over structural columns only (`0..ns`) for rows `0..m_base`.
+    ptr: Vec<usize>,
+    idx: Vec<usize>,
+    val: Vec<f64>,
+    /// `b_w[r]` for each base row.
+    rhs: Vec<f64>,
+    /// Coefficient of column `ns + r` in row `r` (the `-1` of the `[A | -I]`
+    /// convention), or `None` when that column is not a clean singleton for the
+    /// row — in which case rows are not substitutable and the cut is dropped.
+    slack_coef: Vec<Option<f64>>,
+}
 
-/// Rebuild the pre-cut matrix with an explicit, ordered subset of root cuts.
+impl BaseRows {
+    fn build(csc: &SparseCols, m_base: usize, n_base: usize, ns: usize, b: &[f64]) -> Self {
+        let mut counts = vec![0usize; m_base];
+        for j in 0..ns {
+            let (rows, _) = csc.col(j);
+            for &r in rows {
+                if r < m_base {
+                    counts[r] += 1;
+                }
+            }
+        }
+        let mut ptr = Vec::with_capacity(m_base + 1);
+        ptr.push(0);
+        for r in 0..m_base {
+            ptr.push(ptr[r] + counts[r]);
+        }
+        let nnz = ptr[m_base];
+        let mut idx = vec![0usize; nnz];
+        let mut val = vec![0.0f64; nnz];
+        let mut fill = ptr.clone();
+        for j in 0..ns {
+            let (rows, vals) = csc.col(j);
+            for (&r, &v) in rows.iter().zip(vals) {
+                if r < m_base {
+                    idx[fill[r]] = j;
+                    val[fill[r]] = v;
+                    fill[r] += 1;
+                }
+            }
+        }
+        // The identity `s_r = (b_r - A_r·x) / alpha` needs TWO things, and only one
+        // of them is a statement about column `ns+r`:
+        //
+        //   1. column `ns+r` sits alone in row `r`, so `alpha` is well defined; and
+        //   2. row `r` contains no OTHER base slack, because `ptr/idx/val` above
+        //      spans structural columns only -- a second slack in the row would be
+        //      silently dropped by the rewrite, producing a cut that is not implied
+        //      by the LP. That is a false-bound class of bug, so it is refused
+        //      rather than assumed.
+        //
+        // (1) does not imply (2): if some column `ns+q` is *not* a singleton and
+        // reaches into row `r`, then `slack_coef[q]` is correctly `None` while
+        // `slack_coef[r]` would still look fine. Hence the separate per-row tally.
+        // The `[A | -I]` build satisfies both; anything else declines the rewrite
+        // and the cut is dropped.
+        let mut slacks_in_row = vec![0usize; m_base];
+        for j in ns..n_base {
+            let (rows, _) = csc.col(j);
+            for &r in rows {
+                if r < m_base {
+                    slacks_in_row[r] += 1;
+                }
+            }
+        }
+        let mut slack_coef = vec![None; m_base];
+        for r in 0..m_base {
+            let j = ns + r;
+            if j >= n_base {
+                continue;
+            }
+            let (rows, vals) = csc.col(j);
+            if rows.len() == 1 && rows[0] == r && vals[0] != 0.0 && slacks_in_row[r] == 1 {
+                slack_coef[r] = Some(vals[0]);
+            }
+        }
+        BaseRows {
+            ptr,
+            idx,
+            val,
+            rhs: b[..m_base].to_vec(),
+            slack_coef,
+        }
+    }
+}
+
+/// Rewrite `cut` so it references only structural columns `0..ns`.
 ///
-/// [`augment_cols_with_cuts`] appends a *batch* of cuts to a matrix whose column
-/// count already covers every column those cuts reference; it scans `j in 0..n`
-/// and therefore cannot place a coefficient that lands on a slack column the same
-/// call is creating. That is sound for the root loop, where a round's cuts are
-/// separated off the matrix as it stood *before* the round. It is not sound for a
-/// rebuild: a GMI cut's coefficient vector spans all columns of the LP it was read
-/// off, cut slacks included, so replaying round 7's cuts onto the original matrix
-/// would silently drop their coefficients on rounds 1-6's slack columns and leave
-/// a *different, unjustified* row in the LP.
+/// A GMI cut separated off the tableau carries coefficients over *every* column,
+/// slacks included (`separate_gomory_cols` loops `j in 0..n`). Those slack
+/// references are what make cut rows structurally coupled: a coefficient on
+/// column `ns + r` puts a second nonzero into that column, so it is no longer a
+/// singleton, and `solve_lp_cols_warm`'s `slack_for_row` can no longer name a
+/// substitute when row `r`'s logical ends up basic. The basis it returns is then
+/// *short*, `PreparedDual::prepare` refuses it on shape, every node LP cold-solves,
+/// and `separate_gomory_cols` (which requires `basic_vars.len() == m`) silently
+/// stops separating. Measured on `sp150x300d` at 200x8: 1.1% of node LPs accepted
+/// their warm basis and 2079.6 simplex iterations were spent per node, against
+/// 100% and 9.1 for the same root bound (60) once cuts are structural.
 ///
-/// This builds the whole augmented matrix in one pass instead. `cuts[i].coeffs`
-/// may reference any column `< n_base + i` — the original columns plus the slacks
-/// of the cuts before it — and every such coefficient is placed. Cuts referencing
-/// a *dropped* cut's slack are the caller's problem: it must have closed the
-/// dependency set first (see the cleanup in `solve_milp`).
+/// Every substitution is an *equality* identity drawn from a row of the LP:
+///   base row `r`   : `s_r = (b_r - A_r·x) / alpha_r`
+///   cut  row `i`   : `s_i = c_i·x - rhs_i`      (cut rows are `c·x - s = rhs`, `s >= 0`)
+/// so the rewritten inequality is the same half-space over the feasible set, not a
+/// relaxation. Because it derives only from globally valid rows it also stays valid
+/// after any of those rows are removed, which is what makes dropping cuts safe.
+///
+/// Expanding a slack pulls in that row's whole support, so the rewrite can turn a
+/// short tableau cut into a long one, and a long cut costs every node LP that
+/// carries it. Past `max_len` nonzeros the cut is *shortened* rather than dropped,
+/// the same way HiGHS does after `untransform` (`HighsCutGeneration.cpp:982-1012`):
+/// a term whose variable sits at the bound that makes it contribute its minimum at
+/// `x_star` is relaxed into the rhs, smallest coefficient first. That step IS a
+/// relaxation — the cut gets weaker — but it is still valid (the rhs absorbs the
+/// term's minimum over the variable's box, which requires that bound to be finite)
+/// and, because only terms slack at `x_star` are chosen, it is violated there by
+/// the same margin, so it still cuts off the point it was separated for.
+///
+/// Returns `None` when the cut cannot be expressed structurally (an unsubstitutable
+/// row), cannot be shortened enough, or is numerically wild. Dropping a cut is
+/// always sound.
+#[allow(clippy::too_many_arguments)]
+fn substitute_slacks_to_structural(
+    cut: &GomoryCut,
+    base: &BaseRows,
+    prior: &[GomoryCut],
+    ns: usize,
+    n_base: usize,
+    x_star: &[f64],
+    l: &[f64],
+    u: &[f64],
+    max_len: usize,
+    tol: f64,
+    max_dynamism: f64,
+) -> Option<GomoryCut> {
+    let mut coeffs = vec![0.0f64; ns];
+    let head = ns.min(cut.coeffs.len());
+    coeffs[..head].copy_from_slice(&cut.coeffs[..head]);
+    let mut rhs = cut.rhs;
+    for j in ns..cut.coeffs.len() {
+        let a = cut.coeffs[j];
+        if a == 0.0 {
+            continue;
+        }
+        if j < n_base {
+            let r = j - ns;
+            let Some(alpha) = base.slack_coef.get(r).copied().flatten() else {
+                crate::profile::incr(crate::profile::Ctr::SubstDropNoSlack);
+                return None;
+            };
+            let f = a / alpha;
+            for k in base.ptr[r]..base.ptr[r + 1] {
+                coeffs[base.idx[k]] -= f * base.val[k];
+            }
+            rhs -= f * base.rhs[r];
+        } else {
+            // A prior cut, already structural by induction: this pass runs on every
+            // cut before it is appended, so `prior` never carries slack references.
+            let Some(c_i) = prior.get(j - n_base) else {
+                crate::profile::incr(crate::profile::Ctr::SubstDropNoPrior);
+                return None;
+            };
+            let w = ns.min(c_i.coeffs.len());
+            for (dst, src) in coeffs.iter_mut().zip(c_i.coeffs.iter()).take(w) {
+                *dst += a * src;
+            }
+            rhs += a * c_i.rhs;
+        }
+    }
+    if !rhs.is_finite() {
+        crate::profile::incr(crate::profile::Ctr::SubstDropDegenerate);
+        return None;
+    }
+
+    // Substitution builds each coefficient as a sum of scaled row entries, so
+    // cancellation routinely leaves a scatter of near-zero terms. Rejecting the cut
+    // for the resulting coefficient range would throw away nearly everything: with
+    // a plain dynamism gate, 217 of 217 cuts on `fiber` and 75 of 75 on
+    // `mik-250-20-75-1` were refused for that reason alone and the root bounds
+    // regressed (fiber 388985 -> 267429).
+    //
+    // The box `l`/`u` used to weaken is the ROOT box. That is what makes both
+    // weakening steps valid for the whole tree: every node's box is a subset, so a
+    // relaxation sound on the root box is sound on all of them. It holds because
+    // the bounds here come from presolve/FBBT, which are feasibility-based and so
+    // globally valid -- objective-based tightening (reduced-cost fixing, line
+    // ~2256) runs inside the node loop, strictly after this. Moving any
+    // objective-based fixing ahead of the root cut loop would make these bounds
+    // valid only relative to an incumbent and would need re-arguing here.
+    //
+    // HiGHS does not gate on dynamism -- its only `dynamism` line
+    // (`HighsCutGeneration.cpp:1061`) sits inside an `#if 0` debug block. It
+    // *removes* the negligible terms instead (`:783`,
+    // `minCoefficientValue = 100 * feastol * max(maxAbsValue, 1e-3)`) and moves each
+    // to the right-hand side. Same rule here, in `>=` form: dropping term `k`
+    // subtracts its MAXIMUM over the box, which is a relaxation of the original --
+    // never something the original does not imply. A term whose maximising bound is
+    // infinite cannot move, and only then is the cut refused (HiGHS returns `false`
+    // at the same point).
+    {
+        let mut maxabs = 0.0f64;
+        for &v in coeffs.iter() {
+            maxabs = maxabs.max(v.abs());
+        }
+        let min_coef = 100.0 * tol * maxabs.max(1e-3);
+        for k in 0..ns {
+            let a = coeffs[k];
+            if a == 0.0 || a.abs() > min_coef {
+                continue;
+            }
+            let pin = if a > 0.0 { u[k] } else { l[k] };
+            if pin.abs() >= INF {
+                // The term cannot be moved to the rhs: weakening across an
+                // unbounded direction is not a bound. HiGHS refuses the cut at
+                // the same point (`HighsCutGeneration.cpp:783`, returns `false`).
+                //
+                // KEEPING the coefficient instead is exact and was tried: it
+                // costs nothing in soundness and, combined with a dynamism cap
+                // raised past 1e12, recovers 99 cuts on `gsvm2rl3` (root gap
+                // 85.16 % -> 76.11 %) and improves the root gap on 7 of 38
+                // instances against 2 worsened. It is NOT shipped: at a fixed
+                // 5000-node budget the panel came out 3 better / 3 worse, 14
+                // solved either way, 132,724 vs 133,680 nodes -- cert-clean but
+                // neutral, so it stays out under CLAUDE.md §5 (the
+                // `DISCOPT_CUT_INHERIT` rule: sound is not the same as helpful).
+                // Rescuing `gsvm2rl3` needs a cut family whose coefficients are
+                // conditioned, not a laxer numerical gate.
+                crate::profile::incr(crate::profile::Ctr::SubstDropUnbounded);
+                return None;
+            }
+            rhs -= a * pin;
+            coeffs[k] = 0.0;
+        }
+        if !rhs.is_finite() {
+            crate::profile::incr(crate::profile::Ctr::SubstDropDegenerate);
+            return None;
+        }
+    }
+
+    let mut nnz = coeffs.iter().filter(|v| **v != 0.0).count();
+    if nnz == 0 {
+        crate::profile::incr(crate::profile::Ctr::SubstDropDegenerate);
+        return None;
+    }
+    // The ceiling bounds the *inflation* substitution causes, not a cut's intrinsic
+    // length. A cut that was already long costs what it always cost -- capping it
+    // here would discard cuts the engine has always accepted (a 300-item knapsack
+    // separates ~300-nonzero GMI cuts by nature) for a problem the rewrite did not
+    // create. So the effective limit never falls below the row's original nonzero
+    // count; only genuine growth is shortened.
+    let nnz_before = cut.coeffs.iter().filter(|v| **v != 0.0).count();
+    let max_len = max_len.max(nnz_before);
+    if nnz > max_len {
+        // Terms that are already at their minimum at `x_star` cost no violation to
+        // relax away; take the smallest such coefficients until the cut is short
+        // enough. A term can only move to the rhs if the bound it is pinned at is
+        // finite -- INF in this layer is the 1e20 sentinel, not f64::INFINITY.
+        let mut cancellable: Vec<usize> = (0..ns)
+            .filter(|&k| {
+                let a = coeffs[k];
+                if a == 0.0 {
+                    return false;
+                }
+                // Free exactly when the term is already at its MAXIMUM at
+                // `x_star`: the violation after removal is
+                // `old_violation - a*(max_k - x_star[k])`, so pinning at the max
+                // preserves it.
+                if a > 0.0 {
+                    u[k] < INF && (u[k] - x_star[k]).abs() <= tol
+                } else {
+                    l[k] > -INF && (x_star[k] - l[k]).abs() <= tol
+                }
+            })
+            .collect();
+        if nnz - cancellable.len() > max_len {
+            crate::profile::incr(crate::profile::Ctr::SubstDropTooLong);
+            return None;
+        }
+        cancellable.sort_by(|&a, &b| {
+            coeffs[a]
+                .abs()
+                .partial_cmp(&coeffs[b].abs())
+                .unwrap_or(std::cmp::Ordering::Equal)
+                .then(a.cmp(&b))
+        });
+        for &k in &cancellable {
+            if nnz <= max_len {
+                break;
+            }
+            let a = coeffs[k];
+            // The cut is `coeffs·x >= rhs`, so dropping term `k` requires
+            // subtracting that term's MAXIMUM over the box:
+            //   sum_{j!=k} a_j x_j = sum_j a_j x_j - a_k x_k >= rhs - max(a_k x_k)
+            // Subtracting the minimum instead would give an inequality the
+            // original does not imply -- it could cut off a feasible point and
+            // produce a false bound. (HiGHS's rule at `HighsCutGeneration.cpp:998`
+            // is the mirror of this because its cuts are in `<=` form.)
+            rhs -= a * if a > 0.0 { u[k] } else { l[k] };
+            coeffs[k] = 0.0;
+            nnz -= 1;
+        }
+        if nnz > max_len || !rhs.is_finite() {
+            crate::profile::incr(crate::profile::Ctr::SubstDropTooLong);
+            return None;
+        }
+    }
+
+    let (mut amin, mut amax) = (f64::INFINITY, 0.0f64);
+    for &v in &coeffs {
+        if v != 0.0 {
+            amin = amin.min(v.abs());
+            amax = amax.max(v.abs());
+        }
+    }
+    // After the small-coefficient cleanup the range is bounded by construction
+    // (`maxabs / min_coef = 1 / (100 * tol)` whenever `maxabs >= 1e-3`), so this is
+    // a backstop for the tiny-`maxabs` corner the cleanup's `1e-3` floor leaves
+    // open, not the primary filter it used to be.
+    // Split deliberately: a non-finite coefficient and a merely ill-conditioned
+    // one are different failures with different fixes, and folding them into one
+    // counter made this branch mis-diagnosed three times running.
+    if !amax.is_finite() {
+        crate::profile::incr(crate::profile::Ctr::SubstDropNonFinite);
+        return None;
+    }
+    if amax / amin > max_dynamism {
+        crate::profile::incr(crate::profile::Ctr::SubstDropDynamism);
+        return None;
+    }
+    Some(GomoryCut { coeffs, rhs })
+}
+
 fn rebuild_csc_with_cuts(
     base: &SparseCols,
     m_base: usize,
@@ -6376,6 +6748,345 @@ mod root_cut_budget_tests {
     /// half (CLAUDE.md §6): it pins that the two functions genuinely differ here,
     /// so a future "simplification" back to the batch appender fails loudly
     /// instead of silently installing a different row.
+    /// Shared fixtures for the substitution tests: a point and a box wide enough
+    /// that no term is at a bound, so the shortening path never fires and these
+    /// tests measure the identity alone.
+    const X_STAR: [f64; 2] = [0.5, 0.5];
+    const LO: [f64; 2] = [-1e3, -1e3];
+    const UP: [f64; 2] = [1e3, 1e3];
+
+    /// Substitution leaves a scatter of near-zero coefficients behind (cancellation
+    /// between scaled row entries), and rejecting a cut for the resulting
+    /// coefficient range threw away 217 of 217 cuts on `fiber`. The negligible terms
+    /// are removed instead, HiGHS-style. That is a weakening, so it carries the same
+    /// obligation as shortening: the rewritten cut must be *implied by* the original
+    /// over the whole box, never removing a point the original kept.
+    ///
+    /// `x0 - 1e-12*x1 + 0.5*x2 >= 0.3` over `x1 in [2, 3]`: the middle term is far
+    /// below `100 * tol * maxabs = 1e-7` and must be gone, with the right-hand side
+    /// moved by exactly that term's maximum (`a * l1`).
+    #[test]
+    fn the_small_coefficient_cleanup_only_relaxes_the_cut() {
+        let base = BaseRows {
+            ptr: vec![0],
+            idx: vec![],
+            val: vec![],
+            rhs: vec![],
+            slack_coef: vec![],
+        };
+        let cut = GomoryCut {
+            coeffs: vec![1.0, -1e-12, 0.5],
+            rhs: 0.3,
+        };
+        let x_star = [0.1, 2.0, 0.1];
+        let lo = [0.0, 2.0, 0.0];
+        let up = [1.0, 3.0, 1.0];
+        let out = substitute_slacks_to_structural(
+            &cut,
+            &base,
+            &[],
+            3,
+            3,
+            &x_star,
+            &lo,
+            &up,
+            64,
+            1e-9,
+            1e7,
+        )
+        .expect("the cleanup must rewrite this cut, not refuse it");
+        assert_eq!(
+            out.coeffs[1], 0.0,
+            "tiny coefficient survived: {:?}",
+            out.coeffs
+        );
+        assert_eq!(out.coeffs[0], 1.0);
+        assert_eq!(out.coeffs[2], 0.5);
+
+        // Every box point the original keeps, the rewrite must keep too.
+        let mut checked = 0usize;
+        for a in 0..=10 {
+            for b in 0..=10 {
+                for c in 0..=10 {
+                    let x = [a as f64 / 10.0, 2.0 + b as f64 / 10.0, c as f64 / 10.0];
+                    let orig: f64 = (0..3).map(|k| cut.coeffs[k] * x[k]).sum();
+                    let new: f64 = (0..3).map(|k| out.coeffs[k] * x[k]).sum();
+                    if orig >= cut.rhs - 1e-9 {
+                        assert!(
+                            new >= out.rhs - 1e-9,
+                            "cleanup removed a point the original kept: {x:?}"
+                        );
+                    }
+                    checked += 1;
+                }
+            }
+        }
+        assert_eq!(checked, 1331, "the implication probe never ran");
+    }
+
+    /// Shortening is the one step that genuinely weakens a cut, so it carries the
+    /// two properties that make that safe: the shortened cut must be *implied by*
+    /// the original over the whole box (never cutting off a point the original
+    /// kept -- a false bound), and it must still be violated at the point it was
+    /// separated for (or it is useless).
+    ///
+    /// A 4-column cut `x0 + x1 + x2 + x3 >= 1` with a length cap of 2. Columns 2
+    /// and 3 sit at their lower bound 0 at `x_star`, so relaxing them costs
+    /// nothing at that point (`rhs -= a * 0`) and the cut stays `>= 1`.
+    #[test]
+    fn the_cut_shortening_only_weakens_and_keeps_the_violation() {
+        let csc = SparseCols::from_dense(&[1.0, 1.0, 1.0, 1.0, -1.0], 1, 5);
+        let base = BaseRows::build(&csc, 1, 5, 4, &[0.0]);
+        // The cut is written against the row's SLACK -- `-s >= -0.5` -- so it has
+        // one nonzero before the rewrite and four after (`s = x0+x1+x2+x3` from the
+        // row `x0+x1+x2+x3 - s = 0`). That growth is what the ceiling exists to
+        // bound, and it is the only thing that makes the shortening path reachable:
+        // the effective limit never falls below the cut's original nonzero count.
+        //
+        // Rewritten the cut is `-x0 -x1 -x2 -x3 >= -0.5` (the sum is at most 0.5),
+        // violated at `x_star` where the sum is 0.8. Columns 2 and 3 carry a
+        // negative coefficient and sit at their lower bound, which is where such a
+        // term is maximal, so relaxing them is free at `x_star`.
+        let cut = GomoryCut {
+            coeffs: vec![0.0, 0.0, 0.0, 0.0, -1.0],
+            rhs: -0.5,
+        };
+        let x_star = [0.4, 0.4, 0.0, 0.0];
+        let lo = [0.0, 0.0, 0.0, 0.0];
+        let up = [1.0, 1.0, 1.0, 1.0];
+        // What the rewrite produces before any shortening, for the implication check.
+        let expanded = GomoryCut {
+            coeffs: vec![-1.0, -1.0, -1.0, -1.0],
+            rhs: -0.5,
+        };
+        let out = substitute_slacks_to_structural(
+            &cut,
+            &base,
+            &[],
+            4,
+            5,
+            &x_star,
+            &lo,
+            &up,
+            2,
+            1e-9,
+            1e7,
+        )
+        .expect("two terms are at their maximising bound and can be relaxed");
+        let nnz = out.coeffs.iter().filter(|v| **v != 0.0).count();
+        assert!(nnz <= 2, "cut not shortened: {:?}", out.coeffs);
+
+        // Still violated at the point it was separated for.
+        let act: f64 = (0..4).map(|k| out.coeffs[k] * x_star[k]).sum();
+        assert!(act < out.rhs - 1e-9, "shortened cut no longer cuts x_star");
+
+        // And implied by the original everywhere in the box: any point the
+        // shortened cut rejects, the original rejects too.
+        let mut checked = 0usize;
+        for a in 0..6 {
+            for b in 0..6 {
+                for c in 0..6 {
+                    for d in 0..6 {
+                        let x = [
+                            a as f64 / 5.0,
+                            b as f64 / 5.0,
+                            c as f64 / 5.0,
+                            d as f64 / 5.0,
+                        ];
+                        let orig: f64 = (0..4).map(|k| expanded.coeffs[k] * x[k]).sum();
+                        let shortened: f64 = (0..4).map(|k| out.coeffs[k] * x[k]).sum();
+                        if orig >= expanded.rhs - 1e-9 {
+                            assert!(
+                                shortened >= out.rhs - 1e-9,
+                                "shortened cut removed a point the original kept: {x:?}"
+                            );
+                        }
+                        checked += 1;
+                    }
+                }
+            }
+        }
+        assert_eq!(checked, 1296, "implication probe must actually have run");
+    }
+
+    /// The rewrite reads a base row over its STRUCTURAL columns only, so the
+    /// identity `s_r = (b_r - A_r·x) / alpha` is valid only when row `r` holds no
+    /// other base slack -- a second one would be silently dropped and the resulting
+    /// cut would not be implied by the LP, which is a false bound.
+    ///
+    /// Column-singleton-ness of `ns+r` does not establish that. Here row 0 carries
+    /// both its own slack (column 2, a singleton) and a stray entry from column 3,
+    /// so `slack_coef[0]` looks fine by that test alone. The per-row tally must
+    /// still refuse it, and any cut referencing that slack must be dropped rather
+    /// than rewritten.
+    #[test]
+    fn a_base_row_with_two_slacks_refuses_the_rewrite() {
+        // Row 0: `2x0 + 3x1 - s0 + 5*s1 = 6`. Column 2 (`s0`) is a singleton at
+        // row 0; column 3 (`s1`) also reaches into row 0.
+        let csc = SparseCols::from_dense(&[2.0, 3.0, -1.0, 5.0], 1, 4);
+        let (m_base, n_base, ns) = (1usize, 4usize, 2usize);
+        let b = vec![6.0];
+        let base = BaseRows::build(&csc, m_base, n_base, ns, &b);
+        assert_eq!(
+            base.slack_coef[0], None,
+            "row 0 holds a second slack; the rewrite is not valid for it"
+        );
+
+        let cut = GomoryCut {
+            coeffs: vec![1.0, 0.0, 1.0],
+            rhs: 4.0,
+        };
+        assert!(
+            substitute_slacks_to_structural(
+                &cut,
+                &base,
+                &[],
+                ns,
+                n_base,
+                &X_STAR,
+                &LO,
+                &UP,
+                64,
+                1e-9,
+                1e7,
+            )
+            .is_none(),
+            "a cut on an unexpressible slack must be dropped, not rewritten"
+        );
+    }
+
+    /// The slack substitution must be an *identity*, not a relaxation: a cut
+    /// rewritten over structural columns has to cut off exactly the same points
+    /// as the original did in the slack-extended space. If it were even slightly
+    /// stronger it could remove a feasible integer point and produce a false
+    /// bound, which is the one failure this whole change must not introduce.
+    ///
+    /// Base: one row `2x0 + 3x1 - s0 = 6` (so `s0 = 2x0 + 3x1 - 6`), structural
+    /// width 2, slack column 2. A cut `1*x0 + 1*s0 >= 4` therefore means
+    /// `x0 + 2x0 + 3x1 - 6 >= 4`, i.e. `3x0 + 3x1 >= 10`. The rewrite must
+    /// produce exactly that. Random feasible points check the identity rather
+    /// than only the coefficients, so an algebra slip in either direction fails.
+    #[test]
+    fn the_slack_substitution_preserves_the_cut_exactly() {
+        // [A | -I] over 2 structural columns and 1 row.
+        let csc = SparseCols::from_dense(&[2.0, 3.0, -1.0], 1, 3);
+        let (m_base, n_base, ns) = (1usize, 3usize, 2usize);
+        let b = vec![6.0];
+        let base = BaseRows::build(&csc, m_base, n_base, ns, &b);
+        assert_eq!(base.slack_coef[0], Some(-1.0), "row 0 slack must be found");
+
+        let cut = GomoryCut {
+            coeffs: vec![1.0, 0.0, 1.0],
+            rhs: 4.0,
+        };
+        let out = substitute_slacks_to_structural(
+            &cut,
+            &base,
+            &[],
+            ns,
+            n_base,
+            &X_STAR,
+            &LO,
+            &UP,
+            64,
+            1e-9,
+            1e7,
+        )
+        .expect("cut is expressible over structural columns");
+        assert_eq!(
+            out.coeffs.len(),
+            ns,
+            "rewritten cut must be structural-only"
+        );
+
+        let mut checked = 0usize;
+        for i in 0..40 {
+            let x0 = (i as f64) * 0.37 - 5.0;
+            for k in 0..40 {
+                let x1 = (k as f64) * 0.29 - 4.0;
+                // s0 is pinned by the row, exactly as in the LP.
+                let s0 = 2.0 * x0 + 3.0 * x1 - 6.0;
+                let orig = cut.coeffs[0] * x0 + cut.coeffs[1] * x1 + cut.coeffs[2] * s0;
+                let new = out.coeffs[0] * x0 + out.coeffs[1] * x1;
+                assert_eq!(
+                    orig >= cut.rhs - 1e-9,
+                    new >= out.rhs - 1e-9,
+                    "substitution changed the half-space at ({x0}, {x1})"
+                );
+                checked += 1;
+            }
+        }
+        assert_eq!(checked, 1600, "identity probe must actually have run");
+    }
+
+    /// The anti-vacuity half: the cut above genuinely *did* reference a slack, so
+    /// the rewrite is not a no-op copy. Without this a future change that made
+    /// `substitute_slacks_to_structural` return its input unchanged would still
+    /// pass the identity test.
+    #[test]
+    fn the_slack_substitution_actually_rewrites_the_coefficients() {
+        let csc = SparseCols::from_dense(&[2.0, 3.0, -1.0], 1, 3);
+        let base = BaseRows::build(&csc, 1, 3, 2, &[6.0]);
+        let cut = GomoryCut {
+            coeffs: vec![1.0, 0.0, 1.0],
+            rhs: 4.0,
+        };
+        let out = substitute_slacks_to_structural(
+            &cut,
+            &base,
+            &[],
+            2,
+            3,
+            &X_STAR,
+            &LO,
+            &UP,
+            64,
+            1e-9,
+            1e7,
+        )
+        .unwrap();
+        // x0: 1 + 1*2 = 3; x1: 0 + 1*3 = 3; rhs: 4 + 1*6 = 10.
+        assert!((out.coeffs[0] - 3.0).abs() < 1e-12, "got {:?}", out.coeffs);
+        assert!((out.coeffs[1] - 3.0).abs() < 1e-12, "got {:?}", out.coeffs);
+        assert!((out.rhs - 10.0).abs() < 1e-12, "got {}", out.rhs);
+        assert_ne!(out.coeffs[0], cut.coeffs[0], "rewrite must not be a copy");
+    }
+
+    /// A cut referencing an *earlier cut's* slack expands through that cut, which
+    /// is the case that makes rounds 2+ couple. Cut A: `x0 >= 1` (slack column
+    /// `n_base + 0`, with `s_A = x0 - 1`). Cut B references it: `x1 + 2*s_A >= 3`
+    /// means `x1 + 2x0 - 2 >= 3`, i.e. `2x0 + x1 >= 5`.
+    #[test]
+    fn the_slack_substitution_expands_an_earlier_cuts_slack() {
+        let csc = SparseCols::from_dense(&[2.0, 3.0, -1.0], 1, 3);
+        let base = BaseRows::build(&csc, 1, 3, 2, &[6.0]);
+        let cut_a = GomoryCut {
+            coeffs: vec![1.0, 0.0],
+            rhs: 1.0,
+        };
+        let cut_b = GomoryCut {
+            coeffs: vec![0.0, 1.0, 0.0, 2.0],
+            rhs: 3.0,
+        };
+        let out = substitute_slacks_to_structural(
+            &cut_b,
+            &base,
+            &[cut_a],
+            2,
+            3,
+            &X_STAR,
+            &LO,
+            &UP,
+            64,
+            1e-9,
+            1e7,
+        )
+        .unwrap();
+        assert!((out.coeffs[0] - 2.0).abs() < 1e-12, "got {:?}", out.coeffs);
+        assert!((out.coeffs[1] - 1.0).abs() < 1e-12, "got {:?}", out.coeffs);
+        assert!((out.rhs - 5.0).abs() < 1e-12, "got {}", out.rhs);
+    }
+
     #[test]
     fn the_rebuild_places_a_cut_coefficient_on_an_earlier_cuts_slack() {
         let base = SparseCols::from_dense(&[2.0, 3.0], 1, 2);

--- a/crates/discopt-core/src/lp/gomory.rs
+++ b/crates/discopt-core/src/lp/gomory.rs
@@ -225,6 +225,7 @@ pub fn separate_gomory_cols(
     max_dynamism: f64,
 ) -> Vec<GomoryCut> {
     let mut cuts = Vec::new();
+    crate::profile::incr(crate::profile::Ctr::SepGomoryCalls);
     if m == 0 {
         return cuts;
     }
@@ -232,6 +233,7 @@ pub fn separate_gomory_cols(
     // (degenerate phase-2 artifact the caller could not complete) is unusable —
     // decline rather than index past it. Matches the old dense path's `None`.
     if basis.basic_vars.len() != m {
+        crate::profile::incr(crate::profile::Ctr::SepGomoryShortBasis);
         return cuts;
     }
 
@@ -245,6 +247,7 @@ pub fn separate_gomory_cols(
         })
         .collect();
     if lu.factorize_sparse(m, &bcols).is_err() {
+        crate::profile::incr(crate::profile::Ctr::SepGomorySingular);
         return cuts; // singular basis → no cuts (as the dense solve's None did)
     }
 
@@ -268,7 +271,10 @@ pub fn separate_gomory_cols(
     }
     let xb = match ftran_refined(&mut lu, sp, &basis.basic_vars, &rhs_b, tol) {
         Some(xb) => xb,
-        None => return cuts,
+        None => {
+            crate::profile::incr(crate::profile::Ctr::SepGomoryFtranFail);
+            return cuts;
+        }
     };
 
     for (i, &bi) in basis.basic_vars.iter().enumerate() {
@@ -285,7 +291,10 @@ pub fn separate_gomory_cols(
         e_i[i] = 1.0;
         let w = match btran_refined(&mut lu, sp, &basis.basic_vars, &e_i, tol) {
             Some(w) => w,
-            None => continue,
+            None => {
+                crate::profile::incr(crate::profile::Ctr::SepGomoryBtranFail);
+                continue;
+            }
         };
 
         // GMI cut Σ ψ_j x̃_j ≥ 1, accumulated into original-variable space.
@@ -364,7 +373,73 @@ pub fn separate_gomory_cols(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::lp::basis::recover_basis;
+    use crate::lp::basis::{recover_basis, AT_LOWER};
+
+    /// Every refusal inside `separate_gomory_cols` must leave a counter behind.
+    ///
+    /// This function had five uncounted early returns, so "no cuts separated" and
+    /// "never looked at a single tableau row" were the same observation. That is
+    /// the CLAUDE.md §6 failure mode, and it is what hid the short-basis export
+    /// defect (A0'.1): on `neos-2624317-amur` the cold root LP exported 338 basic
+    /// variables for m = 342, every separation call bailed at the length guard,
+    /// and the panel reported `0/0` cuts — read as "nothing to cut".
+    ///
+    /// Asserted as *deltas* around each call, and with the call counter as the
+    /// denominator, so the test itself cannot pass vacuously.
+    #[test]
+    fn a_short_basis_refusal_is_counted_not_silent() {
+        let _guard = crate::profile::test_guard();
+        crate::profile::set_enabled(true);
+
+        // x0 + x1 + s = 1.5, x0,x1 ∈ {0,1} relaxed, s ≥ 0 — the LP of the first
+        // test, whose complete basis is known to separate exactly one GMI cut.
+        let a = [1.0, 1.0, 1.0];
+        let l = [0.0, 0.0, 0.0];
+        let u = [1.0, 1.0, f64::INFINITY];
+        let b = [1.5];
+        let integrality = [true, true, false];
+        let sp = crate::lp::simplex::sparse::SparseCols::from_dense(&a, 1, 3);
+
+        let calls = |()| crate::profile::counter(crate::profile::Ctr::SepGomoryCalls);
+        let short = |()| crate::profile::counter(crate::profile::Ctr::SepGomoryShortBasis);
+
+        // Arm 1: a basis one column short of `m`. It must refuse AND say so.
+        let c0 = calls(());
+        let s0 = short(());
+        let stub = Basis {
+            col_status: vec![AT_LOWER, AT_LOWER, AT_LOWER],
+            basic_vars: vec![], // 0 != m = 1
+        };
+        let cuts = separate_gomory_cols(&sp, 1, 3, &l, &u, &b, &stub, &integrality, 1e-7, 1e9);
+        assert!(cuts.is_empty(), "a short basis cannot yield cuts");
+        assert_eq!(calls(()) - c0, 1, "the call counter is the denominator");
+        assert_eq!(short(()) - s0, 1, "the short-basis refusal must be counted");
+
+        // Arm 2: the complete basis. The refusal counter must NOT move — without
+        // this arm the test would pass on a counter that fires unconditionally.
+        let x = [1.0, 0.5, 0.0];
+        let lp = LpView {
+            a: &a,
+            m: 1,
+            n: 3,
+            c: &[0.0, 0.0, 0.0],
+            l: &l,
+            u: &u,
+        };
+        let good = recover_basis(&x, &lp, 1e-7).expect("basis");
+        let c1 = calls(());
+        let s1 = short(());
+        let cuts = separate_gomory_cols(&sp, 1, 3, &l, &u, &b, &good, &integrality, 1e-7, 1e9);
+        assert_eq!(cuts.len(), 1, "the complete basis still separates its cut");
+        assert_eq!(calls(()) - c1, 1);
+        assert_eq!(
+            short(()) - s1,
+            0,
+            "a complete basis must not count a refusal"
+        );
+
+        crate::profile::set_enabled(false);
+    }
 
     fn dot(a: &[f64], b: &[f64]) -> f64 {
         a.iter().zip(b).map(|(x, y)| x * y).sum()

--- a/crates/discopt-core/src/lp/simplex/primal.rs
+++ b/crates/discopt-core/src/lp/simplex/primal.rs
@@ -1658,6 +1658,64 @@ impl<'a> Simplex<'a> {
     /// redundant; its artificial is left basic (the caller's warm path declines
     /// a short basis, unchanged). `Err` only on a factorization breakdown, which
     /// the caller ignores (basis emitted as-is, exactly as before this pass).
+    /// For each constraint row, pick a nonbasic real column that may replace a
+    /// basic artificial in that row's basis slot, or `-1` if none qualifies.
+    ///
+    /// A candidate must be a **row singleton** (its only nonzero is in that row),
+    /// so swapping it in turns B's slot column `±e_r` into `a·e_r` — a scalar
+    /// multiple, hence still nonsingular — and leaves `x` bit-identical, because a
+    /// basic variable may hold any value and the candidate simply keeps the one it
+    /// already has.
+    ///
+    /// Two admissible tests, applied in that order:
+    ///
+    /// 1. **Value zero** (original). The candidate sits nonbasic at 0, so it was
+    ///    contributing 0 to the RHS and its new basic value is 0.
+    /// 2. **Reduced cost zero** (#A0'.1). The primal argument above never needed
+    ///    the candidate's *value* — what the swap can break is the exported
+    ///    `dual`, since a basic column requires `c_j − yᵀA_j = 0`. Testing that
+    ///    directly admits the dual-degenerate case the value test misses: a slack
+    ///    nonbasic at a NONZERO bound whose reduced cost still vanishes.
+    ///
+    ///    This matters. On `neos-2624317-amur` the cold root LP exported 338 basic
+    ///    variables for m = 342 — 50 rows had their slack nonbasic at a nonzero
+    ///    value with no zero-valued alternative. A short basis makes
+    ///    `separate_gomory_cols` decline outright (`lp/gomory.rs:233`) and
+    ///    `PreparedDual::prepare` refuse every warm start, so the instance got no
+    ///    cuts *and* cold-solved every node, with no counter recording either.
+    ///
+    /// Pass 2 only fills rows pass 1 left empty, so the rule is strictly monotone:
+    /// no basis that completes today can be shortened by it.
+    fn select_row_substitutes(&self, dual: &[f64]) -> Vec<i64> {
+        let mut slack_for_row: Vec<i64> = vec![-1; self.m];
+        for j in 0..self.n {
+            if self.stat[j] == BASIC || self.nb_value(j) != 0.0 {
+                continue;
+            }
+            let (rows, _) = self.cols.col(j);
+            if rows.len() == 1 && slack_for_row[rows[0]] < 0 {
+                slack_for_row[rows[0]] = j as i64;
+            }
+        }
+        if dual.len() != self.m {
+            return slack_for_row; // no usable `y`; pass 2 would be unfounded
+        }
+        for j in 0..self.n {
+            if self.stat[j] == BASIC {
+                continue;
+            }
+            let (rows, vals) = self.cols.col(j);
+            if rows.len() != 1 || slack_for_row[rows[0]] >= 0 {
+                continue;
+            }
+            // d_j = c_j − yᵀA_j, with A_j a singleton in row rows[0].
+            if (self.c[j] - dual[rows[0]] * vals[0]).abs() <= self.tol {
+                slack_for_row[rows[0]] = j as i64;
+            }
+        }
+        slack_for_row
+    }
+
     fn expel_zero_basic_artificials(&mut self, art_sign: &[f64]) -> Result<(), ()> {
         const PIVOT_MIN: f64 = 1e-7;
         const ART_TOL: f64 = 1e-9;
@@ -2596,16 +2654,8 @@ impl<'a> Simplex<'a> {
         // B's support and x_B bit-identical (the entering column was contributing
         // 0 to the RHS and its new basic value is 0), so this is a pure
         // representation fix — the optimum and bound are unchanged.
-        let mut slack_for_row: Vec<i64> = vec![-1; self.m];
-        for j in 0..self.n {
-            if self.stat[j] == BASIC || self.nb_value(j) != 0.0 {
-                continue;
-            }
-            let (rows, _) = self.cols.col(j);
-            if rows.len() == 1 && slack_for_row[rows[0]] < 0 {
-                slack_for_row[rows[0]] = j as i64;
-            }
-        }
+        let slack_for_row = self.select_row_substitutes(&dual);
+
         let mut col_status: Vec<i8> = (0..self.n).map(|j| self.stat[j]).collect();
         let mut basic_vars: Vec<usize> = Vec::with_capacity(self.m);
         for i in 0..self.m {
@@ -2662,6 +2712,119 @@ impl<'a> Simplex<'a> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// #A0'.1: a nonbasic row singleton at a NONZERO bound is a valid basis
+    /// substitute when its reduced cost vanishes.
+    ///
+    /// The export pass that completes a short basis used to require the candidate
+    /// to sit at value 0. That tests the wrong quantity. Swapping a row singleton
+    /// `s` into the slot replaces B's `±e_r` with `a·e_r` and leaves `x`
+    /// bit-identical whatever `s`'s value — a basic variable may hold any value.
+    /// What the swap can invalidate is the exported `dual`, which needs
+    /// `c_s − yᵀA_s = 0`. So the admissible test is on the reduced cost, and the
+    /// value test misses every dual-degenerate case.
+    ///
+    /// Concretely: `neos-2624317-amur` exported 338 basic variables for m = 342
+    /// because 50 rows had their slack nonbasic at a nonzero value. A short basis
+    /// makes `separate_gomory_cols` return empty (`lp/gomory.rs:233`) and
+    /// `PreparedDual::prepare` refuse every warm start — no cuts, no warm starts,
+    /// and no counter recording either.
+    ///
+    /// This pins the rule itself. Row 1's singleton `x2` is nonbasic at its
+    /// nonzero upper bound with `c = 0`, so under any `y` with `y[1] = 0` its
+    /// reduced cost is 0 and it must be accepted; `x3`, a singleton in row 2 with
+    /// `c = 5`, has reduced cost 5 and must be refused.
+    #[test]
+    fn a_nonzero_valued_row_singleton_substitutes_when_its_reduced_cost_vanishes() {
+        // 3 rows x 4 cols. x0 spans rows 0-2; x1,x2,x3 are singletons in rows
+        // 0,1,2 respectively.
+        //   col0 = (1,1,1)  col1 = (1,0,0)  col2 = (0,1,0)  col3 = (0,0,1)
+        let a = [
+            1.0, 1.0, 1.0, // col 0
+            1.0, 0.0, 0.0, // col 1
+            0.0, 1.0, 0.0, // col 2
+            0.0, 0.0, 1.0, // col 3
+        ];
+        // column-major dense -> the LpView the constructor consumes is row-major,
+        // so build the CSC-equivalent through LpView's own layout: a[i*n + j].
+        let n = 4usize;
+        let m = 3usize;
+        let mut row_major = vec![0.0; m * n];
+        for j in 0..n {
+            for i in 0..m {
+                row_major[i * n + j] = a[j * m + i];
+            }
+        }
+        let c = [0.0, 0.0, 0.0, 5.0];
+        let l = [0.0, 0.0, 0.0, 2.0];
+        let u = [10.0, 10.0, 4.0, 10.0];
+        let b = [1.0, 1.0, 1.0];
+        let lp = LpView {
+            a: &row_major,
+            m,
+            n,
+            c: &c,
+            l: &l,
+            u: &u,
+        };
+        let mut sx = Simplex::new(&lp, &b, &SimplexOptions::default());
+
+        // Hand-set the nonbasic statuses the rule reads. x2 sits AT_UPPER (value
+        // 4, nonzero); x1 and x3 sit at their zero lower bounds.
+        sx.stat[0] = BASIC;
+        sx.stat[1] = AT_LOWER;
+        sx.stat[2] = AT_UPPER;
+        sx.stat[3] = AT_LOWER;
+        assert_eq!(
+            sx.nb_value(2),
+            4.0,
+            "x2 must be nonbasic at a NONZERO value"
+        );
+        assert_eq!(
+            sx.nb_value(3),
+            2.0,
+            "x3 must also be nonbasic at a NONZERO value"
+        );
+
+        // A dual with y = 0 everywhere: d_j = c_j. So x1 (c=0) and x2 (c=0)
+        // qualify on reduced cost; x3 (c=5) does not.
+        let dual = vec![0.0; m];
+        let pick = sx.select_row_substitutes(&dual);
+
+        assert_eq!(
+            pick[0], 1,
+            "row 0: x1 is a zero-valued singleton, accepted by the original pass"
+        );
+        assert_eq!(
+            pick[1], 2,
+            "row 1: x2 is nonbasic at 4.0 with zero reduced cost -- the case the \
+             value test misses and this change adds"
+        );
+        assert_eq!(
+            pick[2], -1,
+            "row 2: x3 has reduced cost 5, so substituting it would contradict \
+             the exported dual; it must be refused"
+        );
+
+        // Note on pass 1's own rule, unchanged here: it admits a zero-VALUED
+        // candidate without consulting its reduced cost, so it can hand back a
+        // basis whose dual solution differs from the exported `y`. That is
+        // pre-existing and benign in effect -- `separate_gomory_cols` recomputes
+        // the vertex from the basis, and `PreparedDual::prepare` re-checks dual
+        // feasibility and declines -- so the cost is a refused warm start, never
+        // a wrong bound. Tightening pass 1 to match pass 2 would be a strictly
+        // narrower rule and is deliberately NOT done here: it could shorten a
+        // basis that completes today.
+
+        // Monotonicity: with no usable `y`, pass 2 is skipped and the result is
+        // exactly the original value-test outcome.
+        let none = sx.select_row_substitutes(&[]);
+        assert_eq!(none[0], 1, "pass 1 still fires without a dual");
+        assert_eq!(
+            none[1], -1,
+            "without a dual the nonzero-valued singleton must NOT be taken"
+        );
+    }
 
     fn solve(a: &[f64], m: usize, n: usize, b: &[f64], c: &[f64], l: &[f64], u: &[f64]) -> LpSolve {
         let lp = LpView { a, m, n, c, l, u };

--- a/crates/discopt-core/src/profile.rs
+++ b/crates/discopt-core/src/profile.rs
@@ -18,8 +18,18 @@ use std::time::Instant;
 
 static ENABLED: AtomicBool = AtomicBool::new(false);
 
-/// Enable profiling iff `DISCOPT_PROFILE` is present in the environment. Cheap to
-/// call repeatedly; the first call per process fixes the flag.
+/// Enable profiling iff `DISCOPT_PROFILE` is set to something other than an
+/// off-word (`0`, `false`, `no`, or empty). Cheap to call repeatedly.
+///
+/// This used to arm on mere *presence*, which made `DISCOPT_PROFILE=0` turn
+/// profiling **on** — the opposite of what it reads as, and the opposite of the
+/// convention every other discopt env flag follows (`DISCOPT_MILP_ROOT_CUTS`,
+/// `DISCOPT_OBJ_INTEGRALITY`, …). That is not a cosmetic inconsistency: the
+/// instrument adds an `Instant::now()` per phase and an atomic increment per
+/// counter, so a timing panel that defensively exported `DISCOPT_PROFILE=0`
+/// measured the instrument along with the solver, and its numbers were not the
+/// numbers it reported (CLAUDE.md §9). Caught doing exactly that to a root-cut
+/// graduation panel on 2026-09-05.
 ///
 /// In a **test** build this yields to an explicit [`set_enabled(true)`] override
 /// (see [`TEST_OVERRIDE`]). Every MILP solve calls this on entry, and `cargo test`
@@ -33,10 +43,20 @@ pub fn init_from_env() {
     if TEST_OVERRIDE.load(Ordering::Relaxed) {
         return;
     }
-    ENABLED.store(
-        std::env::var_os("DISCOPT_PROFILE").is_some(),
-        Ordering::Relaxed,
-    );
+    ENABLED.store(env_arms_profiling(), Ordering::Relaxed);
+}
+
+/// Whether `DISCOPT_PROFILE`'s current value means "on". Unset is off; set to an
+/// off-word is off; anything else (`1`, `true`, `yes`, a stray value) is on, so
+/// the historical `DISCOPT_PROFILE=1` keeps working unchanged.
+fn env_arms_profiling() -> bool {
+    match std::env::var("DISCOPT_PROFILE") {
+        Err(_) => false, // unset, or not valid UTF-8 -- treat as off
+        Ok(v) => !matches!(
+            v.trim().to_ascii_lowercase().as_str(),
+            "" | "0" | "false" | "no"
+        ),
+    }
 }
 
 /// The profiling side of entering a MILP solve: arm from the environment, then
@@ -625,6 +645,58 @@ pub fn dump() {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// `DISCOPT_PROFILE=0` must mean OFF.
+    ///
+    /// The flag armed on mere *presence*, so the one value a careful caller would
+    /// export to suppress the instrument turned it on. The cost is not cosmetic:
+    /// the instrument adds an `Instant::now()` per phase and an atomic per
+    /// counter, so a timing panel that set `DISCOPT_PROFILE=0` for hygiene was
+    /// timing the instrument too, and its numbers were not the numbers it
+    /// reported (CLAUDE.md §9). Caught doing that to a root-cut graduation panel
+    /// on 2026-09-05.
+    ///
+    /// Calls the real predicate against the real variable -- asserting a
+    /// re-typed copy of the rule would pass even if the shipped rule were
+    /// deleted. Holds [`TEST_LOCK`] because it mutates process-global state that
+    /// every sibling solve's `init_from_env` reads, and restores the prior value
+    /// on the way out so it cannot leak into the rest of the suite.
+    #[test]
+    fn discopt_profile_zero_means_off_not_on() {
+        let _guard = test_guard();
+        let prior = std::env::var_os("DISCOPT_PROFILE");
+        let mut checked = 0;
+        for (v, want) in [
+            ("", false),
+            ("0", false),
+            ("false", false),
+            ("FALSE", false),
+            ("no", false),
+            (" 0 ", false),
+            ("1", true),
+            ("true", true),
+            ("yes", true),
+            ("2", true),
+        ] {
+            std::env::set_var("DISCOPT_PROFILE", v);
+            assert_eq!(
+                env_arms_profiling(),
+                want,
+                "DISCOPT_PROFILE={v:?} should arm profiling = {want}"
+            );
+            checked += 1;
+        }
+        std::env::remove_var("DISCOPT_PROFILE");
+        assert!(!env_arms_profiling(), "unset DISCOPT_PROFILE must be off");
+        checked += 1;
+
+        match prior {
+            Some(v) => std::env::set_var("DISCOPT_PROFILE", v),
+            None => std::env::remove_var("DISCOPT_PROFILE"),
+        }
+        // §6: the probe must prove it fired rather than report a silent pass.
+        assert_eq!(checked, 11, "the value table was not walked");
+    }
 
     /// `init_from_env` must not disarm a measurement a test explicitly armed.
     ///

--- a/crates/discopt-core/src/profile.rs
+++ b/crates/discopt-core/src/profile.rs
@@ -429,6 +429,19 @@ counters!(
     DualRefactorizations,
     DualRefacCap,
     DualRefacFtFail,
+    // Why GMI separation produced nothing. `separate_gomory_cols` had FIVE
+    // uncounted early returns, so a panel that never once looked at a tableau row
+    // reported "0 cuts" — indistinguishable from "looked and found none". That is
+    // exactly the CLAUDE.md §6 failure mode, and it hid the short-basis export
+    // defect (A0'.1) for weeks: on `neos-2624317-amur` every call bailed at
+    // `basic_vars.len() != m` and the instrument said nothing. `SepGomoryCalls` is
+    // the denominator; a healthy run has calls > 0 and the four refusal counters
+    // small against it.
+    SepGomoryCalls,
+    SepGomoryShortBasis,
+    SepGomorySingular,
+    SepGomoryFtranFail,
+    SepGomoryBtranFail,
 );
 
 /// Add `n` to a counter (for accumulated quantities such as nonzero counts,

--- a/crates/discopt-core/src/profile.rs
+++ b/crates/discopt-core/src/profile.rs
@@ -391,6 +391,14 @@ counters!(
     // full separation output.
     RootCutsGenerated,
     RootCutsKept,
+    RootCutsSubstDropped,
+    SubstDropNoSlack,
+    SubstDropNoPrior,
+    SubstDropDegenerate,
+    SubstDropTooLong,
+    SubstDropDynamism,
+    SubstDropUnbounded,
+    SubstDropNonFinite,
     // Why a warm DUAL re-optimize was refused, forcing the primal fallback. On the
     // `rsyn0840m` OA master with a real root cut pool, 588 of 589 node LPs took the
     // primal path at 556 pivots each -- these separate "the shape is wrong" from

--- a/crates/discopt-core/src/profile.rs
+++ b/crates/discopt-core/src/profile.rs
@@ -20,11 +20,42 @@ static ENABLED: AtomicBool = AtomicBool::new(false);
 
 /// Enable profiling iff `DISCOPT_PROFILE` is present in the environment. Cheap to
 /// call repeatedly; the first call per process fixes the flag.
+///
+/// In a **test** build this yields to an explicit [`set_enabled(true)`] override
+/// (see [`TEST_OVERRIDE`]). Every MILP solve calls this on entry, and `cargo test`
+/// runs the suite on a thread pool, so without that yield a driver test on a
+/// sibling thread disarms a counter-based probe mid-measurement and it reads 0 —
+/// the CLAUDE.md §6 failure mode of an instrument that silently measures nothing.
+/// `TEST_LOCK` cannot cover this: the clobbering test never touches the profile
+/// API, it just runs a solve.
 pub fn init_from_env() {
+    #[cfg(test)]
+    if TEST_OVERRIDE.load(Ordering::Relaxed) {
+        return;
+    }
     ENABLED.store(
         std::env::var_os("DISCOPT_PROFILE").is_some(),
         Ordering::Relaxed,
     );
+}
+
+/// The profiling side of entering a MILP solve: arm from the environment, then
+/// clear the per-run counters so the numbers belong to this solve.
+///
+/// Both halves yield to [`TEST_OVERRIDE`]. The reset half matters as much as the
+/// arm half: `cargo test` runs the suite on a thread pool and *every* MILP solve
+/// passes through here, so a sibling test that merely calls the driver used to
+/// zero the counters of a test that had already armed them and started measuring —
+/// which reads as "this path never executed" rather than as interference
+/// (CLAUDE.md §6). A test that owns the measurement calls [`reset`] itself; that
+/// entry point stays unconditional.
+pub fn begin_solve() {
+    init_from_env();
+    #[cfg(test)]
+    if TEST_OVERRIDE.load(Ordering::Relaxed) {
+        return;
+    }
+    reset();
 }
 
 /// Whether profiling is currently active.
@@ -353,6 +384,13 @@ counters!(
     // `rsyn0840m` OA master: 14 cold root solves = 23.1 s of a 24.2 s cut loop).
     RootCutRounds,
     RootCutWarmReopt,
+    // Root cut cleanup: cuts separated at the root vs. cuts still in the LP after
+    // the slack ones are dropped. `Kept == Generated` means the cleanup found
+    // nothing to remove -- either every cut is tight at the final root solution or
+    // the dependency closure held them all -- and the per-node row count is the
+    // full separation output.
+    RootCutsGenerated,
+    RootCutsKept,
     // Why a warm DUAL re-optimize was refused, forcing the primal fallback. On the
     // `rsyn0840m` OA master with a real root cut pool, 588 of 589 node LPs took the
     // primal path at 556 pivots each -- these separate "the shape is wrong" from
@@ -495,11 +533,27 @@ pub fn counter_snapshot() -> Vec<(&'static str, u64)> {
         .collect()
 }
 
+/// Set while a test holds profiling on via [`set_enabled`]. While it is set,
+/// [`init_from_env`] leaves `ENABLED` alone, so a solve running on a sibling test
+/// thread cannot switch the measurement off underneath the test that armed it.
+///
+/// Deliberately one-directional: `set_enabled(true)` raises it, `set_enabled(false)`
+/// clears it. A test that arms the counters through the env var instead (the
+/// `DISCOPT_PROFILE` route, which some driver tests need because they measure the
+/// driver's own `init_from_env` path) is therefore unaffected.
+#[cfg(test)]
+static TEST_OVERRIDE: AtomicBool = AtomicBool::new(false);
+
 /// Force the profiling flag on/off. Test-only: production toggles it exactly once
 /// via [`init_from_env`]. Exposed so a Rust test can deterministically observe a
 /// [`counter`] without setting the `DISCOPT_PROFILE` env var process-wide.
+///
+/// `true` also raises [`TEST_OVERRIDE`], which keeps a concurrent solve's
+/// `init_from_env` from disarming the measurement; `false` clears it and restores
+/// the ordinary env-driven behaviour.
 #[cfg(test)]
 pub fn set_enabled(on: bool) {
+    TEST_OVERRIDE.store(on, Ordering::Relaxed);
     ENABLED.store(on, Ordering::Relaxed);
 }
 
@@ -544,5 +598,95 @@ pub fn dump() {
     for i in 0..NC {
         let v = CVALS[i].swap(0, Ordering::Relaxed);
         eprintln!("  {:<18} {:>10}", CNAMES[i], v);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `init_from_env` must not disarm a measurement a test explicitly armed.
+    ///
+    /// Every MILP solve calls `init_from_env` on entry and `cargo test` runs the
+    /// suite on a thread pool, so before the `TEST_OVERRIDE` yield an unrelated
+    /// driver test on a sibling thread would switch `ENABLED` back off in the
+    /// middle of a counter-based probe, which then read 0 and failed as "this
+    /// path never executed" (CLAUDE.md §6). `TEST_LOCK` cannot cover that: the
+    /// clobbering test never touches the profile API, it just runs a solve.
+    ///
+    /// Asserted deterministically rather than by racing threads: the clobber is a
+    /// plain `init_from_env` call, so calling it directly is the same event.
+    #[test]
+    fn init_from_env_does_not_disarm_an_explicit_test_override() {
+        let _guard = test_guard();
+        // Precondition, or the test proves nothing: with the override cleared,
+        // `init_from_env` really does drive the flag from the (unset) env var.
+        set_enabled(false);
+        assert!(
+            std::env::var_os("DISCOPT_PROFILE").is_none(),
+            "this test reads the unset-env behaviour; DISCOPT_PROFILE is set"
+        );
+        ENABLED.store(true, Ordering::Relaxed);
+        init_from_env();
+        assert!(
+            !enabled(),
+            "without an override, init_from_env must follow the env var"
+        );
+
+        set_enabled(true);
+        init_from_env();
+        assert!(
+            enabled(),
+            "init_from_env disarmed an explicit set_enabled(true) -- a concurrent \
+             solve would silently zero a counter-based probe"
+        );
+        set_enabled(false);
+        assert!(!enabled(), "set_enabled(false) must clear the override");
+    }
+
+    /// The other half of the same hazard: `begin_solve` must not CLEAR the
+    /// counters of a measurement a test armed.
+    ///
+    /// The driver resets the per-run counters on entry to every solve. Under the
+    /// test thread pool that meant a sibling test's solve zeroed an armed probe
+    /// mid-measurement, and the probe read 0 -- indistinguishable from "the code
+    /// under test never ran". Observed as a ~2-in-3 flake on the root-cut cleanup
+    /// test, whose `RootCutsGenerated` came back 0 while `RootCutRounds` was
+    /// non-zero.
+    #[test]
+    fn begin_solve_does_not_clear_counters_under_a_test_override() {
+        let _guard = test_guard();
+        assert!(
+            std::env::var_os("DISCOPT_PROFILE").is_none(),
+            "this test reads the unset-env behaviour; DISCOPT_PROFILE is set"
+        );
+
+        // Precondition: with no override, `begin_solve` really does clear.
+        set_enabled(false);
+        set_enabled(true);
+        incr_by(Ctr::RootCutRounds, 7);
+        assert_eq!(counter(Ctr::RootCutRounds), 7, "counter did not record");
+        set_enabled(false);
+        // `set_enabled(false)` dropped the override but also `ENABLED`; the value
+        // stays in CVALS, which is what `begin_solve` clears.
+        begin_solve();
+        assert_eq!(
+            counter(Ctr::RootCutRounds),
+            0,
+            "without an override, begin_solve must clear the run counters"
+        );
+
+        set_enabled(true);
+        incr_by(Ctr::RootCutRounds, 5);
+        assert_eq!(counter(Ctr::RootCutRounds), 5);
+        begin_solve();
+        assert_eq!(
+            counter(Ctr::RootCutRounds),
+            5,
+            "begin_solve cleared an armed test's counters -- a concurrent solve \
+             would make the probe read 0 and look like dead code"
+        );
+        set_enabled(false);
+        reset();
     }
 }

--- a/crates/discopt-core/src/profile.rs
+++ b/crates/discopt-core/src/profile.rs
@@ -79,8 +79,30 @@ pub fn begin_solve() {
 }
 
 /// Whether profiling is currently active.
+///
+/// Under a [`set_enabled(true)`] test override this is **thread-scoped**: only the
+/// thread that raised the override sees profiling as on. `TEST_OVERRIDE` alone was
+/// not enough. It stops a sibling test from *disarming* the owner's measurement,
+/// but the owner leaves `ENABLED` globally true, so every concurrent solve on the
+/// pool kept incrementing the same global counters — the owner then read its own
+/// events plus theirs. That is not a hypothetical: CI's
+/// `root_cut_rounds_reoptimize_warm_instead_of_cold_solving` asked for
+/// `cut_rounds = 12` and read `RootCutRounds = 20`, i.e. 8 rounds belonging to
+/// other tests, and failed on the derived `warm_reopt == rounds - 1` identity.
+/// An instrument that over-counts is as broken as one that counts nothing.
+///
+/// The scope this buys is the *owning thread*, so a counter incremented on a rayon
+/// worker inside the measured solve is not visible to the owner. No counter test
+/// reads one: every reader measures either a direct simplex/separator call or the
+/// driver's root loop, all of which run on the caller's thread. A test that ever
+/// does want a worker-thread counter will read 0, which its
+/// `assert!(n >= …)` floor must catch loudly rather than pass vacuously.
 #[inline(always)]
 pub fn enabled() -> bool {
+    #[cfg(test)]
+    if TEST_OVERRIDE.load(Ordering::Relaxed) {
+        return TEST_OWNS_MEASUREMENT.with(|owns| owns.get());
+    }
     ENABLED.load(Ordering::Relaxed)
 }
 
@@ -585,6 +607,15 @@ pub fn counter_snapshot() -> Vec<(&'static str, u64)> {
 #[cfg(test)]
 static TEST_OVERRIDE: AtomicBool = AtomicBool::new(false);
 
+#[cfg(test)]
+thread_local! {
+    /// Raised on the one thread that called `set_enabled(true)`. While
+    /// `TEST_OVERRIDE` is up, [`enabled`] consults this instead of `ENABLED`, so
+    /// the override arms the owner's thread and nobody else's. See [`enabled`] for
+    /// why the global flag alone let sibling tests inflate a measurement.
+    static TEST_OWNS_MEASUREMENT: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
+}
+
 /// Force the profiling flag on/off. Test-only: production toggles it exactly once
 /// via [`init_from_env`]. Exposed so a Rust test can deterministically observe a
 /// [`counter`] without setting the `DISCOPT_PROFILE` env var process-wide.
@@ -594,6 +625,7 @@ static TEST_OVERRIDE: AtomicBool = AtomicBool::new(false);
 /// the ordinary env-driven behaviour.
 #[cfg(test)]
 pub fn set_enabled(on: bool) {
+    TEST_OWNS_MEASUREMENT.with(|owns| owns.set(on));
     TEST_OVERRIDE.store(on, Ordering::Relaxed);
     ENABLED.store(on, Ordering::Relaxed);
 }
@@ -661,6 +693,43 @@ mod tests {
     /// deleted. Holds [`TEST_LOCK`] because it mutates process-global state that
     /// every sibling solve's `init_from_env` reads, and restores the prior value
     /// on the way out so it cannot leak into the rest of the suite.
+    /// A sibling thread's work must not land in the measuring thread's counters.
+    ///
+    /// Before the thread-scoped override, `set_enabled(true)` left `ENABLED` true
+    /// process-wide, so every concurrent solve on `cargo test`'s pool incremented
+    /// the same globals and the owner read its own events *plus* theirs. This is
+    /// the exact shape that made CI's root-cut-round test see 20 rounds when it
+    /// asked for 12. Fails before the fix, passes after.
+    #[test]
+    fn a_sibling_threads_counters_do_not_land_in_this_threads_measurement() {
+        let _guard = test_guard();
+        set_enabled(true);
+        reset();
+
+        let sibling = std::thread::spawn(|| {
+            // No `set_enabled` here: this thread is a bystander, exactly like a
+            // test that merely runs a solve while another test is measuring.
+            let mut n = 0;
+            for _ in 0..1000 {
+                incr(Ctr::RootCutRounds);
+                n += 1;
+            }
+            n
+        });
+        let emitted: u32 = sibling.join().expect("sibling panicked");
+
+        let mine = counter(Ctr::RootCutRounds);
+        set_enabled(false);
+
+        // §6: prove the sibling actually ran, or "0 stray counts" is vacuous.
+        assert_eq!(emitted, 1000, "the sibling never emitted anything");
+        assert_eq!(
+            mine, 0,
+            "{mine} of the sibling's 1000 increments leaked into this thread's \
+             measurement; a counter test would read its own events plus theirs"
+        );
+    }
+
     #[test]
     fn discopt_profile_zero_means_off_not_on() {
         let _guard = test_guard();

--- a/crates/discopt-core/tests/dive_schedule_default_off.rs
+++ b/crates/discopt-core/tests/dive_schedule_default_off.rs
@@ -54,6 +54,8 @@ fn stride_unset_never_dives_away_from_the_root() {
         initial_incumbent: None,
         node_hook_rounds: 0,
         node_hook_cut_cap: 0,
+        root_cut_time_s: None,
+        root_cut_prune: true,
         simplex: SimplexOptions::default(),
     };
     let res = solve_milp(&lp, &b, 0.0, &opts);

--- a/crates/discopt-core/tests/dive_schedule_off_root.rs
+++ b/crates/discopt-core/tests/dive_schedule_off_root.rs
@@ -69,6 +69,8 @@ fn options() -> MilpOptions {
         initial_incumbent: None,
         node_hook_rounds: 0,
         node_hook_cut_cap: 0,
+        root_cut_time_s: None,
+        root_cut_prune: true,
         simplex: SimplexOptions::default(),
     }
 }

--- a/crates/discopt-python/src/lp_bindings.rs
+++ b/crates/discopt-python/src/lp_bindings.rs
@@ -1100,7 +1100,9 @@ impl MilpNodeHook for PyMilpNodeHook {
                     max_pool_cuts=128, heuristics=true, presolve=true, strong_branch=true,
                     node_propagation=false, reduced_cost_fixing=true,
                     sb_max_cands=6, sb_node_budget=48,
-                    initial_incumbent=None, time_limit_s=None, debug_hook=None))]
+                    initial_incumbent=None, time_limit_s=None, root_cut_time_s=None,
+                    root_cut_prune=true,
+                    debug_hook=None))]
 pub fn solve_milp_py<'py>(
     py: Python<'py>,
     c: PyReadonlyArray1<'py, f64>,
@@ -1129,6 +1131,8 @@ pub fn solve_milp_py<'py>(
     sb_node_budget: usize,
     initial_incumbent: Option<PyReadonlyArray1<'py, f64>>,
     time_limit_s: Option<f64>,
+    root_cut_time_s: Option<f64>,
+    root_cut_prune: bool,
     debug_hook: Option<Py<PyAny>>,
 ) -> PyResult<(String, Bound<'py, PyArray1<f64>>, f64, f64, usize, usize)> {
     let dims = a.shape();
@@ -1197,6 +1201,8 @@ pub fn solve_milp_py<'py>(
         sb_node_budget,
         initial_incumbent,
         time_limit_s,
+        root_cut_time_s,
+        root_cut_prune,
         debug_hook,
         // No lazy separator on this entry point: it keeps the historical
         // 6-tuple return and the driver's untouched path. `solve_milp_lazy_csc_py`
@@ -1222,7 +1228,9 @@ pub fn solve_milp_py<'py>(
                     max_pool_cuts=128, heuristics=true, presolve=true, strong_branch=true,
                     node_propagation=false, reduced_cost_fixing=true,
                     sb_max_cands=6, sb_node_budget=48,
-                    initial_incumbent=None, time_limit_s=None, debug_hook=None))]
+                    initial_incumbent=None, time_limit_s=None, root_cut_time_s=None,
+                    root_cut_prune=true,
+                    debug_hook=None))]
 #[allow(clippy::too_many_arguments)]
 pub fn solve_milp_csc_py<'py>(
     py: Python<'py>,
@@ -1256,6 +1264,8 @@ pub fn solve_milp_csc_py<'py>(
     sb_node_budget: usize,
     initial_incumbent: Option<PyReadonlyArray1<'py, f64>>,
     time_limit_s: Option<f64>,
+    root_cut_time_s: Option<f64>,
+    root_cut_prune: bool,
     debug_hook: Option<Py<PyAny>>,
 ) -> PyResult<(String, Bound<'py, PyArray1<f64>>, f64, f64, usize, usize)> {
     let col_ptr_v: Vec<usize> = col_ptr.as_slice()?.iter().map(|&x| x as usize).collect();
@@ -1313,6 +1323,8 @@ pub fn solve_milp_csc_py<'py>(
         sb_node_budget,
         initial_incumbent,
         time_limit_s,
+        root_cut_time_s,
+        root_cut_prune,
         debug_hook,
         // No lazy separator on this entry point: it keeps the historical
         // 6-tuple return and the driver's untouched path. `solve_milp_lazy_csc_py`
@@ -1375,7 +1387,9 @@ pub fn solve_milp_csc_py<'py>(
                     max_pool_cuts=128, heuristics=true, presolve=true, strong_branch=true,
                     node_propagation=false, reduced_cost_fixing=true,
                     sb_max_cands=6, sb_node_budget=48,
-                    initial_incumbent=None, time_limit_s=None, debug_hook=None,
+                    initial_incumbent=None, time_limit_s=None, root_cut_time_s=None,
+                    root_cut_prune=true,
+                    debug_hook=None,
                     node_callback=None, node_hook_rounds=0, node_hook_cut_cap=0))]
 #[allow(clippy::too_many_arguments)]
 pub fn solve_milp_lazy_csc_py<'py>(
@@ -1411,6 +1425,8 @@ pub fn solve_milp_lazy_csc_py<'py>(
     sb_node_budget: usize,
     initial_incumbent: Option<PyReadonlyArray1<'py, f64>>,
     time_limit_s: Option<f64>,
+    root_cut_time_s: Option<f64>,
+    root_cut_prune: bool,
     debug_hook: Option<Py<PyAny>>,
     node_callback: Option<Py<PyAny>>,
     node_hook_rounds: usize,
@@ -1493,6 +1509,8 @@ pub fn solve_milp_lazy_csc_py<'py>(
         sb_node_budget,
         initial_incumbent,
         time_limit_s,
+        root_cut_time_s,
+        root_cut_prune,
         debug_hook,
         Some(lazy_callback),
         node_callback,
@@ -1536,6 +1554,8 @@ fn run_milp_hooked<'py>(
     sb_node_budget: usize,
     initial_incumbent: Option<PyReadonlyArray1<'py, f64>>,
     time_limit_s: Option<f64>,
+    root_cut_time_s: Option<f64>,
+    root_cut_prune: bool,
     debug_hook: Option<Py<PyAny>>,
     lazy_callback: Option<Py<PyAny>>,
     node_callback: Option<Py<PyAny>>,
@@ -1577,6 +1597,8 @@ fn run_milp_hooked<'py>(
         initial_incumbent: initial_incumbent
             .map(|arr| arr.as_slice().map(|s| s.to_vec()))
             .transpose()?,
+        root_cut_time_s: parse_budget_secs(root_cut_time_s)?,
+        root_cut_prune,
         simplex: SimplexOptions {
             tol,
             max_iter: 100_000,

--- a/docs/dev/milp-competitiveness-plan.md
+++ b/docs/dev/milp-competitiveness-plan.md
@@ -286,7 +286,145 @@ entry experiment this section was written to run — "does HiGHS also leave 7–
 at the mik root?" — is answered **no** (it leaves 1.5–1.8 %), so Stage 2 is not
 killed; it is deferred behind a bigger, cheaper win.
 
-## 3. Stages
+## 2.6 Why HiGHS needs so few nodes — the mechanism, measured
+
+HiGHS closes **16 of the 38 in a single node**: `app2-2`, `b-ball`, `beavma`,
+`dcmulti`, `f2gap40400`, `gen`, `gr4x6`, `gt2`, `khb05250`, `neos-1425699`,
+`neos-5192052-neckar`, `nexp-50-20-1-1`, `nexp-50-20-4-2`, `sp150x300d`,
+`supportcase14`, `supportcase16`. One node means the root — after presolve, cuts
+and heuristics — both *produces* the optimum and *proves* it. Total panel nodes:
+HiGHS 15,417, discopt 4,693,240 at its best arm. That is ~300×.
+
+The mechanism is not one missing component; it is two, multiplying.
+
+**First: the last few percent of root gap is worth orders of magnitude of tree.**
+Tree size grows roughly exponentially in the residual gap, so the interesting
+comparison is not "discopt closes 74 % of the mik root gap" but what is *left*.
+At 200 × 8, discopt leaves 4.5 % on `mik-250-20-75-*`; HiGHS leaves 1.7 %
+(§2.5). A 2.6× wider residual gap is not a 2.6× bigger tree. The same pattern
+holds on `sp150x300d` (15.71 % vs 0.00 %), `nexp-50-20-1-1` (30.00 % vs 0.00 %)
+and `beavma` (31.05 % vs 0.00 %) — on those three HiGHS's root bound is *exact*
+and discopt's is not close, which is precisely why HiGHS needs one node and
+discopt needs 10⁵.
+
+**Second: with no incumbent, nothing prunes.** A node is cut off only when its
+bound is worse than the incumbent. discopt reaches the end of its budget 22-45 %
+above the optimum on the four `mik`, and finds **no feasible point at all** on
+`enlight_hard` and `neos-2624317-amur`. A tree with a poor incumbent explores
+nodes that a good one deletes outright, regardless of how good the bound is.
+This is why `mik` burns 289 k-563 k nodes against HiGHS's 558-1055 despite a
+dual gap of only 2.1-2.7 %.
+
+Neither alone explains the ratio; together they do. And they are not independent
+— a good incumbent early prunes the tree that would otherwise be needed to lift
+the bound.
+
+## 3. The parity plan
+
+*Goal:* 38/38 on this panel inside HiGHS's wall-clock envelope. That is the
+definition of done; every stage below is scored against it.
+
+*Ordering principle, from §1's measured decomposition:* **the bound is short on
+17 of 17 failures; the incumbent is additionally short on 14 of 17.** Bound work
+is therefore necessary everywhere and primal work is necessary on 14 and
+sufficient on none — no instance closes until the bound arrives, however good the
+incumbent. That is a strict ordering, and it is why Track A precedes Track B. But
+Track B is not optional: on the `mik` family the bound is already within 2.6 % and
+the tree still does not close, so Track A alone does not reach 38/38 either.
+
+### Track A — the bound (needed by 17/17)
+
+**A0. Graduate the root cut budget. Ready now; no new code.**
+This was net-*negative* before the structural-space fix (`cut200_prune` 11/38
+against base 18/38) because every cut broke node warm starts. With that fixed it
+is net-positive: `cut500_prune` **21/38 against base 19/38 at 47 % fewer nodes**,
+190/190 runs, zero certification aborts, no false bound. That meets CLAUDE.md §5's
+double bar — cert-clean *and* net-positive — which it did not before. Needs one
+confirming panel on an unloaded machine for the wall-clock column, then the
+default flips.
+*Expected: +2 instances, already measured.*
+
+**A1. Finish the cut lifecycle (the remainder of the old Stage 1).**
+The warm-start half is done. Still missing: stall-based termination instead of the
+fixed round budget (discopt's `1e-7*(1+|prev_obj|)` test is far tighter than
+HiGHS's `stall < 3` against cumulative gain or SCIP's `objreldiff ≤ 1e-4`); cut
+*aging* (SCIP `LP_ROWAGELIMIT 10`, `set.c:263`; HiGHS ages basic cut rows at
+`mip_lp_age_limit`, `HighsLpRelaxation.cpp:595-642`); and a cut *pool* rather
+than the constraint matrix. Also: `CUT_MAX_PARALLEL = 0.99` is 10× laxer than
+both references (HiGHS `maxpar = 0.1`, `HighsCutPool.cpp:320`; SCIP `MINORTHO
+0.90`), so near-duplicate cuts are being kept.
+*Expected: the budget can then go higher than 500 without paying for it, which is
+what A2 needs.*
+
+**A2. A second cut family — cMIR/flow-cover and knapsack cover.**
+GMI is discopt's only family. §2.5 shows the existing separators already close
+70-92 % of the root gap, so this is not "discopt has no cuts" — it is the last
+few percent, which §2.6 argues is where the tree size lives. Deferred behind A1
+deliberately: cMIR is only worth having once a large cut set is affordable.
+The instances it should move are the mixed-knapsack and set-covering shapes that
+dominate the failures — `mik-*`, `nexp-*`, `sp150x300d`, `beavma`.
+*Entry experiment before building (CLAUDE.md §4, the #727 RLT lesson): separate
+cMIR at the root on those instances only, and measure the root gap against the
+4.5 %/15.7 %/30.0 % baselines. If it does not move them on the real instances, it
+does not get built.*
+
+**A3. The two instances that get no usable cuts at all.**
+`gsvm2rl3` — 31 cuts separated, all discarded as ill-conditioned, 42 % dual gap.
+`neos-2624317-amur` — zero cuts generated, 100 % dual gap, no feasible point.
+Relaxing the numerical gates is already **falsified** (see "Falsified: relaxing
+the cut-cleanup's numerical gates"): it rescues `gsvm2rl3`'s root gap but is
+node-neutral, so these need a family whose coefficients are conditioned by
+construction, i.e. A2. Tracked here so they are not silently dropped.
+
+### Track B — the incumbent (needed by 14/17)
+
+discopt's failures are not marginal on this axis: 22-45 % above optimum on the
+`mik` family, and no feasible point at all on two instances. This is the half
+that was invisible while only the bound was instrumented.
+
+**B1. Node selection and plunging.** discopt uses `SelectionStrategy::BestFirst`
+and carries a best-estimate field that is not wired to the driver. SCIP's default
+is `nodesel_estimate` (`STDPRIORITY 200000`, the highest of five,
+`nodesel_estimate.c:48`); HiGHS alternates best-estimate plunges with a forced
+best-bound pop every 10 leaves (`HighsMipSolver.cpp:504-516`). Cheapest item in
+Track B — the field exists — and it is the one that most directly attacks "no
+incumbent".
+
+**B2. Real primal heuristics.** In rough order of value-per-unit-work: diving
+variants, RENS, feasibility pump, RINS, local branching. Two instances find no
+feasible point at all, which is a feasibility-pump-shaped problem specifically.
+
+*Scoring note for Track B:* an incumbent improvement shows up as **nodes and
+solved-count**, not as root gap. Measure it at a fixed node budget, not a time
+limit, until the machine is reliably quiet.
+
+### Track C — measured NOT to be the difference. Do not spend here.
+
+Recorded so this ground is not re-covered:
+
+- **Presolve** — `h_nopre ≈ h_full` everywhere on the root-bound probe; worth
+  ~0-3 pp of root gap (§2.5a). §1c independently put it at ≤2 instances.
+- **Symmetry** — 0 instances on this panel (§1c).
+- **`node_propagation`** — graduated ON, but gains **zero** instances; the HiGHS
+  review's "3-6 instances" is falsified (Stage 0.1).
+- **Relaxing the cut numerical gates** — cert-clean but node-neutral; falsified
+  and reverted, with the measurement recorded at the refusal site.
+- **`cut_select`** — falsified earlier: `fiber` 2986.5 → 6457.4 it/node, `mik`
+  acceptance 100 % → 35.0 %.
+
+### Measurement discipline for every stage below
+
+1. Node-limited panels while machine load is high — a time limit measures the
+   machine (CLAUDE.md §9). Load was ~68 during the 2026-09-05 work; every
+   conclusion drawn that day rests on node counts and counters, never wall.
+2. Every bound-changing item behind a default-off flag with the §5 double bar
+   (cert-clean AND net-positive) over the 38 panel *and* the in-repo MINLP corpus.
+3. Entry experiment before implementation, on **real corpus instances**, with a
+   named kill criterion.
+
+## 3bis. Stage detail (the original numbering, retained)
+
+
 
 Reordered from the first draft per §2, and re-weighted per §2.5 — Stage 1 is now
 the lever and Stage 2 is deferred behind it. Every bound-changing piece goes behind a
@@ -570,11 +708,28 @@ Sequentially-lifted knapsack cover (upgrading `lp/cover.rs` from unlifted) is
 
 ## 4. Success metric
 
-The §0 panel at matched `mip_rel_gap = 1e-4`, TL = 20 s. Base is **18/38 at
-444.93 s** (19/38 once the tolerance is matched); HiGHS **36/38 at 76.77 s**
-interleaved, 38/38 at 66.85 s alone. "Competitive" is solved-count within a few
-instances of HiGHS's with total wall within ~2×. Every stage reports against this
-same table.
+The §0 panel at matched `mip_rel_gap = 1e-4`, TL = 20 s. "Competitive" is
+solved-count within a few instances of HiGHS's with total wall within ~2×. Every
+stage reports against this same table.
+
+Current standing, matched tolerance, 190/190 runs, zero certification aborts:
+
+| arm | solved | wall | med(solved) | nodes |
+|---|---|---|---|---|
+| base_16x1 | 19/38 | 430.41 s | 0.170 s | 8,853,388 |
+| cut200_prune | 20/38 | 400.50 s | 0.130 s | 6,459,226 |
+| **cut500_prune** (best) | **21**/38 | 399.97 s | 0.138 s | 4,693,240 |
+| **highs** | **38**/38 | **71.95 s** | 1.039 s | **15,417** |
+
+Distance to go: **17 instances, ~5.6× wall, ~300× nodes.** Intermediate targets,
+so a stage can be scored before parity is reached: A0 → 21/38 (measured, banked);
+A1 → 24/38; A2 → 30/38; B1+B2 → 35/38. These are targets, not predictions — a
+stage that misses its target is re-scoped against the measurement, per §4 of
+CLAUDE.md, not carried forward on hope.
+
+*Caveat on every wall column here:* machine load was 66-69 during the 2026-09-05
+panel. Node counts are load-independent and carry the conclusions; the wall
+figures need one quiet re-run before they are quoted outside this document.
 
 ## 5. Licensing note for the owner
 

--- a/docs/dev/milp-competitiveness-plan.md
+++ b/docs/dev/milp-competitiveness-plan.md
@@ -521,10 +521,45 @@ This was net-*negative* before the structural-space fix (`cut200_prune` 11/38
 against base 18/38) because every cut broke node warm starts. With that fixed it
 is net-positive: `cut500_prune` **21/38 against base 19/38 at 47 % fewer nodes**,
 190/190 runs, zero certification aborts, no false bound. That meets CLAUDE.md §5's
-double bar — cert-clean *and* net-positive — which it did not before. Needs one
-confirming panel on an unloaded machine for the wall-clock column, then the
-default flips.
+double bar — cert-clean *and* net-positive — which it did not before.
 *Expected: +2 instances, already measured.*
+
+**GRADUATED default-ON, 2026-09-05.** `_milp_root_cut_budget` now returns the
+budget unless `DISCOPT_MILP_ROOT_CUTS=0`; the legacy `root_cuts=16, cut_rounds=1`
+single pass stays intact and reachable, which is what the panel A/Bs.
+
+Confirming panel: 38 instances, `gap_tol=1e-4`, 20 s each, both arms interleaved
+*within* every replicate, 2 replicates, and the whole panel run **twice** under
+different machine load.
+
+| arm | solved | total wall | med(solved) | nodes | gap on the 17 open |
+|---|---|---|---|---|---|
+| off (16 / 1) | 18-19/38 | 424.9 s ±4.2 | 0.158 s | 9,409,627 | mean 0.2028, med 0.1052 |
+| on (500 / 50 / select) | **21**/38 | 399.8 s ±1.0 | 0.135 s | **5,353,150** | mean **0.1494**, med **0.0265** |
+
+*Cert-clean*: 304 bound-vs-reference comparisons across the two runs, zero
+violations; `fiber`, `gt2` and `neos-3611689-kaihu` go feasible → optimal and
+nothing regresses. *Net-positive*: +3 instances, −43 % nodes, and a materially
+better dual bound exactly on §1b's pure-dual family.
+
+**On the wall column, and why it is not the basis of this verdict.** The machine
+never idled below load ~5 — two `myst start` dev servers hold ~100 % CPU each,
+and a foreign `pytest` arrived mid-run on the first attempt (load peaked at 58).
+Per CLAUDE.md §9 the wall numbers are corroboration only. The verdict rests on
+solved count, node count and dual bound, which are load-independent, and which
+**both runs reproduced to four significant figures** (0.2028 → 0.1494 in each) —
+two runs under different load agreeing exactly is stronger evidence than one
+quiet run would have been. `gradpanel.py` now samples load per solve so a
+contaminated row is recorded rather than inferred, and `gradscore.py` refuses to
+issue a timing verdict when it sees contention.
+
+**The cost, stated rather than buried.** Cuts buy the hard instances by taxing
+the easy ones: ON is *slower* on 11 of the 18 both arms solve —
+`neos-3611447-jijia` 7.5 → 13.9 s, `enlight8` 5.4 → 10.5 s, `22433`
+0.31 → 2.51 s — against 7 faster (`bppc8-02` 3.79 → 1.44 s). Net-positive at 38
+instances, but the per-instance tax is precisely the argument for A1's
+stall-based termination and cut aging. A1 should be scored on removing this tax
+without giving back the +3.
 
 **A0 configuration check (2026-09-05) — the shipped setting is not the banked
 one, and it had never been measured.** The banked arm is `cut500_prune` =
@@ -1065,7 +1100,7 @@ so a stage can be scored before parity is reached:
 
 | stage | target | basis for the target |
 |---|---|---|
-| A0 + A0.1 | 21/38 | measured, banked (`cut500_prune`) |
+| A0 + A0.1 | 21/38 | **MET, 2026-09-05 — graduated default-ON.** 18-19/38 → **21/38** at −43 % nodes, dual gap on the 17 open instances 0.2028 → 0.1494; cert-clean over 304 bound-vs-optimum comparisons across two independent runs, zero violations, three instances feasible → optimal and none the reverse. Shipped at `_milp_root_cut_budget`'s configuration, not `cut500_prune`'s — see Track A0 |
 | A0′.1 | 21/38 | **MET, 2026-09-05.** No solved-count target — a correctness repair scored on counters and LP work. Delivered: `DualPrepRejectShape` 300 → 0 on amur, `RootCutsGenerated` 0 → 102, and **−37.5 % simplex iterations** panel-wide at unchanged nodes and a cert-clean panel. A0′.2 was falsified and demoted — see Track A0′ |
 | A1 | 24/38 | cut lifecycle makes a >500 budget affordable |
 | A2 | 30/38 | the family HiGHS actually closes its last few percent with |

--- a/docs/dev/milp-competitiveness-plan.md
+++ b/docs/dev/milp-competitiveness-plan.md
@@ -526,6 +526,46 @@ confirming panel on an unloaded machine for the wall-clock column, then the
 default flips.
 *Expected: +2 instances, already measured.*
 
+**A0 configuration check (2026-09-05) — the shipped setting is not the banked
+one, and it had never been measured.** The banked arm is `cut500_prune` =
+`root_cuts=500, cut_rounds=8, cut_select=False, root_cut_prune=True`. What
+`_milp_root_cut_budget` (`solver.py:21476-21510`) actually hands `solve_milp_py`
+is **different**: `root_cuts=500, cut_rounds=50, cut_select=True,
+root_cut_time_s=max(0.5, 0.5·engine_budget)`. Flipping the default as written
+would therefore have shipped a configuration no panel had ever run — the A0.1
+wiring step above silently changes the thing A0 measured.
+
+Measured with a **node**-budget panel (`scratchpad/miplib/armpanel.py`, 38
+instances, `max_nodes=2000`, `gap_tol=1e-4`, three arms rotated per instance).
+Node budgets rather than time budgets deliberately: the machine was at load ~21
+all day, and node counts, iteration counts and dual bounds are load-independent
+where wall-clock is not (CLAUDE.md §9). `time_limit_s=300` was present only as a
+hang guard and bound on no row.
+
+| arm | config | solved | nodes | simplex iters |
+|---|---|---|---|---|
+| `off` | 16 / 1 / no-select (today's default) | 11/38 | 59,070 | 1,498,688 |
+| `prod` | 500 / 50 / select (what `_milp_root_cut_budget` ships) | 11/38 | 57,524 | 1,618,863 |
+| `p500` | 500 / 8 / no-select (the banked `cut500_prune`) | 11/38 | 58,646 | 1,941,550 |
+
+Cert-clean: 114 bound-vs-reference-optimum comparisons, **zero violations**, and
+no instance changed solved status in either direction.
+
+The payoff is in the **bound**, on the 27 instances no arm finished within 2000
+nodes — mean dual gap `off` 0.2496 → `prod` **0.1883** (−25 %), median 0.1435 →
+**0.0404**; `prod` is strictly better than `off` on 16, worse on 4, tied on 7.
+The four `mik-250-20-75-*` move 0.143/0.127/0.145/0.162 → 0.038/0.036/0.037/0.038
+— the §1b pure-dual family is exactly where the cuts land.
+
+**The banked claim transfers, and the shipped configuration is the better of the
+two**: `prod` beats `p500` on mean gap (0.1883 vs 0.1919), on best-arm wins
+(19 vs 12) and on simplex iterations (1.62 M vs 1.94 M). So A0.1's wiring does
+not need to be re-pointed at `cut500_prune`; `_milp_root_cut_budget` stays as it
+is. Caveat on scope: at a 2000-node budget no arm converts a better bound into a
+*solve*, so this panel confirms cert-cleanliness and bound quality but says
+nothing about the banked "+2 instances", which was a 20 s wall-clock result. That
+column still needs the unloaded-machine panel named above before the flip.
+
 **A0.1 — wire the graduated budget to the product path.** The
 `_STRONG_CUT_PROFILE` 200 × 10 escalation
 (`python/discopt/solvers/milp_simplex.py:66-96, 985-1022`) sits on the OA/relaxer

--- a/docs/dev/milp-competitiveness-plan.md
+++ b/docs/dev/milp-competitiveness-plan.md
@@ -1,0 +1,357 @@
+# Closing the MILP gap to HiGHS/SCIP — measured plan
+
+Status: entry measurements done 2026-09-05; source review against HiGHS 1.14 and
+SCIP 10.0.2 done 2026-09-05. **No stage below has been started.**
+Goal: discopt competitive with HiGHS/SCIP on pure MILP.
+
+## 0. The measurement this plan replaces
+
+The prior plan was "raise the root cut budget and clean up slack cuts". It looked
+net-positive on a 30-instance synthetic lattice panel (26/30 vs base 25/30).
+**On a real corpus it is net-negative and the claim is retracted** (CLAUDE.md §11).
+
+38 MIPLIB 2017 "easy" instances (size-filtered, and every one validated by having
+HiGHS reproduce the published optimum from *the converted arrays discopt
+receives*), TL = 20 s, arms interleaved per instance, 190/190 runs, no
+certification abort:
+
+| arm | solved | wall | med(solved) | nodes | kept/gen |
+|---|---|---|---|---|---|
+| base_16x1 | **18**/38 | 444.93 s | 0.139 s | 8,312,044 | 0/0 |
+| cut200_noprune | 11/38 | 573.62 s | 0.235 s | 1,964,690 | 0/0 |
+| cut200_prune | 11/38 | 529.55 s | 0.160 s | 1,327,506 | 2544/5720 |
+| cut500_prune | 11/38 | 541.52 s | 0.196 s | 694,144 | 3709/12671 |
+| **highs** | **36**/38 | **76.77 s** | 0.802 s | 15,073 | 0/0 |
+
+`DISCOPT_MILP_ROOT_CUTS` therefore **stays default-OFF**. The cleanup
+(`root_cut_prune`) is retained only because it is strictly better *within* the
+cut path (529 s / 1.33 M nodes vs 573 s / 1.96 M); it does not rescue the budget.
+
+**Both source reviews independently read that row as a lifecycle failure, not a
+cut-quality failure**: cuts added under a fixed budget and then carried in every
+node LP forever. See §2.1.
+
+### 0.1 Methodology corrections carried into every later panel
+
+- **Matched gap tolerance.** That run gave discopt `gap_tol = 1e-6` (relative —
+  `tree_manager.rs:992`) against HiGHS's default `mip_rel_gap = 1e-4`, a 100×
+  tighter stopping rule. I first estimated this at "exactly one instance". That
+  understated it: at matched 1e-4, `neos-1425699` goes from **640,669 nodes,
+  unsolved** to **29 nodes, 0.00 s**. No comparison number may be published at
+  mismatched tolerances again.
+- **Nodes, not wall, is the diagnostic.** Twelve of the twenty instances discopt
+  fails, HiGHS finishes in **one node**.
+
+### 0.2 The sharpest single fact on the panel
+
+HiGHS closes `b-ball`, `sp150x300d`, `beavma`, `nexp-50-20-1-1`,
+`nexp-50-20-4-2`, `khb05250`, `gen`, `dcmulti`, `app2-2`, `f2gap40400`, `gr4x6`,
+`supportcase14` and `supportcase16` in **one node**. One node means the root LP —
+after presolve, root cuts and root heuristics — both *produces* the optimum and
+*proves* it. discopt spends 350 k–870 k nodes on several of those same instances.
+
+This is a **root-strength** problem, not a tree-search problem. It is why Stage
+0's search-side flips move zero instances, and it is the reason the stage order
+below puts root cut control and cMIR ahead of everything on the search side.
+Almost everything that matters happens before the first branch.
+
+## 1. Where the gap is
+
+### 1a. The failures present as primal-short
+
+Decomposing base's 20 failures into primal gap `(inc − opt)/(1+|opt|)` and dual
+gap `(opt − bound)/(1+|opt|)`: **15/20 are primal-short**, and two
+(`enlight_hard`, `neos-2624317-amur`) never find a feasible point at all. Worst
+primal gaps: `neos-911970` 208.5 %, `fiber` 57.7 %, `nexp-50-20-1-1` 56.7 %,
+`beavma` 42.2 %, `sp150x300d` 34.3 %. Six have a dual gap ≤ 3 % (`obra` 0.46,
+`kaihu` 0.80, `iskar` 1.40, `istra` 2.56, `neos17` 2.56, `fiber` 3.02) — a decent
+incumbent alone would close those trees.
+
+§1c argues this is largely a *symptom*: a weak dual bound upstream of the missing
+incumbents. It is not, however, dismissed — see Stage 3.
+
+### 1b. The four `mik-250-20-75-*` are a pure dual failure
+
+They already hold the **optimum as incumbent** (primal gap ≈ 0) and still carry a
+7–10 % dual gap after ~700 k nodes. HiGHS: 558–1055 nodes, 3.6–5.2 s. `mik` is
+the textbook mixed-integer-knapsack (cMIR) family.
+
+discopt's MILP driver separates **cover + Gomory only** (`milp_driver.rs:1065`,
+`:1081`; in-tree at `:2300`, cover only), with `cut_select=false` and
+`node_cuts=false` as shipped defaults (`lp_bindings.rs:1099`).
+
+### 1c. Presolve, heuristics and symmetry are NOT the difference
+
+Ablation of HiGHS itself over the whole panel, HiGHS alone on the machine,
+TL = 20 s, 190 comparisons:
+
+| HiGHS arm | solved | wall | nodes |
+|---|---|---|---|
+| full | 38/38 | 66.85 s | 15,417 |
+| no_presolve | 36/38 | 114.38 s | 36,261 |
+| no_heur | 37/38 | 80.12 s | 41,521 |
+| no_sym | 38/38 | 71.79 s | 16,368 |
+| **bare** (all three off) | **37/38** | **119.93 s** | 54,420 |
+
+Presolve is worth ≤2 instances and ~1.7× wall; symmetry is 0. discopt's own MILP
+presolve is dimension-preserving FBBT (`milp_driver.rs:677`) and HiGHS's really
+does reduce (`nexp-50-20-1-1` 1030×540 → 728×280) — but the reduction is not what
+closes these instances.
+
+**Correction (CLAUDE.md §11).** An earlier draft of this document said HiGHS
+"reaches 37/38 with zero heuristic effort". That is wrong.
+`mip_heuristic_effort=0` does **not** disable HiGHS's heuristics: feasibility
+jump, rounding, shifting and RENS are gated by separate `mip_heuristic_run_*`
+booleans (`HighsOptions.h:490-495`, registered **default `true`** at
+`:1213-1215`), and `moreHeuristicsAllowed`
+(`HighsMipSolverData.cpp:611-673`) grants an unconditional 10,000-iteration
+heuristic LP budget even at effort 0 (`:627-629`); incumbents also arrive from
+integral node LPs (`HighsSearch.cpp:966-971`) and strong-branch LPs (`:601-606`).
+The `bare` arm still had a small primal side. The *direction* survives — cuts +
+LP + branching + propagation dominate — but the absolute claim does not.
+
+## 2. What the two source reviews established
+
+Reviews of this plan against `ref/HiGHS/` and `ref/scipoptsuite-10.0.2/`. They
+were run independently and **converge on the same reordering**: the plan's target
+(cuts) was right, its first action was wrong, and it omitted the two things that
+make aggressive root cutting affordable at all.
+
+### 2.1 Cut lifecycle is the missing prerequisite, not a refinement
+
+Neither solver carries root cuts forever, and neither budgets the root by rounds.
+
+- HiGHS: `HighsLpRelaxation::performAging` (`HighsLpRelaxation.cpp:595-642`) ages
+  basic cut rows at every node LP and deletes at `mip_lp_age_limit` = 10;
+  `removeObsoleteRows` (`:522-539`) drops basic cut rows after the root; the pool
+  re-separates by violation with score `viol/(nActiveNzs·sqrt(norm))` and a 0.1
+  parallelism cap (`HighsCutPool.cpp:168-364`), pool age limit 30.
+- SCIP: `separating/maxroundsroot = -1` (`set.c:471`) — no round budget at all.
+  It stops on **stalling**: `maxstallroundsroot` 10 (`:475`), stall test at
+  `solve.c:2965-2975` (objreldiff ≤ 1e-4 **and** a fractionality test). Cuts are
+  dynamic rows removed after `lp/rowagelimit` = 10 LPs nonbasic (`set.c:263`),
+  pool age limit 80. And directly on point for the `root_cut_prune` work on this
+  branch: `SCIP_DEFAULT_LP_CLEANUPROWSROOT = TRUE` (`set.c:268`) — SCIP removes
+  new **basic** rows after the root LP *by default*, on the same argument;
+  `CLEANUPROWS = TRUE` (`:267`) does it after every LP, which is Stage 1's aging
+  half. Selection is `cutsel_hybrid` (efficacy 1.0, objparal 0.1,
+  intsupport 0.1, minortho root 0.90 — `cutsel_hybrid.c:46-57`).
+
+discopt appends cuts to the matrix permanently (`augment_csc_with_cuts`,
+`rebuild_csc_with_cuts`) and budgets by fixed round/cut counts. That is the exact
+shape of the §0 regression.
+
+### 2.2 The plan's original Stage 1 would have re-run an experiment already killed
+
+`docs/dev/certification-gap-plan.md` records **CUT-1** and **CUTS-1** as NO-GO,
+re-confirmed 2026-07-10 on HEAD `059165fc`: oracle injection of SCIP's *actual*
+cMIR cut coefficients closed ≤1.8 % (nvs17) and 0 % (nvs19/24), and
+`DISCOPT_CMIR_AGGREGATION` ON/OFF gave **0× node reduction**, bit-identical bound
+and node count. `lp/aggregation.rs:1-46` carries the same finding in its header.
+
+**Why this does not settle the MILP case, stated as a precondition rather than
+assumed away.** That NO-GO was measured on the MINLP lifted-McCormick class,
+where *discopt's default root already closes 99.9 % of the gap* — the separator
+was inert because there was nothing left to cut. On `mik` the root leaves 7–10 %.
+The premise that made cMIR inert does not hold here. **But that is a hypothesis,
+and it is the first thing Stage 2 must test** (§3, Stage 2 entry experiment). If
+HiGHS's own root bound on `mik` is also 7–10 % and it wins on nodes instead, then
+cuts are not the `mik` lever and Stage 2 is re-scoped to search.
+
+### 2.3 What `separate_mir` actually has, verified in-tree
+
+Not taken on the reviewers' word — read directly:
+
+- deltas = `{1} ∪ {1/|a_j| : j integer}` (`mir.rs:226-232`) — **no** best/2, /4, /8
+  refinement (SCIP: `SCIPcutGenerationHeuristicCMIR`, `cuts.c:8339`).
+- complementation: two fixed patterns, all-lower and near-upper
+  (`mir.rs:236-254`) — **no** per-integer post-hoc flips.
+- simple bounds only — **no** VUB/VLB substitution (HiGHS:
+  `HighsTransformedLp.cpp:127-330`; SCIP: `VARTYPEUSEVBDS 2`). This is what makes
+  cMIR behave like flow cover on fixed-charge structure — i.e. `nexp`,
+  `sp150x300d`, `fiber`, `beavma`.
+- one cut per row, ranked by raw violation, with no lifted-cover competition
+  (HiGHS: `HighsCutGeneration.cpp:1391-1491`).
+- **discopt's slack columns are continuous**, so every pure-integer row is
+  weakened; SCIP adds integral row slacks to the δ/complementation set.
+
+So "call the existing MIR" is not a small step to HiGHS parity. It is most of
+`HighsCutGeneration`.
+
+### 2.4 Divergence between the two reviews, unresolved
+
+HiGHS's reviewer says row-by-row MIR on raw rows is the shape HiGHS deliberately
+avoids (separation is on tableau rows or *tight* rows only — `HighsPathSeparator`
+types a row with both slacks above feastol as unusable). SCIP's reviewer says
+single-row MIR is not intrinsically wrong — SCIP tries the un-aggregated row
+first (`sepa_aggregation.c` Step 1 at `naggrs=0`) — and that the real defect is
+§2.3's feature list. **Both agree the current `separate_mir` fed raw equality
+rows in both orientations would read as "MIR does nothing".** The tight-row
+filter is cheap and is adopted; the disagreement does not change Stage 2.
+
+## 3. Stages
+
+Reordered from the first draft per §2. Every bound-changing piece goes behind a
+default-off flag with the §5 double bar (cert-clean AND net-positive) over the 38
+panel *and* the in-repo MINLP corpus. Propagation, aging, restarts and node
+selection are contractions or reorderings and need only the bound-neutral or
+cert-clean check.
+
+### Stage 0 — flips of things already built (zero code)
+
+Ranked first because the code exists and shipping it off is the whole defect.
+
+1. **`node_propagation=true`** — FBBT per node with children inheriting tightened
+   bounds (`milp_driver.rs:2007`), which is HiGHS's `localdom.propagate()`
+   (`HighsSearch.cpp:875`) and SCIP's `PROPFREQ 1` (`cons_linear.c:155`).
+   Defaults **false** in the PyO3 signature at all three call sites
+   (`lp_bindings.rs:1101, :1229, :1388`). Pure contraction ⇒ cert-clean is
+   automatic. 
+
+   **MEASURED 2026-09-05, 38 instances, matched `gap_tol=1e-4`, TL = 20 s,
+   114/114 runs, zero certification aborts:**
+
+   | arm | solved | wall | med(solved) | nodes |
+   |---|---|---|---|---|
+   | base | 19/38 | 413.62 s | 0.101 s | 8,969,820 |
+   | nodeprop | 19/38 | 395.90 s | 0.081 s | 7,838,764 |
+   | highs | 38/38 | 66.35 s | 0.959 s | 15,417 |
+
+   **The HiGHS review predicted "~3-6 instances" from this flag. That is
+   falsified: it gains zero.** What it does deliver is −12.6 % nodes, −20 %
+   median solve time, and large per-instance wins — `flugpl` 11.0×, `enlight8`
+   9.8×, `gt2` 4.8×, `bppc8-02` 1.9× (10.55 s → 2.44 s). On timed-out instances
+   the dual bound is better on 8 and worse on 5; the standouts are
+   `enlight_hard` 28.95 % → **10.53 %** and `beavma` 28.94 % → 22.33 %, against a
+   real regression on `fiber` (2.92 % → 6.28 %). `neos-3610051-istra` newly
+   *finds* the optimum (primal 12.00 % → 0.00 %) and ends 1.35 % from proving it.
+
+   Verdict: cert-clean and mildly net-positive, so it graduates ON — but it is
+   **not a lever on the gap**, and nothing downstream should be planned as if
+   Stage 0 buys instances. Caveat (CLAUDE.md §9): machine load rose from 2.85 to
+   13.84 during the run, so the *wall* column is soft; node counts are
+   load-independent and carry the conclusion, and arms rotated per instance so
+   load hit all three alike. `base` is 19/38 here vs 18/38 in §0 — that one
+   instance is the §0.1 tolerance correction, now paid for.
+
+   **The `mik` family is untouched** (1.25–1.30× nodes, still ~600 k against
+   HiGHS's 558–1055). Propagation is not the `mik` mechanism; §1b stands.
+2. **`cut_select=true`** — `lp/cut_select.rs` exists and ships off
+   (`lp_bindings.rs:1099`).
+3. **Best-estimate node selection with plunging** — discopt uses
+   `SelectionStrategy::BestFirst` (`tree_manager.rs`) and has a best-estimate
+   field that is not the driver. SCIP's default is `nodesel_estimate` (verified: `STDPRIORITY 200000` at
+   `nodesel_estimate.c:48`, the highest of the five selectors — `bfs` 100000,
+   `hybridestim` 50000) with
+   plunging; HiGHS alternates best-estimate plunges with a forced best-bound pop
+   every 10 leaves (`HighsMipSolver.cpp:504-516`). Improves early incumbents,
+   which is §1a.
+
+*Kill criterion:* each flip measured alone on the 38 panel at matched tolerance;
+anything that does not improve solved-count or nodes stays off.
+
+### Stage 1 — root cut-loop control (the §0 prerequisite)
+
+Replace fixed round/cut budgets with stall-based termination, cut aging, and
+efficacy+orthogonality selection; move root cuts into a pool rather than the
+matrix.
+
+- Stall rule to replace `root.obj <= prev_obj + 1e-7*(1+|prev_obj|)`, which is
+  far tighter than either reference (HiGHS `stall < 3` with a 1.001 test against
+  *cumulative* gain; SCIP `objreldiff ≤ 1e-4` plus a fractionality test).
+- Delete cut rows that are basic/slack after the root (the `root_cut_prune` work
+  already on this branch is the first half of this), then age basic cut rows
+  in-tree with a ~10-LP limit, with deleted cuts held in a pool re-checked for
+  violation.
+- Row deletion must fix up the warm basis (HiGHS falls back to `firstrootbasis`,
+  `HighsMipSolver.cpp:635-639`).
+
+*Entry experiment:* re-run the cut200 arm with (a) `cut_select` on, (b) slack-cut
+drop, (c) both. *Kill:* if (b) alone does not recover a substantial share of the
+7 instances the cut budget lost, aging is not the mechanism and Stage 1 re-scopes.
+
+### Stage 2 — cMIR done properly
+
+*Attribution first, before any code:* compare discopt's post-cut root bound
+against HiGHS's root bound on the four `mik` plus the six ≤3 %-dual instances.
+**This is the test of §2.2's precondition.** If HiGHS's root gap on `mik` is also
+7–10 %, cuts are not the lever there and this stage is re-scoped to search.
+
+If confirmed, build in fidelity order, measuring after each: (1) integral row
+slacks treated as integer in the δ/complementation set; (2) separate on the
+current LP *including* previously added cuts, scored by efficacy `viol/‖α‖` not
+raw violation; (3) VUB/VLB substitution; (4) the full δ set incl. best/2,/4,/8
+and per-integer complementation flips; (5) tight-row filtering; (6) aggregation
+depth ≥3.
+
+*Kill:* root gap on `mik` fails to close ≥3 pp after (1)–(4).
+
+### Stage 3 — primal
+
+Reordered from FJ-first. SCIP has no feasibility-jump at all and still gets first
+incumbents; RENS is the cheapest for us because it reuses `milp_driver.rs`
+recursively.
+
+1. RENS on the root LP. 2. Propagation-backed rounding (needs Stage 0.1 anyway).
+3. Rounding/shifting after *every* root separation round — HiGHS's
+`rootSeparationRound` (`HighsMipSolverData.cpp:1783-1790`) is what produces the
+one-node solves. 4. Feasibility jump **only if** `enlight_hard` and
+`neos-2624317-amur` still lack an incumbent.
+
+### Stage 4 — restarts
+
+Root restart when reduced-cost fixing + propagation has fixed ≥5 % of integers
+(SCIP `restartfac` 0.025 / `immrestartfac` 0.05, `solve.c:4601-4603`). discopt
+already has `reduced_cost_fix` (`:2766`). Cert-neutral contraction. Also: root
+reduced-cost "lurking bounds" (`HighsRedcostFixing.cpp:36-71, :194+`) fire free
+tightenings every time the incumbent improves.
+
+### Stage 5 — conflict analysis; Stage 6 — clique/implication tables
+
+Both default-ON in SCIP (`set.c:108-172`). Conflict analysis needs a per-node
+bound-change log — a real build. Clique extraction feeds propagation, knapsack
+separation and heuristics; `presolve/cliques.rs` and `implied_bounds.rs` exist
+and are unwired on the MILP path.
+
+### Stage 7 — dimension-reducing presolve with postsolve
+
+Last, per §1c (≤2 instances, large build — the matrix path has no postsolve
+chain). Note restarts (Stage 4) want re-presolve, so there is a coupling.
+
+### Explicitly dropped
+
+Symmetry on this panel (0 instances, both reviews agree); GUB and superadditive
+cover lifting (OFF by default in SCIP — `cons_knapsack.c:127, :146`); more raw
+Gomory budget (measured negative, §0); CSC-native MIR before a dense root-gap
+gain is shown; oddcycle/cgmip/closecuts/lagromory (freq −1 in SCIP); local
+branching/DINS as first-incumbent tools.
+
+Sequentially-lifted knapsack cover (upgrading `lp/cover.rs` from unlifted) is
+*not* dropped but is low priority: ~0.5–1 instance, low risk, and irrelevant to
+`mik` (cover fires only on binary rows).
+
+## 4. Success metric
+
+The §0 panel at matched `mip_rel_gap = 1e-4`, TL = 20 s. Base is **18/38 at
+444.93 s** (19/38 once the tolerance is matched); HiGHS **36/38 at 76.77 s**
+interleaved, 38/38 at 66.85 s alone. "Competitive" is solved-count within a few
+instances of HiGHS's with total wall within ~2×. Every stage reports against this
+same table.
+
+## 5. Licensing note for the owner
+
+discopt is **EPL-2.0**. HiGHS is MIT (compatible inbound). SCIP 10 is Apache-2.0,
+which can be combined but not relicensed. Both reviews were instructed to
+describe algorithms, not paste source, and neither returned code. If the cMIR δ
+and complementation loop in Stage 2 ends up a close derivation of
+`SCIPcutGenerationHeuristicCMIR`, or the transform step of
+`HighsTransformedLp::transform`, that is an attribution decision for the owner
+before merge, not something to settle in a PR.
+
+## 6. Reproduction
+
+`scratchpad/miplib/` holds `loader.py` (MPS → engine arrays via highspy, so both
+solvers see byte-identical matrices), `hs.py` (the shared HiGHS arm), `screen.py`
+(the fidelity + tractability gate that built `panel.json`), `miplib_ab.py` (the
+§0 arm panel), `attribute.py` (the §1c ablation), `switches_ab.py` (Stage 0) and
+`pathology.py` (the `khb05250` 3-nodes-in-20 s probe).

--- a/docs/dev/milp-competitiveness-plan.md
+++ b/docs/dev/milp-competitiveness-plan.md
@@ -46,9 +46,15 @@ node LP forever. See §2.1.
 
 HiGHS closes `b-ball`, `sp150x300d`, `beavma`, `nexp-50-20-1-1`,
 `nexp-50-20-4-2`, `khb05250`, `gen`, `dcmulti`, `app2-2`, `f2gap40400`, `gr4x6`,
-`supportcase14` and `supportcase16` in **one node**. One node means the root LP —
-after presolve, root cuts and root heuristics — both *produces* the optimum and
-*proves* it. discopt spends 350 k–870 k nodes on several of those same instances.
+`supportcase14` and `supportcase16` in **one node**. discopt spends 350 k–870 k
+nodes on several of those same instances.
+
+*Read §2.6 before drawing conclusions from that count.* "One node" is HiGHS
+incrementing `num_nodes` on root *close*, not a statement that the root LP was
+integral — and per-instance ablation shows the closer is a **restart** on
+`beavma`/`dcmulti`, **integral-objective rounding** on `sp150x300d`, and a
+**sub-MIP incumbent** on `nexp-50-20-4-2`. `b-ball`'s 1 node is an artifact of the
+engine-form conversion: HiGHS takes 126 nodes on the original MPS.
 
 This was originally written up as "a **root-strength** problem, not a tree-search
 problem." I retracted that on 2026-09-05 in favour of a primal/dual/proof split
@@ -288,14 +294,35 @@ killed; it is deferred behind a bigger, cheaper win.
 
 ## 2.6 Why HiGHS needs so few nodes — the mechanism, measured
 
-HiGHS closes **16 of the 38 in a single node**: `app2-2`, `b-ball`, `beavma`,
-`dcmulti`, `f2gap40400`, `gen`, `gr4x6`, `gt2`, `khb05250`, `neos-1425699`,
-`neos-5192052-neckar`, `nexp-50-20-1-1`, `nexp-50-20-4-2`, `sp150x300d`,
-`supportcase14`, `supportcase16`. One node means the root — after presolve, cuts
-and heuristics — both *produces* the optimum and *proves* it. Total panel nodes:
-HiGHS 15,417, discopt 4,693,240 at its best arm. That is ~300×.
+Total panel nodes: HiGHS 15,417, discopt 4,693,240 at its best arm. ~300×.
+HiGHS closes **16 of the 38 in a single node**. Before drawing conclusions from
+that number, three corrections to how it must be read (all measured 2026-09-05,
+`scratchpad/parity/attrib/panelform.py`, highspy 1.12.0, 30 s, the same engine-form
+arrays discopt receives):
 
-The mechanism is not one missing component; it is two, multiplying.
+- **"1 node" does not mean "the root LP was integral."** HiGHS increments
+  `num_nodes` on root *close* (`HighsMipSolverData.cpp:1802-1808, 1840-1850,
+  1879-1884, 2370-2376`). It means the root loop — LP, cuts, heuristics,
+  restarts — reached `mip_rel_gap` before any branching.
+- **The closer is often not the cuts.** Per-instance ablation: on `beavma` root
+  cuts do 99.4 % and a **restart** finishes it (`norestart`: 7 nodes); on
+  `sp150x300d` cuts reach 68.18 of 69 and the bound then jumps to 69 with *no new
+  cuts* — that is `computeNewUpperLimit` integral-objective rounding, not
+  separation; on `nexp-50-20-4-2` the sub-MIP incumbent is load-bearing
+  (`noheur` **times out**). Only `nexp-50-20-1-1` closes on root cuts alone.
+- **`b-ball`'s "1 node" is a formulation artifact.** On the original MPS, HiGHS
+  takes **126 nodes** and its bound stalls at −1.5996 with 303 conflicts. The
+  1-node result is a property of the engine-form conversion, not of HiGHS.
+
+And two of the panel's hardest instances are **not** root-closable by HiGHS
+either: `gsvm2rl3` takes **634 nodes** (root 0.012 → 0.2306, 67 % of the gap, then
+1394 conflicts and 15,179 strong-branching iterations), and
+`neos-2624317-amur`'s HiGHS root bound stays at **0** — no HiGHS cut family fires
+at its root, and it needs 3,838 nodes, 9,775 conflicts and 56,531 SB iterations
+(38 % of all its LP iterations). **Treating amur as a root-cut problem would be
+wrong**; it is a branching-and-conflicts problem for HiGHS too.
+
+With those corrections, the mechanism is two effects multiplying.
 
 **First: the last few percent of root gap is worth orders of magnitude of tree.**
 Tree size grows roughly exponentially in the residual gap, so the interesting
@@ -303,21 +330,54 @@ comparison is not "discopt closes 74 % of the mik root gap" but what is *left*.
 At 200 × 8, discopt leaves 4.5 % on `mik-250-20-75-*`; HiGHS leaves 1.7 %
 (§2.5). A 2.6× wider residual gap is not a 2.6× bigger tree. The same pattern
 holds on `sp150x300d` (15.71 % vs 0.00 %), `nexp-50-20-1-1` (30.00 % vs 0.00 %)
-and `beavma` (31.05 % vs 0.00 %) — on those three HiGHS's root bound is *exact*
-and discopt's is not close, which is precisely why HiGHS needs one node and
-discopt needs 10⁵.
+and `beavma` (31.05 % vs 0.00 %).
 
 **Second: with no incumbent, nothing prunes.** A node is cut off only when its
 bound is worse than the incumbent. discopt reaches the end of its budget 22-45 %
 above the optimum on the four `mik`, and finds **no feasible point at all** on
-`enlight_hard` and `neos-2624317-amur`. A tree with a poor incumbent explores
-nodes that a good one deletes outright, regardless of how good the bound is.
-This is why `mik` burns 289 k-563 k nodes against HiGHS's 558-1055 despite a
-dual gap of only 2.1-2.7 %.
+`enlight_hard` and `neos-2624317-amur`. This is why `mik` burns 289 k-563 k nodes
+against HiGHS's 558-1055 despite a dual gap of only 2.1-2.7 %.
 
 Neither alone explains the ratio; together they do. And they are not independent
 — a good incumbent early prunes the tree that would otherwise be needed to lift
 the bound.
+
+### 2.6a The separator-level answer: HiGHS has no GMI at all
+
+Worth stating plainly because it inverts the natural assumption. HiGHS's tableau
+separator does **not** generate Gomory mixed-integer cuts. It uses tableau rows
+only as *base inequalities* fed to cMIR and lifted-cover generation with bound
+substitution (`HighsTableauSeparator.cpp:40-244`, `HighsCutGeneration.cpp:505-738,
+1391-1491`, `HighsTransformedLp.cpp:20-140, 150-460`), alongside three basis-free
+families: Path (`HighsPathSeparator.cpp:170-549`), Mod-k
+(`HighsModkSeparator.cpp:30-267`), implied-bound
+(`HighsImplications.cpp:583-660`) and clique (`HighsCliqueTable.cpp:1604-1712`).
+
+So the 70-92 % of root gap discopt's GMI already closes is being compared against
+a solver that closes its last few percent with a *different and stronger* family.
+This is the strongest single argument for A2, and it is why A2 is cMIR/flow-cover
+rather than "more GMI".
+
+**HiGHS also never rejects a cut for coefficient range.** Its only dynamism check
+is inside `#if 0` (`HighsCutGeneration.cpp:1045-1063`). It gates *source rows*
+instead — Tableau drops basis-inverse rows with weight ratio > 1e4, Path follows
+only arcs with weight in `[feastol, 1/feastol]` (`checkWeight`, `:222-229`).
+SCIP likewise **repairs rather than rejects**: `postprocessCut` (`cuts.c:3748-3810`)
+runs `removeZeros(feastol)` → `cutTightenCoefs` → `removeZeros` again, and declares
+a cut unusable only when a small coefficient's cancelling bound is infinite
+(`:935-1000`). discopt is the outlier in refusing whole cuts on a numerical gate.
+
+## 2.7 Instrument correction: PR #1164's `kept/gen` column is an artifact
+
+`RootCutsGenerated`/`RootCutsKept` increment only inside the cut-cleanup block
+(`milp_driver.rs:1226-1229`), which is gated by `prune_base` (`:934-939`) —
+`Some(..)` only when `root_cut_prune && root_cuts > 0 && cut_rounds > 1`. **At
+`cut_rounds = 1` they never fire.** The `0/0` cells reported for `base_16x1` and
+`cut200_noprune` therefore mean *not counted*, not *no cuts generated*. The base
+arm does cut: `b-ball`'s root bound is −1.705882 at `root_cuts=16` against
+−1.818182 at `root_cuts=0`, and `enlight_hard` goes 21 → 23. This is a CLAUDE.md
+§6 failure (a probe that measured nothing and was believed) and PR #1164's body
+carries the correction.
 
 ## 3. The parity plan
 
@@ -332,6 +392,62 @@ incumbent. That is a strict ordering, and it is why Track A precedes Track B. Bu
 Track B is not optional: on the `mik` family the bound is already within 2.6 % and
 the tree still does not close, so Track A alone does not reach 38/38 either.
 
+### Track A0′ — two measured defects that block whole mechanisms. Do these first.
+
+Both were found by the 2026-09-05 engine audit and both are **confirmed by
+discopt's own split counters** (`scratchpad/miplib/verify_claims.py`, run with
+`DISCOPT_PROFILE=1` set before `import discopt`, deltas taken pre/post). Each is
+days of work, not weeks, and each unblocks machinery that is already built.
+
+**A0′.1 — the short basis export (`neos-2624317-amur`).**
+The cold root LP returns **338 basic variables for m = 342**. Everything
+downstream declines silently: `separate_gomory_cols` returns empty at its
+`basis.basic_vars.len() != m` guard (`lp/gomory.rs:233-235`) — with **no
+counter**, so the panel reads "zero cuts" when the truth is "never looked" — and
+`PreparedDual::prepare` refuses the warm start on shape, so nodes cold-solve.
+Confirmed here: on amur, zero `RootCuts*` and zero `SubstDrop*` counters fire at
+all, and `DualPrepRejectShape = 300` against `DualPrepAccept = 80`.
+
+Origin: `lp/simplex/primal.rs:2585-2627`; the eligibility test at `:2601` is
+`stat[j] != BASIC && nb_value(j) == 0.0` with `rows.len() == 1`. 50 of 342 rows
+have their slack nonbasic at a *nonzero* value with no zero-valued structural
+substitute, so the basis cannot be completed. At a complete basis a numpy replica
+finds 201 fractional integer basics and **70 admissible GMI cuts** on the same
+instance. Note this is *necessary but not sufficient* for amur: §2.6 shows HiGHS's
+root bound on amur is 0 too, so cuts alone will not close it — but nothing else can
+start while cuts, warm starts and strong branching are all disabled at once.
+*Also add counters at `gomory.rs:233-235, 246-248, 271`: three silent early
+returns, none instrumented. CLAUDE.md §6.*
+
+**A0′.2 — zero-then-pin in the cut cleanup (`gsvm2rl3`, plus 6 at-risk).**
+`gsvm2rl3` separates 31 cuts and discards **all 31**. Confirmed here:
+`SubstDropUnbounded = 31`, `SubstDropDynamism = 0` — so the refusal is the
+infinite-bound pin at `milp_driver.rs:3213-3222`, **not** the dynamism backstop.
+(The earlier diagnosis blamed dynamism; the counter split shipped in
+`6375b1fb` is what disproved it.)
+
+Mechanism: `gsvm2rl3` has **61 FREE columns**, all basic at the root. Every GMI
+cut carries pure cancellation noise on them — 4e-19 … 3e-16 absolute, ≤ 1.2e-17
+*relative*, with 994/994 entries ≤ 1e-12 relative. The cleanup tries to pin each
+such column at `u[k]`/`l[k]`, both infinite, and refuses the whole cut. HiGHS
+handles exactly this by **zeroing `|v| <= small_matrix_value` first**
+(`HighsTransformedLp.cpp:337-341`) and only refusing genuinely free columns that
+carry *real* coefficients (`:173-176`). SCIP does the same via `removeZeros`
+before the infinite-bound test. discopt pins before zeroing; the order is
+backwards.
+
+*Honest expectation.* Recovering these particular cuts is already measured
+**node-neutral on `gsvm2rl3`** (3 better / 3 worse at a fixed 5000-node budget —
+see "Falsified: relaxing the cut-cleanup's numerical gates"). Zero-then-pin is a
+*different* fix from the one that was falsified — dropping a 1e-17-relative
+roundoff term is exact to tolerance, where keeping it was not — and it is the rule
+both reference solvers use. It ships because the rule is wrong, not because
+`gsvm2rl3` is expected to flip. The breadth argument is the reason to expect more:
+**18 of 100 MPS files carry FR columns; 6 are on this panel** — `gsvm2rl3`,
+`iskar`, `istra`, `jijia`, `kaihu`, `obra`. Only `gsvm2rl3` is *verified* affected;
+the other five are at risk and are the kill criterion. If the panel does not move
+on those six, the fix stays (it is a correctness repair) but claims no credit.
+
 ### Track A — the bound (needed by 17/17)
 
 **A0. Graduate the root cut budget. Ready now; no new code.**
@@ -344,59 +460,139 @@ confirming panel on an unloaded machine for the wall-clock column, then the
 default flips.
 *Expected: +2 instances, already measured.*
 
+**A0.1 — wire the graduated budget to the product path.** The
+`_STRONG_CUT_PROFILE` 200 × 10 escalation
+(`python/discopt/solvers/milp_simplex.py:66-96, 985-1022`) sits on the OA/relaxer
+entry. `Model.solve()` on a pure MILP goes `_milp_engine_default_on`
+(`solver.py:21457-21474`) → `_solve_milp_simplex` (`:21563`) → `solve_milp_py`
+(`:21692-21706`) with `_cut_opts = {}` unless `DISCOPT_MILP_ROOT_CUTS=1`
+(`:21476-21510`). **A graduated cut default that never reaches a plain MILP solve
+buys nothing for users.** Near-zero code; do it in the same PR as A0.
+
 **A1. Finish the cut lifecycle (the remainder of the old Stage 1).**
 The warm-start half is done. Still missing: stall-based termination instead of the
-fixed round budget (discopt's `1e-7*(1+|prev_obj|)` test is far tighter than
-HiGHS's `stall < 3` against cumulative gain or SCIP's `objreldiff ≤ 1e-4`); cut
-*aging* (SCIP `LP_ROWAGELIMIT 10`, `set.c:263`; HiGHS ages basic cut rows at
-`mip_lp_age_limit`, `HighsLpRelaxation.cpp:595-642`); and a cut *pool* rather
-than the constraint matrix. Also: `CUT_MAX_PARALLEL = 0.99` is 10× laxer than
-both references (HiGHS `maxpar = 0.1`, `HighsCutPool.cpp:320`; SCIP `MINORTHO
-0.90`), so near-duplicate cuts are being kept.
-*Expected: the budget can then go higher than 500 without paying for it, which is
-what A2 needs.*
+fixed round budget; cut *aging*; and a cut *pool* rather than the constraint
+matrix. Both references agree on the shape and neither uses a fixed budget:
+HiGHS runs `while (scaledOptimal && !fractional.empty() && stall < 3)` with
+`maxSepaRounds = min(2·sqrt(maxTreeSizeLog2), ∞)` and an LP-iteration cap of
+`max(10000, 10·avg)` (`HighsMipSolverData.cpp:1912-1915`); SCIP has
+`maxroundsroot = -1` (`set.c:471`) and stops on `objreldiff ≤ 1e-4 AND nfracs ≥
+(0.9 − 0.1·nstall)·prev` (`solve.c:2963-2996`), exiting at 10 stalls at the root
+and 1 in the tree (`set.c:475, 477`). discopt's `1e-7*(1+|prev_obj|)` test is far
+tighter than either. Aging: SCIP `LP_ROWAGELIMIT 10` (`set.c:263`), `cutagelimit
+80` (`:483`); HiGHS ages basic cut rows at `mip_lp_age_limit`
+(`HighsLpRelaxation.cpp:595-642`) and drops basic cut rows after the root
+(`:522-539`). Also: `CUT_MAX_PARALLEL = 0.99` is 10× laxer than both references
+(HiGHS `maxpar = 0.1`, `HighsCutPool.cpp:320`; SCIP `MINORTHO 0.90`), so
+near-duplicate cuts are being kept.
+*Both source reviews independently confirmed A1-before-A2: the lifecycle is the
+prerequisite, since a stronger family is only affordable once a large cut set is.*
+*Expected: the budget can then go higher than 500 without paying for it.*
 
-**A2. A second cut family — cMIR/flow-cover and knapsack cover.**
-GMI is discopt's only family. §2.5 shows the existing separators already close
-70-92 % of the root gap, so this is not "discopt has no cuts" — it is the last
-few percent, which §2.6 argues is where the tree size lives. Deferred behind A1
-deliberately: cMIR is only worth having once a large cut set is affordable.
-The instances it should move are the mixed-knapsack and set-covering shapes that
-dominate the failures — `mik-*`, `nexp-*`, `sp150x300d`, `beavma`.
+**A2. The second cut family — cMIR/flow-cover with bound substitution, and
+lifted knapsack covers.**
+Correcting an earlier phrasing: GMI is *not* discopt's only separator —
+`lp/mir.rs:206`, `lp/aggregation.rs:86` and `lp/cover.rs` all exist. But `mir` and
+`aggregation` are reachable only from `bnb/convex_kernel.rs:680, 1972` and
+`lp_bindings.rs:285`; **`milp_driver.rs` imports neither.** What is genuinely
+absent is flow cover, variable-upper-bound substitution and lifted covers — a
+`grep` of `crates/discopt-core/src/lp/*.rs` for flow-cover / VUB / bound
+substitution returns nothing.
+
+The structure census says this is exactly the right family for the failures
+(executed, `scratchpad/parity/struct_probe.py`): `nexp-50-20-1-1` is 1030 columns,
+245 binaries, objective on binaries only, with **245 two-variable VUB rows
+`x_a ≤ u_a y_a`** and 50 all-continuous flow rows. `sp150x300d` is 1050 columns,
+300 binaries, **150 big-M VUB rows** (binary coefficient ≥ 100× the continuous
+one), and **all 750 continuous variables have finite upper bounds**, so
+coefficient tightening fires on all 150.
+
+SCIP's named answer for that class, in order: varbound upgrade
+(`cons_varbound.c:108`, priority +50000), coefficient tightening
+(`cons_linear.c:9003` — `x − M y ≤ 0` with `x ≤ ub_x` reduces M to `ub_x`), then
+lifted flow cover and cMIR with VUB substitution (`sepa_aggregation.c:860-965`;
+`SCIPcalcFlowCover` `cuts.c:11645`, citing Gu/Nemhauser/Savelsbergh 1999;
+`SCIPcalcKnapsackCover` `:924`; `SCIPcutGenerationHeuristicCMIR` `:940`;
+`VARTYPEUSEVBDS 2`). For `mik-*`/`beavma`, SCIP's lifted covers come from
+`cons_knapsack` at `SEPAPRIORITY +600000` — *before any separator plugin* —
+with sequential lifted minimal covers (`:5564, :2581, :5316, :4801, :5035`), and
+for non-upgraded mixed rows via `SCIPseparateRelaxedKnapsack`
+(`cons_knapsack.c:5781`, called from `cons_linear.c:7538-7620`), which relaxes
+continuous and general-integer variables to their bounds or variable bounds.
+
+**Coefficient tightening is the cheapest item in A2 and should be measured
+first** — it is presolve-level, needs no separator, and the census says it fires
+on all 150 `sp150x300d` VUB rows.
+
 *Entry experiment before building (CLAUDE.md §4, the #727 RLT lesson): separate
-cMIR at the root on those instances only, and measure the root gap against the
-4.5 %/15.7 %/30.0 % baselines. If it does not move them on the real instances, it
-does not get built.*
+cMIR at the root on `mik-*`, `nexp-*`, `sp150x300d`, `beavma` only, and measure
+the root gap against the 4.5 %/15.7 %/30.0 %/31.1 % baselines. If it does not move
+them on the real instances, it does not get built.*
 
-**A3. The two instances that get no usable cuts at all.**
-`gsvm2rl3` — 31 cuts separated, all discarded as ill-conditioned, 42 % dual gap.
-`neos-2624317-amur` — zero cuts generated, 100 % dual gap, no feasible point.
-Relaxing the numerical gates is already **falsified** (see "Falsified: relaxing
-the cut-cleanup's numerical gates"): it rescues `gsvm2rl3`'s root gap but is
-node-neutral, so these need a family whose coefficients are conditioned by
-construction, i.e. A2. Tracked here so they are not silently dropped.
+**A3. Branching quality — the node-48 cliff.**
+`sb_active = opts.strong_branch && tm.stats().total_nodes < opts.sb_node_budget`
+(`milp_driver.rs:1434`) with a budget of **48 nodes** and ≤ 6 candidates. After
+node 48, any variable with fewer than 8 observations falls back to
+`default_cost = 1.0` in both directions, so the product score degenerates to
+most-fractional for **> 99.99 % of every tree on this panel**.
+`reliability_threshold = 8` is hardcoded at `tree_manager.rs:276`. The engine audit
+rates this the single biggest quality gap in the driver. For scale, HiGHS spends
+15,179 SB iterations on `gsvm2rl3` and 56,531 on `amur` — 38 % of that instance's
+total LP work — where discopt spends its entire SB allowance in the first 48
+nodes. Reliability branching (SB until a variable has *k* reliable observations,
+not until node *k*) is the standard form and is what both references implement.
+*Caveat from the b-ball probe: this will do nothing on dual-degenerate instances
+— see Track C.*
 
 ### Track B — the incumbent (needed by 14/17)
 
 discopt's failures are not marginal on this axis: 22-45 % above optimum on the
-`mik` family, and no feasible point at all on two instances. This is the half
-that was invisible while only the bound was instrumented.
+`mik` family, and no feasible point at all on two instances.
 
-**B1. Node selection and plunging.** discopt uses `SelectionStrategy::BestFirst`
-and carries a best-estimate field that is not wired to the driver. SCIP's default
-is `nodesel_estimate` (`STDPRIORITY 200000`, the highest of five,
-`nodesel_estimate.c:48`); HiGHS alternates best-estimate plunges with a forced
-best-bound pop every 10 leaves (`HighsMipSolver.cpp:504-516`). Cheapest item in
-Track B — the field exists — and it is the one that most directly attacks "no
-incumbent".
+The inventory is now definitive (2026-09-05 audit). **ON:** per-node rounding
+(`try_rounding_csc`, `milp_driver.rs:2299-2311` — nearest then floor, original
+rows only) and a single root repair dive (`try_dive_repair`, `:2334-2344`, body
+`:3742+`). **INERT:** off-root dives — `DIVE_STRIDE_DEFAULT = 0` (`:317`), and
+`dive_batch_eligible` (`:351-360`) requires `!has_incumbent`, so it **can never
+improve an existing incumbent**. **ABSENT:** feasibility pump, RINS, RENS, local
+branching, any sub-MIP/LNS, shifting, ZI-round, feasibility jump,
+propagation-based diving, plunging, restarts — and *any* improvement heuristic
+whatsoever once an incumbent exists. That last one is the finding: discopt's first
+incumbent is very nearly its last.
 
-**B2. Real primal heuristics.** In rough order of value-per-unit-work: diving
-variants, RENS, feasibility pump, RINS, local branching. Two instances find no
-feasible point at all, which is a feasibility-pump-shaped problem specifically.
+**B1. Node selection and plunging.** `SelectionStrategy::BestFirst` is
+**hardcoded** at `milp_driver.rs:717` with `export_batch(64)` at `:1370`;
+`DepthFirst` and `BestEstimate` exist in `bnb/pool.rs:10-18` (`:66-81`, `:82-96`)
+and the driver never uses them. SCIP's default is `nodesel_estimate`
+(`STDPRIORITY 200000`, the highest of five, `nodesel_estimate.c:48`) with plunge
+parameters at `:56-62` (MINPLUNGEDEPTH `maxdepth/10`, MAXPLUNGEDEPTH
+`maxdepth/2`, MAXPLUNGEQUOT 0.25, BESTNODEFREQ 10). Cheapest item in Track B —
+the strategy exists and is unreachable — and the one that most directly attacks
+"no incumbent".
 
-*Scoring note for Track B:* an incumbent improvement shows up as **nodes and
-solved-count**, not as root gap. Measure it at a fixed node budget, not a time
-limit, until the machine is reliably quiet.
+**B2. Real primal heuristics.** Two shared pieces have to be built before any of
+them: a **probing fix-propagate-undo stack** and a **reduced-copy sub-MILP call**.
+With those, in order of value-per-unit-work:
+1. **Randomized rounding after every root separation round while no incumbent** —
+   HiGHS's `randomizedRounding` has no option and always runs
+   (`HighsMipSolverData.cpp:1783-1790`); it is the source of `b-ball`'s incumbent.
+2. **Shift-and-propagate** — SCIP's answer for the no-feasible-point case
+   (`heur_shiftandpropagate.c:66-71`): runs *before* the root LP, relaxes
+   continuous variables out of the rows, repeatedly fixes the discrete variable
+   that most reduces weighted row violation, propagates in probing mode,
+   `onlywithoutsol TRUE`. This is the shape of `enlight_hard` and `amur`.
+3. **Feasibility pump**, then **RENS**, then **RINS**/local branching (sub-MIP).
+   Measured relevance: on `nexp-50-20-4-2` HiGHS's sub-MIP incumbent is
+   load-bearing — `noheur` times out where the default takes 1 node.
+
+*Do not port* `ziRound` or `shifting`: both are **default OFF** in HiGHS
+(`HighsOptions.h:1234-1241`).
+
+**B3. Restarts.** Measured as the actual closer on `beavma` (`norestart`: 1 → 7
+nodes) and `dcmulti` (two restarts), and `noheur` `beavma` closes via **five**
+restarts. SCIP triggers at ≥ 2.5 % root integer fixings (`set.c:363-371`,
+`solve.c:4953-4958`). discopt has none. Cheap relative to B2 and independently
+measured to matter.
 
 ### Track C — measured NOT to be the difference. Do not spend here.
 
@@ -404,13 +600,47 @@ Recorded so this ground is not re-covered:
 
 - **Presolve** — `h_nopre ≈ h_full` everywhere on the root-bound probe; worth
   ~0-3 pp of root gap (§2.5a). §1c independently put it at ≤2 instances.
-- **Symmetry** — 0 instances on this panel (§1c).
+  (Caveat: SCIP's *coefficient tightening* is presolve-shaped and is **not**
+  covered by this negative — it is an A2 item with its own census evidence.)
+- **Symmetry** — 0 instances on this panel (§1c); HiGHS `nosym` is identical to
+  default on every instance ablated.
 - **`node_propagation`** — graduated ON, but gains **zero** instances; the HiGHS
   review's "3-6 instances" is falsified (Stage 0.1).
 - **Relaxing the cut numerical gates** — cert-clean but node-neutral; falsified
-  and reverted, with the measurement recorded at the refusal site.
+  and reverted, with the measurement recorded at the refusal site. (A0′.2 is a
+  *different* change: zero-then-pin, not keep-and-widen.)
 - **`cut_select`** — falsified earlier: `fiber` 2986.5 → 6457.4 it/node, `mik`
   acceptance 100 % → 35.0 %.
+- **Integral-objective cutoff tightening** — **already built and wired.**
+  `bnb/obj_integral.rs` computes the lattice and `set_objective_lattice`
+  feeds `cutoff_value` (`tree_manager.rs:1105-1113`), default ON via
+  `DISCOPT_OBJ_INTEGRALITY`. Both source reviews flagged HiGHS's
+  `computeNewUpperLimit` as a possible gap; it is not one. It simply does not
+  apply to `b-ball`, whose objective variable is continuous
+  (`obj_integral.rs:121` correctly declines a lattice).
+- **Pruning mechanics** — verified exact. `tree_manager.rs:557-562` prunes on
+  `node_lb >= cutoff_value()`; `cutoff_value` is the incumbent exactly;
+  `gap_tol` is applied only at `milp_driver.rs:1357, 1872`; the global bound is
+  recomputed from the open frontier every batch (`:917, 923-973`); ties are
+  explored, not pruned; and **no objective cutoff reaches the node LP** —
+  `SimplexOptions` has no such field and a grep of `lp/simplex/*.rs` for
+  `cutoff|obj_limit|objective_limit` is empty. SCIP's cutoff test
+  (`SCIPsetIsGE(lowerbound, cutoffbound)`, `solve.c:3164`, eps 1e-9, with
+  `cutoffbound = upperbound` exactly, `primal.c:428-441`) would not prune those
+  nodes either. An earlier "pruning mechanics" framing was retracted and both
+  reviews independently confirmed the retraction.
+- **`b-ball` by branching or by strong branching** — it is a **dual-degenerate
+  plateau, measured**. The bound is flat at −1.705882 from node 127 through
+  32,099 nodes under *every* switch tried: whole-tree strong branching with
+  16,044 calls, `sb_max_cands=30`, `node_propagation`, heuristics off,
+  reduced-cost fixing off, `node_cuts`, `root_cut_prune` off. A degeneracy probe
+  found **350/350 child LPs equal to their parent** (176 at depth 1, 174 at
+  depth 2). Every pseudocost is 0, so branching is a coin flip. Structure: 8
+  assignment rows each picking 5 of 11 over 88 binaries, 11 linking equalities
+  `2·x_i = Σ_k x_{i,k}`, 11 rows `x12 ≤ x_i`, objective `min −x12`; the LP gives
+  40/11 = 1.818 and the integer answer is `floor(40/11) = 3` → −1.5. **Only cuts
+  or presolve can move this instance.** A HiGHS-style gap-aware node prune would
+  not help either: its threshold is −1.50015 against a frontier at −1.500673.
 
 ### Measurement discipline for every stage below
 
@@ -421,7 +651,10 @@ Recorded so this ground is not re-covered:
    (cert-clean AND net-positive) over the 38 panel *and* the in-repo MINLP corpus.
 3. Entry experiment before implementation, on **real corpus instances**, with a
    named kill criterion.
-
+4. Every new silent early return gets a counter. Two of this plan's root causes
+   (A0′.1, A0′.2) were invisible for weeks because the code declined without
+   counting, and one of them was misdiagnosed three times before the counter was
+   split. CLAUDE.md §6.
 ## 3bis. Stage detail (the original numbering, retained)
 
 
@@ -722,10 +955,22 @@ Current standing, matched tolerance, 190/190 runs, zero certification aborts:
 | **highs** | **38**/38 | **71.95 s** | 1.039 s | **15,417** |
 
 Distance to go: **17 instances, ~5.6× wall, ~300× nodes.** Intermediate targets,
-so a stage can be scored before parity is reached: A0 → 21/38 (measured, banked);
-A1 → 24/38; A2 → 30/38; B1+B2 → 35/38. These are targets, not predictions — a
-stage that misses its target is re-scoped against the measurement, per §4 of
-CLAUDE.md, not carried forward on hope.
+so a stage can be scored before parity is reached:
+
+| stage | target | basis for the target |
+|---|---|---|
+| A0 + A0.1 | 21/38 | measured, banked (`cut500_prune`) |
+| A0′.1 + A0′.2 | 21/38 | **no solved-count target.** Both are correctness repairs that unblock machinery; scored on *counters* (amur: `SepGomory` calls > 0 and `DualPrepRejectShape` → ~0; gsvm2rl3: `SubstDropUnbounded` → 0) and on the 6 FR-column instances, not on solves |
+| A1 | 24/38 | cut lifecycle makes a >500 budget affordable |
+| A2 | 30/38 | the family HiGHS actually closes its last few percent with |
+| A3 | — | branching quality; scored on nodes at fixed solved-count, not on solves |
+| B1 + B3 | 33/38 | node selection + restarts, both cheap and both measured to matter |
+| B2 | 35/38 | the sub-MIP/pump ladder |
+
+These are targets, not predictions — a stage that misses its target is re-scoped
+against the measurement, per §4 of CLAUDE.md, not carried forward on hope. A0′
+deliberately claims no solved-count: it is first in the order because it unblocks
+three mechanisms at once, not because it is expected to move the panel by itself.
 
 *Caveat on every wall column here:* machine load was 66-69 during the 2026-09-05
 panel. Node counts are load-independent and carry the conclusions; the wall

--- a/docs/dev/milp-competitiveness-plan.md
+++ b/docs/dev/milp-competitiveness-plan.md
@@ -50,10 +50,43 @@ HiGHS closes `b-ball`, `sp150x300d`, `beavma`, `nexp-50-20-1-1`,
 after presolve, root cuts and root heuristics — both *produces* the optimum and
 *proves* it. discopt spends 350 k–870 k nodes on several of those same instances.
 
-This is a **root-strength** problem, not a tree-search problem. It is why Stage
-0's search-side flips move zero instances, and it is the reason the stage order
-below puts root cut control and cMIR ahead of everything on the search side.
-Almost everything that matters happens before the first branch.
+This was originally written up as "a **root-strength** problem, not a tree-search
+problem." I retracted that on 2026-09-05 in favour of a primal/dual/proof split
+claiming *"8 of 17 failures already hold a dual bound within ~5 % and still cannot
+close."* **That retraction was itself wrong and is withdrawn the same day**
+(CLAUDE.md §11). It classified failures by an arbitrary 5 % threshold bearing no
+relation to the solver's stopping rule, and was published without checking it
+against that rule. Recorded here rather than deleted, because the error mode — a
+threshold chosen for readability and then reasoned from as if it were the
+convergence test — is worth not repeating.
+
+Re-derived against the actual tolerance (`gap_tol = 1e-4`), over the 17 instances
+unsolved at the strongest arm of the post-structural-space panel:
+
+| class | count | meaning |
+|---|---|---|
+| dual gap already within `gap_tol` | **0** | no pruning / node-selection / cutoff defect exists on this panel |
+| PURE-BOUND — incumbent optimal, only bound missing | 3 | `b-ball` 4.5e-4, `neos-3610051-istra` 9.0e-3, `neos-3610040-iskar` 1.0e-2 |
+| BOTH SHORT — bound *and* incumbent | 14 | dual 4.6e-3 … 1.0; primal 22 % … no feasible point at all |
+
+**The bound is short on 17 of 17. The incumbent is additionally short on 14 of 17.**
+
+The instance I had held up as the sharpest evidence of a mechanics failure does not
+survive contact with the tolerance. `b-ball`'s bound is `-1.500672636` against an
+optimum of `-1.5` — a relative dual gap of `4.484e-4` against a `1e-4` stopping
+rule. It has not converged. It is short by a factor of ~4.5 in bound and is
+behaving exactly as specified. Its 200,839 nodes against HiGHS's 1 measure how
+much bound HiGHS gets at the root that discopt never gets anywhere, not a failure
+to use a bound it already had.
+
+**Consequence for the stage order.** The original framing was closer to right than
+its first correction, but the precise statement is narrower than either: this is a
+**bound-strength** problem — root or in-tree — on *every* failing instance, with a
+**primal-heuristic** problem layered on 14 of them. Bound work is necessary
+everywhere. Primal work is necessary on 14 and sufficient on none, because no
+instance closes until the bound arrives regardless of how good the incumbent is.
+That is a strict ordering, and the stages below follow it: bound first, primal as
+the accelerant that makes the bound's tree cheaper.
 
 ## 1. Where the gap is
 
@@ -189,9 +222,74 @@ first (`sepa_aggregation.c` Step 1 at `naggrs=0`) — and that the real defect i
 rows in both orientations would read as "MIR does nothing".** The tight-row
 filter is cheap and is adopted; the disagreement does not change Stage 2.
 
+## 2.5 The root-bound attribution — measured 2026-09-05, and it reorders §3
+
+Run before building anything (CLAUDE.md §4). Both arms read the *same* converted
+arrays. discopt at the root (`max_nodes` ≤ 3, first finite bound); HiGHS at
+`mip_max_nodes=1`. Dual gap as `(opt − bound)/(1+|opt|)`. 14/14 executed, 0
+vacuous.
+
+| instance | d_lp | d_root 16×1 | **d_big 200×8** | h_nopre | h_full | own cuts close |
+|---|---|---|---|---|---|---|
+| mik-250-20-75-1 | 18.99 | 17.29 | **4.63** | 1.94 | 1.84 | 75.6 % |
+| mik-250-20-75-2 | 18.16 | 16.03 | **4.81** | 1.64 | 1.52 | 73.5 % |
+| mik-250-20-75-3 | 16.13 | 14.03 | **4.53** | 1.68 | 1.76 | 71.9 % |
+| mik-250-20-75-5 | 17.46 | 15.86 | **4.47** | 2.12 | 1.72 | 74.4 % |
+| fiber | 61.55 | 37.94 | **6.01** | 2.31 | 1.95 | 90.2 % |
+| b-ball | 12.73 | 8.24 | **0.99** | 0.01 | −0.00 | 92.2 % |
+| sp150x300d | 50.00 | 35.71 | **15.71** | 2.86 | 0.00 | 68.6 % |
+| beavma | 58.66 | 52.58 | **31.05** | 1.04 | 0.00 | 47.1 % |
+| nexp-50-20-1-1 | 53.33 | 53.33 | **30.00** | −0.00 | −0.00 | 43.8 % |
+| neos-3611689-kaihu | 15.10 | 13.78 | **9.31** | 3.75 | 2.50 | 38.3 % |
+| neos-3610040-iskar | 8.30 | 7.41 | **6.57** | 4.51 | 5.26 | 20.9 % |
+| neos-3610051-istra | 8.89 | 8.73 | **6.55** | 4.11 | 2.00 | 26.3 % |
+| neos17 | 12.98 | 12.93 | **10.91** | 4.96 | 1.76 | 16.0 % |
+| neos-3118745-obra | 0.46 | 0.46 | **0.29** | 0.46 | 0.39 | 35.7 % |
+
+Three things fall out, and the third overturns the §3 ordering as first drafted.
+
+**(a) HiGHS's root strength is not presolve.** `h_nopre` ≈ `h_full` everywhere —
+mik 1.9–2.1 % with presolve off against 1.5–1.8 % with it on, `nexp` 0.00 either
+way. Presolve is worth ~0–3 pp of root gap. §1c said ≤2 instances; this says the
+root bound specifically owes it almost nothing. **Stage 7 stays last, confirmed.**
+(HiGHS exposes no cuts-off switch — the only `mip_*` option records in
+`HighsOptions.h` are `allow_restart`, the six `heuristic_run_*` booleans,
+`improving_solution_save`, `max_nodes`, `report_level` — so its *cut* share cannot
+be ablated this way. An earlier version of this probe labelled
+`mip_root_presolve_only` as "cuts off"; it is not a cut switch, and that arm was
+deleted rather than reinterpreted.)
+
+**(b) discopt's shipped root budget is drastically undersized.** 16 cuts × 1
+round moves mik 18.99 → 17.29 (9 % of the gap) and `nexp-50-20-1-1` 53.33 → 53.33
+(nothing at all).
+
+**(c) discopt's EXISTING separators already close 70–92 % of the root gap on the
+instances that matter — and this is the finding that reorders the plan.** At
+200 × 8, with no new cut family: mik 17.46 → **4.47** (74 %), `fiber` 61.55 →
+**6.01** (90 %), `b-ball` 12.73 → **0.99** (92 %), `sp150x300d` 50.00 → **15.71**
+(69 %). Cover + Gomory, today, gets mik from 17 % to 4.5 % against HiGHS's 1.7 %.
+
+Set (c) against §0: **the 200-cut arm produced those bounds and still solved 7
+fewer instances than base.** discopt is already generating cuts strong enough to
+be competitive at the root and then losing the solve by carrying every one of
+them in every node LP forever. That is not a cut-quality deficit. It is a cut
+*lifecycle* deficit, and §2.1's reviews called it correctly.
+
+**Consequence for §3.** As first drafted, Stage 1 (lifecycle) was framed as a
+prerequisite for Stage 2 (cMIR), with cMIR as the large lever — the HiGHS review
+put it at 10–15 instances. That is now the wrong weighting and I am recording the
+correction here rather than carrying it (CLAUDE.md §4, §11). **Stage 1 is the
+lever**; the bound it needs to pay off already exists. Stage 2 is demoted: it is
+what takes mik from 4.5 % to HiGHS's 1.7 % *after* Stage 1 makes a large root cut
+set affordable, and it is not worth starting until Stage 1 is measured. The
+entry experiment this section was written to run — "does HiGHS also leave 7–10 %
+at the mik root?" — is answered **no** (it leaves 1.5–1.8 %), so Stage 2 is not
+killed; it is deferred behind a bigger, cheaper win.
+
 ## 3. Stages
 
-Reordered from the first draft per §2. Every bound-changing piece goes behind a
+Reordered from the first draft per §2, and re-weighted per §2.5 — Stage 1 is now
+the lever and Stage 2 is deferred behind it. Every bound-changing piece goes behind a
 default-off flag with the §5 double bar (cert-clean AND net-positive) over the 38
 panel *and* the in-repo MINLP corpus. Propagation, aging, restarts and node
 selection are contractions or reorderings and need only the bound-neutral or
@@ -250,7 +348,7 @@ Ranked first because the code exists and shipping it off is the whole defect.
 *Kill criterion:* each flip measured alone on the 38 panel at matched tolerance;
 anything that does not improve solved-count or nodes stays off.
 
-### Stage 1 — root cut-loop control (the §0 prerequisite)
+### Stage 1 — root cut-loop control — **THE LEVER** (§2.5c)
 
 Replace fixed round/cut budgets with stall-based termination, cut aging, and
 efficacy+orthogonality selection; move root cuts into a pool rather than the
@@ -270,14 +368,106 @@ matrix.
 drop, (c) both. *Kill:* if (b) alone does not recover a substantial share of the
 7 instances the cut budget lost, aging is not the mechanism and Stage 1 re-scopes.
 
-### Stage 2 — cMIR done properly
+**RESOLVED — the kill criterion fired, and the mechanism turned out to be
+neither aging nor selection.** Both arms are dead:
 
-*Attribution first, before any code:* compare discopt's post-cut root bound
-against HiGHS's root bound on the four `mik` plus the six ≤3 %-dual instances.
-**This is the test of §2.2's precondition.** If HiGHS's root gap on `mik` is also
-7–10 %, cuts are not the lever there and this stage is re-scoped to search.
+- **(a) `cut_select` is falsified.** It does not help and on two instances it
+  *creates* the pathology. `fiber` at 200×8 goes from 2986.5 to 6457.4
+  iterations/node with selection on; `mik-250-20-75-1`, which is perfectly
+  healthy at 100 % warm-start acceptance and 6.1 iterations/node, drops to
+  **35.0 % acceptance and 515.3 iterations/node**. The textbook
+  efficacy+orthogonality fix makes things worse here.
+- **(b) slack-cut drop** fired its kill criterion earlier.
 
-If confirmed, build in fidelity order, measuring after each: (1) integral row
+The real mechanism is a **column-space defect**, not a lifecycle one.
+`separate_gomory_cols` loops `for j in 0..n` over the full working width
+(`lp/gomory.rs:215`), so every cut carries coefficients on base slack and
+earlier-cut surplus columns. A coefficient on column `ns + r` puts a *second*
+nonzero into that column, so it stops being a singleton;
+`solve_lp_cols_warm`'s basis reconstruction requires a singleton substitute
+(`lp/simplex/primal.rs:2599-2640`) and otherwise returns a **short** basis;
+`PreparedDual::prepare` refuses a short basis on shape
+(`lp/simplex/dual.rs:521,532`, `DualPrepRejectShape`) and the node cold-solves;
+the cold solve returns another short basis, so the state is self-sustaining. A
+short basis *also* silently disables GMI separation outright
+(`lp/gomory.rs:236`).
+
+Measured directly: `fiber` at 50×2 took **729 shape rejections against 2
+acceptances** (0.3 % warm-start acceptance), while the same instance's base
+16×1 arm ran at 100 %. That is the 492× per-node cost, and it explains why the
+cut arms produce a strong bound and then lose solves: they are paying two to
+three orders of magnitude more simplex iterations per node for it.
+
+`root_cut_prune` is a trigger rather than a cause — its dependency-closure sweep
+keeps a cut precisely *because* something references its surplus column, so it
+preferentially retains the cross-referencing cuts and discards the clean
+singleton ones. On `sp150x300d` removing the prune reaches the **identical**
+bound (60) at 22.3 instead of 2079.6 iterations/node.
+
+**Fix (implemented):** rewrite every cut into structural space before it is
+appended, HiGHS-style. HiGHS never has this problem because
+`HighsTransformedLp::transform` expands slack coefficients back into structural
+ones *before* generating the cut (`HighsTransformedLp.cpp:447,469-482`). The
+same rewrite here uses the exact equality identities the LP rows already supply
+(`s_r = (b_r - A_r·x)/alpha` for a base row, `s_i = c_i·x - rhs_i` for a cut
+row), so it is an identity, not a relaxation. Two follow-on steps are genuine
+weakenings and are bounded accordingly: negligible coefficients left by
+cancellation are moved to the right-hand side at their maximum over the box
+(HiGHS `HighsCutGeneration.cpp:783`), and a cut whose nonzero count *grows* past
+`100 + 0.15·n` is shortened the same way rather than dropped (`:982-1012`).
+
+*Measured result* (6 instances × 4 arms, 400 nodes, `RootCutsSubstDropped` and
+the five per-reason counters armed):
+
+| | before | after |
+|---|---|---|
+| warm-start acceptance | 0.3–1.1 % on the cut arms | **100 % on 22 of 24 arms**, 94.8 % worst |
+| `DualPrepRejectShape` | 588–822 per arm | **0** on 23 of 24 arms |
+| `fiber` 200×8 iterations/node | 2986.5 | **99.5** |
+| `sp150x300d` 200×8 iterations/node | 2079.6 | **10.7** |
+| `mik` 200×8 `sel` iterations/node | 515.3 | **5.6** |
+| `fiber` 200×8 root bound | 388985 | 381984 |
+| `mik` 200×8 root bound | −51927.6 | −51972.4 |
+| `blend2` 200×8 root bound | 7.14624 | **7.16601** |
+
+Cut quality is preserved (within 0.02–0.1 % on every instance, better on
+`blend2`) while the per-node cost falls 30–240×. A first attempt used a
+substitution-density guard instead, which restored warm start but dropped so
+many cuts that root bounds collapsed (`mik` to −58655.4, zero cuts kept); that
+is recorded here as falsified, and the shortening-not-dropping design replaced
+it. A plain dynamism gate failed the same way — 217 of 217 cuts on `fiber` and
+75 of 75 on `mik` refused for coefficient range alone — which is why the
+negligible terms are removed rather than the cut rejected. HiGHS does not gate
+on dynamism at all: its only `dynamism` line sits inside an `#if 0` debug block
+(`HighsCutGeneration.cpp:1061`).
+
+Stage 1's remaining items (stall-based termination, in-tree aging, a violation
+re-checked pool) stand, but they are now optimizations on a working cut path
+rather than the fix for it.
+
+*Why this is now the lever, not a prerequisite.* §2.5c measured discopt's own
+existing separators closing **70–92 %** of the root gap at 200 × 8 on exactly the
+instances that fail — mik 17.46 → 4.47, `fiber` 61.55 → 6.01, `b-ball` 12.73 →
+0.99 — while §0 measured that same 200-cut arm solving **7 fewer** instances. The
+bound Stage 2 was going to be built to produce is already being produced and then
+thrown away by carrying it in every node LP. Stage 1 is the difference between
+having that bound and being able to use it.
+
+*Target:* recover base's 19 and convert the cut arm's root strength into solves.
+The mik family is the cleanest probe — a 4.5 % root gap should not need 600 k
+nodes.
+
+### Stage 2 — cMIR done properly (DEFERRED behind Stage 1 per §2.5)
+
+*The attribution this stage was gated on has been run* (§2.5). HiGHS's mik root
+gap is **1.5–1.8 %**, not 7–10 %, so §2.2's precondition holds and cMIR is not
+killed. But §2.5c also showed discopt's existing separators reach 4.5 % on mik
+unaided, so cMIR is worth roughly the 4.5 % → 1.7 % remainder — real, but second
+to Stage 1, and **not to be started until Stage 1 is measured**. Starting it
+first would build a stronger cut into the same lifecycle that is currently
+converting strong cuts into lost solves.
+
+When it is started, build in fidelity order, measuring after each: (1) integral row
 slacks treated as integer in the δ/complementation set; (2) separate on the
 current LP *including* previously added cuts, scored by efficacy `viol/‖α‖` not
 raw violation; (3) VUB/VLB substitution; (4) the full δ set incl. best/2,/4,/8
@@ -317,6 +507,54 @@ and are unwired on the MILP path.
 
 Last, per §1c (≤2 instances, large build — the matrix path has no postsolve
 chain). Note restarts (Stage 4) want re-presolve, so there is a coupling.
+
+### Falsified: relaxing the cut-cleanup's numerical gates (2026-09-05)
+
+*Hypothesis.* The substitution's two numerical gates are throwing away usable
+cuts. Evidence prompting it: on `gsvm2rl3` the root separator emitted 31 cuts and
+kept **zero**, leaving an 85 % root gap, and HiGHS has no dynamism gate at all —
+its only `dynamism` line (`HighsCutGeneration.cpp:1061`) sits inside an `#if 0`.
+
+*Entry experiment.* Two gates, tested separately and then together, over all 38
+panel instances with a false-bound assertion on every run.
+
+1. **Relaxing the dynamism cap alone** (1e7 → 1e300): 7 instances better, 2
+   worse on root gap. `gsvm2rl3` **unchanged** — its cuts never reach the cap.
+2. **Keeping an unremovable small coefficient** instead of refusing the cut
+   (exact, no weakening): **0 of 38 changed.** Its cuts are then killed by the
+   dynamism cap instead.
+3. **Both together**: `gsvm2rl3` goes 0 → 99 cuts and 85.16 % → 76.11 % root gap;
+   7 better / 2 worse overall. At an intermediate cap of 1e12 the result is 6
+   better / 2 worse and `gsvm2rl3` stays at zero cuts — its coefficient range
+   exceeds 1e12, i.e. those cuts are genuinely ill-conditioned.
+
+*Kill criterion and result.* The bar is CLAUDE.md §5's second half: net-positive,
+not merely sound. Measured at a **fixed 5000-node budget** (deterministic, so the
+loaded machine could not contaminate it — load average was ~68 throughout, which
+invalidates any wall-clock or time-limited solved-count):
+
+| arm | solved | total nodes | dual gap better | worse |
+|---|---|---|---|---|
+| base (1e7, refuse) | 14/38 | 133,680 | — | — |
+| 1e12 + keep | 14/38 | 132,724 | 3 | 3 |
+
+**Cert-clean but neutral, so it does not ship** — the `DISCOPT_CUT_INHERIT` rule.
+The root-bound gain does not survive into tree progress. Not flagged, not
+default-off-with-a-knob: reverted, with the measurement recorded in a comment at
+the refusal site so the next person does not re-run it.
+
+*What it did leave behind.* One counter covered three distinct failures
+(unbounded-bound refusal, non-finite coefficient, ill-conditioned ratio), and I
+mis-diagnosed `gsvm2rl3` three times in a row off it — first as "dynamism", then
+as "the unbounded branch", before measurement showed it is the ratio test acting
+on cuts the unbounded branch let through. The counter is now split into
+`SubstDropUnbounded`, `SubstDropNonFinite` and `SubstDropDynamism`. That split is
+the shippable part of this experiment.
+
+*Carried forward.* `gsvm2rl3` (42 % dual gap) and `neos-2624317-amur` (zero cuts
+generated at all, 100 % dual gap, no feasible point) are not cut-*gating*
+failures. They need a cut family whose coefficients are conditioned by
+construction, which is Stage 2's business, not a threshold change.
 
 ### Explicitly dropped
 

--- a/docs/dev/milp-competitiveness-plan.md
+++ b/docs/dev/milp-competitiveness-plan.md
@@ -392,7 +392,7 @@ incumbent. That is a strict ordering, and it is why Track A precedes Track B. Bu
 Track B is not optional: on the `mik` family the bound is already within 2.6 % and
 the tree still does not close, so Track A alone does not reach 38/38 either.
 
-### Track A0′ — two measured defects that block whole mechanisms. Do these first.
+### Track A0′ — the audit's two candidate defects. One survives; do it first.
 
 Both were found by the 2026-09-05 engine audit and both are **confirmed by
 discopt's own split counters** (`scratchpad/miplib/verify_claims.py`, run with
@@ -419,34 +419,60 @@ start while cuts, warm starts and strong branching are all disabled at once.
 *Also add counters at `gomory.rs:233-235, 246-248, 271`: three silent early
 returns, none instrumented. CLAUDE.md §6.*
 
-**A0′.2 — zero-then-pin in the cut cleanup (`gsvm2rl3`, plus 6 at-risk).**
-`gsvm2rl3` separates 31 cuts and discards **all 31**. Confirmed here:
-`SubstDropUnbounded = 31`, `SubstDropDynamism = 0` — so the refusal is the
-infinite-bound pin at `milp_driver.rs:3213-3222`, **not** the dynamism backstop.
-(The earlier diagnosis blamed dynamism; the counter split shipped in
-`6375b1fb` is what disproved it.)
+**A0′.2 — `gsvm2rl3`'s 31 refused cuts. FALSIFIED as a priority item; demoted.**
 
-Mechanism: `gsvm2rl3` has **61 FREE columns**, all basic at the root. Every GMI
-cut carries pure cancellation noise on them — 4e-19 … 3e-16 absolute, ≤ 1.2e-17
-*relative*, with 994/994 entries ≤ 1e-12 relative. The cleanup tries to pin each
-such column at `u[k]`/`l[k]`, both infinite, and refuses the whole cut. HiGHS
-handles exactly this by **zeroing `|v| <= small_matrix_value` first**
-(`HighsTransformedLp.cpp:337-341`) and only refusing genuinely free columns that
-carry *real* coefficients (`:173-176`). SCIP does the same via `removeZeros`
-before the infinite-bound test. discopt pins before zeroing; the order is
-backwards.
+The audit proposed this as the second high-leverage fix: `gsvm2rl3` separates 31
+cuts and discards all 31 at the infinite-bound pin
+(`milp_driver.rs:3213-3222`) — confirmed here, `SubstDropUnbounded = 31`,
+`SubstDropDynamism = 0`, so the *site* is right and the earlier
+dynamism-backstop diagnosis was wrong. The instance has 61 FREE columns carrying
+≤ 1.2e-17-relative cancellation noise, and the prescription was "zero before
+pinning, as HiGHS does at `HighsTransformedLp.cpp:337-341`."
 
-*Honest expectation.* Recovering these particular cuts is already measured
-**node-neutral on `gsvm2rl3`** (3 better / 3 worse at a fixed 5000-node budget —
-see "Falsified: relaxing the cut-cleanup's numerical gates"). Zero-then-pin is a
-*different* fix from the one that was falsified — dropping a 1e-17-relative
-roundoff term is exact to tolerance, where keeping it was not — and it is the rule
-both reference solvers use. It ships because the rule is wrong, not because
-`gsvm2rl3` is expected to flip. The breadth argument is the reason to expect more:
-**18 of 100 MPS files carry FR columns; 6 are on this panel** — `gsvm2rl3`,
-`iskar`, `istra`, `jijia`, `kaihu`, `obra`. Only `gsvm2rl3` is *verified* affected;
-the other five are at risk and are the kill criterion. If the panel does not move
-on those six, the fix stays (it is a correctness repair) but claims no credit.
+**Four measurements killed it, in order (2026-09-05):**
+
+1. **The HiGHS mechanism is not what was reported, and is not portable.** The
+   `small_matrix_value` cleanup at `:340` runs *after* the free-column refusal at
+   `:173`, so it is not what saves HiGHS. What actually saves it is upstream, in
+   the separator: `HighsTableauSeparator.cpp:158-165` discards basis-inverse
+   weights with `maxAbsRowVal(row) * |weight| <= feastol` **before the row is
+   aggregated**, so noise never becomes a nonzero. discopt's GMI path cannot
+   adopt that: filtering `w` breaks the `ābar_B = e_i` identity that lets
+   `gomory.rs` skip basic columns, and skipping them would then be an
+   uncompensated — unsound — drop. HiGHS gets away with it because its filtered
+   weights feed a general aggregator (`transform` + cMIR), not a tableau row with
+   assumed unit structure.
+2. **Compensated summation cannot help.** The residues are 4e-19 … 3e-16, which
+   is per-*product* rounding in `f * base.val[k]`, not summation error. Kahan or
+   Neumaier accumulation removes the latter and not the former.
+3. **FBBT cannot bound the columns.** The SCIP review's explanation — "SCIP would
+   refuse these cuts too; the difference is that its presolve bounds the
+   variables first" — does not hold here. Ten interval-arithmetic FBBT passes over
+   `gsvm2rl3` move it from **61 free structural columns to 61**
+   (`scratchpad/miplib/fbbt_free.py`).
+4. **The breadth argument evaporates.** The claim was "18 of 100 MPS files have FR
+   columns; 6 on this panel." Six panel instances do have them
+   (`scratchpad/miplib/freecount.py`) — but five carry exactly **one** free column
+   (the objective variable) and **none of them loses a single cut**
+   (`scratchpad/miplib/breadth.py`): `SubstDropUnbounded = 0` on all five, with
+   24-176 cuts generated each. Only `gsvm2rl3`, with 61, is affected.
+
+So the item reduces to: one instance out of 38, whose cut recovery is **already
+measured node-neutral** (3 better / 3 worse at a fixed 5000-node budget — see
+"Falsified: relaxing the cut-cleanup's numerical gates"), with no sound fix
+identified. The refusal at the pin is **correct as written**: dropping a term
+whose maximising bound is infinite is not a relaxation, and no amount of
+smallness makes it one in exact arithmetic. It stays.
+
+*What would revive it:* a cut family whose coefficients are conditioned by
+construction (A2), or a genuine bound derivation for those 61 columns that FBBT
+cannot reach. Not a laxer numerical gate — that road has now been measured shut
+twice.
+
+*Lesson recorded (CLAUDE.md §4, §11):* three separate expert-supplied mechanisms
+for this one instance — dynamism backstop, zero-then-pin, presolve bounding — were
+each plausible, each cited to real source, and each wrong. The counters and a
+20-line numpy FBBT settled in minutes what the citations could not.
 
 ### Track A — the bound (needed by 17/17)
 
@@ -960,7 +986,7 @@ so a stage can be scored before parity is reached:
 | stage | target | basis for the target |
 |---|---|---|
 | A0 + A0.1 | 21/38 | measured, banked (`cut500_prune`) |
-| A0′.1 + A0′.2 | 21/38 | **no solved-count target.** Both are correctness repairs that unblock machinery; scored on *counters* (amur: `SepGomory` calls > 0 and `DualPrepRejectShape` → ~0; gsvm2rl3: `SubstDropUnbounded` → 0) and on the 6 FR-column instances, not on solves |
+| A0′.1 | 21/38 | **no solved-count target.** A correctness repair that unblocks three mechanisms; scored on *counters* (amur: `SepGomory` calls > 0, `DualPrepRejectShape` → ~0), not on solves. A0′.2 was falsified and demoted — see Track A0′ |
 | A1 | 24/38 | cut lifecycle makes a >500 budget affordable |
 | A2 | 30/38 | the family HiGHS actually closes its last few percent with |
 | A3 | — | branching quality; scored on nodes at fixed solved-count, not on solves |
@@ -968,7 +994,7 @@ so a stage can be scored before parity is reached:
 | B2 | 35/38 | the sub-MIP/pump ladder |
 
 These are targets, not predictions — a stage that misses its target is re-scoped
-against the measurement, per §4 of CLAUDE.md, not carried forward on hope. A0′
+against the measurement, per §4 of CLAUDE.md, not carried forward on hope. A0′.1
 deliberately claims no solved-count: it is first in the order because it unblocks
 three mechanisms at once, not because it is expected to move the panel by itself.
 

--- a/docs/dev/milp-competitiveness-plan.md
+++ b/docs/dev/milp-competitiveness-plan.md
@@ -419,6 +419,46 @@ start while cuts, warm starts and strong branching are all disabled at once.
 *Also add counters at `gomory.rs:233-235, 246-248, 271`: three silent early
 returns, none instrumented. CLAUDE.md §6.*
 
+**Result (2026-09-05) — shipped, cert-clean, net-positive on LP work.** The
+eligibility test was wrong in its *quantity*, not merely its strictness. Swapping
+a nonbasic row singleton `s` into a basic artificial's slot replaces `B`'s column
+`±e_r` with `a·e_r` — a scalar multiple, still nonsingular — and leaves `x`
+bit-identical whatever `s`'s value, because a basic variable may hold any value.
+The primal argument never needed value zero. What the swap *can* break is the
+exported `dual`, since a basic column requires `c_j − yᵀA_j = 0`. So the
+admissible criterion is the **reduced cost**, and the value test missed every
+dual-degenerate case. Fixed by a second pass (`select_row_substitutes`,
+`primal.rs`) that fills only the rows pass 1 left empty — strictly monotone, so no
+basis that completed before can be shortened.
+
+Counter deltas on amur at the settings above: `DualPrepRejectShape` 300 → **0**,
+`DualPrepAccept` 80 → **191**, `RootCutsGenerated` 0 → **102**, `RootCutsKept`
+0 → **25**. Three blocked mechanisms unblocked by one criterion change.
+
+38-instance node-limited differential panel (`nodepanel.py`, budget 5000,
+`gap_tol=1e-4`, `root_cuts=500`, `cut_rounds=8`, `root_cut_prune=True`):
+
+- *Cert-clean.* 76 bound-vs-optimum comparisons executed, zero violations;
+  solved count unchanged at 14/38, no certified instance regressed.
+- *Bound-neutral in the tree.* 133,680 → 133,662 nodes (−0.01 %); 36 of 38
+  instances bit-identical in nodes **and** iterations. Expected: a warm start does
+  not move an LP optimum, so it cannot move the tree.
+- *Net-positive in LP work.* Total simplex iterations **6,492,081 → 4,057,317
+  (−37.5 %)**, entirely in the four short-basis instances — `neos-3610040-iskar`
+  1,898,737 → 29,372 (**−98.5 %**), `neos-2624317-amur` −20.8 %, `neos-911970`
+  −6.2 %, `neos-3118745-obra` −1.5 %. The 34 untouched instances moving by exactly
+  zero iterations also rules out nondeterminism as the source of the four deltas.
+
+No wall-clock claim: load was 30–70 all day (CLAUDE.md §9). Iterations and nodes
+are load-independent, which is why the gate is stated on them.
+
+This is the shape to expect from every A0′ item: it does not move the solved
+count by itself, because a node-limited panel spends its budget either way. It
+removes a *blockage*, and the items downstream of it (A1's cut budget, A3's
+strong branching) are the ones that convert freed LP work into bound. Note also
+`convex_kernel.rs:652,1948` carries the same defect on the MINLP path — out of
+scope for the MILP panel, and it needs the MINLP corpus to gate.
+
 **A0′.2 — `gsvm2rl3`'s 31 refused cuts. FALSIFIED as a priority item; demoted.**
 
 The audit proposed this as the second high-leverage fix: `gsvm2rl3` separates 31
@@ -986,7 +1026,7 @@ so a stage can be scored before parity is reached:
 | stage | target | basis for the target |
 |---|---|---|
 | A0 + A0.1 | 21/38 | measured, banked (`cut500_prune`) |
-| A0′.1 | 21/38 | **no solved-count target.** A correctness repair that unblocks three mechanisms; scored on *counters* (amur: `SepGomory` calls > 0, `DualPrepRejectShape` → ~0), not on solves. A0′.2 was falsified and demoted — see Track A0′ |
+| A0′.1 | 21/38 | **MET, 2026-09-05.** No solved-count target — a correctness repair scored on counters and LP work. Delivered: `DualPrepRejectShape` 300 → 0 on amur, `RootCutsGenerated` 0 → 102, and **−37.5 % simplex iterations** panel-wide at unchanged nodes and a cert-clean panel. A0′.2 was falsified and demoted — see Track A0′ |
 | A1 | 24/38 | cut lifecycle makes a >500 budget affordable |
 | A2 | 30/38 | the family HiGHS actually closes its last few percent with |
 | A3 | — | branching quality; scored on nodes at fixed solved-count, not on solves |

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -21486,18 +21486,50 @@ def _milp_root_cut_budget(engine_budget: float) -> Optional[dict]:
     efficacy/orthogonality selection takes the prodplan root bound to **89.3%**
     in 4.7 s.
 
-    Bound-CHANGING (CLAUDE.md §5), so it ships default-OFF behind
-    ``DISCOPT_MILP_ROOT_CUTS=1`` until a corpus-wide differential panel is
-    cert-clean AND net-positive. Nothing here can make a bound unsound -- a
-    Gomory/cover cut is valid for the integer hull either way -- but "sound" is
-    not the bar; "measurably helpful broadly" is (the ``DISCOPT_CUT_INHERIT``
-    lesson).
+    Bound-CHANGING (CLAUDE.md §5), so this shipped default-OFF until a
+    corpus-wide differential panel came back cert-clean AND net-positive.
+    Nothing here can make a bound unsound -- a Gomory/cover cut is valid for the
+    integer hull either way -- but "sound" is not the bar; "measurably helpful
+    broadly" is (the ``DISCOPT_CUT_INHERIT`` lesson).
+
+    **Graduated default-ON 2026-09-05.** 38 MIPLIB instances, ``gap_tol=1e-4``,
+    20 s each, both arms interleaved within every replicate, 2 replicates, run
+    twice under different machine load:
+
+    ==========================  ==========  ==========  ==================
+    arm                         solved      nodes       gap on the 17 open
+    ==========================  ==========  ==========  ==================
+    off (``root_cuts=16``, 1)   18-19/38    9.41 M      mean 0.2028
+    on (this budget)            **21/38**   **5.35 M**  **mean 0.1494**
+    ==========================  ==========  ==========  ==================
+
+    *Cert-clean*: 304 bound-vs-reference-optimum comparisons across the two runs,
+    zero violations, and no certification regression -- ``fiber``, ``gt2`` and
+    ``neos-3611689-kaihu`` go feasible -> optimal, none go the other way.
+    *Net-positive*: +3 instances, -43 % nodes, and the dual gap on the instances
+    nobody closes drops from 0.2028 to 0.1494 (median 0.1052 -> 0.0265). The
+    four ``mik-250-20-75-*`` -- a pure *dual* failure family -- go from ~0.14 to
+    ~0.037 at a matched node budget.
+
+    The honest cost: cuts buy the hard instances by taxing the easy ones. ON is
+    *slower* on 11 of the 18 both arms solve (``neos-3611447-jijia`` 7.5 -> 13.9 s,
+    ``enlight8`` 5.4 -> 10.5 s, ``22433`` 0.31 -> 2.51 s) and faster on 7
+    (``bppc8-02`` 3.79 -> 1.44 s). Total wall still fell in both runs
+    (426 -> 398 s, 425 -> 400 s), but this machine never idles below load ~5, so
+    per CLAUDE.md §9 the *wall* column is corroboration only -- the verdict rests
+    on solved count, node count and dual bound, which are load-independent and
+    which both runs reproduced to four digits. The per-instance tax is the
+    argument for the plan's A1 (stall-based termination and cut aging), not a
+    reason to withhold the budget.
+
+    Set ``DISCOPT_MILP_ROOT_CUTS=0`` to restore the binding's historical
+    ``root_cuts=16, cut_rounds=1`` single pass.
 
     ``root_cut_time_s`` is what makes 50 rounds safe to ask for: without it a
     long separation phase on a large root LP would spend the engine's whole slice
     proving a bound with no time left to branch.
     """
-    if os.environ.get("DISCOPT_MILP_ROOT_CUTS", "0").lower() in ("0", "false", "no"):
+    if os.environ.get("DISCOPT_MILP_ROOT_CUTS", "1").lower() in ("0", "false", "no"):
         return None
     return {
         "root_cuts": 500,
@@ -21683,7 +21715,8 @@ def _solve_milp_simplex(
     if initial_point is not None and np.asarray(initial_point).size == n_orig:
         _seed = np.ascontiguousarray(np.asarray(initial_point, dtype=np.float64).ravel())
 
-    # Root cut budget (default-off; see ``_milp_root_cut_budget``). Passed as
+    # Root cut budget (default-ON since 2026-09-05; see ``_milp_root_cut_budget``,
+    # whose docstring carries the graduation panel). Passed as
     # keywords so the binding's own defaults stand when the flag is off -- these
     # same defaults also serve the MINLP per-node relaxer, which is why the
     # budget is raised HERE and not by changing them.

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -21473,6 +21473,43 @@ def _milp_engine_default_on() -> bool:
     return os.environ.get("DISCOPT_MILP_ENGINE", "1").lower() not in ("0", "false", "no")
 
 
+def _milp_root_cut_budget(engine_budget: float) -> Optional[dict]:
+    """Root cut options for the pure-MILP engine, or ``None`` to keep the
+    binding's historical ``root_cuts=16, cut_rounds=1`` single pass.
+
+    Measured motivation (30-instance MILP panel, 20 s/instance): on the
+    lot-sizing / production-planning family the root dual bound the engine
+    proves is **18.9%** of the optimum, while HiGHS closes the same instances at
+    **100%** of theirs at its own root. That is not a missing cut *class* -- the
+    engine already separates cover and GMI cuts -- it is the budget: one round of
+    at most 16 cuts. Raising the same separator to 500 cuts over 50 rounds with
+    efficacy/orthogonality selection takes the prodplan root bound to **89.3%**
+    in 4.7 s.
+
+    Bound-CHANGING (CLAUDE.md §5), so it ships default-OFF behind
+    ``DISCOPT_MILP_ROOT_CUTS=1`` until a corpus-wide differential panel is
+    cert-clean AND net-positive. Nothing here can make a bound unsound -- a
+    Gomory/cover cut is valid for the integer hull either way -- but "sound" is
+    not the bar; "measurably helpful broadly" is (the ``DISCOPT_CUT_INHERIT``
+    lesson).
+
+    ``root_cut_time_s`` is what makes 50 rounds safe to ask for: without it a
+    long separation phase on a large root LP would spend the engine's whole slice
+    proving a bound with no time left to branch.
+    """
+    if os.environ.get("DISCOPT_MILP_ROOT_CUTS", "0").lower() in ("0", "false", "no"):
+        return None
+    return {
+        "root_cuts": 500,
+        "cut_rounds": 50,
+        "cut_select": True,
+        # Half the engine's slice, floored so a very short budget still gets one
+        # useful pass. The loop stops early on tailing off, so on an instance
+        # whose root closes in two rounds this ceiling is never reached.
+        "root_cut_time_s": max(0.5, 0.5 * float(engine_budget)),
+    }
+
+
 def _one_hot_swap_reseed(model: Model, x_lifted: np.ndarray, budget: float) -> Optional[np.ndarray]:
     """A lifted-space seed built by improving *x_lifted* with an assignment-aware
     swap over the ORIGINAL variables, or ``None`` when unavailable.
@@ -21646,6 +21683,12 @@ def _solve_milp_simplex(
     if initial_point is not None and np.asarray(initial_point).size == n_orig:
         _seed = np.ascontiguousarray(np.asarray(initial_point, dtype=np.float64).ravel())
 
+    # Root cut budget (default-off; see ``_milp_root_cut_budget``). Passed as
+    # keywords so the binding's own defaults stand when the flag is off -- these
+    # same defaults also serve the MINLP per-node relaxer, which is why the
+    # budget is raised HERE and not by changing them.
+    _cut_opts = _milp_root_cut_budget(_milp_budget) or {}
+
     status, x_struct, obj, bound, nodes, _lp_iters = solve_milp_py(
         np.ascontiguousarray(lp_data.c, dtype=np.float64),
         A,
@@ -21660,6 +21703,7 @@ def _solve_milp_simplex(
         initial_incumbent=_seed,
         time_limit_s=float(_milp_budget),
         debug_hook=_debug.rust_hook(),
+        **_cut_opts,
     )
 
     # Feasibility gate (shared by the return path below and the #698 re-entry

--- a/python/tests/test_lagrangian_bb_hook.py
+++ b/python/tests/test_lagrangian_bb_hook.py
@@ -271,9 +271,25 @@ def _branching_brute(c, n, cap=5, target=35):
 
 
 @pytest.mark.correctness
-def test_hook_sound_and_helpful_on_a_branching_tree():
+def test_hook_sound_and_helpful_on_a_branching_tree(monkeypatch):
     """In-tree coverage: the instance branches deeply; the hook must stay sound
-    (same optimum as hook-off and brute force) and must not *increase* nodes."""
+    (same optimum as hook-off and brute force) and must not *increase* nodes.
+
+    Both arms are pinned to the Python ``_solve_milp_bb`` path
+    (``DISCOPT_MILP_ENGINE=0``) because that is the *only* engine the hook runs
+    on: `solver.py`'s router deliberately declines to reroute a
+    ``lagrangian_bound=True`` solve to the monolithic Rust MILP engine (which has
+    no per-node hook). Without the pin the two arms are different solvers, so
+    ``on.node_count <= off.node_count`` compares the hook against an unrelated
+    engine rather than against itself-minus-the-hook. That latent flaw surfaced
+    when the A0 root cut budget graduated default-ON: the Rust engine began
+    closing this instance at the root, ``off.node_count`` collapsed to 1, and the
+    "does it branch" precondition failed. Measured with the pin (both cut
+    settings, five instance sizes): off 13/11/25/101/89 nodes vs on 1/1/1/31/15 —
+    the hook's real, large benefit, which the cross-engine comparison had been
+    hiding behind luck.
+    """
+    monkeypatch.setenv("DISCOPT_MILP_ENGINE", "0")
     m_off, c, n = _branching_instance()
     opt = _branching_brute(c, n)
     off = m_off.solve(time_limit=60)

--- a/python/tests/test_milp_engine_routing.py
+++ b/python/tests/test_milp_engine_routing.py
@@ -20,7 +20,11 @@ not upgrade the status, and it must not cross the incumbent.
 
 import pytest
 from discopt.modeling.core import Model, SolveResult
-from discopt.solver import _merge_engine_bound, _milp_engine_default_on
+from discopt.solver import (
+    _merge_engine_bound,
+    _milp_engine_default_on,
+    _milp_root_cut_budget,
+)
 
 
 def _milp(maximize: bool = False) -> Model:
@@ -58,6 +62,39 @@ def test_opt_out_is_honored(monkeypatch, off):
     """CLAUDE.md §5 keeps the legacy path reachable; that is what the panel A/Bs."""
     monkeypatch.setenv("DISCOPT_MILP_ENGINE", off)
     assert _milp_engine_default_on() is False
+
+
+def test_root_cut_budget_is_on_by_default(monkeypatch):
+    """Track A0 graduated the root cut budget default-ON on 2026-09-05.
+
+    38 MIPLIB instances at 20 s, both arms interleaved, two replicates, run
+    twice: 18-19/38 -> 21/38 solved, 9.41 M -> 5.35 M nodes, and the dual gap on
+    the 17 instances neither arm closes 0.2028 -> 0.1494 -- cert-clean over 304
+    bound-vs-optimum comparisons with zero violations. Fails against the
+    default-off gate this replaces.
+    """
+    monkeypatch.delenv("DISCOPT_MILP_ROOT_CUTS", raising=False)
+    opts = _milp_root_cut_budget(20.0)
+    assert opts is not None, "the graduated budget must reach a plain Model.solve()"
+    # Pin the panel's configuration, not merely "some cuts": A0.1's whole failure
+    # mode was wiring a *different* budget than the one that was measured.
+    assert opts["root_cuts"] == 500
+    assert opts["cut_rounds"] == 50
+    assert opts["cut_select"] is True
+    assert opts["root_cut_time_s"] == 10.0  # half the engine slice
+
+
+@pytest.mark.parametrize("off", ["0", "false", "no", "FALSE", "No"])
+def test_root_cut_budget_opt_out_restores_the_legacy_single_pass(monkeypatch, off):
+    """§5 requires the legacy path stay intact and reachable after a graduation."""
+    monkeypatch.setenv("DISCOPT_MILP_ROOT_CUTS", off)
+    assert _milp_root_cut_budget(20.0) is None
+
+
+def test_root_cut_budget_floor_survives_a_tiny_slice(monkeypatch):
+    """A short budget still gets one useful separation pass rather than none."""
+    monkeypatch.delenv("DISCOPT_MILP_ROOT_CUTS", raising=False)
+    assert _milp_root_cut_budget(0.2)["root_cut_time_s"] == 0.5
 
 
 def test_gate_is_not_cached(monkeypatch):


### PR DESCRIPTION
## What this does

`_milp_root_cut_budget` returned `None` unless `DISCOPT_MILP_ROOT_CUTS=1`, so a
plain `Model.solve()` on a pure MILP got the binding's historical
`root_cuts=16, cut_rounds=1` single pass. **It now returns the budget by
default.** `DISCOPT_MILP_ROOT_CUTS=0` restores the legacy single pass — that is
the arm the panel A/Bs, and CLAUDE.md §5 requires it stay intact and reachable.

This is Track A0 of `docs/dev/milp-competitiveness-plan.md`, plus the A0.1 wiring
step it depends on.

## The graduation panel (CLAUDE.md §5)

38 MIPLIB instances, `gap_tol=1e-4`, 20 s each, both arms interleaved **within**
every replicate, 2 replicates, and the whole panel run **twice** under different
machine load.

| arm | solved | total wall | med(solved) | nodes | dual gap on the 17 open |
|---|---|---|---|---|---|
| off (`root_cuts=16`, 1 round) | 18-19/38 | 424.9 s ±4.2 | 0.158 s | 9,409,627 | mean 0.2028, med 0.1052 |
| on (500 / 50 / select) | **21**/38 | 399.8 s ±1.0 | 0.135 s | **5,353,150** | mean **0.1494**, med **0.0265** |

**Cert-clean.** 304 bound-vs-reference-optimum comparisons across the two runs,
**zero violations**, and no certification regression: `fiber`, `gt2` and
`neos-3611689-kaihu` go `feasible → optimal`, and nothing goes the other way.

**Net-positive.** +3 instances, −43 % nodes, and the dual bound improves exactly
on the plan's §1b pure-*dual* failure family — in the companion node-budget panel
the four `mik-250-20-75-*` go from ~0.14 to ~0.037 at a matched node budget.

## Two things I am not dressing up

**The wall column is not the basis of this verdict.** This machine never idled
below load ~5 — two `myst start` dev servers hold ~100 % CPU each — and a foreign
`pytest` arrived mid-run on the first attempt, peaking at load 58. Per CLAUDE.md
§9 the wall numbers are corroboration only. The verdict rests on solved count,
node count and dual bound, which are load-independent, and which **both runs
reproduced to four significant figures** (0.2028 → 0.1494 in each). Two runs
under different load agreeing exactly is stronger than one quiet run would have
been, but it is not the quiet run the plan asked for, and I am labelling it as
such. `gradpanel.py` now samples load per solve, and `gradscore.py` refuses to
issue a timing verdict when it sees contention, so next time this is recorded
rather than inferred afterwards.

**Cuts buy the hard instances by taxing the easy ones.** ON is *slower* on 11 of
the 18 instances both arms solve — `neos-3611447-jijia` 7.5 → 13.9 s, `enlight8`
5.4 → 10.5 s, `22433` 0.31 → 2.51 s — against 7 faster (`bppc8-02`
3.79 → 1.44 s). Net-positive at 38 instances, but that per-instance tax is
precisely what the plan's **A1** (stall-based termination, cut aging, a cut pool)
exists to remove. A1 should be scored on removing this tax *without* giving back
the +3.

## An A0.1 hazard the panel surfaced

The plan banked `cut500_prune` = 500 cuts / 8 rounds / **no** selection. What
`_milp_root_cut_budget` actually ships is **different**: 500 / 50 / `cut_select=True`
with `root_cut_time_s = max(0.5, 0.5·engine_budget)`. Flipping the default as the
plan described would have shipped a configuration no panel had ever run — the
wiring step silently changes the thing A0 measured.

So I measured all three arms (38 instances, `max_nodes=2000`, rotated per
instance — a node budget because the machine was at load ~21 and nodes are
load-independent where wall is not). The shipped configuration is the **better**
of the two: mean gap 0.1883 vs 0.1919, 19 vs 12 best-arm wins, and 1.62 M vs
1.94 M simplex iterations. `_milp_root_cut_budget` therefore stays as written,
and the new tests **pin that exact configuration** rather than merely asserting
"some cuts are on".

## Verification

- `pytest python/tests/test_milp_engine_routing.py` — **28 passed**. Two of the
  three new tests were confirmed **failing** against the default-off gate before
  the change (`2 failed, 26 passed`).
- `pytest -m smoke` — **1165 passed**, 1 skipped, 2 xpassed. This now exercises
  the new default throughout.
- `pytest -m slow python/tests/test_adversarial_recent_fixes.py` — **19 passed**.
- `ruff check python/` and `ruff format --check python/` — clean.
- No Rust changed, so no `cargo test` is required for this diff (the Rust on this
  branch is #1167/#1168's, already tested there).

**Base note:** this is stacked on #1168, but `ci.yml` only triggers for PRs based
on `main`, so it targets `main` to get checks. The diff therefore also shows
#1164/#1167/#1168's commits until those merge, at which point it reduces to the
three files above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014E81XM1j2J5sydzj9nFFFp
