### PR TITLE
docs: record the owner's reference-implementation policy and Stage 2's papers

### DIFF
--- a/docs/dev/milp-competitiveness-plan.md
+++ b/docs/dev/milp-competitiveness-plan.md
@@ -1121,11 +1121,27 @@ figures need one quiet re-run before they are quoted outside this document.
 
 discopt is **EPL-2.0**. HiGHS is MIT (compatible inbound). SCIP 10 is Apache-2.0,
 which can be combined but not relicensed. Both reviews were instructed to
-describe algorithms, not paste source, and neither returned code. If the cMIR δ
-and complementation loop in Stage 2 ends up a close derivation of
-`SCIPcutGenerationHeuristicCMIR`, or the transform step of
-`HighsTransformedLp::transform`, that is an attribution decision for the owner
-before merge, not something to settle in a PR.
+describe algorithms, not paste source, and neither returned code.
+
+**Decided 2026-09-05; the standing policy is `docs/dev/reference-provenance.md`.**
+Read for the idea, implement independently from the published paper, cite and
+acknowledge the source. So Stage 2 builds cMIR from {cite:t}`Marchand2001` and
+lifted covers from {cite:t}`Gu1998` / {cite:t}`Gu1999`, using
+`SCIPcutGenerationHeuristicCMIR` and `HighsTransformedLp::transform` only to
+settle a specific ambiguity the papers leave open -- not as the thing being
+transcribed -- and names the file that informed it in the module header.
+
+One caveat that policy file states and that this note previously implied the
+wrong way round: **being in Rust is not itself the protection.** A translation
+into another language is still a derivative work. What protects an independent
+reimplementation is that algorithms and mathematical methods are not
+copyrightable, only their expression is -- so the safety comes from working from
+the paper, which is a practice that can be skipped, not from the change of
+language, which is automatic. The distinction decides which step is load-bearing.
+
+What still comes to the owner is narrower than this note used to say: a routine
+with **no published description**, where the reference implementation is the
+specification.
 
 ## 6. Reproduction
 

--- a/docs/dev/reference-provenance.md
+++ b/docs/dev/reference-provenance.md
@@ -1,0 +1,56 @@
+# Reading HiGHS and SCIP: the provenance policy
+
+`ref/` holds reading copies of the HiGHS and SCIP sources. It is gitignored and
+never vendored. HiGHS is MIT, SCIP 10 and SoPlex are Apache-2.0; discopt is
+EPL-2.0. The reference-reading agent definitions (`.claude/agents/highs-expert.md`,
+`.claude/agents/scip-expert.md`) used to end this topic by telling the reader to
+"flag that to the owner as a licensing/attribution decision rather than deciding
+it yourself." The owner has now made that call, and this file is where it lives
+so it survives outside a gitignored directory.
+
+## The decision (owner, 2026-09-05)
+
+> "We can't port it directly, but we can use it for inspiration and implement
+> something similar. ... We should be careful to acknowledge and make it
+> different"
+
+**Read for the idea, implement it independently, cite the source.** Three things
+follow. The third is a correction, not a restatement.
+
+### 1. Work from the published paper, not the source file
+
+Where a paper exists, implement from the paper. cMIR is {cite:t}`Marchand2001`;
+lifted cover inequalities are {cite:t}`Gu1998`; lifted flow covers are
+{cite:t}`Gu1999`. This produces an independent expression *and* usually a better
+implementation, because a paper states the conditions that code leaves implicit.
+Add the entry to `docs/references.bib` and cite it in the module header.
+
+Use the reference source to settle a *specific* question the paper leaves
+ambiguous — a tolerance, a degenerate case, an ordering — not as the thing being
+transcribed.
+
+### 2. Acknowledge
+
+A module whose design came from reading a reference implementation says so in its
+header, naming the file that informed it. That is the "acknowledge" half of the
+decision and it costs one line. `lp/aggregation.rs` already carries this shape.
+
+### 3. Do not lean on "it's in a different language, so it isn't copying"
+
+This premise gets offered as the reason the whole question is moot. It is not
+sound and the policy must not rest on it: **a translation into another language
+is still a derivative work**, and reimplementing a C++ routine in Rust does not
+by itself make a close transcription safe.
+
+What actually protects an independent reimplementation is that **algorithms and
+mathematical methods are not copyrightable — only their expression is.** The
+protection therefore comes from writing discopt's own expression of the method,
+which is exactly what (1) and (2) produce. It does not come from the change of
+language. Stating the real reason matters because it tells you *which* practices
+are load-bearing: working from the paper is, and being in Rust is not.
+
+## What still gets escalated
+
+One case remains genuinely open: a routine with **no published description**,
+where the reference implementation *is* the specification and any correct version
+would closely resemble it. Bring those to the owner rather than deciding them.

--- a/docs/references.bib
+++ b/docs/references.bib
@@ -2361,3 +2361,36 @@
   year    = {2017},
   doi     = {10.1039/C6SC05720A}
 }
+
+@article{Marchand2001,
+  author  = {Marchand, Hugues and Wolsey, Laurent A.},
+  title   = {Aggregation and Mixed Integer Rounding to Solve {MIPs}},
+  journal = {Operations Research},
+  volume  = {49},
+  number  = {3},
+  pages   = {363--371},
+  year    = {2001},
+  doi     = {10.1287/opre.49.3.363.11211},
+}
+
+@article{Gu1998,
+  author  = {Gu, Zonghao and Nemhauser, George L. and Savelsbergh, Martin W. P.},
+  title   = {Lifted Cover Inequalities for 0-1 Integer Programs: Computation},
+  journal = {INFORMS Journal on Computing},
+  volume  = {10},
+  number  = {4},
+  pages   = {427--437},
+  year    = {1998},
+  doi     = {10.1287/ijoc.10.4.427},
+}
+
+@article{Gu1999,
+  author  = {Gu, Zonghao and Nemhauser, George L. and Savelsbergh, Martin W. P.},
+  title   = {Lifted Flow Cover Inequalities for Mixed 0-1 Integer Programs},
+  journal = {Mathematical Programming},
+  volume  = {85},
+  number  = {3},
+  pages   = {439--467},
+  year    = {1999},
+  doi     = {10.1007/s101070050067},
+}


### PR DESCRIPTION
Records the owner's decision on how discopt may use the HiGHS and SCIP sources in
`ref/`, and adds the three papers Stage 2 will be built from so the citations
exist before the code does.

## Why it needed a home in the repo

Both reference-reading agent definitions ended this topic by telling the reader
to "flag that to the owner as a licensing/attribution decision rather than
deciding it yourself", and §5 of the competitiveness plan deferred the same
question. The owner has now answered it:

> We can't port it directly, but we can use it for inspiration and implement
> something similar. ... We should be careful to acknowledge and make it
> different

The agent files live under `.claude/`, which is gitignored — so writing the
decision there would have left it on one machine. It goes in
`docs/dev/reference-provenance.md` instead, and plan §5 now points at it rather
than continuing to ask.

## One correction, which is the reason this is worth reviewing

The reason usually offered for all of this being moot is *"it's in another
language, so it isn't copying."* That is not sound, and a policy resting on it
would be resting on nothing: **a translation into another language is still a
derivative work.**

What actually protects an independent reimplementation is that **algorithms and
mathematical methods are not copyrightable — only their expression is.** The
protection therefore comes from producing discopt's own expression of the
method, which is what working from the published paper does.

This is not a pedantic distinction. It decides *which practice is load-bearing*:
working from the paper is a step that can be skipped, and being in Rust is
automatic and guarantees nothing. A policy that credits the language would let
the one protective step lapse while feeling safe.

## What the policy says

1. **Implement from the paper**, using the reference source only to settle a
   specific ambiguity the paper leaves open — not as the thing being transcribed.
2. **Acknowledge** in the module header, naming the file that informed it
   (`lp/aggregation.rs` already has this shape).
3. Do not rely on the language argument, per above.

Escalation to the owner is now reserved for the case that is genuinely still
open: a routine with **no published description**, where the reference
implementation *is* the specification.

## Papers added

`docs/references.bib` 231 → 234 entries, no duplicate keys (checked
programmatically, not by eye):

- `Marchand2001` — Marchand & Wolsey, *Aggregation and mixed integer rounding to
  solve MIPs*, Operations Research 49(3):363–371 — the cMIR source for Stage 2.
- `Gu1998` — Gu, Nemhauser & Savelsbergh, *Lifted cover inequalities for 0-1
  integer programs: computation*, INFORMS J. Computing 10(4):427–437.
- `Gu1999` — same authors, *Lifted flow cover inequalities for mixed 0-1 integer
  programs*, Math. Programming 85(3):439–467.

## Verification

Docs only — no code, no solver behavior touched. `git show --stat` confirms the
diff is three files under `docs/`. Nothing to run beyond CI's lint job, which is
why the code jobs skip.

This PR **closes no issue** — it records a decision, so merging it is the owner's
call rather than something the standing "closes an issue + green" bar covers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014E81XM1j2J5sydzj9nFFFp
