### PR TITLE
fix(correctness): #1160 an axis-reduced sum is several rows, not one

### DIFF
--- a/crates/discopt-core/src/expr.rs
+++ b/crates/discopt-core/src/expr.rs
@@ -1243,7 +1243,24 @@ impl ExprArena {
                 // of the two flat vectors.
                 self.evaluate_matmul(*left, *right, x)
             }
-            ExprNode::Sum { operand, .. } => {
+            ExprNode::Sum { operand, axis } => {
+                if axis.is_some() {
+                    // An axis reduction is ARRAY-valued: `sum(A, axis=1)` on a
+                    // (2, 3) operand is two row sums, not one sum of six terms.
+                    // This evaluator is scalar-valued, so there is no honest
+                    // answer -- returning the full sum silently answers a
+                    // DIFFERENT model, and the Python LP/QP repr extractors then
+                    // emit one collapsed row and certify its optimum (#1160).
+                    // NaN is this arena's established "not scalar-representable"
+                    // signal (see the Index fall-through above); every extractor
+                    // that probes the repr checks for it and falls back to a
+                    // per-component path. The arena carries no shape inference,
+                    // so a 1-D `axis=0` operand -- which IS a full reduction --
+                    // is refused here too; `_relax.scalarize.sum_is_full_reduction`
+                    // is the precise predicate, on the Python side where shapes
+                    // are known.
+                    return f64::NAN;
+                }
                 // Sum all elements of the operand.
                 self.evaluate_sum_all(*operand, x)
             }
@@ -1642,7 +1659,15 @@ impl ModelRepr {
                 _ => f64::NAN,
             },
             ExprNode::MatMul { left, right } => self.evaluate_matmul(*left, *right, x),
-            ExprNode::Sum { operand, .. } => self.evaluate_sum_all(*operand, x),
+            ExprNode::Sum { operand, axis } => {
+                // Array-valued unless it is a full reduction -- see the matching
+                // guard in `ExprArena::evaluate` (#1160).
+                if axis.is_some() {
+                    f64::NAN
+                } else {
+                    self.evaluate_sum_all(*operand, x)
+                }
+            }
             ExprNode::SumOver { terms } => terms.iter().map(|t| self.evaluate_node(*t, x)).sum(),
         }
     }
@@ -2040,6 +2065,39 @@ mod tests {
             index_spec_to_flat(&IndexSpec::Tuple(vec![1, 2]), &[3, 4]),
             6
         );
+    }
+
+    #[test]
+    fn test_axis_reduced_sum_is_not_scalar_representable() {
+        // #1160: `sum(A, axis=k)` is ARRAY-valued -- one row per surviving
+        // element. This evaluator returns one f64, so the only honest answer is
+        // NaN (the arena's "not scalar-representable" signal, which every
+        // repr-based extractor checks for). Returning the full sum answered a
+        // DIFFERENT model: `sum(A, axis=1) <= b` was extracted as the single row
+        // `sum(A) <= b` and its optimum certified.
+        let mut arena = ExprArena::new();
+        let a = arena.add(ExprNode::Variable {
+            name: "A".into(),
+            index: 0,
+            size: 6,
+            shape: vec![2, 3],
+        });
+        let pt = [1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0];
+
+        let full = arena.add(ExprNode::Sum {
+            operand: a,
+            axis: None,
+        });
+        assert!((arena.evaluate(full, &pt) - 21.0).abs() < 1e-12);
+
+        for axis in [0_usize, 1] {
+            let reduced = arena.add(ExprNode::Sum {
+                operand: a,
+                axis: Some(axis),
+            });
+            let v = arena.evaluate(reduced, &pt);
+            assert!(v.is_nan(), "axis={axis} evaluated to {v}, expected NaN");
+        }
     }
 
     #[test]

--- a/python/discopt/_relax/canonical_expr.py
+++ b/python/discopt/_relax/canonical_expr.py
@@ -45,7 +45,7 @@ from typing import Any, Optional
 
 import numpy as np
 
-from discopt._relax.scalarize import scalar_elements
+from discopt._relax.scalarize import scalar_elements, sum_is_full_reduction
 from discopt.modeling.core import (
     BinaryOp,
     Constant,
@@ -448,6 +448,11 @@ class _Canonicalizer:
 
         if isinstance(expr, SumExpression):
             # sum(array_variable) over its elements is affine; anything else is opaque.
+            # Only a FULL reduction collapses to one affine form: `sum(A, axis=1)`
+            # is one row per row of `A`, and folding its elements into a single
+            # canonical sum is the axis-collapse of #1160.
+            if not sum_is_full_reduction(expr):
+                raise UnsupportedCanonicalization("axis-reduced sum (array-valued)")
             op = expr.operand
             if isinstance(op, Variable):
                 from discopt._relax.term_classifier import _compute_var_offset

--- a/python/discopt/_relax/convexity/linear_context.py
+++ b/python/discopt/_relax/convexity/linear_context.py
@@ -29,6 +29,7 @@ from typing import Optional
 import numpy as np
 
 from discopt._relax.convexity.lattice import Sign, is_strict, sign_from_bounds
+from discopt._relax.scalarize import sum_is_full_reduction
 from discopt.modeling.core import (
     BinaryOp,
     Constant,
@@ -149,6 +150,12 @@ def extract_affine(
             return None
 
         if isinstance(node, SumExpression):
+            # A full reduction contributes one row whose terms are the operand's
+            # elements at a uniform scale. An axis reduction is array-valued --
+            # several rows -- so this single coefficient row would be their sum
+            # (#1160). Abstain rather than describe a row the model does not have.
+            if not sum_is_full_reduction(node):
+                return None
             return walk(node.operand, scale)
 
         if isinstance(node, SumOverExpression):

--- a/python/discopt/_relax/dependent_vars.py
+++ b/python/discopt/_relax/dependent_vars.py
@@ -60,6 +60,7 @@ import numpy as np
 # isolating extractor below short-circuits on "target absent -> coefficient 0",
 # which is what the dependent-output pattern requires.
 from discopt._relax.objective_epigraph import VarNameIndex, WorkCounter, _const_value
+from discopt._relax.scalarize import sum_is_full_reduction
 from discopt.modeling.core import (
     BinaryOp,
     Constant,
@@ -220,6 +221,13 @@ def _isolated_affine_coeffs(expr, index=None, work=None):
             bad |= names
             continue
         if isinstance(node, SumExpression):
+            # A full reduction passes the multiplier straight through to the
+            # operand's elements. An axis reduction is array-valued -- the node
+            # stands for several rows -- so the coefficient this walk reports
+            # would be for none of them (#1160). Mark the names unprovable.
+            if not sum_is_full_reduction(node):
+                bad |= names
+                continue
             stack.append((node.operand, mult))
             continue
         # SumOverExpression (a reduction carrying the name -> not a scalar

--- a/python/discopt/_relax/milp_relaxation.py
+++ b/python/discopt/_relax/milp_relaxation.py
@@ -33,6 +33,7 @@ import scipy.sparse as sp
 from discopt._relax._numeric import is_effectively_finite as _is_effectively_finite
 from discopt._relax.discretization import DiscretizationState
 from discopt._relax.model_utils import flat_variable_bounds
+from discopt._relax.scalarize import sum_is_full_reduction
 from discopt._relax.term_classifier import (
     NonlinearTerms,
     _compute_var_offset,
@@ -1387,6 +1388,13 @@ def _expr_to_polynomial(expr: Expression, model: Model) -> _AffineSquare | None:
                 return visit(e.operand, -scale)
             return False
         if isinstance(e, SumExpression):
+            # A full reduction distributes ``scale`` over the operand's elements
+            # and yields the one polynomial this walk returns. An axis reduction
+            # is array-valued -- one polynomial per surviving element -- so
+            # descending would merge rows the model keeps apart and hand the
+            # caller a single quadratic form for several constraints (#1160).
+            if not sum_is_full_reduction(e):
+                return False
             return visit(e.operand, scale)
         if isinstance(e, SumOverExpression):
             # ``dm.sum(f, over=...)`` / ``dm.sum(term for ...)`` builds an n-ary
@@ -1897,6 +1905,13 @@ def _linearize_affine_expr_sparse(
                 raise ValueError(f"Non-affine power in univariate argument: {e}")
 
         if isinstance(e, SumExpression):
+            # Only a full reduction is the single affine row this builds; an axis
+            # reduction stands for one row per surviving element, and folding its
+            # elements together with one uniform scale is the #1160 collapse.
+            # ``ValueError`` is this walk's "not affine" signal -- every caller
+            # catches it and abstains.
+            if not sum_is_full_reduction(e):
+                raise ValueError(f"Axis-reduced sum is array-valued, not one affine row: {e}")
             op = e.operand
             if isinstance(op, Variable):
                 offset = _compute_var_offset(op, model)

--- a/python/discopt/_relax/obbt.py
+++ b/python/discopt/_relax/obbt.py
@@ -18,6 +18,7 @@ from typing import Optional
 import numpy as np
 
 from discopt._flat_index import resolve_scalar_slot
+from discopt._relax.scalarize import sum_is_full_reduction
 from discopt.modeling.core import Model
 from discopt.solvers import SolveStatus
 from discopt.solvers.lp_backend import (
@@ -499,6 +500,12 @@ def _extract_linear_constraints(
             return None
 
         if isinstance(expr, SumExpression):
+            # Only a full reduction is the single row this returns. An axis
+            # reduction stands for one row per surviving element, and merging
+            # their coefficients would hand OBBT a constraint the model does not
+            # contain -- an invalid tightening, not just a weak one (#1160).
+            if not sum_is_full_reduction(expr):
+                return None
             return _extract_coeffs(expr.operand)
 
         if isinstance(expr, SumOverExpression):
@@ -639,6 +646,10 @@ def _extract_linear_objective(
                 return {slot: 1.0}, 0.0
             return None
         if isinstance(expr, SumExpression):
+            # See the sibling extractor above: an axis reduction is several rows,
+            # not one (#1160).
+            if not sum_is_full_reduction(expr):
+                return None
             return _extract(expr.operand)
         if isinstance(expr, SumOverExpression):
             merged: dict[int, float] = {}

--- a/python/discopt/_relax/problem_classifier.py
+++ b/python/discopt/_relax/problem_classifier.py
@@ -28,6 +28,7 @@ if TYPE_CHECKING:
 # route the problem class — does not pull in JAX. That keeps LP/MILP/MIQP solves
 # free of JAX/XLA cold-start.
 from discopt._flat_index import resolve_scalar_slot
+from discopt._relax.scalarize import sum_is_full_reduction
 from discopt.modeling.core import (
     BinaryOp,
     Constant,
@@ -483,8 +484,23 @@ def _extract_linear_coefficients_sparse(expr, model: Model, n: int):
                 continue
 
             if isinstance(node, SumExpression):
-                # sum(expr) reduces expr to a scalar: element-collapse is legitimate
-                # here (uniform scale), so allow array nodes beneath this point.
+                # A FULL reduction sums its operand to a scalar: element-collapse
+                # is legitimate here (uniform scale), so allow array nodes beneath
+                # this point. An AXIS reduction is array-valued — ``sum(A, axis=1)``
+                # is one row per row of ``A`` — so descending would fold rows the
+                # model keeps apart and emit ``sum(A) <= b`` for ``sum(A, axis=1)
+                # <= b``, a strictly larger feasible set certified as the answer
+                # (#1160). Refuse so ``extract_lp_data()`` routes the body to the
+                # tape/autodiff extractor, which fans it out into one row per
+                # element. Under ``allow_array`` an enclosing reduction already
+                # sums every element with this same uniform scale, and summing a
+                # partial sum's elements is summing the operand's, so the collapse
+                # is exact there and stays allowed.
+                if not allow_array and not sum_is_full_reduction(node):
+                    raise _NotLinearError(
+                        "axis-reduced sum in scalar position (vector-valued body); "
+                        "routing to the per-component extractor"
+                    )
                 stack.append((node.operand, scale, True))
                 continue
 
@@ -764,7 +780,15 @@ def _extract_quadratic_terms(expr, model: Model, n: int):
                 continue
 
             if isinstance(node, SumExpression):
-                # sum(expr) reduces to a scalar: array collapse legitimate below here.
+                # Full reduction: array collapse legitimate below here. Axis
+                # reduction: array-valued, one row per surviving element, so
+                # descending would fold separate rows into one (#1160) — see the
+                # matching guard in ``_extract_linear_coefficients_sparse``.
+                if not allow_array and not sum_is_full_reduction(node):
+                    raise _NotQuadraticError(
+                        "axis-reduced sum in scalar position (vector-valued body); "
+                        "routing to the per-component extractor"
+                    )
                 stack.append((node.operand, scale, True))
                 continue
 

--- a/python/discopt/_relax/scalarize.py
+++ b/python/discopt/_relax/scalarize.py
@@ -73,7 +73,13 @@ logger = logging.getLogger(__name__)
 #: Sentinel for "no memoized shape on this node" (``None`` is a real answer).
 _MISS = object()
 
-__all__ = ["scalar_elements", "static_shape", "MAX_SCALAR_ELEMENTS"]
+__all__ = [
+    "scalar_elements",
+    "static_shape",
+    "sum_result_shape",
+    "sum_is_full_reduction",
+    "MAX_SCALAR_ELEMENTS",
+]
 
 #: Refuse to expand a single expression into more scalar elements than this.
 #: A relaxation row per element is the point of the exercise, but an accidental
@@ -119,6 +125,56 @@ def static_shape(expr: Expression) -> Optional[tuple[int, ...]]:
     return shape
 
 
+def sum_result_shape(expr: SumExpression) -> Optional[tuple[int, ...]]:
+    """Static shape of what a ``SumExpression`` node *evaluates to*, or ``None``.
+
+    ``axis=None`` is a full reduction: the node is a scalar whatever the operand
+    is, so nothing about the operand needs to be known. An ``axis=k`` reduction
+    leaves the operand's other axes standing, so the node is **array-valued** and
+    stands for one row per surviving element — ``dm.sum(A, axis=1)`` on a
+    ``(2, 3)`` variable is two independent row sums, not one sum of six terms
+    (issue #1160).
+
+    ``None`` means "not known", never "scalar": callers must treat it the way
+    :func:`scalar_elements` treats it, as "keep your conservative path".
+    """
+    if expr.axis is None:
+        return ()
+    operand_shape = static_shape(expr.operand)
+    if operand_shape is None:
+        return None
+    nd = len(operand_shape)
+    axes = expr.axis if isinstance(expr.axis, tuple) else (expr.axis,)
+    reduced: set[int] = set()
+    for a in axes:
+        if not isinstance(a, (int, np.integer)):
+            return None
+        a = int(a)
+        if not -nd <= a < nd:
+            # numpy would raise here; this module does not guess what the
+            # evaluator would have done with an out-of-range axis.
+            return None
+        reduced.add(a % nd)
+    return tuple(d for i, d in enumerate(operand_shape) if i not in reduced)
+
+
+def sum_is_full_reduction(expr: SumExpression) -> bool:
+    """True only when this ``SumExpression`` node provably evaluates to a scalar.
+
+    The predicate every structural walker needs before it descends into
+    ``.operand`` and folds the operand's elements together with one uniform
+    scale. That fold is exactly right for a full reduction and *wrong* for an
+    axis reduction, where the elements belong to different rows: collapsing
+    ``dm.sum(A, axis=1) <= 2`` into ``dm.sum(A) <= 2`` deletes the per-row caps
+    and certifies an optimum the real model does not have (issue #1160).
+
+    False on an unknown shape, deliberately — the caller then abstains and the
+    body routes to an extractor that fans an array-valued body out into one row
+    per element (the tape/autodiff rungs), which is slower and correct.
+    """
+    return sum_result_shape(expr) == ()
+
+
 def _static_shape_uncached(expr: Expression) -> Optional[tuple[int, ...]]:
     if isinstance(expr, Constant):
         return tuple(int(d) for d in expr.value.shape)
@@ -154,10 +210,11 @@ def _static_shape_uncached(expr: Expression) -> Optional[tuple[int, ...]]:
         return _matmul_shape(static_shape(expr.left), static_shape(expr.right))
 
     if isinstance(expr, SumExpression):
-        # A full reduction is scalar. An axis-reduction's shape depends on the
-        # evaluator's axis semantics for a partially-known operand — report
-        # unknown rather than re-derive them here.
-        return () if expr.axis is None else None
+        # A full reduction is scalar; an axis reduction keeps the operand's other
+        # axes. One definition of that, shared with the ``sum_is_full_reduction``
+        # guard the relaxation-side walkers use (#1160), so the two can never
+        # disagree about what a ``SumExpression`` node stands for.
+        return sum_result_shape(expr)
 
     if isinstance(expr, SumOverExpression):
         shapes = [static_shape(t) for t in expr.terms]

--- a/python/tests/test_981_vectorized_relaxation.py
+++ b/python/tests/test_981_vectorized_relaxation.py
@@ -114,10 +114,17 @@ def test_unscalarizable_expression_reports_unknown_not_empty():
     m = Model("u")
     X = m.continuous("X", lb=0, ub=1, shape=(2, 3))
 
-    # An axis-reduction: array-valued, but its shape depends on evaluator axis
-    # semantics the rewrite deliberately does not re-derive.
+    # An axis-reduction is array-valued. Its shape used to be reported as
+    # *unknown* here so the walk would not re-derive numpy's axis semantics; #1160
+    # made those semantics load-bearing (a walker that treats the node as scalar
+    # collapses rows and certifies the wrong model), so they are derived in one
+    # place now -- `scalarize.sum_result_shape` -- and this is that answer.
     axis_reduction = dm.sum(X, axis=0)
-    assert static_shape(axis_reduction) is None
+    assert static_shape(axis_reduction) == (3,)
+
+    # The contract this test exists for is unchanged: the rewrite still cannot
+    # EXPAND an axis reduction (``_elem`` has no ``SumExpression`` case), so
+    # callers keep their previous behaviour rather than losing rows.
     assert scalar_elements(axis_reduction) is None
 
 

--- a/python/tests/test_correctness.py
+++ b/python/tests/test_correctness.py
@@ -25,6 +25,7 @@ from dataclasses import dataclass
 from typing import Callable
 
 import discopt.modeling as dm
+import numpy as np
 import pytest
 from discopt.modeling.core import Model, SolveResult
 from discopt.modeling.examples import example_simple_minlp
@@ -66,6 +67,19 @@ def assert_optimal_value(
     )
 
 
+def _elements(value) -> list[tuple[str, float]]:
+    """``(label, scalar)`` for every element of a solution entry.
+
+    A scalar variable yields one unlabelled element; a shaped variable yields one
+    per flat element, labelled ``[i]`` so a failure names the offending slot.
+    """
+    arr = np.asarray(value, dtype=np.float64)
+    if arr.ndim == 0:
+        return [("", float(arr))]
+    flat = arr.reshape(-1)
+    return [(f"[{i}]", float(flat[i])) for i in range(flat.size)]
+
+
 def assert_integer_feasible(
     result: SolveResult,
     integer_var_names: list[str],
@@ -75,12 +89,15 @@ def assert_integer_feasible(
     """Assert all integer/binary variables are integral within tolerance."""
     assert result.x is not None, f"[{name}] No solution"
     for var_name in integer_var_names:
-        val = float(result.x[var_name])
-        rounded = round(val)
-        assert abs(val - rounded) <= tol, (
-            f"[{name}] Variable {var_name}={val:.8f} is not integral "
-            f"(nearest integer={rounded}, gap={abs(val - rounded):.2e})"
-        )
+        # ``result.x[name]`` is an array for a shaped variable; every element of
+        # it is a decision variable and must be checked (a bare ``float()`` on a
+        # size>1 array raises, so this is coverage the panel could not carry).
+        for pos, val in _elements(result.x[var_name]):
+            rounded = round(val)
+            assert abs(val - rounded) <= tol, (
+                f"[{name}] Variable {var_name}{pos}={val:.8f} is not integral "
+                f"(nearest integer={rounded}, gap={abs(val - rounded):.2e})"
+            )
 
 
 def assert_bounds_satisfied(
@@ -92,9 +109,9 @@ def assert_bounds_satisfied(
     """Assert all variable values are within their declared bounds."""
     assert result.x is not None, f"[{name}] No solution"
     for var_name, (lb, ub) in bounds.items():
-        val = float(result.x[var_name])
-        assert val >= lb - tol, f"[{name}] {var_name}={val:.8f} violates lower bound {lb}"
-        assert val <= ub + tol, f"[{name}] {var_name}={val:.8f} violates upper bound {ub}"
+        for pos, val in _elements(result.x[var_name]):
+            assert val >= lb - tol, f"[{name}] {var_name}{pos}={val:.8f} violates lower bound {lb}"
+            assert val <= ub + tol, f"[{name}] {var_name}{pos}={val:.8f} violates upper bound {ub}"
 
 
 # ──────────────────────────────────────────────────────────
@@ -488,6 +505,58 @@ def _build_power_nlp() -> Model:
 
 
 # ──────────────────────────────────────────────────────────
+# Axis-reduced sums (issue #1160)
+#
+# ``dm.sum(X, axis=k)`` is array-valued: one constraint row per surviving
+# element. The relaxation side used to fold it into a single row, so these were
+# solved as the axis-COLLAPSED model and its optimum certified. The `.nl` reader
+# emits no ``SumExpression``, so no `.nl` panel can cover this class — it lives
+# or dies with these Python-API instances.
+# ──────────────────────────────────────────────────────────
+
+
+def _build_row_capped_axis_sum() -> Model:
+    """min -sum(A) s.t. sum(A, axis=1) <= 2, A in [0,1]^(2x3).
+
+    Two independent row caps of 2, so the optimum is -4 (e.g. two ones per row).
+    Collapsed to the single cap ``sum(A) <= 2`` it reads -2.
+    """
+    m = dm.Model("row_capped_axis_sum")
+    A = m.continuous("A", shape=(2, 3), lb=0, ub=1)
+    m.subject_to(dm.sum(A, axis=1) <= 2)
+    m.minimize(-dm.sum(A))
+    return m
+
+
+def _build_column_capped_axis_sum() -> Model:
+    """min -sum(B) s.t. sum(B, axis=0) <= 1 on binary B of shape (2,3).
+
+    Reduces the OTHER axis: each of the 3 columns may carry at most one of its
+    2 entries, so the optimum is -3. Collapsed it reads -1.
+    """
+    m = dm.Model("column_capped_axis_sum")
+    B = m.binary("B", shape=(2, 3))
+    m.subject_to(dm.sum(B, axis=0) <= 1)
+    m.minimize(-dm.sum(B))
+    return m
+
+
+def _build_quadratic_axis_sum() -> Model:
+    """min -sum(A) s.t. sum(A*A, axis=1) <= 1/2, A in [0,1]^(2x3).
+
+    Nonlinear body, same reduction. Per row Cauchy-Schwarz gives
+    ``sum(a) <= sqrt(3 * 1/2)``, attained with all three equal at
+    ``sqrt(1/6) <= 1``; two rows give ``6*sqrt(1/6) = sqrt(6)``, so the optimum
+    is ``-sqrt(6) ~= -2.449490``.
+    """
+    m = dm.Model("quadratic_axis_sum")
+    A = m.continuous("A", shape=(2, 3), lb=0, ub=1)
+    m.subject_to(dm.sum(A * A, axis=1) <= 0.5)
+    m.minimize(-dm.sum(A))
+    return m
+
+
+# ──────────────────────────────────────────────────────────
 # Build the test instance registry
 # ──────────────────────────────────────────────────────────
 
@@ -689,6 +758,31 @@ INSTANCES: list[ProblemInstance] = [
         integer_vars=["x", "y"],
         bounds={"x": (0, 5), "y": (0, 5), "z": (0, 3)},
         description="Quadratic with 2 integers + 1 continuous",
+    ),
+    # --- Axis-reduced sums (issue #1160) ---
+    ProblemInstance(
+        name="row_capped_axis_sum",
+        build_fn=_build_row_capped_axis_sum,
+        expected_obj=-4.0,
+        integer_vars=[],
+        bounds={"A": (0, 1)},
+        description="sum(A, axis=1) <= 2: per-row caps, not one total cap",
+    ),
+    ProblemInstance(
+        name="column_capped_axis_sum",
+        build_fn=_build_column_capped_axis_sum,
+        expected_obj=-3.0,
+        integer_vars=["B"],
+        bounds={"B": (0, 1)},
+        description="Binary sum(B, axis=0) <= 1: per-column caps",
+    ),
+    ProblemInstance(
+        name="quadratic_axis_sum",
+        build_fn=_build_quadratic_axis_sum,
+        expected_obj=-math.sqrt(6.0),
+        integer_vars=[],
+        bounds={"A": (0, 1)},
+        description="Nonlinear sum(A*A, axis=1) <= 1/2: per-row caps",
     ),
 ]
 

--- a/python/tests/test_issue_1160_axis_sum_certificate.py
+++ b/python/tests/test_issue_1160_axis_sum_certificate.py
@@ -1,0 +1,376 @@
+"""Issue #1160: a constraint on ``dm.sum(X, axis=k)`` must not be solved as the
+axis-*collapsed* model.
+
+``dm.sum(A, axis=1)`` on a ``(2, 3)`` variable is **two** row sums; the relaxation
+side folded it into one sum of six terms, so ``sum(A, axis=1) <= 2`` was solved as
+``sum(A) <= 2`` — a strictly smaller feasible set — and the collapsed optimum was
+returned with ``status="optimal"`` and a dual bound that excludes the true one.
+Before the fix the reproducer below certified ``-2`` (bound ``-2``) on a model
+whose true optimum is ``-4``, with discopt's own ``verify_point`` confirming the
+``-4`` point feasible.
+
+Every objective assertion here is paired with a **bound** assertion: for a
+minimize, a valid dual bound must be ``<= true optimum``, and the objective alone
+would pass on a build that merely got lucky on the primal. Each case also carries
+an independently verified feasible witness at the true optimum, so "the solver and
+the test agree" cannot be an agreement between two copies of the same mistake.
+
+The `.nl` reader emits no ``SumExpression`` at all, so no `.nl` panel or gate
+covers this class — these models are the coverage.
+"""
+
+from __future__ import annotations
+
+import math
+
+import discopt.modeling.core as dm
+import numpy as np
+import pytest
+from discopt._relax import problem_classifier as pc
+from discopt._relax.scalarize import scalar_elements
+from discopt.validation.feasibility import verify_point
+
+# ``sum_result_shape`` / ``sum_is_full_reduction`` are imported inside the two
+# tests that exercise them directly, not at module scope: a module-level import
+# makes the whole file uncollectable on a tree without the fix, which downgrades
+# the fail-before evidence for the solve tests from "certifies -2 against a true
+# -4" to "ImportError".
+
+TOL = 1e-4
+
+#: ``_ENTERED`` counts calls into :func:`_assert_min_certificate`; ``_COMPARISONS``
+#: counts the ones that reached the objective/bound comparison. A guard that skips
+#: its own assertions reports a pass while measuring nothing (CLAUDE.md §6), so
+#: teardown asserts the two agree — and that they are non-zero whenever any solve
+#: test ran at all (all of them being deselected by a marker expression is not the
+#: failure this guards against). It is a ``teardown_module`` hook and not a test on
+#: purpose: as a test it would be position-dependent under ``pytest-randomly``.
+_ENTERED = [0]
+_COMPARISONS = [0]
+
+
+def teardown_module(module):  # noqa: ANN001, ANN201 - pytest hook
+    assert _COMPARISONS[0] == _ENTERED[0], (
+        f"{_ENTERED[0] - _COMPARISONS[0]} certificate check(s) entered but never "
+        "reached their objective/bound comparison"
+    )
+    if _ENTERED[0]:
+        assert _COMPARISONS[0] > 0, "solve tests ran but measured nothing"
+
+
+def _solve(model):
+    return model.solve(time_limit=120.0, gap_tolerance=1e-6, max_nodes=200_000)
+
+
+def _assert_min_certificate(model, true_opt: float, witness: np.ndarray, name: str) -> None:
+    """The witness is feasible at ``true_opt``, and the solve certifies it.
+
+    Asserts, for a *minimize* model: the witness is genuinely feasible with the
+    claimed objective; the returned objective equals the true optimum; and the
+    dual bound is ``<= true_opt`` — a bound above the optimum has fathomed it
+    away, which is the #1160 failure even when the objective happens to be right.
+    """
+    _ENTERED[0] += 1
+    scale = max(1.0, abs(true_opt))
+
+    v = verify_point(model, witness, with_objective=True)
+    assert v.ok, f"[{name}] the witness for the true optimum is not feasible: {v.reason}"
+    assert v.objective == pytest.approx(true_opt, abs=TOL * scale), (
+        f"[{name}] witness objective {v.objective} != claimed true optimum {true_opt}"
+    )
+
+    result = _solve(model)
+    _COMPARISONS[0] += 1
+    assert result.status in ("optimal", "feasible"), f"[{name}] status={result.status}"
+    assert result.objective == pytest.approx(true_opt, abs=TOL * scale), (
+        f"[{name}] objective {result.objective} != true optimum {true_opt} "
+        "(the axis-collapsed model's answer?)"
+    )
+    if result.bound is not None:
+        assert result.bound <= true_opt + TOL * scale, (
+            f"[{name}] dual bound {result.bound} is ABOVE the true optimum {true_opt}: "
+            "the certificate excludes the optimum"
+        )
+
+
+# --------------------------------------------------------------------------- #
+# The reproducer from the issue, and its neighbours
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.pr_correctness
+def test_row_capped_axis_sum_is_not_solved_as_the_total_cap():
+    """min -sum(A) s.t. sum(A, axis=1) <= 2 — two row caps, optimum -4.
+
+    Collapsed to ``sum(A) <= 2`` this certifies -2 (issue #1160's reproducer).
+    """
+    m = dm.Model("sum_axis1")
+    A = m.continuous("A", shape=(2, 3), lb=0, ub=1)
+    m.subject_to(dm.sum(A, axis=1) <= 2)
+    m.minimize(-dm.sum(A))
+    _assert_min_certificate(m, -4.0, np.array([1.0, 1, 0, 1, 1, 0]), "sum_axis1")
+
+
+@pytest.mark.correctness
+def test_column_capped_axis_sum_reduces_the_other_axis():
+    """axis=0 caps each of the 3 columns at 1 -> optimum -3, collapsed gives -1."""
+    m = dm.Model("sum_axis0")
+    A = m.continuous("A", shape=(2, 3), lb=0, ub=1)
+    m.subject_to(dm.sum(A, axis=0) <= 1)
+    m.minimize(-dm.sum(A))
+    _assert_min_certificate(m, -3.0, np.array([1.0, 1, 1, 0, 0, 0]), "sum_axis0")
+
+
+@pytest.mark.correctness
+def test_axis_sum_on_a_three_dimensional_variable():
+    """A (2,2,2) variable reduced on axis 2: four caps of 1 -> optimum -4."""
+    m = dm.Model("sum_axis_3d")
+    A = m.continuous("A", shape=(2, 2, 2), lb=0, ub=1)
+    m.subject_to(dm.sum(A, axis=2) <= 1)
+    m.minimize(-dm.sum(A))
+    _assert_min_certificate(m, -4.0, np.array([1.0, 0, 1, 0, 1, 0, 1, 0]), "sum_axis_3d")
+
+
+@pytest.mark.correctness
+def test_axis_sum_with_an_equality_sense():
+    """== is the same class: each row sums to exactly 2, maximizing sum(A*A)."""
+    m = dm.Model("sum_axis_eq")
+    A = m.continuous("A", shape=(2, 3), lb=0, ub=1)
+    m.subject_to(dm.sum(A, axis=1) == 2)
+    m.minimize(-dm.sum(A * A))
+    _assert_min_certificate(m, -4.0, np.array([1.0, 1, 0, 1, 1, 0]), "sum_axis_eq")
+
+
+@pytest.mark.pr_correctness
+def test_integer_model_with_an_axis_sum():
+    """MILP: binaries with a per-row cap of 2 -> optimum -4, collapsed gives -2."""
+    m = dm.Model("sum_axis_milp")
+    B = m.binary("B", shape=(2, 3))
+    m.subject_to(dm.sum(B, axis=1) <= 2)
+    m.minimize(-dm.sum(B))
+    _assert_min_certificate(m, -4.0, np.array([1.0, 1, 0, 1, 1, 0]), "sum_axis_milp")
+
+
+@pytest.mark.pr_correctness
+def test_nonlinear_axis_sum_keeps_its_rows():
+    """min -sum(A) s.t. sum(A*A, axis=1) <= 1/2 on A in [0,1]^(2x3).
+
+    The linear class can be fixed by a term collector the nonlinear path does not
+    share, so this case is not redundant. Per row, Cauchy–Schwarz gives
+    ``sum(a) <= sqrt(3 * 1/2)`` with equality iff all three are equal at
+    ``sqrt(1/6) <= 1``; two rows give ``6 * sqrt(1/6) = sqrt(6)``.
+    """
+    m = dm.Model("sum_axis_quadratic")
+    A = m.continuous("A", shape=(2, 3), lb=0, ub=1)
+    m.subject_to(dm.sum(A * A, axis=1) <= 0.5)
+    m.minimize(-dm.sum(A))
+    _assert_min_certificate(
+        m, -math.sqrt(6.0), np.full(6, math.sqrt(1.0 / 6.0)), "sum_axis_quadratic"
+    )
+
+
+@pytest.mark.correctness
+def test_transcendental_axis_sum_keeps_its_rows():
+    """sum(exp(A), axis=1) <= 1 + e per row; optimum -4*log((1+e)/2)."""
+    a = math.log((1.0 + math.e) / 2.0)
+    m = dm.Model("sum_axis_exp")
+    A = m.continuous("A", shape=(2, 2), lb=0, ub=1)
+    m.subject_to(dm.sum(dm.exp(A), axis=1) <= 1.0 + math.e)
+    m.minimize(-dm.sum(A))
+    _assert_min_certificate(m, -4.0 * a, np.full(4, a), "sum_axis_exp")
+
+
+# --------------------------------------------------------------------------- #
+# Controls: the fix must not refuse a *full* reduction
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.pr_correctness
+def test_full_reduction_still_takes_the_algebraic_fast_path():
+    """A plain ``sum(x)`` body is still one algebraic row — no over-refusal.
+
+    Without this control the guard could have been "abstain on every
+    ``SumExpression``", which is sound and would silently retire the fast
+    extractor for every model in the corpus.
+    """
+    m = dm.Model("plain_sum")
+    x = m.continuous("x", shape=(4,), lb=0, ub=1)
+    m.subject_to(dm.sum(x) <= 2)
+    m.minimize(-dm.sum(x))
+
+    terms, const = pc._extract_linear_coefficients_sparse(m._constraints[0].body, m, 4)
+    assert terms == {0: 1.0, 1: 1.0, 2: 1.0, 3: 1.0}
+    assert const == pytest.approx(-2.0)
+
+    lp = pc.extract_lp_data_algebraic(m)
+    assert np.asarray(pc.dense_A(lp.A_eq)).shape[0] == 1
+
+    _assert_min_certificate(m, -2.0, np.array([1.0, 1.0, 0.0, 0.0]), "plain_sum")
+
+
+@pytest.mark.correctness
+def test_axis_sum_under_an_outer_full_reduction_still_collapses():
+    """``sum(sum(A, axis=1))`` sums every element, so the collapse is exact there.
+
+    The guard is on *scalar position*, not on the node type: an enclosing full
+    reduction sums the partial sums' elements with the same uniform scale, which
+    is summing the operand's elements.
+    """
+    m = dm.Model("nested_sum")
+    A = m.continuous("A", shape=(2, 3), lb=0, ub=1)
+    m.subject_to(dm.sum(dm.sum(A, axis=1)) <= 2)
+    m.minimize(-dm.sum(A))
+
+    terms, const = pc._extract_linear_coefficients_sparse(m._constraints[0].body, m, 6)
+    assert terms == dict.fromkeys(range(6), 1.0)
+    assert const == pytest.approx(-2.0)
+
+    _assert_min_certificate(m, -2.0, np.array([1.0, 1, 0, 0, 0, 0]), "nested_sum")
+
+
+@pytest.mark.correctness
+def test_axis_zero_on_a_one_dimensional_operand_is_a_full_reduction():
+    """``sum(x, axis=0)`` on a 1-D variable IS scalar; it must stay correct."""
+    m = dm.Model("axis0_1d")
+    x = m.continuous("x", shape=(4,), lb=0, ub=1)
+    m.subject_to(dm.sum(x, axis=0) <= 2)
+    m.minimize(-dm.sum(x))
+    _assert_min_certificate(m, -2.0, np.array([1.0, 1.0, 0.0, 0.0]), "axis0_1d")
+
+
+# --------------------------------------------------------------------------- #
+# The shared predicate and the guards that consume it
+# --------------------------------------------------------------------------- #
+
+
+def _model_with_shapes():
+    m = dm.Model("shapes")
+    A = m.continuous("A", shape=(2, 3), lb=0, ub=1)
+    x = m.continuous("x", shape=(4,), lb=0, ub=1)
+    return m, A, x
+
+
+def test_sum_result_shape_reduces_only_the_named_axis():
+    from discopt._relax.scalarize import sum_is_full_reduction, sum_result_shape
+
+    _m, A, x = _model_with_shapes()
+    cases = [
+        (dm.sum(A), ()),
+        (dm.sum(A, axis=0), (3,)),
+        (dm.sum(A, axis=1), (2,)),
+        (dm.sum(A, axis=-1), (2,)),
+        (dm.sum(A * A, axis=1), (2,)),
+        (dm.sum(x, axis=0), ()),
+        (dm.sum(dm.sum(A, axis=1)), ()),
+        (dm.sum(dm.sum(A, axis=1), axis=0), ()),
+        (dm.sum(A, axis=5), None),  # numpy would raise: no guess
+    ]
+    for expr, expected in cases:
+        assert sum_result_shape(expr) == expected, f"{expr!r} -> {sum_result_shape(expr)!r}"
+        assert sum_is_full_reduction(expr) is (expected == ())
+    assert len(cases) == 9
+
+
+def test_the_derived_shape_matches_what_the_evaluator_actually_produces():
+    """The predicate is checked against the model's own row fan-out, not asserted.
+
+    ``sum_result_shape`` re-derives numpy's axis semantics, so it has to be
+    measured against the thing that defines them here: the evaluator, which emits
+    one row per flat element of a constraint body. A predicate that disagreed
+    with the evaluator would put the guards on the wrong side of the fold.
+    """
+    from discopt._relax.scalarize import sum_result_shape
+    from discopt._tape_nlp_evaluator import try_build
+
+    checked = 0
+    for shape, axis in [((2, 3), 1), ((2, 3), 0), ((2, 3), -1), ((2, 2, 2), 2), ((4,), 0)]:
+        m = dm.Model("fanout")
+        A = m.continuous("A", shape=shape, lb=0, ub=1)
+        body_sum = dm.sum(A, axis=axis)
+        m.subject_to(body_sum <= 1)
+        m.minimize(-dm.sum(A))
+
+        derived = sum_result_shape(body_sum)
+        assert derived == np.sum(np.zeros(shape), axis=axis).shape
+
+        ev = try_build(m)
+        assert ev is not None, f"tape evaluator declined shape={shape} axis={axis}"
+        rows = np.asarray(
+            ev.evaluate_constraints(np.zeros(int(np.prod(shape)))), dtype=np.float64
+        ).reshape(-1)
+        assert rows.size == max(1, int(np.prod(derived))), (
+            f"shape={shape} axis={axis}: derived {derived} but the evaluator "
+            f"emitted {rows.size} row(s)"
+        )
+        checked += 1
+    assert checked == 5
+
+
+def test_scalar_elements_still_declines_an_axis_reduced_body():
+    """`static_shape` got sharper; `scalar_elements` must not silently change.
+
+    ``_elem`` has no ``SumExpression`` case, so an axis-reduced body is still
+    "not statically scalarizable" — callers keep their previous path.
+    """
+    _m, A, _x = _model_with_shapes()
+    assert scalar_elements(dm.sum(A, axis=1)) is None
+    assert scalar_elements(dm.sum(A, axis=1) - 2) is None
+
+
+def test_linear_extractor_refuses_an_axis_reduced_body():
+    m, A, _x = _model_with_shapes()
+    body = (dm.sum(A, axis=1) <= 2).body
+    with pytest.raises(pc._NotLinearError):
+        pc._extract_linear_coefficients_sparse(body, m, 6)
+
+
+def test_quadratic_extractor_refuses_an_axis_reduced_body():
+    m, A, _x = _model_with_shapes()
+    body = (dm.sum(A * A, axis=1) <= 2).body
+    with pytest.raises((pc._NotQuadraticError, pc._NotLinearError)):
+        pc._extract_quadratic_terms(body, m, 6)
+
+
+def test_lp_extraction_emits_one_row_per_surviving_element():
+    """``extract_lp_data`` must fan the body out, not collapse it.
+
+    The repr rung probes the Rust arena at unit vectors and reduces a constraint
+    to ONE row; that rung is what produced the collapsed LP. It now declines (see
+    the NaN test below) and the tape rung supplies two rows with two right-hand
+    sides.
+    """
+    m = dm.Model("rows")
+    A = m.continuous("A", shape=(2, 3), lb=0, ub=1)
+    m.subject_to(dm.sum(A, axis=1) <= 2)
+    m.minimize(-dm.sum(A))
+
+    lp = pc.extract_lp_data(m)
+    A_eq = np.asarray(pc.dense_A(lp.A_eq))
+    assert A_eq.shape[0] == 2, f"expected one LP row per row of A, got {A_eq.shape}"
+    assert np.allclose(np.asarray(lp.b_eq), [2.0, 2.0])
+    # Row 0 must touch A[0, :] only, row 1 A[1, :] only — a collapsed row would
+    # carry all six original columns.
+    assert np.allclose(A_eq[0, :6], [1, 1, 1, 0, 0, 0])
+    assert np.allclose(A_eq[1, :6], [0, 0, 0, 1, 1, 1])
+
+
+def test_rust_repr_reports_an_axis_sum_as_not_scalar_representable():
+    """The scalar Rust evaluator answers NaN, never the full sum.
+
+    A number here is a wrong answer to a different model, and every repr-based
+    extractor accepts it as a coefficient; NaN is the arena's existing
+    "not scalar-representable" signal and makes those extractors decline.
+    """
+    from discopt._rust import model_to_repr
+
+    m = dm.Model("repr_nan")
+    A = m.continuous("A", shape=(2, 3), lb=0, ub=1)
+    m.subject_to(dm.sum(A, axis=1) <= 2)  # constraint 0: array-valued
+    m.subject_to(dm.sum(A) <= 5)  # constraint 1: full reduction, scalar
+    m.minimize(-dm.sum(A))
+
+    repr_ = model_to_repr(m, getattr(m, "_builder", None))
+    x = np.full(6, 0.5)
+    assert math.isnan(repr_.evaluate_constraint(0, x))
+    assert repr_.evaluate_constraint(1, x) == pytest.approx(3.0 - 5.0)
+    assert repr_.evaluate_objective(x) == pytest.approx(-3.0)

--- a/python/tests/test_pr_correctness.py
+++ b/python/tests/test_pr_correctness.py
@@ -13,6 +13,7 @@ Each instance is chosen to cover a distinct solver code path:
 * ``binary_knapsack``          — pure 0-1 MILP
 * ``binary_cubic_minlp``       — tiny mixed continuous/binary nonconvex MINLP
 * ``exp_binary_minlp``         — OA-friendly convex MINLP with ``exp``
+* ``row_capped_axis_sum``      — array-valued ``dm.sum(A, axis=1)`` rows (#1160)
 
 The full ``circle_minlp`` case stays in the nightly correctness suite. It
 exercises a nonconvex circle superlevel shape, but it is too expensive for this
@@ -36,6 +37,7 @@ from test_correctness import (
     _build_binary_knapsack,
     _build_constrained_quadratic,
     _build_exp_binary_minlp,
+    _build_row_capped_axis_sum,
     _build_simple_minlp,
     assert_optimal_value,
 )
@@ -93,6 +95,18 @@ PR_INSTANCES: list[ProblemInstance] = [
         integer_vars=["y"],
         bounds={"x": (0, 3), "y": (0, 1)},
         description="OA-friendly convex MINLP",
+    ),
+    # The `.nl` corpus contains no ``SumExpression`` at all, so an axis-reduced
+    # sum has no coverage in any `.nl` panel or gate — which is how #1160's false
+    # certificate survived. This is the PR-tier probe for that class; it solves in
+    # well under a second.
+    ProblemInstance(
+        name="row_capped_axis_sum",
+        build_fn=_build_row_capped_axis_sum,
+        expected_obj=-4.0,
+        integer_vars=[],
+        bounds={"A": (0, 1)},
+        description="Array-valued sum(A, axis=1) <= 2: per-row caps",
     ),
 ]
 

--- a/scratchpad/issue1160/README.md
+++ b/scratchpad/issue1160/README.md
@@ -1,0 +1,28 @@
+# #1160 — `dm.sum(X, axis=k)` was solved as the axis-collapsed model
+
+Measurement harnesses for the fix. Every script prints an executed-comparison
+count and exits non-zero when it made none (CLAUDE.md §6).
+
+| script | what it measures |
+|---|---|
+| `repro.py` | the issue's reproducer verbatim (`sum(A, axis=1) <= 2`, true optimum -4) |
+| `probe_paths.py` | which LP extractor claims the model and how many rows each emits |
+| `panel.py` | 6 axis-reduced models (linear axis=0/1, convex quadratic, nonconvex `>=`, bilinear, `exp`) against hand-derived optima, checking objective **and** `bound <= true optimum` |
+| `panel2.py` | 7 more (MILP, MIQP, QP, least-squares, `==` sense, 3-D operand, 1-D `axis=0`) |
+| `nl_neutrality.py` | bound-neutrality on the in-repo 66-instance `.nl` corpus: counts guard invocations during **real solves** (with an instrument self-test that fails if the counter is dead) and dumps per-instance status/objective/bound/node_count for an A/B diff |
+
+## Results
+
+Baseline (`570ca9a`), `panel.py` + `panel2.py`: **4 of 12 wrong** —
+`lin_axis1` -2 (true -4), `lin_axis0` -1 (true -3), `milp_axis1` -2 (true -4),
+`lin_axis_3d` -1 (true -4). Each returned `status="optimal"` with the wrong
+value *as the dual bound*, while `verify_point` confirmed the true optimum's
+point feasible. After the fix: **12 of 12 correct**, every bound at or below the
+true optimum.
+
+`nl_neutrality.py` on the 66 in-repo `.nl` instances (10 s / 3000 nodes each):
+`GUARD_CALLS: 0` — the guarded branch is not merely inert, it is never reached,
+measured during real solves (the instrument's self-test on a Python-API model
+counts 3 calls / 2 refusals in the same process). The A/B over 264 compared
+fields differs in 8, all `bound`/`node_count` on time-limited instances; three
+repetitions of *each* arm produce the other arm's values (see the PR).

--- a/scratchpad/issue1160/nl_neutrality.py
+++ b/scratchpad/issue1160/nl_neutrality.py
@@ -1,0 +1,111 @@
+"""Bound-neutrality evidence for the #1160 guards on the `.nl` corpus.
+
+Two measurements, both during REAL solves (a claim about which code runs cannot
+be made from a parsed model -- a relaxation pass constructs nodes mid-solve):
+
+1. every ``sum_is_full_reduction`` call is counted, and every call that returned
+   False (the only way any guard changes behaviour) is counted separately;
+2. every ``SumExpression`` node handed to a guarded walker is counted.
+
+Prints the counts and the per-instance (status, objective, bound, node_count) so
+the run can be diffed against the same script on the baseline tree. Exits
+non-zero if it made no observation at all.
+"""
+
+import glob
+import json
+import os
+import sys
+
+import discopt._relax.scalarize as scalarize
+
+CALLS = [0]
+REFUSALS = [0]
+GUARDED = ["absent"]
+
+# CLAUDE.md 8: the arm must say WHICH tree it loaded. The baseline tree has no
+# `sum_is_full_reduction`; asserting the marker absent there is what stops a
+# mixed arm (editable install + pkgutil path) from being reported as a baseline.
+print("discopt.scalarize file:", scalarize.__file__)
+if hasattr(scalarize, "sum_is_full_reduction"):
+    GUARDED[0] = "present"
+    _real = scalarize.sum_is_full_reduction
+
+    def counting(expr):
+        CALLS[0] += 1
+        out = _real(expr)
+        if not out:
+            REFUSALS[0] += 1
+        return out
+
+    scalarize.sum_is_full_reduction = counting
+    for mod in (
+        "discopt._relax.problem_classifier",
+        "discopt._relax.milp_relaxation",
+        "discopt._relax.obbt",
+        "discopt._relax.canonical_expr",
+        "discopt._relax.dependent_vars",
+        "discopt._relax.convexity.linear_context",
+    ):
+        __import__(mod)
+        m = sys.modules[mod]
+        if hasattr(m, "sum_is_full_reduction"):
+            m.sum_is_full_reduction = counting
+print("GUARD MARKER:", GUARDED[0])
+
+import discopt.modeling.core as dm  # noqa: E402
+from discopt.modeling import from_nl  # noqa: E402
+
+# Instrument self-test (CLAUDE.md 6): a counter that reports 0 because the patch
+# never took hold is indistinguishable from a counter that reports 0 because the
+# branch never runs. Solve one Python-API axis-sum model first and require the
+# counters to MOVE; then reset them for the `.nl` measurement.
+if GUARDED[0] == "present":
+    _probe = dm.Model("selftest")
+    _A = _probe.continuous("A", shape=(2, 3), lb=0, ub=1)
+    _probe.subject_to(dm.sum(_A, axis=1) <= 2)
+    _probe.minimize(-dm.sum(_A))
+    _probe.solve(time_limit=30, gap_tolerance=1e-6)
+    print(f"SELFTEST calls={CALLS[0]} refusals={REFUSALS[0]}")
+    if CALLS[0] == 0 or REFUSALS[0] == 0:
+        sys.exit("instrument is dead: the axis-sum self-test moved no counter")
+    CALLS[0] = 0
+    REFUSALS[0] = 0
+
+TIME_LIMIT = float(os.environ.get("NL_TIME_LIMIT", "10"))
+MAX_NODES = int(os.environ.get("NL_MAX_NODES", "3000"))
+
+files = sorted(glob.glob("python/tests/data/minlplib_nl/*.nl"))
+limit = int(os.environ.get("NL_LIMIT", "0"))
+if limit:
+    files = files[:limit]
+only = os.environ.get("NL_ONLY")
+if only:
+    wanted = {n.strip() for n in only.split(",")}
+    files = [f for f in files if os.path.basename(f)[:-3] in wanted]
+
+rows = {}
+for path in files:
+    name = os.path.basename(path)[:-3]
+    try:
+        model = from_nl(path)
+        r = model.solve(time_limit=TIME_LIMIT, gap_tolerance=1e-6, max_nodes=MAX_NODES)
+        rows[name] = {
+            "status": r.status,
+            "objective": r.objective,
+            "bound": r.bound,
+            "node_count": getattr(r, "node_count", None),
+        }
+    except Exception as exc:  # a load/solve failure is data, not something to hide
+        rows[name] = {"error": f"{type(exc).__name__}: {exc}"}
+    print(f"{name:24s} {rows[name]}", flush=True)
+
+print(f"INSTANCES: {len(rows)}")
+print(f"GUARD_CALLS: {CALLS[0]}")
+print(f"GUARD_REFUSALS (axis-reduced sums seen): {REFUSALS[0]}")
+out = os.environ.get("NL_OUT")
+if out:
+    with open(out, "w") as fh:
+        json.dump(rows, fh, indent=1, sort_keys=True)
+if not rows:
+    sys.exit("probe solved nothing")

--- a/scratchpad/issue1160/panel.py
+++ b/scratchpad/issue1160/panel.py
@@ -1,0 +1,131 @@
+"""Axis-reduced-sum correctness panel.
+
+Each case: a model built with dm.sum(..., axis=k), its TRUE optimum (derived by
+hand and cross-checked with verify_point on a witness), and the answer the
+axis-collapsed model would give.  Prints an executed-comparison count and exits
+non-zero if it is zero.
+"""
+import sys
+import numpy as np
+import discopt.modeling.core as dm
+from discopt.validation.feasibility import verify_point
+
+TOL = 1e-4
+cases = []
+
+
+def case(name, build, true_opt, witness=None):
+    cases.append((name, build, true_opt, witness))
+
+
+# 1. linear, axis=1 (per-row cap)
+def b1():
+    m = dm.Model("lin_axis1")
+    A = m.continuous("A", shape=(2, 3), lb=0, ub=1)
+    m.subject_to(dm.sum(A, axis=1) <= 2)
+    m.minimize(-dm.sum(A))
+    return m
+
+
+case("lin_axis1", b1, -4.0, np.array([1.0, 1, 0, 1, 1, 0]))
+
+
+# 2. linear, axis=0 (per-column cap)
+def b2():
+    m = dm.Model("lin_axis0")
+    A = m.continuous("A", shape=(2, 3), lb=0, ub=1)
+    m.subject_to(dm.sum(A, axis=0) <= 1)
+    m.minimize(-dm.sum(A))
+    return m
+
+
+case("lin_axis0", b2, -3.0, np.array([1.0, 1, 1, 0, 0, 0]))
+
+
+# 3. convex quadratic, axis=1: per row max sum with sum-sq <= 0.5 is 3*sqrt(1/6)
+def b3():
+    m = dm.Model("quad_axis1")
+    A = m.continuous("A", shape=(2, 3), lb=0, ub=1)
+    m.subject_to(dm.sum(A * A, axis=1) <= 0.5)
+    m.minimize(-dm.sum(A))
+    return m
+
+
+case("quad_axis1", b3, -2 * 3 * np.sqrt(1.0 / 6.0), np.full(6, np.sqrt(1 / 6)))
+
+
+# 4. nonconvex quadratic (>= on a convex body), axis=1: each row needs sum-sq >= 2
+#    with a <= 1, so at least two vars at 1 -> min row sum 2, total 4.
+def b4():
+    m = dm.Model("nonconvex_axis1")
+    A = m.continuous("A", shape=(2, 3), lb=0, ub=1)
+    m.subject_to(dm.sum(A * A, axis=1) >= 2)
+    m.minimize(dm.sum(A))
+    return m
+
+
+case("nonconvex_axis1", b4, 4.0, np.array([1.0, 1, 0, 1, 1, 0]))
+
+
+# 5. bilinear across two variables, axis=1
+def b5():
+    m = dm.Model("bilinear_axis1")
+    X = m.continuous("X", shape=(2, 2), lb=0, ub=1)
+    Y = m.continuous("Y", shape=(2, 2), lb=0, ub=1)
+    m.subject_to(dm.sum(X * Y, axis=1) <= 0.5)
+    m.minimize(-dm.sum(X) - dm.sum(Y))
+    return m
+
+
+# per row: max sum(x)+sum(y) s.t. x1y1+x2y2 <= 0.5, all in [0,1].
+# x1=y1=1 uses 1.0 > 0.5, so take x1=1,y1=0.5,x2=1,y2=0 -> 2.5? check: 1*0.5+1*0=0.5, sum=2.5
+# better: x1=1,y1=0,x2=1,y2=0.5 same. or x1=1,x2=1,y1=0.5,y2=0 -> 2.5.
+# Try x1=x2=1, y1=y2=0.25 -> 0.5 -> sum = 2.5.  Upper bound argument: sum<=4 but
+# constraint binds. Leave the true value to a fine grid search below.
+case("bilinear_axis1", b5, None, None)
+
+
+# 6. transcendental, axis=1: sum(exp(A), axis=1) <= 3*e^0 + ... use log to be exact
+def b6():
+    m = dm.Model("exp_axis1")
+    A = m.continuous("A", shape=(2, 2), lb=0, ub=1)
+    m.subject_to(dm.sum(dm.exp(A), axis=1) <= 1 + np.e)
+    m.minimize(-dm.sum(A))
+    return m
+
+
+# per row: exp(a1)+exp(a2) <= 1+e, max a1+a2. By symmetry a1=a2=log((1+e)/2)=0.6187
+# -> row sum 1.2375, total 2.4749.  (a=1,b=0 gives row sum 1.)
+_a = np.log((1 + np.e) / 2)
+case("exp_axis1", b6, -4 * _a, np.full(4, _a))
+
+
+def main():
+    compared = 0
+    bad = []
+    for name, build, true_opt, witness in cases:
+        m = build()
+        r = m.solve(time_limit=120, gap_tolerance=1e-6)
+        line = f"{name:18s} status={r.status:10s} obj={r.objective!r:24s} bound={r.bound!r}"
+        if witness is not None:
+            v = verify_point(m, witness, with_objective=True)
+            line += f"  witness_ok={v.ok} witness_obj={v.objective}"
+        print(line, flush=True)
+        if true_opt is not None:
+            compared += 1
+            ok_obj = r.objective is not None and abs(r.objective - true_opt) <= TOL * max(
+                1.0, abs(true_opt)
+            )
+            # minimize sense in every case: a valid dual bound is <= the true optimum
+            ok_bound = r.bound is None or r.bound <= true_opt + TOL * max(1.0, abs(true_opt))
+            print(f"    true={true_opt:.6f} obj_ok={ok_obj} bound_ok={ok_bound}", flush=True)
+            if not (ok_obj and ok_bound):
+                bad.append(name)
+    print("COMPARISONS:", compared)
+    print("FAILING:", bad)
+    if compared == 0:
+        sys.exit("probe made no comparisons")
+    sys.exit(1 if bad else 0)
+
+
+main()

--- a/scratchpad/issue1160/panel2.py
+++ b/scratchpad/issue1160/panel2.py
@@ -1,0 +1,123 @@
+"""More axis-sum cases: integer/MILP, QP objective, least-squares, matmul-free."""
+import sys
+import numpy as np
+import discopt.modeling.core as dm
+from discopt.validation.feasibility import verify_point
+
+TOL = 1e-4
+cases = []
+
+
+def case(name, build, true_opt, witness=None):
+    cases.append((name, build, true_opt, witness))
+
+
+def b_milp():
+    m = dm.Model("milp_axis1")
+    B = m.binary("B", shape=(2, 3))
+    m.subject_to(dm.sum(B, axis=1) <= 2)
+    m.minimize(-dm.sum(B))
+    return m
+
+
+case("milp_axis1", b_milp, -4.0, np.array([1.0, 1, 0, 1, 1, 0]))
+
+
+def b_miqp():
+    m = dm.Model("miqp_axis1")
+    B = m.binary("B", shape=(2, 3))
+    m.subject_to(dm.sum(B, axis=1) <= 2)
+    m.minimize(dm.sum(B * B) - 4 * dm.sum(B))
+    return m
+
+
+# each b in {0,1}: b*b - 4b = -3b, so minimize -3*sum(B) with per-row cap 2 -> -12
+case("miqp_axis1", b_miqp, -12.0, np.array([1.0, 1, 0, 1, 1, 0]))
+
+
+def b_qp():
+    m = dm.Model("qp_axis1")
+    A = m.continuous("A", shape=(2, 3), lb=0, ub=1)
+    m.subject_to(dm.sum(A, axis=1) <= 2)
+    m.minimize(dm.sum(A * A) - 4 * dm.sum(A))
+    return m
+
+
+# with the row sum pinned at its cap 2, min sum(a^2) - 4*sum(a) = min sum(a^2) - 8
+# spreads the row equally: 3*(2/3)^2 - 8 = -6.667 per row -> -13.333
+case("qp_axis1", b_qp, -40.0 / 3.0, np.array([1.0, 1, 0, 1, 1, 0]))
+
+
+def b_ls():
+    m = dm.Model("ls_axis1")
+    A = m.continuous("A", shape=(2, 3), lb=0, ub=1)
+    m.subject_to(dm.sum(A, axis=1) <= 2)
+    m.minimize(dm.sum((A - 1) * (A - 1)))
+    return m
+
+
+# min sum (a-1)^2 with row sum <= 2 spreads: a = 2/3 -> 3*(1/9) = 1/3 per row -> 2/3
+case("ls_axis1", b_ls, 2.0 / 3.0, np.array([1.0, 1, 0, 1, 1, 0]))
+
+
+def b_eq():
+    m = dm.Model("lin_eq_axis1")
+    A = m.continuous("A", shape=(2, 3), lb=0, ub=1)
+    m.subject_to(dm.sum(A, axis=1) == 2)
+    m.minimize(-dm.sum(A * A))
+    return m
+
+
+# per row sum exactly 2 -> maximize sum of squares -> two at 1 -> 2 per row -> -4
+case("lin_eq_axis1", b_eq, -4.0, np.array([1.0, 1, 0, 1, 1, 0]))
+
+
+def b_3d():
+    m = dm.Model("lin_axis_3d")
+    A = m.continuous("A", shape=(2, 2, 2), lb=0, ub=1)
+    m.subject_to(dm.sum(A, axis=2) <= 1)
+    m.minimize(-dm.sum(A))
+    return m
+
+
+# 4 rows of 2, each capped at 1 -> total 4
+case("lin_axis_3d", b_3d, -4.0, np.array([1.0, 0, 1, 0, 1, 0, 1, 0]))
+
+
+def b_1d():
+    m = dm.Model("lin_axis0_1d")
+    x = m.continuous("x", shape=(4,), lb=0, ub=1)
+    m.subject_to(dm.sum(x, axis=0) <= 2)
+    m.minimize(-dm.sum(x))
+    return m
+
+
+# axis=0 on a 1-D operand IS a full reduction -> -2
+case("lin_axis0_1d", b_1d, -2.0, np.array([1.0, 1, 0, 0]))
+
+
+def main():
+    compared = 0
+    bad = []
+    for name, build, true_opt, witness in cases:
+        m = build()
+        r = m.solve(time_limit=120, gap_tolerance=1e-6)
+        line = f"{name:16s} status={r.status:10s} obj={r.objective!r:24s} bound={r.bound!r}"
+        if witness is not None:
+            v = verify_point(m, witness, with_objective=True)
+            line += f"  witness_ok={v.ok} obj={v.objective}"
+        print(line, flush=True)
+        compared += 1
+        ok_obj = r.objective is not None and abs(r.objective - true_opt) <= TOL * max(1, abs(true_opt))
+        ok_bound = r.bound is None or r.bound <= true_opt + TOL * max(1, abs(true_opt))
+        print(f"    true={true_opt:.6f} obj_ok={ok_obj} bound_ok={ok_bound}", flush=True)
+        if not (ok_obj and ok_bound):
+            bad.append(name)
+    print("COMPARISONS:", compared)
+    print("FAILING:", bad)
+    if compared == 0:
+        sys.exit("no comparisons")
+    sys.exit(1 if bad else 0)
+
+
+main()

--- a/scratchpad/issue1160/probe_paths.py
+++ b/scratchpad/issue1160/probe_paths.py
@@ -1,0 +1,46 @@
+"""Which extractor claims the axis-sum model, and how many rows does it emit?
+
+Prints an executed-check count and exits non-zero if nothing was checked.
+"""
+import numpy as np
+import discopt.modeling.core as dm
+from discopt._relax import problem_classifier as pc
+
+checks = 0
+
+def build_linear():
+    m = dm.Model("sum_axis")
+    A = m.continuous("A", shape=(2, 3), lb=0, ub=1)
+    m.subject_to(dm.sum(A, axis=1) <= 2)
+    m.minimize(-dm.sum(A))
+    return m
+
+m = build_linear()
+print("class:", pc.classify_problem(m))
+checks += 1
+
+try:
+    terms, const = pc._extract_linear_coefficients_sparse(m._constraints[0].body, m, 6)
+    print("algebraic row terms:", terms, "const:", const)
+    checks += 1
+except Exception as exc:
+    print("algebraic refused:", type(exc).__name__, exc)
+    checks += 1
+
+try:
+    lp = pc.extract_lp_data_algebraic(m)
+    print("algebraic LP A_eq shape:", np.asarray(pc.dense_A(lp.A_eq)).shape)
+except Exception as exc:
+    print("algebraic LP refused:", type(exc).__name__, exc)
+checks += 1
+
+lp2 = pc.extract_lp_data(m)
+print("extract_lp_data A_eq shape:", np.asarray(pc.dense_A(lp2.A_eq)).shape, "b:", lp2.b_eq)
+checks += 1
+
+tape = pc._extract_lp_data_tape(m)
+print("tape LP:", None if tape is None else (np.asarray(pc.dense_A(tape.A_eq)).shape, tape.b_eq))
+checks += 1
+
+print("CHECKS:", checks)
+assert checks > 0

--- a/scratchpad/issue1160/repro.py
+++ b/scratchpad/issue1160/repro.py
@@ -1,0 +1,14 @@
+import numpy as np
+import discopt.modeling.core as dm
+from discopt.validation.feasibility import verify_point
+
+m = dm.Model("sum_axis")
+A = m.continuous("A", shape=(2, 3), lb=0, ub=1)
+m.subject_to(dm.sum(A, axis=1) <= 2)     # per-ROW cap
+m.minimize(-dm.sum(A))                   # maximize the total
+
+r = m.solve(time_limit=60, gap_tolerance=1e-6)
+print("status", r.status, "obj", r.objective, "bound", r.bound)
+
+better = np.array([1., 1., 0., 1., 1., 0.])
+print(verify_point(m, better, with_objective=True))


### PR DESCRIPTION
## Summary

`dm.sum(X, axis=k)` is **array-valued**: on a `(2, 3)` variable, `sum(A, axis=1)` is two row sums, not one sum of six terms. Every structural walker that met a `SumExpression` descended into `.operand` and folded its elements together with one uniform scale — exactly right for a full reduction, and a *different model* for an axis one. So `sum(A, axis=1) <= 2` was extracted as the single row `sum(A) <= 2`, a strictly smaller feasible set, and the collapsed optimum came back as `status="optimal"` with a **dual bound that excludes the true optimum**:

```
min -sum(A)  s.t.  sum(A, axis=1) <= 2,  A in [0,1]^(2x3)
   returned:  optimal   obj -2.0000000   bound -2.0000000
   truth:     -4  (verify_point on [1,1,0,1,1,0] -> ok=True, objective=-4.0)
```

The fix is one predicate plus the guards that consume it:

* **`_relax/scalarize.sum_result_shape` / `sum_is_full_reduction`** derive what a `SumExpression` node evaluates to, in one place, and return `False` on an unknown shape (abstain, never "assume scalar"). `static_shape` now shares that derivation instead of reporting an axis reduction as unknown; `scalar_elements` behaviour is unchanged (`_elem` still has no `SumExpression` case), which #981's contract test pins in both files.
* **Guards that abstain** when a node in scalar position is not a full reduction, so the body routes to an extractor that fans it out into one row per element: the linear and quadratic algebraic extractors (`problem_classifier`), `canonical_expr`, `milp_relaxation`'s polynomial and affine walks, both OBBT row extractors, `convexity/linear_context`, and `dependent_vars`. Under an *enclosing* full reduction the collapse is exact (summing a partial sum's elements is summing the operand's), so `sum(sum(A, axis=1))` stays on the fast path — with a test.
* **Rust**: `ExprArena::evaluate` / `ModelRepr::evaluate_node` return `NaN` for an axis-reduced `Sum` instead of the full sum. The arena is scalar-valued and has no honest number for an array-valued node; `NaN` is its existing "not scalar-representable" signal (the same one `Index` already uses), so the repr-based LP/QP extractors — which check for non-finite coefficients — decline instead of emitting a collapsed row. The arena carries no shape inference, so a 1-D `axis=0` operand (genuinely a full reduction) is refused there too and handled by the Python side, where shapes are known.

Walkers that only *detect* structure or propagate curvature were left alone deliberately: summation is linear, so a partial sum of convex terms is convex, and descending is sound for them. `binary_multilinear_reform` and `gdp_reformulate` already refuse array-valued nodes structurally; `least_squares` already guarded on `axis`.

Closes #1160

**Interaction with #1158 (open):** that PR carries this bug as `xfail(strict=True)` in `test_interval_sum_reduction.py`, to convert to a failure the moment #1160 lands. Whichever merges second needs that xfail flipped to a plain assertion. This PR does **not** touch `interval_eval`; #1158's `SumExpression` reduction there is a distinct defect (a full reduction was not reduced either) and stays its.

## Correctness

- [x] Cannot produce a false certificate. Every change is either a **refusal** (a walker abstains and the body routes to a per-component extractor that emits one row per element) or the replacement of a wrong number with `NaN`, which callers already test for. No path gains a bound it did not have; four paths lose a row set they were fabricating.
- [x] No validation, fallback, or safety guard was weakened. The guards are additions in the abstaining direction, and the controls below check they did not over-refuse: a plain `sum(x)` body still takes the algebraic fast path as a single row, and `sum(sum(A, axis=1))` still collapses.

### The measurement

12 axis-reduced models with hand-derived optima (`scratchpad/issue1160/panel.py`, `panel2.py`), each checked for the objective, `bound <= true optimum`, and an independently `verify_point`-verified feasible witness:

| model | baseline `570ca9a` | true | this PR |
|---|---|---|---|
| `sum(A, axis=1) <= 2` (linear) | **-2.000** (bound -2.000) | -4 | -4.000 |
| `sum(A, axis=0) <= 1` (linear) | **-1.000** (bound -1.000) | -3 | -3.000 |
| `sum(B, axis=1) <= 2` (binary/MILP) | **-2.000** (bound -2.000) | -4 | -4.000 |
| `sum(A, axis=2) <= 1` (3-D operand) | **-1.000** (bound -1.000) | -4 | -4.000 |
| 8 others (convex quadratic, nonconvex `>=`, bilinear, `exp`, MIQP, QP, least-squares, `==`, 1-D `axis=0`) | correct | — | correct |

Baseline: 4 of 12 returned the axis-collapsed answer **as the dual bound**. This PR: 12 of 12 correct, every bound at or below the true optimum.

## Tests run (state the result — numbers, not adjectives)

- [x] `pytest -m smoke python/tests/` → **1129 passed, 21 skipped, 9386 deselected, 2 xpassed**, 384 s
- [x] `pytest -m slow python/tests/test_adversarial_recent_fixes.py` → **19 passed**, 162 s
- [x] `cargo test -p discopt-core` → **691 passed, 0 failed** (plus the new `test_axis_reduced_sum_is_not_scalar_representable`); `cargo fmt --check` clean
- [x] `ruff check python/` / `ruff format --check python/` clean (pinned 0.14.6); `mypy python/discopt/` → no issues in 335 source files
- [x] `pytest python/tests/test_issue_1160_axis_sum_certificate.py` → **16 passed** (10 default-selected + 6 `correctness`)
- [x] `pytest python/tests/test_correctness.py -m correctness -k "axis_sum or zero_incorrect"` → **8 passed**; `test_pr_correctness.py` → **7 passed** in 0.9 s
- [x] A default LP solve of an axis-sum model imports **0** `jax` modules (the new import is numpy-only; the tape rung is what handles the fanned-out rows)

One smoke failure had to be resolved rather than tolerated: `test_981_vectorized_relaxation.py::test_unscalarizable_expression_reports_unknown_not_empty` pinned `static_shape(sum(X, axis=0)) is None` — the deliberate "do not re-derive numpy's axis semantics" that #1160 made load-bearing. The test now pins the derived `(3,)` **and keeps its actual contract** (`scalar_elements(...) is None`, i.e. the rewrite still cannot expand it, so callers lose no rows). The derivation is not merely asserted: a new test cross-checks it against the model's own evaluator row fan-out on 5 shape/axis pairs.

## Regression test

`python/tests/test_issue_1160_axis_sum_certificate.py` — 16 tests. On `570ca9a`, **8 fail** and 8 pass (the module is collectable there on purpose: `sum_is_full_reduction` is imported inside the two tests that need it, so the fail-before evidence is "certifies -2 against a true -4", not `ImportError`):

```
default selection   6 failed, 4 passed   (row-cap -2 vs -4, MILP -2 vs -4, the predicate,
                                          the extractor refusal, LP rows 1 vs 2, Rust NaN)
-m correctness      2 failed, 4 passed   (axis=0 -1 vs -3, 3-D -1 vs -4)
```

All 16 pass here. Each solve case asserts **three** things — objective, `bound <= true optimum`, and a `verify_point`-verified witness — because the objective alone passes on a build that got lucky on the primal, and a witness the test derived by the same reasoning as the solver would be two copies of one mistake. Where a blanket "abstain on every `SumExpression`" would have passed everything vacuously, controls check the full-reduction fast path still fires (one algebraic row for `sum(x) <= 2`) and that `sum(sum(A, axis=1))` still collapses. A `teardown_module` hook asserts every entered certificate check reached its comparison (CLAUDE.md §6); it is a hook, not a test, because `pytest-randomly` makes a counter-test position-dependent.

- [x] Added a regression test that fails before / passes after

Panel coverage (the `.nl` reader emits no `SumExpression`, so no `.nl` panel or gate can cover this class): three axis-reduced instances join `INSTANCES` in `test_correctness.py` (and therefore `TestCorrectnessGate`), one joins the PR-fast subset in `test_pr_correctness.py`. The panel's bound and integrality assertions are now array-aware — `float(result.x[name])` raises on a shaped variable, which is why the panel had no vector-variable instance at all.

## Bound-changing / performance change?

Not a flagged bound change: no cut, relaxation or flag is introduced. It does change which extractor claims a **Python-API model containing an axis-reduced sum** — from one that emitted a wrong row to ones that emit the right rows. For `.nl` models the claim is that nothing changes, and that is measured, not argued:

* **Structural:** the only producer of an `ExprNode::Sum` with a non-`None` axis is the Python `SumExpression` conversion in `expr_bindings.rs` (`substitute.rs` only copies an existing axis). The `.nl` parser produces `SumOver` nodes exclusively.
* **Executed, during real solves** (`scratchpad/issue1160/nl_neutrality.py`, 66 in-repo `.nl` instances, 10 s / 3000 nodes each): `GUARD_CALLS: 0`, `GUARD_REFUSALS: 0`. The instrument self-tests first — it solves one Python-API axis-sum model in the same process and exits non-zero unless the counters move (they read `calls=3 refusals=2`) — so "0" means the branch is unreached, not that the probe was dead. Each arm prints the loaded `scalarize.__file__` and a `GUARD MARKER: present/absent` line, so a mixed arm cannot be reported as a baseline (CLAUDE.md §8).
* **A/B against `570ca9a`**, 264 compared fields (status, objective, bound, node_count × 66): **8 differences**, no status difference, no objective difference except `tspn10`'s last ulp. All 8 are on instances that end on the 10 s budget, and three repetitions of *each* arm produce the other arm's values:

```
4stufen   bound   base panel 20282.037943778414 | base reps 1-3 ALL 20282.03794377718 = head
nvs05     bound   base reps: 1.3186745502725463 / 1.317783743759922 / 0.6322668573311564
                  (three distinct values in the base arm; head's value is the first of them)
tanksize  nodes   base 472/388/391/355   head 456/384/400/390
tls2      nodes   head 165/165/141/141   (141 = the base panel's value)
syn05hfsg nodes   head 33/43/39/35
tspn10    obj     base 225.12607170016818 | head reps give both ...16818 and ...17003
```

- Measurement: in-repo 66-instance `.nl` corpus, baseline `570ca9a`, 10 s / 3000 nodes per instance; plus the 12-model axis-sum panel above.

## Observed but not addressed

* `structure-cut presolve skipped: index 2 is out of bounds for axis 0 with size 2` — the optional SymPy cut recognizer raises on any *shaped* variable, with or without an axis sum (reproduced on a body with no axis anywhere). It is swallowed and the pass is skipped, so it is a lost cut, not a wrong bound. Pre-existing and out of scope here.
* A vector-valued objective (`m.minimize(dm.sum(A, axis=1))`, an ill-formed model) now raises a JAX `TypeError` about non-scalar output instead of silently minimizing the collapsed total. Loud beats silent, but the message names JAX internals rather than the modelling mistake; rejecting a provably non-scalar objective at `minimize()` would be the better refusal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kb9QJDNftT6hE999fcbrAa

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kb9QJDNftT6hE999fcbrAa)_