### PR TITLE
fix(pyomo): #1178 stream the solver log for tee=True instead of stream=True

### DIFF
--- a/docs/dev/solve-routing.md
+++ b/docs/dev/solve-routing.md
@@ -27,7 +27,8 @@ Model.solve(...)                                          [modeling/core.py:2680
   ▼
 solve_model(...)                                          [solver.py:2017]
   │
-  ├─ stream=True ───────────────────────────► _solve_streaming  (yields SolveUpdate)
+  ├─ stream=True ───────────────────────────► _solve_streaming  (NotImplementedError:
+  │                                             no backend yields SolveUpdate yet)
   │
   ├─ EXPLICIT SOLVER SELECTOR
   │     solver="amp"      ──► solve_amp      (Adaptive Multivariate Partitioning)

--- a/docs/pyomo_solver.md
+++ b/docs/pyomo_solver.md
@@ -41,7 +41,14 @@ Pyomo solver options map to `Model.solve` keyword arguments:
 | `timelimit` (or `time_limit`) | `time_limit` |
 | `mipgap` / `gap` | `gap_tolerance` |
 | `threads` | `threads` |
-| `tee=True` | `stream=True` |
+
+`tee=True` is not an option passed to `Model.solve`: for the duration of the solve
+the plugin attaches a stdout handler to the `discopt` logger (and lifts it to
+`INFO` if it is quieter), so the solver log streams to the terminal the way Pyomo
+users expect, then restores the logger. It is deliberately *not* mapped onto
+`Model.solve(stream=True)` — that kwarg asks for an iterator of `SolveUpdate`
+instead of a `SolveResult` and is not implemented, which used to make every
+`tee=True` solve return termination `error` with no solution loaded (issue #1178).
 
 Pass them per solve or persistently:
 

--- a/python/discopt/modeling/core.py
+++ b/python/discopt/modeling/core.py
@@ -4504,7 +4504,10 @@ class Model:
             Compute sensitivities w.r.t. Parameters.
         stream : bool, default False
             If True, return an iterator of :class:`SolveUpdate` instead of
-            the final result.
+            the final result. **Not implemented** — no backend produces the update
+            feed, so this currently raises ``NotImplementedError``. It is not a
+            "print the solver log" switch: for that, attach a handler to the
+            ``discopt`` logger at INFO (what the Pyomo plugin's ``tee=True`` does).
         deterministic : bool, default False
             Make the search a function of the model rather than of machine speed,
             by rendering every **role-2** wall budget inert — the sub-budgets that
@@ -5309,8 +5312,19 @@ class Model:
         return result
 
     def _solve_streaming(self, **kwargs) -> Iterator["SolveUpdate"]:
-        """Streaming solve that yields updates during B&B."""
-        raise NotImplementedError("Streaming solve requires solver backend")
+        """Streaming solve that yields updates during B&B.
+
+        Not implemented: no backend produces the :class:`SolveUpdate` feed yet, so
+        ``solve(stream=True)`` raises rather than returning a partial answer. The
+        message names the parameter because a caller mistaking ``stream`` for
+        "print the solver log" is exactly how issue #1178 happened — for that, hook
+        the ``discopt`` logger at INFO (see ``discopt.pyomo``'s ``tee`` handling).
+        """
+        raise NotImplementedError(
+            "Model.solve(stream=True) is not implemented: no solver backend yields "
+            "SolveUpdate progress. Call solve() without stream= for a SolveResult; "
+            "to watch progress, attach a handler to the 'discopt' logger at INFO."
+        )
 
     # ── Infeasibility analysis ──
 

--- a/python/discopt/modeling/examples.py
+++ b/python/discopt/modeling/examples.py
@@ -663,6 +663,11 @@ def example_llm_formulation():
 
 def example_streaming():
     """
+    NOTE: streaming is not implemented yet — ``solve(stream=True)`` raises
+    ``NotImplementedError`` because no backend produces the ``SolveUpdate`` feed.
+    To watch a solve in progress today, attach a handler to the ``discopt``
+    logger at INFO (which is what the Pyomo plugin's ``tee=True`` does).
+
     import discopt
 
     m = dm.Model("large_problem")

--- a/python/discopt/pyomo/solver.py
+++ b/python/discopt/pyomo/solver.py
@@ -11,9 +11,12 @@ Importing this module registers the solver, so it activates via the
 
 from __future__ import annotations
 
+import contextlib
 import logging
 import os
+import sys
 import tempfile
+from collections.abc import Iterator
 from typing import Any
 
 from pyomo.opt import OptSolver, SolverFactory, SolverResults
@@ -21,6 +24,48 @@ from pyomo.opt import OptSolver, SolverFactory, SolverResults
 from . import _mapping, _writer
 
 logger = logging.getLogger(__name__)
+
+
+@contextlib.contextmanager
+def _tee_solver_log(enabled: bool) -> Iterator[None]:
+    """Stream discopt's solver log to stdout for the duration of a solve.
+
+    Pyomo's ``tee=True`` means *show me the solver's log*. discopt has no
+    stdout-printing "verbose" mode: it reports progress through the ``discopt``
+    logger at INFO, so teeing means attaching a stdout handler to that logger and
+    lifting its level for the call, then restoring both.
+
+    This is deliberately **not** ``Model.solve(stream=True)`` — that kwarg asks for
+    an iterator of ``SolveUpdate`` instead of a ``SolveResult`` (and today raises
+    ``NotImplementedError``), which is a different feature entirely. Mapping
+    ``tee`` onto it made every ``tee=True`` solve return termination ``error`` with
+    no solution loaded (issue #1178).
+
+    Propagation is left alone: a caller who configured their own handlers keeps
+    seeing what they asked for.
+    """
+    if not enabled:
+        yield
+        return
+
+    discopt_logger = logging.getLogger("discopt")
+    handler = logging.StreamHandler(sys.stdout)
+    handler.setLevel(logging.INFO)
+    handler.setFormatter(logging.Formatter("%(message)s"))
+    previous_level = discopt_logger.level
+    # NOTSET (0) means "inherit", which for an unconfigured root is WARNING, so it
+    # needs lifting too; a level already at or below INFO is left as the user set it.
+    raise_level = previous_level == logging.NOTSET or previous_level > logging.INFO
+    discopt_logger.addHandler(handler)
+    if raise_level:
+        discopt_logger.setLevel(logging.INFO)
+    try:
+        yield
+    finally:
+        discopt_logger.removeHandler(handler)
+        handler.flush()
+        if raise_level:
+            discopt_logger.setLevel(previous_level)
 
 
 @SolverFactory.register("discopt", doc="discopt hybrid MINLP solver (in-process)")
@@ -79,8 +124,6 @@ class DiscoptSolver(OptSolver):
         if timelimit is not None:
             options.setdefault("time_limit", timelimit)
         solve_kwargs = _mapping.translate_options(options)
-        if tee:
-            solve_kwargs.setdefault("stream", True)
 
         return self._solve_via_nl(
             model,
@@ -88,6 +131,7 @@ class DiscoptSolver(OptSolver):
             load_solutions=load_solutions,
             keepfiles=keepfiles,
             warmstart=warmstart,
+            tee=tee,
         )
 
     # -- Core flow -------------------------------------------------------------
@@ -99,6 +143,7 @@ class DiscoptSolver(OptSolver):
         load_solutions: bool,
         keepfiles: bool,
         warmstart: bool,
+        tee: bool = False,
     ) -> SolverResults:
         import discopt.modeling as dm
 
@@ -123,10 +168,33 @@ class DiscoptSolver(OptSolver):
                 if seed:
                     solve_kwargs.setdefault("initial_solution", seed)
 
-            try:
-                result = discopt_model.solve(**solve_kwargs)
-            except Exception as exc:  # noqa: BLE001 - surface as a structured result
-                return self._error_results(model, f"discopt.solve failed: {exc}")
+            # The header/footer are logged at INFO so ``tee=True`` always shows a
+            # solver log: the core logs INFO during the search, but a model small
+            # enough to finish in presolve can otherwise say nothing at all. Both
+            # are outside the try, and format only with ``%s``, so a log line can
+            # never turn a completed solve into an ``error`` result.
+            with _tee_solver_log(tee):
+                logger.info(
+                    "discopt %s: solving %s variables, %s constraints",
+                    ".".join(str(part) for part in self.version() or ()) or "unknown version",
+                    len(cols),
+                    len(rows),
+                )
+                try:
+                    result = discopt_model.solve(**solve_kwargs)
+                except Exception as exc:  # noqa: BLE001 - surface as a structured result
+                    logger.info("discopt failed: %s", exc)
+                    return self._error_results(model, f"discopt.solve failed: {exc}")
+                wall = getattr(result, "wall_time", None)
+                logger.info(
+                    "discopt finished: status=%s objective=%s bound=%s nodes=%s wall=%s",
+                    getattr(result, "status", "unknown"),
+                    getattr(result, "objective", None),
+                    getattr(result, "bound", None),
+                    getattr(result, "node_count", None),
+                    # isinstance, not a try/except: formatting must not be able to raise.
+                    f"{wall:.3f}s" if isinstance(wall, (int, float)) else wall,
+                )
 
             return self._build_results(
                 model,

--- a/python/tests/test_gdpopt_heuristics_core_units.py
+++ b/python/tests/test_gdpopt_heuristics_core_units.py
@@ -1550,7 +1550,7 @@ class TestSolveOptionPaths:
         m = dm.Model("stream")
         x = m.continuous("x", lb=0, ub=1)
         m.minimize(x)
-        with pytest.raises(NotImplementedError, match="Streaming solve"):
+        with pytest.raises(NotImplementedError, match=r"stream=True\) is not implemented"):
             m.solve(stream=True, llm=True)
 
     def test_gradient_vector_parameter_reshape(self):

--- a/python/tests/test_pyomo_interface.py
+++ b/python/tests/test_pyomo_interface.py
@@ -119,6 +119,80 @@ def test_options_passthrough(opt, monkeypatch):
     assert captured.get("gap_tolerance") == 1e-3
 
 
+def test_tee_matches_no_tee(opt, capsys):
+    """`tee=True` solves identically to `tee=False` and streams the log (issue #1178).
+
+    Before the fix, `tee` was mapped onto `Model.solve(stream=True)` — a different
+    feature (an iterator of SolveUpdate) that raises NotImplementedError — so every
+    `tee=True` solve came back as termination `error` with no solution loaded.
+    """
+    quiet = _tiny_minlp()
+    res_quiet = opt.solve(quiet, tee=False)
+    capsys.readouterr()  # drop anything the quiet solve emitted
+
+    loud = _tiny_minlp()
+    res_loud = opt.solve(loud, tee=True)
+    out = capsys.readouterr().out
+
+    assert res_loud.solver.termination_condition == res_quiet.solver.termination_condition
+    assert res_loud.solver.termination_condition == pyo.TerminationCondition.optimal
+    assert pyo.value(loud.obj) == pytest.approx(pyo.value(quiet.obj), abs=1e-6)
+    assert loud.x.value == pytest.approx(quiet.x.value, abs=1e-6)
+    assert loud.y.value == pytest.approx(quiet.y.value, abs=1e-6)
+    assert out.strip(), "tee=True produced no solver log on stdout"
+
+
+def test_tee_attaches_a_stdout_handler_then_restores_it(opt, monkeypatch):
+    """`tee=True` attaches a stdout handler for the solve and removes it after."""
+    import logging
+    import sys
+
+    import discopt.modeling as dm
+
+    discopt_logger = logging.getLogger("discopt")
+    before_handlers = list(discopt_logger.handlers)
+    before_level = discopt_logger.level
+
+    during: dict[str, object] = {}
+    orig = dm.Model.solve
+
+    def spy(self, *a, **k):
+        added = [h for h in discopt_logger.handlers if h not in before_handlers]
+        during["added"] = added
+        during["effective_level"] = discopt_logger.getEffectiveLevel()
+        return orig(self, *a, **k)
+
+    monkeypatch.setattr(dm.Model, "solve", spy)
+    opt.solve(_tiny_minlp(), tee=True)
+
+    assert "added" in during, "Model.solve was never reached — the probe measured nothing"
+    added = during["added"]
+    assert len(added) == 1, f"expected exactly one tee handler, saw {added}"
+    assert isinstance(added[0], logging.StreamHandler)
+    assert added[0].stream is sys.stdout
+    assert during["effective_level"] <= logging.INFO
+
+    # ...and the logger is left exactly as it was found.
+    assert discopt_logger.handlers == before_handlers
+    assert discopt_logger.level == before_level
+
+
+def test_tee_does_not_request_streaming(opt, monkeypatch):
+    """`tee=True` must not reach `Model.solve` as `stream=True` (issue #1178)."""
+    import discopt.modeling as dm
+
+    captured = {}
+    orig = dm.Model.solve
+
+    def spy(self, *a, **k):
+        captured.update(k)
+        return orig(self, *a, **k)
+
+    monkeypatch.setattr(dm.Model, "solve", spy)
+    opt.solve(_tiny_minlp(), tee=True)
+    assert "stream" not in captured
+
+
 def test_duals_when_exposed(opt):
     """Convex NLP min (x-3)^2 s.t. x>=4 -> KKT multiplier ~2; sign matches the
     AMPL/Pyomo convention (cross-checked against ipopt's value 2.0)."""


### PR DESCRIPTION
## Summary

`SolverFactory('discopt').solve(m, tee=True)` returned termination `error` and left every
variable uninitialized, while the identical model solved fine with `tee=False`.

Root cause: the plugin mapped Pyomo's `tee` onto `Model.solve(stream=True)`. Those are
unrelated features — `stream=True` asks for an iterator of `SolveUpdate` instead of a
`SolveResult`, and `Model._solve_streaming` raises `NotImplementedError` because no backend
produces that feed. The bridge caught the exception and turned every `tee=True` solve into an
error result with no solution loaded.

Pyomo's `tee` means "show me the solver log", and discopt reports progress through the
`discopt` logger at INFO. `tee=True` now attaches a stdout handler to that logger for the
duration of the solve (lifting the level to INFO only when it is quieter), then removes the
handler and restores the level. Propagation is untouched, so a caller's own handlers keep
working. A header and footer line are logged at INFO around the solve so `tee=True` always
shows a log even for a model that finishes in presolve; both sit outside the `try` and format
only with `%s`, so a log line can never turn a completed solve into an error result.

The change also makes the dead `stream` parameter honest rather than leaving the next caller
to repeat the same mistake: the `NotImplementedError` now names the parameter and points at
the logger, and the `Model.solve` docstring, `docs/pyomo_solver.md` (whose options table
documented `tee=True → stream=True`), the solve-routing diagram, and the streaming example all
say it is not implemented. Implementing the `SolveUpdate` feed is a separate feature and is not
in this change.

Measured on the issue's reproducer, Python 3.12, editable build of this tree:

Pre-fix
```
tee= False optimal      obj= 5.0
tee= True  error   msg= discopt.solve failed: Streaming solve requires solver backend
ValueError: No value for uninitialized VarData object x[1]
```

Post-fix
```
tee= False optimal      obj= 5.0
discopt 0.8.1: solving 5 variables, 2 constraints
Using POUNCE (pure-Rust Ipopt port)
discopt finished: status=optimal objective=5.0 bound=5.0 nodes=1 wall=0.003s
tee= True  optimal      obj= 5.0
```

Closes #1178

## Correctness

No solver math is touched. The change is confined to the Pyomo bridge's logging setup plus an
exception message and documentation; the `.nl` round-trip, the solve call, and the
solution/dual mapping are unchanged. `tee=True` now takes the *same* code path as `tee=False`,
which is precisely the defect being fixed — previously the two paths diverged and the `tee=True`
one never reached a solution.

- [x] Cannot produce a false certificate (N/A — no solver-math change)
- [x] No validation, fallback, or safety guard was weakened to make a check pass

## Tests run (state the result — numbers, not adjectives)

- [x] `pytest -m smoke` → 1133 passed, 20 skipped, 9421 deselected, 2 xpassed (363.6 s)
- [x] `pytest -m slow python/tests/test_adversarial_recent_fixes.py` → 19 passed (164.0 s)
- [x] `cargo test -p discopt-core` → N/A (no Rust touched)
- [x] `ruff check` / `ruff format --check` clean; `mypy python/discopt/pyomo/` → no issues in 4 source files

`pytest python/tests/test_pyomo_interface.py` → 14 passed.

One pre-existing test, `test_gdpopt_heuristics_core_units.py::TestSolveOptionPaths::test_streaming_solve_not_implemented`,
matched the old `NotImplementedError` text; its regex now matches the new message. It still
asserts the same behavior (streaming raises).

## Regression test

Three tests added to `python/tests/test_pyomo_interface.py`:

- `test_tee_matches_no_tee` — `tee=True` returns the same termination and the same
  objective/variable values as `tee=False`, and puts a non-empty log on stdout.
- `test_tee_attaches_a_stdout_handler_then_restores_it` — a probe inside `Model.solve` asserts
  exactly one `StreamHandler` on `sys.stdout` is attached during the solve and the logger's
  handlers and level are identical afterwards; it fails loudly if the probe never ran.
- `test_tee_does_not_request_streaming` — `stream` is never forwarded to `Model.solve`.

All three fail on the pre-fix plugin (verified by stashing only `python/discopt/pyomo/solver.py`:
`3 failed, 11 deselected`) and pass after.

- [x] Added a regression test that fails before / passes after

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JaE8JQUwExMSXFwehaq3JK

---
_Generated by [Claude Code](https://claude.ai/code/session_01JaE8JQUwExMSXFwehaq3JK)_