### PR TITLE
feat(gdp): #1182 exact continuous simplex/CNF lowering of disjunctions

### DIFF
--- a/docs/dev/performance-plan.md
+++ b/docs/dev/performance-plan.md
@@ -5443,6 +5443,40 @@ an economy-of-scale sizing idiom, not a one-off. That is the concrete fixture #1
 entry condition asks for, and it is a *capability* fixture: on those rows the exact
 continuous lowering is not faster than the alternatives, it is the only one there is.
 
+### E4 — the SOS1 reference, which only exists on MPEC models
+
+Requirement 4 of #1182 asks for a benchmark against "exact GDP/SOS1 references".
+E1/E2 cover the exact GDP references. SOS1 in this tree is not a general
+disjunction lowering — it is one of `discopt.mpec`'s complementarity encodings — so
+the SOS1 comparison exists only where a complementarity does. A relation
+`0 <= f ⊥ g >= 0` is reachable through four exact encodings, all through the same
+certified `Model.solve`; `method="scholtes"` is deliberately absent, being a
+homotopy of *local* solves whose result is not a certificate.
+
+| model | arm | status | objective | nodes | wall | source `min(f, g)` | certified |
+|---|---|---|---|---|---|---|---|
+| distance | sos1 | optimal | 1 | 3 | 0.36 s | 9.3e−11 | yes |
+| distance | gdp/big-m | optimal | 1 | 3 | 0.04 s | 6.1e−11 | yes |
+| distance | gdp/hull | optimal | 1 | 3 | 0.05 s | 7.5e−12 | yes |
+| distance | **gdp/simplex** | optimal | 1 | 11 | **15.70 s** | **1.4e−17** | yes |
+| chain4 | sos1 | optimal | 1 | 29 | 0.06 s | 2.2e−11 | yes |
+| chain4 | gdp/big-m | optimal | 1 | 9 | 0.06 s | 4.9e−12 | yes |
+| chain4 | gdp/hull | optimal | 1 | 9 | 0.18 s | 6.6e−12 | yes |
+| chain4 | **gdp/simplex** | optimal | 1 | **5** | **14.65 s** | 5.5e−08 | yes |
+
+All four certify the same optimum, so the encoding is sound here too. The
+node-count signal is **mixed** — the simplex arm wins on `chain4` (5 vs 9) and
+loses on `distance` (11 vs 3) — while the wall-time signal is uniformly bad:
+100–250× slower, and near-constant at ~15 s across two models of different size,
+which suggests a per-node cost in the spatial path rather than search. Stated
+plainly so it is not read as a partial win: a node-count win that costs 244× wall
+does not meet §5's *net-positive* bar, and one of the two models is a synthetic
+chain I wrote for this probe rather than a corpus instance (`distance` is the
+repo's own `test_mpec.py` fixture). The one column where the lowering is
+consistently better is the **source complementarity residual** on `distance`
+(1.4e−17 against 6.1e−11), which is a property of the encoding being exact rather
+than regularized — worth recording, not worth a default change.
+
 **Retraction of the framing in #1182's own text.** The issue asks for "a model where
 the deferred lowering is expected to beat the exact GDP/SOS1 path" and reads that as a
 performance question. E1/E2 answer it negatively and that answer is binding: no

--- a/docs/dev/performance-plan.md
+++ b/docs/dev/performance-plan.md
@@ -5350,3 +5350,101 @@ between two time-limited runs, not a lost result. Supplemented with the
 `syn`/`rsyn`/`squfl` class at 20 s and 60 s: no route win lost at either budget.
 `DISCOPT_CONVEX_ROUTE_DECISION_POINT=0` restores the #1066 policy, which is kept
 intact and tested.
+
+## 26. #1182 exact continuous (simplex/CNF) lowering: the speed motive is falsified; a capability motive survives (2026-09-05)
+
+**Hypothesis under test** (RFC #1123, deferred to #1182, from Theorem 1 of
+[arXiv:2601.03906v1](https://arxiv.org/abs/2601.03906v1)): replacing each disjunction
+by its exact continuous simplex lowering removes the selector binaries and therefore
+gives a *faster certified* solve than discopt's big-M / hull lowering.
+
+**Kill criterion, fixed before running.** On the in-repo native GDP corpus
+(`benchmarks.gdplib_native`, SCIP/BARON-certified optima) the simplex arm must reach
+the same certified optimum as big-M/hull on at least one instance with strictly less
+wall time or fewer nodes. If it certifies nothing the classical lowerings certify, the
+hypothesis is falsified for certified global solving.
+
+**Probes** (`scratchpad/issue1182/`, each printing an executed-comparison count and
+exiting non-zero at zero, per CLAUDE.md §6): `E1_entry_experiment.py` (real GDP
+corpus), `E2_paper_class.py` (the paper's own obstacle-avoidance class),
+`E3_bigm_refusal.py` (capability), `E5_corpus_refusal_scan.py` (GDPlib scan). Logs
+are committed beside them. Both arms go through the same `Model.solve` certified path
+— which is the comparison the paper does *not* make: its §5 runs local Ipopt on both
+sides, and its "Big M" baseline also eliminates the binaries continuously.
+
+### E1 — real corpus, 60 s cap, `load average 0.17` at start
+
+| instance | arm | status | objective | bound | nodes | wall | clauses | literal occ. | weight vars | rows | Jac. nnz |
+|---|---|---|---|---|---|---|---|---|---|---|---|
+| jobshop | big-m | optimal | 11 | 11 | 13 | 0.32 s | – | – | 6 | 12 | 30 |
+| jobshop | hull | optimal | 11 | 11 | 7 | 0.04 s | – | – | 6 | 42 | 96 |
+| jobshop | **simplex** | optimal | 11 | 11 | **251** | **4.82 s** | 3 | 6 | 6 | 6 | 18 |
+| ex1_linan_2023 | big-m | optimal | −0.9996 | −0.9996 | 15 | 5.31 s | – | – | 9 | 20 | 45 |
+| ex1_linan_2023 | hull | optimal | −0.9996 | −0.9996 | 9 | 5.86 s | – | – | 9 | 40 | 92 |
+| ex1_linan_2023 | **simplex** | **feasible** | −0.9996 | −1.0166 | 437 | **60.1 s (cap)** | 48 | 224 | 224 | 96 | 144 |
+| small_batch | big-m | optimal | 167427.66 | 167427.65 | 3 | 7.21 s | – | – | 9 | 34 | 73 |
+| small_batch | hull | optimal | 167427.66 | 167427.65 | 3 | 10.07 s | – | – | 9 | 55 | 121 |
+| small_batch | **simplex** | optimal | 167427.66 | 167427.65 | 3 | 11.66 s | 24 | 72 | 72 | 48 | 100 |
+
+Two independent runs gave identical node counts (251 / 437 / 3), so the ordering is
+not a timing artefact. **0 of 3 instances** meet the kill criterion, and
+`ex1_linan_2023` regresses from certified to uncertified. The size table is also the
+answer to #1182's requirement 4: on `ex1_linan_2023` the *declared* rows barely move
+while clauses go 0 → 48 and weight variables 9 → 224, because each `a == v` disjunct
+is two predicates and CNF distribution is multiplicative (2⁴ + 2⁵ = 48 clauses). A
+clause count alone would have hidden that.
+
+### E2 — the paper's own class, where CNF distribution is a no-op
+
+Obstacle avoidance for a discrete-time double integrator: one 4-way disjunction of
+*single* linear predicates per step, i.e. 1 clause and 4 weights, the shape most
+favourable to the lowering. Two interleaved repetitions, 60 s cap:
+
+| steps | arm | status | objective | bound | nodes | wall (rep 0 / rep 1) |
+|---|---|---|---|---|---|---|
+| 3 | big-m | optimal | 15.2 | 15.2 | 97 | 0.89 s / 0.53 s |
+| 3 | hull | time_limit | – | 14.4 | 3999 / 4191 | 60.4 s / 60.1 s |
+| 3 | **simplex** | feasible | 15.2 | 15.156 | 761 | 31.8 s / 32.3 s |
+| 5 | big-m | optimal | 2.4414 | 2.4414 | 347 | 2.10 s / 2.28 s |
+| 5 | hull | time_limit | – | 2.4 | 2015 | 60.2 s / 60.2 s |
+| 5 | **simplex** | feasible | 2.4414 | 2.4 | 1433 / 1401 | 60.0 s / 60.1 s |
+
+The lowering finds the optimal incumbent and cannot close the gap; big-M certifies in
+under 3 s. So the loss is not an artefact of instance selection — it holds on the
+class the mechanism was designed for. **The speed motive is falsified and recorded as
+such: `"simplex"` is opt-in, is never selected by `gdp_method="auto"`, and this
+section is the reason.**
+
+### E3/E5 — what survives: a capability, not a speed claim
+
+discopt's big-M pass refuses a disjunct row whose interval enclosure is unbounded;
+the Furman–Sawaya–Grossmann hull refuses a row that is not finite at the origin
+(`HullPerspectiveOriginError`). Theorem 1 needs neither. E3 measures all four cells:
+
+| fixture | big-m | hull | simplex |
+|---|---|---|---|
+| unbounded `x` in `x <= 1` | **refused** | optimal | optimal |
+| finite box (control) | optimal | optimal | optimal |
+| `log(x) <= 0`, `x` unbounded above | optimal | **refused** | optimal |
+| `1/x <= 1` on a box straddling 0 | **refused** | **refused** | **optimal, bound 0** |
+
+The last row is a class no lowering in this tree could handle before. E5 asks how
+often it occurs on a real corpus rather than in a constructed fixture (the #727 RLT
+lesson), scanning every disjunct row of 17 GDPlib models with Pyomo's own interval
+propagation and an origin evaluation:
+
+| | disjunct rows | unbounded enclosure (big-M refuses) | non-finite at origin (hull refuses) | both |
+|---|---|---|---|---|
+| **17 GDPlib models** | **11,058** | 18 | 79 | **18** |
+
+The 79 are `gdp_col` (28), `hda` (33) and `stranded_gas` (18); the 18 that hit both
+are `stranded_gas`, where the row is `log` of a capacity sum whose box includes 0 —
+an economy-of-scale sizing idiom, not a one-off. That is the concrete fixture #1182's
+entry condition asks for, and it is a *capability* fixture: on those rows the exact
+continuous lowering is not faster than the alternatives, it is the only one there is.
+
+**Retraction of the framing in #1182's own text.** The issue asks for "a model where
+the deferred lowering is expected to beat the exact GDP/SOS1 path" and reads that as a
+performance question. E1/E2 answer it negatively and that answer is binding: no
+default may be changed on this mechanism, and any future claim that it is faster owes
+a measurement that contradicts these two tables first.

--- a/docs/disjunction_semantics.md
+++ b/docs/disjunction_semantics.md
@@ -192,9 +192,12 @@ $$\sum_j \lambda_{ij}\,p_{ij}(z) \le 0,\qquad \lambda_i \ge 0,\qquad \sum_j \lam
 A discopt disjunction is $\bigvee_j \bigwedge_k c_{jk}$, so CNF conversion
 distributes over the conjunctions and produces $\prod_j |P_j|$ clauses, where an
 equality row counts as **two** predicates. That blowup is real and is refused above
-`MAX_CNF_CLAUSES` rather than expanded silently; the four size quantities — clauses,
+`MAX_CNF_CLAUSES` rather than expanded silently; the size quantities — clauses,
 literal occurrences, weight variables, rows — are recorded **separately** on
 `Model._simplex_lowerings`, because reducing one says nothing about the others.
+The fourth quantity, structural Jacobian nonzeros, is a whole-model number and is
+read with `structural_jacobian_nonzeros(lowered_model)`; it refuses a model still
+carrying a disjunction rather than counting that row as zero.
 
 ### What it guarantees, and what it does not
 
@@ -236,8 +239,11 @@ point:
 
 ### Why it is not the default
 
-On every corpus benchmarked in #1182 it is slower than big-M and certifies strictly
-less. It exists for the disjunct rows the other two lowerings **refuse**: big-M
+On every corpus benchmarked in #1182 it is slower than big-M and never certifies
+more. On general disjunctions it certifies strictly less; on the MPEC models, where
+the exact SOS1 and GDP encodings are also available, all four certify the same
+optimum and the lowering is 100–250× slower in wall time with a mixed node-count
+signal. It exists for the disjunct rows the other two lowerings **refuse**: big-M
 raises when a row's interval enclosure is unbounded, and hull raises
 `HullPerspectiveOriginError` when the row is not finite at the origin. Theorem 1
 needs neither — its weights are bounded by construction and it forms no perspective.

--- a/docs/disjunction_semantics.md
+++ b/docs/disjunction_semantics.md
@@ -174,3 +174,72 @@ Two rules follow, and both are load-bearing:
    bound on a minimum; a dual bound is the certificate and never comes from a local
    solve. This asymmetry is what lets a local mode warm-start the global solver
    without contaminating it.
+
+## 7. The exact continuous (simplex/CNF) lowering — `gdp_method="simplex"`
+
+Issue #1182 (deferred from RFC #1123) adds a third exact lowering beside big-M and
+hull, implemented in `discopt._relax.simplex_lowering`. It is **opt-in**, and the
+reasons it is opt-in are measurements, recorded in `docs/dev/performance-plan.md`
+§26 with the probes in `scratchpad/issue1182/`.
+
+### What it emits
+
+Theorem 1 of Wehbeh & Kerrigan ([arXiv:2601.03906v1](https://arxiv.org/abs/2601.03906v1))
+replaces a CNF clause $\bigvee_j [p_{ij}(z) \le 0]$ with
+
+$$\sum_j \lambda_{ij}\,p_{ij}(z) \le 0,\qquad \lambda_i \ge 0,\qquad \sum_j \lambda_{ij} = 1 .$$
+
+A discopt disjunction is $\bigvee_j \bigwedge_k c_{jk}$, so CNF conversion
+distributes over the conjunctions and produces $\prod_j |P_j|$ clauses, where an
+equality row counts as **two** predicates. That blowup is real and is refused above
+`MAX_CNF_CLAUSES` rather than expanded silently; the four size quantities — clauses,
+literal occurrences, weight variables, rows — are recorded **separately** on
+`Model._simplex_lowerings`, because reducing one says nothing about the others.
+
+### What it guarantees, and what it does not
+
+- **Exact in projection onto the model variables.** The lifted problem stays
+  nonconvex; exactness is a statement about the projected feasible set. Because the
+  objective is a function of the source variables, a certified global solve of the
+  lowered model is a certificate for the source model — this path introduces no
+  local-only result and needs no local/certified distinction of its own (§6).
+- **`ONE_WAY` activation only.** `EXACTLY_ONE_TRUE` is refused, not approximated:
+  §3.1 of the paper represents strict negation with an existential exponential lift,
+  and substituting a closed inequality or a fixed margin would change the declared
+  feasible set (§5's rule).
+
+### The weights are witnesses, not selectors
+
+$\lambda_{ij}$ is an **existential witness** for "some literal of clause $i$ holds".
+By §4's taxonomy it is an existential compiler auxiliary — but unlike a selector
+binary it is *continuous* in $[0, 1]$, so:
+
+- a fractional $\lambda$ at a feasible point is **not** failed Boolean integrality,
+  and must never be reported as one;
+- it must not be turned into a recovered named Boolean assignment. Reading truth off
+  the weighted row is wrong in a way the source rows expose: at $\lambda = (0.4, 0.6)$
+  with $p_1 = 2$ and $p_2 = -4$ the weighted row reads $-1.6 \le 0$ while the first
+  literal is violated by $2$.
+
+The supported questions are answered on the **declared** predicates at the returned
+point:
+
+- `disjunction_residuals(model, point)` — per disjunction, $\min_j \max_k p_{jk}(z)$,
+  each residual carrying the definition string that produced it. The point is an
+  argument, never cached state, so a report taken elsewhere cannot stand in for
+  source validation. A model declaring no disjunction raises rather than returning an
+  empty report that would read as a pass.
+- `selected_disjuncts(model, point)` — which disjuncts actually hold. The answer is a
+  **set**: under `SELECT_ONE` a point may lie in several disjuncts (§2), and it is
+  empty when the disjunction is violated, which callers must treat as a failed
+  validation rather than as "the first disjunct".
+
+### Why it is not the default
+
+On every corpus benchmarked in #1182 it is slower than big-M and certifies strictly
+less. It exists for the disjunct rows the other two lowerings **refuse**: big-M
+raises when a row's interval enclosure is unbounded, and hull raises
+`HullPerspectiveOriginError` when the row is not finite at the origin. Theorem 1
+needs neither — its weights are bounded by construction and it forms no perspective.
+Scanning 11,058 GDPlib disjunct rows found 18 (in `stranded_gas`, `log` of a capacity
+sum whose box includes 0) that hit **both** refusals.

--- a/python/discopt/__init__.py
+++ b/python/discopt/__init__.py
@@ -108,6 +108,12 @@ if (
         _os.environ.setdefault("JAX_PERSISTENT_CACHE_MIN_COMPILE_TIME_SECS", "0")
         _os.environ.setdefault("JAX_PERSISTENT_CACHE_MIN_ENTRY_SIZE_BYTES", "0")
 
+from discopt._relax.simplex_lowering import (
+    disjunction_residuals as disjunction_residuals,
+)
+from discopt._relax.simplex_lowering import (
+    selected_disjuncts as selected_disjuncts,
+)
 from discopt.callbacks import (
     CallbackContext as CallbackContext,
 )

--- a/python/discopt/_relax/gdp_reformulate.py
+++ b/python/discopt/_relax/gdp_reformulate.py
@@ -3,6 +3,12 @@
 Converts indicator constraints, disjunctive constraints, and SOS constraints
 into standard MINLP constraints via big-M reformulation.
 
+Disjunctions additionally support ``"hull"``, ``"mbigm"``, ``"auto"`` and the
+exact *continuous* ``"simplex"`` lowering of #1182 (Theorem 1 of
+arXiv:2601.03906v1, implemented in :mod:`discopt._relax.simplex_lowering`).
+``"simplex"`` emits no selector binary at all; see that module for why it is
+opt-in and which disjunct rows only it can lower.
+
 The reformulation is applied as a preprocessing step before the model is
 passed to the NLP evaluator and solver. If no GDP constraints exist, the
 original model is returned unchanged (zero overhead).
@@ -111,10 +117,17 @@ def reformulate_gdp(
     method : str, default "big-m"
         Reformulation method for disjunctive constraints:
         ``"big-m"`` (default), ``"hull"`` (convex hull),
-        ``"mbigm"`` (multiple big-M with LP-based tightening), or
+        ``"mbigm"`` (multiple big-M with LP-based tightening),
         ``"auto"`` to dispatch per-disjunction via the F1 advisor in
         :mod:`discopt._relax.gdp_advisor` (each disjunction independently
-        gets the structurally-best of the three).
+        gets the structurally-best of the three), or ``"simplex"`` for the exact
+        continuous CNF lowering of #1182
+        (:mod:`discopt._relax.simplex_lowering`), which introduces continuous
+        weights in ``[0, 1]`` instead of selector binaries. ``"simplex"`` is
+        measurably slower than big-M/hull on the corpora benchmarked in #1182
+        and exists for the disjunct rows neither of them can lower at all
+        (unbounded interval enclosure *and* non-finite at the origin); it is
+        never selected by ``"auto"``.
         Indicator and SOS constraints always use big-M regardless.
     respect_disjunction_methods : bool, default True
         Whether a disjunction-local ``method`` override should take precedence
@@ -175,6 +188,27 @@ def reformulate_gdp(
         new_model._variables.append(var)
         return var
 
+    _weight_counter = [0]
+
+    def _add_simplex_weight(size: int) -> Variable:
+        """Allocate one Theorem-1 weight vector: continuous, in ``[0, 1]``.
+
+        Continuous **on purpose**: these are existential witnesses, not
+        selectors, so a fractional value at a feasible point is not a failed
+        Boolean integrality (#1182 requirement 1).
+        """
+        from discopt._relax.simplex_lowering import SIMPLEX_WEIGHT_PREFIX
+
+        name = f"{SIMPLEX_WEIGHT_PREFIX}{_weight_counter[0]}"
+        _weight_counter[0] += 1
+        while name in _taken:
+            name = f"{SIMPLEX_WEIGHT_PREFIX}{_weight_counter[0]}"
+            _weight_counter[0] += 1
+        _taken.add(name)
+        var = Variable(name, VarType.CONTINUOUS, (size,), 0.0, 1.0, new_model)
+        new_model._variables.append(var)
+        return var
+
     # In auto mode, ask the F1 advisor for a per-disjunction
     # recommendation up front; if any disjunction (or indicator) is
     # routed to mbigm we still need the LP relaxation precomputed.
@@ -202,7 +236,11 @@ def reformulate_gdp(
                 chosen = override
             else:
                 chosen = auto_advice.get(ci, method) if method == "auto" else method
-            if chosen == "hull":
+            if chosen == "simplex":
+                new_vars, new_cons = _reformulate_disjunction_simplex(
+                    c, new_model, _add_simplex_weight, ci
+                )
+            elif chosen == "hull":
                 new_vars, new_cons = _reformulate_disjunction_hull(c, new_model, _add_aux_binary)
             else:
                 # big-m and mbigm both go through _reformulate_disjunction;
@@ -941,6 +979,32 @@ def _reformulate_disjunction(
                 )
 
     return new_vars, new_cons
+
+
+def _reformulate_disjunction_simplex(
+    dc: _DisjunctiveConstraint,
+    model: Model,
+    add_weight,
+    index: int,
+) -> tuple[list[Variable], list[Constraint]]:
+    """Reformulate a disjunction with the exact continuous lowering of #1182.
+
+    Thin adapter over :func:`discopt._relax.simplex_lowering.
+    lower_disjunction_simplex`: the mathematics, the refusals and the size
+    accounting live there. The record is appended to ``model._simplex_lowerings``
+    so the four size quantities of #1182 requirement 4 stay inspectable after
+    the pass, and so a caller can see which disjunctions became witnesses rather
+    than selectors.
+
+    ``new_vars`` is returned empty on purpose: the weight variables are already
+    registered on ``model`` by ``add_weight`` (as ``_add_aux_binary`` does for
+    selectors), and the caller uses the returned list only for logging.
+    """
+    from discopt._relax.simplex_lowering import lower_disjunction_simplex
+
+    record, rows = lower_disjunction_simplex(dc, add_weight, index=index)
+    model._simplex_lowerings.append(record)
+    return [], rows
 
 
 def _reformulate_disjunction_nested(

--- a/python/discopt/_relax/simplex_lowering.py
+++ b/python/discopt/_relax/simplex_lowering.py
@@ -89,6 +89,7 @@ from dataclasses import dataclass, field
 import numpy as np
 
 from discopt.modeling.core import (
+    GDP_AUX_PREFIX,
     Constraint,
     DisjunctionSemantics,
     Expression,
@@ -113,8 +114,11 @@ __all__ = [
 ]
 
 #: Name prefix of the Theorem-1 weight variables. They are *witnesses*, not
-#: selectors — see the module docstring.
-SIMPLEX_WEIGHT_PREFIX = "_simplex_lam_"
+#: selectors — see the module docstring. Built on ``GDP_AUX_PREFIX`` on purpose:
+#: that is the namespace ``Model._check_name`` refuses to user-facing factories
+#: (``docs/disjunction_semantics.md`` §4), so a user variable cannot collide with
+#: a weight, and the existential-auxiliary status is visible in the name.
+SIMPLEX_WEIGHT_PREFIX = f"{GDP_AUX_PREFIX}simplex_lam_"
 
 #: Clause budget per disjunction. CNF distribution is multiplicative in the
 #: disjunct sizes, so a disjunction of four 3-row disjuncts is already 81

--- a/python/discopt/_relax/simplex_lowering.py
+++ b/python/discopt/_relax/simplex_lowering.py
@@ -1,0 +1,458 @@
+r"""Exact continuous (simplex/CNF) lowering of disjunctions — issue #1182.
+
+Theorem 1 of Wehbeh & Kerrigan, *Exact Continuous Reformulations of Logic
+Constraints in Nonlinear Optimization and Optimal Control Problems*
+(`arXiv:2601.03906v1 <https://arxiv.org/abs/2601.03906v1>`_), replaces a CNF
+clause :math:`\bigvee_j [p_{ij}(z) \le 0]` with
+
+.. math::
+
+    \sum_j \lambda_{ij}\, p_{ij}(z) \le 0, \qquad
+    \lambda_i \ge 0, \qquad \sum_j \lambda_{ij} = 1 .
+
+This is exact **in projection onto the original variables** ``z``: pick
+:math:`\lambda_i = e_k` for any satisfied literal ``k``, and conversely a convex
+combination of the :math:`p_{ij}` that is :math:`\le 0` forces
+:math:`\min_j p_{ij} \le 0`. The lifted problem stays nonconvex — exactness is a
+statement about the projected feasible set, never about convexity.
+
+A discopt disjunction is :math:`\bigvee_j \bigwedge_k c_{jk}`, so CNF conversion
+distributes,
+
+.. math::
+
+    \bigvee_j \bigwedge_k p_{jk}
+    \;=\; \bigwedge_{(k_1,\dots,k_J)} \bigl(\textstyle\bigvee_j p_{j,k_j}\bigr),
+
+with :math:`\prod_j |P_j|` clauses. Each equality row ``h == 0`` is two
+predicates (``h <= 0`` and ``-h <= 0``), which is where the blowup comes from on
+grid-style GDPs — measured, not hidden: :class:`LoweringSizes` reports clauses,
+literal occurrences and weight variables **separately**, and a disjunction whose
+clause count exceeds :data:`MAX_CNF_CLAUSES` is refused loudly rather than
+silently expanded.
+
+Why this is **not** the default (measured, #1182)
+-------------------------------------------------
+The entry experiment (``scratchpad/issue1182/``) compared this lowering against
+big-M and hull, both solved by the same certified global path:
+
+* On the in-repo native GDP corpus (jobshop, ex1_linan_2023, small_batch) it was
+  slower on all three and failed to certify ``ex1_linan_2023`` at all within
+  60 s, where big-M and hull certify in ~6 s.
+* On the paper's own class — obstacle-avoidance optimal control, where the CNF
+  distribution is a no-op — it also failed to certify what big-M certifies.
+
+So the *performance* motive for this lowering is falsified for certified global
+solving, and ``"simplex"`` is opt-in. What survives, and is why it exists, is a
+**capability**: discopt's big-M pass refuses a disjunct row whose interval
+enclosure is unbounded, and the Furman–Sawaya–Grossmann hull refuses a row that
+is not finite at the origin (:class:`~discopt._relax.gdp_reformulate.
+HullPerspectiveOriginError`). Theorem 1 needs neither — its weights are bounded
+in ``[0, 1]`` by construction and it forms no perspective. Scanning 11,058
+GDPlib disjunct rows found 18 rows (in ``stranded_gas``, ``log`` of a capacity
+sum whose box includes 0) that hit **both** refusals, i.e. rows no lowering in
+this tree could handle before.
+
+Those two refusals are **not** guards this lowering steps around. Each is a
+statement about its own lowering's validity: a fabricated finite ``M``, or a
+fabricated ``g(0)``, produces rows that are not the declared feasible set. Theorem
+1 fabricates neither quantity because it needs neither. What it hands the
+relaxation layer is an ordinary algebraic row — ``sum_j lambda_ij p_ij(z) <= 0``
+— of exactly the kind an unlowered model may already contain (discopt accepts
+``1/x <= 1`` on a zero-straddling box as a plain constraint today), so the
+soundness question it raises is the relaxation layer's usual one and not a new
+exemption.
+
+The weights are witnesses, not selectors
+----------------------------------------
+:math:`\lambda_{ij}` is an *existential witness* for "some literal of clause i
+holds". It is a continuous variable in ``[0, 1]``, never a binary, so a
+fractional value is not failed Boolean integrality; and it must not be turned
+into a named Boolean assignment. The honest answer to "which disjunct holds?" is
+:func:`selected_disjuncts`, which reads the **declared source predicates** at the
+returned point and can legitimately return more than one disjunct when they
+overlap. :func:`disjunction_residuals` likewise measures the source rows, not the
+weighted rows, so neither a satisfied weighted row nor a report cached at another
+point can stand in for source validation.
+
+Because the lowering is exact in projection, a certified global solve of the
+lowered model is a certificate for the source model; this path introduces no
+local-only result, so it needs no local/certified status distinction of its own.
+"""
+
+from __future__ import annotations
+
+import itertools
+import math
+from dataclasses import dataclass, field
+
+import numpy as np
+
+from discopt.modeling.core import (
+    Constraint,
+    DisjunctionSemantics,
+    Expression,
+    Model,
+    SelectorActivation,
+    _DisjunctiveConstraint,
+)
+
+__all__ = [
+    "MAX_CNF_CLAUSES",
+    "SIMPLEX_WEIGHT_PREFIX",
+    "DisjunctionResidual",
+    "DisjunctionResidualReport",
+    "LoweringSizes",
+    "SimplexLoweringRecord",
+    "SimplexLoweringRefused",
+    "disjunction_residuals",
+    "lower_disjunction_simplex",
+    "selected_disjuncts",
+]
+
+#: Name prefix of the Theorem-1 weight variables. They are *witnesses*, not
+#: selectors — see the module docstring.
+SIMPLEX_WEIGHT_PREFIX = "_simplex_lam_"
+
+#: Clause budget per disjunction. CNF distribution is multiplicative in the
+#: disjunct sizes, so a disjunction of four 3-row disjuncts is already 81
+#: clauses. Exceeding this is refused rather than expanded, because the cost is
+#: not visible in the model the user wrote.
+MAX_CNF_CLAUSES = 1024
+
+
+class SimplexLoweringRefused(ValueError):
+    """The disjunction is outside Theorem 1's contract, or exceeds the CNF budget.
+
+    A refusal, never a fallback: every case here would otherwise be lowered to
+    something that is *not* the declared feasible set (CLAUDE.md §3).
+    """
+
+
+@dataclass
+class LoweringSizes:
+    """The four size quantities of #1182 requirement 4, counted **separately**.
+
+    They are deliberately not summed into one "model size": the temporal
+    constructions of the paper reduce clause counts, and that alone says nothing
+    about literal occurrences, weight variables or Jacobian structure.
+    """
+
+    disjunctions: int = 0
+    cnf_clauses: int = 0
+    literal_occurrences: int = 0
+    weight_variables: int = 0
+    rows: int = 0
+
+    def add(self, other: "LoweringSizes") -> None:
+        self.disjunctions += other.disjunctions
+        self.cnf_clauses += other.cnf_clauses
+        self.literal_occurrences += other.literal_occurrences
+        self.weight_variables += other.weight_variables
+        self.rows += other.rows
+
+
+@dataclass
+class SimplexLoweringRecord:
+    """What one disjunction was lowered to.
+
+    Carries no selector and no Boolean assignment, by design: ``weight_names``
+    names continuous witnesses, and reading a disjunct choice off them is the
+    error requirement 1 of #1182 exists to prevent. Use
+    :func:`selected_disjuncts`.
+    """
+
+    name: str
+    n_disjuncts: int
+    weight_names: list[str] = field(default_factory=list)
+    sizes: LoweringSizes = field(default_factory=LoweringSizes)
+
+
+@dataclass
+class DisjunctionResidual:
+    """Source-predicate residual of one disjunction at one point.
+
+    ``violation`` is ``min_j max_k p_jk(z)`` over the **declared** disjunct rows:
+    ``<= 0`` exactly when some disjunct holds. ``definition`` travels with the
+    number so a residual can never be read as a different quantity.
+    """
+
+    name: str
+    per_disjunct: list[float]
+    violation: float
+    definition: str = "min_j max_k p_jk(z) over the declared disjunct rows"
+
+
+@dataclass
+class DisjunctionResidualReport:
+    """Residuals for every disjunction of a model at one specific point.
+
+    The point is an argument, not state: there is no cached report, so a report
+    taken at another point cannot stand in for source validation (#1182
+    requirement 3).
+    """
+
+    residuals: list[DisjunctionResidual] = field(default_factory=list)
+    comparisons: int = 0
+
+    @property
+    def max_violation(self) -> float:
+        """Worst source violation over all disjunctions.
+
+        Raises when the report measured nothing, so "no violations" can never be
+        the reading of a report that traversed no rows (CLAUDE.md §6).
+        """
+        if not self.residuals:
+            raise ValueError(
+                "no disjunction was measured; a max violation over an empty "
+                "report would read as a pass"
+            )
+        return max(r.violation for r in self.residuals)
+
+
+# ── predicate normalization ──────────────────────────────────────────────────
+
+
+def _require_scalar(body: Expression, where: str) -> None:
+    try:
+        shape = body.shape
+    except AttributeError:
+        # Shape not statically known (reductions, matmul, ...). A reduction is a
+        # scalar; anything else would need per-element weights.
+        return
+    if shape not in ((), (1,)):
+        raise SimplexLoweringRefused(
+            f"{where}: disjunct row has shape {shape}; Theorem 1 needs one weight "
+            "per literal, so a vector row would need per-element weights and a "
+            "per-element CNF distribution. Expand the row into scalar rows "
+            "(one Constraint per element) or use gdp_method='big-m'/'hull'."
+        )
+
+
+def _predicates_of(con: Constraint, where: str) -> list[Expression]:
+    """Normalize one disjunct row to the predicates ``p`` meaning ``p <= 0``."""
+    if isinstance(con, _DisjunctiveConstraint):
+        raise SimplexLoweringRefused(
+            f"{where}: a nested disjunction is not an algebraic predicate. "
+            "Theorem 1 is stated over predicates p(z) <= 0; flatten the nesting "
+            "or use gdp_method='big-m'."
+        )
+    if not isinstance(con, Constraint):
+        raise SimplexLoweringRefused(
+            f"{where}: disjunct row is a {type(con).__name__}, not a Constraint."
+        )
+    if con.rhs != 0.0:
+        raise SimplexLoweringRefused(
+            f"{where}: non-normalized rhs {con.rhs!r}; rows must be 'body sense 0'."
+        )
+    _require_scalar(con.body, where)
+    if con.sense == "<=":
+        return [con.body]
+    if con.sense == ">=":
+        return [-con.body]
+    if con.sense == "==":
+        # An equality is a conjunction of two predicates, and CNF distribution is
+        # multiplicative over it — the source of the blowup measured in #1182.
+        return [con.body, -con.body]
+    raise SimplexLoweringRefused(f"{where}: unknown constraint sense {con.sense!r}")
+
+
+def _require_projection_semantics(dc: _DisjunctiveConstraint, where: str) -> None:
+    semantics = getattr(dc, "semantics", DisjunctionSemantics.SELECT_ONE)
+    if semantics.activation is not SelectorActivation.ONE_WAY:
+        raise SimplexLoweringRefused(
+            f"{where}: declares DisjunctionSemantics.{semantics.name}, whose "
+            f"activation is {semantics.activation.name}. Theorem 1 reproduces the "
+            "union of the disjuncts, i.e. ONE_WAY activation. REIFIED needs the "
+            "paper's §3.1 existential exponential lift for strict negation; "
+            "substituting a closed inequality or a fixed margin would change the "
+            "declared feasible set, so this is refused rather than approximated."
+        )
+
+
+# ── the lowering ─────────────────────────────────────────────────────────────
+
+
+def lower_disjunction_simplex(
+    dc: _DisjunctiveConstraint,
+    add_weight,
+    *,
+    index: int = 0,
+    max_clauses: int = MAX_CNF_CLAUSES,
+) -> tuple[SimplexLoweringRecord, list[Constraint]]:
+    """Emit Theorem 1's rows for one disjunction.
+
+    Parameters
+    ----------
+    dc
+        The declared disjunction. Its rows are read, never mutated.
+    add_weight
+        ``add_weight(size) -> Variable`` allocating a continuous weight vector in
+        ``[0, 1]`` on the model being built.
+    index
+        Position of ``dc`` in the source constraint list, used only for naming an
+        anonymous disjunction.
+    max_clauses
+        Per-disjunction CNF budget; exceeding it raises
+        :class:`SimplexLoweringRefused`.
+
+    Returns
+    -------
+    (record, rows)
+        ``record`` carries the size counts and the witness names; ``rows`` are
+        the constraints to add.
+    """
+    name = dc.name or f"disj{index}"
+    where = f"simplex lowering of {name!r}"
+    _require_projection_semantics(dc, where)
+
+    per_disjunct: list[list[Expression]] = []
+    for j, disjunct in enumerate(dc.disjuncts):
+        preds: list[Expression] = []
+        for con in disjunct:
+            preds.extend(_predicates_of(con, f"{where}, disjunct {j}"))
+        if not preds:
+            raise SimplexLoweringRefused(
+                f"{where}: disjunct {j} declares no rows, so it is satisfied by "
+                "every point and the disjunction is vacuous. Remove it or state "
+                "the intended predicate."
+            )
+        per_disjunct.append(preds)
+
+    n_disjuncts = len(per_disjunct)
+    n_clauses = math.prod(len(p) for p in per_disjunct)
+    if n_clauses > max_clauses:
+        sizes = [len(p) for p in per_disjunct]
+        raise SimplexLoweringRefused(
+            f"{where}: CNF distribution over disjunct predicate counts {sizes} "
+            f"yields {n_clauses} clauses ({n_clauses * n_disjuncts} literal "
+            f"occurrences and as many weight variables), above the budget of "
+            f"{max_clauses}. Each equality row counts twice. Raise max_clauses "
+            "deliberately, or use gdp_method='big-m'/'hull', whose size is "
+            "linear in the disjunct rows."
+        )
+
+    record = SimplexLoweringRecord(
+        name=name,
+        n_disjuncts=n_disjuncts,
+        sizes=LoweringSizes(
+            disjunctions=1,
+            cnf_clauses=n_clauses,
+            literal_occurrences=n_clauses * n_disjuncts,
+            weight_variables=n_clauses * n_disjuncts,
+            rows=2 * n_clauses,
+        ),
+    )
+
+    rows: list[Constraint] = []
+    for i, clause in enumerate(itertools.product(*per_disjunct)):
+        lam = add_weight(n_disjuncts)
+        record.weight_names.append(lam.name)
+
+        simplex_body: Expression = lam[0]
+        weighted: Expression = lam[0] * clause[0]
+        for j in range(1, n_disjuncts):
+            simplex_body = simplex_body + lam[j]
+            weighted = weighted + lam[j] * clause[j]
+
+        rows.append(
+            Constraint(
+                body=simplex_body - 1.0,
+                sense="==",
+                rhs=0.0,
+                name=f"_simplex_{name}_c{i}_weights",
+            )
+        )
+        rows.append(
+            Constraint(
+                body=weighted,
+                sense="<=",
+                rhs=0.0,
+                name=f"_simplex_{name}_c{i}_clause",
+            )
+        )
+    return record, rows
+
+
+# ── source-predicate validation (requirement 1) ──────────────────────────────
+
+
+def _flat_point(model: Model, x_by_name) -> np.ndarray:
+    parts = []
+    for v in model._variables:
+        if x_by_name is None or v.name not in x_by_name:
+            raise KeyError(
+                f"variable {v.name!r} is absent from the point handed in; a source "
+                "residual is measured on the declared operands and cannot be "
+                "reconstructed from the lowered rows"
+            )
+        arr = np.asarray(x_by_name[v.name], dtype=np.float64).reshape(-1)
+        if arr.size != v.size:
+            raise ValueError(f"{v.name}: expected {v.size} value(s) in the point, got {arr.size}")
+        parts.append(arr)
+    return np.concatenate(parts) if parts else np.zeros(0, dtype=np.float64)
+
+
+def _residual_of(model: Model, dc: _DisjunctiveConstraint, name: str, flat, counter):
+    from discopt._relax.dag_compiler import compile_expression
+
+    per_disjunct: list[float] = []
+    for j, disjunct in enumerate(dc.disjuncts):
+        worst = -math.inf
+        for con in disjunct:
+            for body in _predicates_of(con, f"residual of {name!r}, disjunct {j}"):
+                value = float(np.max(np.asarray(compile_expression(body, model)(flat))))
+                worst = max(worst, value)
+                counter[0] += 1
+        per_disjunct.append(worst)
+    return DisjunctionResidual(name=name, per_disjunct=per_disjunct, violation=min(per_disjunct))
+
+
+def disjunction_residuals(model: Model, point) -> DisjunctionResidualReport:
+    """Measure every disjunction of ``model`` at ``point``, on the SOURCE rows.
+
+    ``model`` is the model **as written** — the one still carrying its
+    ``either_or`` disjunctions — and ``point`` is a ``{name: value}`` mapping such
+    as :attr:`SolveResult.x`. Auxiliary entries in ``point`` (selector binaries,
+    hull disaggregates, Theorem-1 weights) are ignored: the residual is a function
+    of the declared operands and the source variables only.
+
+    Raises rather than returning an empty report when ``model`` declares no
+    disjunction, so "no violations" can never be the reading of a probe that
+    traversed nothing (CLAUDE.md §6).
+    """
+    flat = _flat_point(model, point)
+    counter = [0]
+    report = DisjunctionResidualReport()
+    for index, c in enumerate(model._constraints):
+        if isinstance(c, _DisjunctiveConstraint):
+            name = c.name or f"disj{index}"
+            report.residuals.append(_residual_of(model, c, name, flat, counter))
+    report.comparisons = counter[0]
+    if not report.residuals:
+        raise ValueError(
+            "the model declares no disjunction, so this report would measure "
+            "nothing; check you passed the model as written, not a lowered copy"
+        )
+    return report
+
+
+def selected_disjuncts(model: Model, point, *, tolerance: float = 1e-6) -> dict[str, list[int]]:
+    """Which disjuncts actually hold at ``point``, read off the source predicates.
+
+    This is the honest replacement for reading a disjunct choice off a selector:
+    under the Theorem-1 lowering there is no selector, and the weights are
+    existential witnesses that may be fractional at a perfectly feasible point.
+
+    Returns a mapping from disjunction name to the list of disjunct indices whose
+    rows all hold within ``tolerance``. The list may hold **more than one** index
+    when the disjuncts overlap — ``SELECT_ONE`` selects one disjunct but does not
+    forbid a point from lying in another — and is empty when the disjunction is
+    violated at this point, which callers must treat as a failed validation
+    rather than as "the first disjunct".
+    """
+    report = disjunction_residuals(model, point)
+    return {
+        r.name: [j for j, v in enumerate(r.per_disjunct) if v <= tolerance]
+        for r in report.residuals
+    }

--- a/python/discopt/_relax/simplex_lowering.py
+++ b/python/discopt/_relax/simplex_lowering.py
@@ -94,6 +94,7 @@ from discopt.modeling.core import (
     Expression,
     Model,
     SelectorActivation,
+    Variable,
     _DisjunctiveConstraint,
 )
 
@@ -108,6 +109,7 @@ __all__ = [
     "disjunction_residuals",
     "lower_disjunction_simplex",
     "selected_disjuncts",
+    "structural_jacobian_nonzeros",
 ]
 
 #: Name prefix of the Theorem-1 weight variables. They are *witnesses*, not
@@ -150,6 +152,63 @@ class LoweringSizes:
         self.literal_occurrences += other.literal_occurrences
         self.weight_variables += other.weight_variables
         self.rows += other.rows
+
+
+def structural_jacobian_nonzeros(model: Model) -> int:
+    """Structural nonzeros of the constraint Jacobian: sum over rows of |vars(row)|.
+
+    The fourth quantity of #1182 requirement 4, and the one that is **not** a
+    per-disjunction property, so it lives here rather than on
+    :class:`LoweringSizes`: it is a whole-model number and only means anything
+    when compared between two lowerings of the same model. Structural, not
+    numeric — a coefficient that happens to be zero at some point still occupies
+    a Jacobian entry, and the point is to compare sparsity patterns.
+
+    Rows a lowering did not produce (indicator, SOS and logical constraints, and
+    any disjunction left unlowered) are **not** silently skipped: they are not
+    ``Constraint`` rows, and counting them as zero would understate the pattern,
+    so this refuses when it meets one.
+    """
+    from discopt.modeling.core import _DisjunctiveConstraint as _DC
+
+    nnz = 0
+    for index, row in enumerate(model._constraints):
+        if isinstance(row, Constraint):
+            nnz += len(_variables_in(row.body))
+            continue
+        kind = "an unlowered disjunction" if isinstance(row, _DC) else type(row).__name__
+        raise ValueError(
+            f"constraint {index} is {kind}, which has no Jacobian row of its own; "
+            "count nonzeros on the LOWERED model, where every row is algebraic, "
+            "or the comparison silently omits it"
+        )
+    return nnz
+
+
+def _variables_in(expr) -> set[str]:
+    """Names of the variables an expression touches (structural, not numeric)."""
+    seen: set[str] = set()
+    visited: set[int] = set()
+    stack = [expr]
+    while stack:
+        node = stack.pop()
+        if id(node) in visited:
+            continue
+        visited.add(id(node))
+        if isinstance(node, Variable):
+            seen.add(node.name)
+            continue
+        for attr in ("operands", "args", "children"):
+            kids = getattr(node, attr, None)
+            if kids:
+                stack.extend(kids)
+                break
+        else:
+            for attr in ("left", "right", "operand", "base", "expr", "body"):
+                kid = getattr(node, attr, None)
+                if kid is not None and not isinstance(kid, (int, float, str)):
+                    stack.append(kid)
+    return seen
 
 
 @dataclass

--- a/python/discopt/_relax/simplex_lowering.py
+++ b/python/discopt/_relax/simplex_lowering.py
@@ -277,12 +277,30 @@ class DisjunctionResidualReport:
 
 
 def _require_scalar(body: Expression, where: str) -> None:
+    """Refuse a disjunct row that is not statically one scalar predicate.
+
+    Theorem 1 weights **one literal**, so an array-valued row would need
+    per-element weights and a per-element CNF distribution. Rows whose shape is
+    not statically known (reductions, matmul, custom calls) are refused too, and
+    that is deliberate rather than conservative-by-accident: ``Expression.shape``
+    raises for both a scalar reduction and an array-valued one, and #1160 is
+    exactly the case where an axis-reduced sum turned out to be several rows
+    rather than one. Treating "shape unknown" as "scalar" would weight a vector
+    of predicates with a single lambda and silently emit a different feasible
+    set, so the unknown case takes the refusing branch (CLAUDE.md §3). big-M and
+    hull remain available for such a row.
+    """
     try:
         shape = body.shape
-    except AttributeError:
-        # Shape not statically known (reductions, matmul, ...). A reduction is a
-        # scalar; anything else would need per-element weights.
-        return
+    except AttributeError as exc:
+        raise SimplexLoweringRefused(
+            f"{where}: the disjunct row's shape is not statically known "
+            f"({exc}), so it cannot be established to be a single scalar "
+            "predicate. Theorem 1 weights one literal per disjunct; an "
+            "array-valued row (an axis-reduced sum, a matmul) would need "
+            "per-element weights. Expand the row into scalar rows, or use "
+            "gdp_method='big-m'/'hull'."
+        ) from exc
     if shape not in ((), (1,)):
         raise SimplexLoweringRefused(
             f"{where}: disjunct row has shape {shape}; Theorem 1 needs one weight "

--- a/python/discopt/modeling/core.py
+++ b/python/discopt/modeling/core.py
@@ -2774,6 +2774,13 @@ class Model:
         # each; the mark lived on the relation as weakrefs first and the method
         # as a plain field, and both were wrong for the same reason.
         self._lowered_complementarities: dict = {}
+        # Size accounting for the #1182 exact continuous (simplex/CNF) lowering,
+        # one ``SimplexLoweringRecord`` per disjunction that pass handled. Empty
+        # on every other GDP method and on any model that was never lowered, so
+        # a reader never has to ask whether the attribute exists. Declared here
+        # rather than attached by the pass so the four size quantities of #1182
+        # requirement 4 survive pickling and copying with the model.
+        self._simplex_lowerings: list = []
         # Decomposition annotations (Benders / Lagrangian). Populated by
         # ``set_stage``/``first_stage``/``second_stage``/``set_block``/
         # ``mark_coupling``; consumed by ``discopt.decomposition``. Empty by

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -7282,6 +7282,14 @@ def solve_model(
         - ``"big-m"`` (default), ``"hull"`` (convex hull), ``"mbigm"``,
           ``"auto"`` — reformulate disjunctions into a standard algebraic
           MIP/MINLP, then dispatch normally.
+        - ``"simplex"`` — the exact *continuous* CNF lowering of #1182
+          (:mod:`discopt._relax.simplex_lowering`): each disjunction becomes
+          continuous weights in ``[0, 1]`` on a simplex and no selector binary
+          at all. Exact in projection onto the model variables, so a certified
+          solve of the lowered model certifies the original. Measurably slower
+          than big-M/hull on every corpus benchmarked in #1182 and never chosen
+          by ``"auto"``; it exists for disjunct rows big-M and hull both refuse
+          (unbounded interval enclosure *and* non-finite at the origin).
         - ``"loa"`` — *native* logic-based Outer Approximation on the
           disjunctive form (dispatches to :func:`solve_gdpopt_loa`), not a
           reformulation.
@@ -7998,6 +8006,15 @@ def solve_model(
 
         gdp_methods = {"big-m", "hull", "mbigm", "auto"}
         native_gdp_methods = {"loa"}
+        if gdp_method == "simplex":
+            raise ValueError(
+                "gdp_method='simplex' lowers every disjunction to continuous "
+                "weights (#1182), leaving no selector binary for the MIP-NLP "
+                "family to branch or decompose on, so the combination is "
+                "contradictory rather than merely slow. Use the default solver "
+                "with gdp_method='simplex', or solver='mip-nlp' with "
+                f"gdp_method in {{{', '.join(sorted(repr(m) for m in gdp_methods))}}}."
+            )
         if gdp_method == "oa":
             warnings.warn(
                 "gdp_method='oa' is deprecated for selecting MINLP OA. Use "

--- a/python/tests/test_1182_simplex_lowering.py
+++ b/python/tests/test_1182_simplex_lowering.py
@@ -571,3 +571,22 @@ def test_a_weight_name_cannot_collide_with_a_user_variable():
     m, _x = _overlap_model()
     with pytest.raises(ValueError, match="reserved"):
         m.continuous(f"{SIMPLEX_WEIGHT_PREFIX}0", lb=0.0, ub=1.0)
+
+
+@pytest.mark.unit
+def test_a_row_whose_shape_is_not_statically_known_is_refused_not_assumed_scalar():
+    """ "Shape unknown" takes the refusing branch, not the scalar branch.
+
+    ``Expression.shape`` raises for a scalar reduction and for an array-valued
+    one alike, and #1160 is the case where an axis-reduced sum was several rows
+    rather than one. Weighting a vector of predicates with a single lambda would
+    emit a different feasible set, so the unknown case refuses.
+    """
+    m = dm.Model("unknown_shape")
+    a = m.continuous("a", (2, 3), lb=-1.0, ub=1.0)
+    m.minimize(a[0, 0])
+    row = dm.sum(a, axis=1) <= 0.0
+    dc = _DisjunctiveConstraint(disjuncts=[[row], [a[0, 0] >= 1.0]], name="u")
+    with pytest.raises(SimplexLoweringRefused) as exc:
+        lower_disjunction_simplex(dc, lambda size: _fake_weight(m, size, []))
+    assert "not statically known" in str(exc.value) or "shape" in str(exc.value)

--- a/python/tests/test_1182_simplex_lowering.py
+++ b/python/tests/test_1182_simplex_lowering.py
@@ -553,3 +553,21 @@ def test_jacobian_nonzeros_is_the_fourth_size_quantity_and_refuses_a_gdp_row():
 
     with pytest.raises(ValueError, match="unlowered disjunction"):
         structural_jacobian_nonzeros(build())
+
+
+@pytest.mark.unit
+def test_a_weight_name_cannot_collide_with_a_user_variable():
+    """The prefix lives inside the reserved ``GDP_AUX_PREFIX`` namespace.
+
+    ``docs/disjunction_semantics.md`` §4 makes that namespace the enforced
+    boundary between user Boolean identities and existential compiler
+    auxiliaries. A weight is the latter, so it belongs inside it — and
+    ``Model._check_name`` then keeps a user variable out of the namespace
+    rather than leaving the guarantee to a naming convention.
+    """
+    from discopt.modeling.core import GDP_AUX_PREFIX
+
+    assert SIMPLEX_WEIGHT_PREFIX.startswith(GDP_AUX_PREFIX)
+    m, _x = _overlap_model()
+    with pytest.raises(ValueError, match="reserved"):
+        m.continuous(f"{SIMPLEX_WEIGHT_PREFIX}0", lb=0.0, ub=1.0)

--- a/python/tests/test_1182_simplex_lowering.py
+++ b/python/tests/test_1182_simplex_lowering.py
@@ -1,0 +1,525 @@
+"""Issue #1182 — the exact continuous (simplex/CNF) lowering of disjunctions.
+
+Pins Theorem 1 of arXiv:2601.03906v1 as implemented in
+:mod:`discopt._relax.simplex_lowering`, and each requirement #1182 carries
+forward from @bernalde's comment on #1148:
+
+1. residuals are measured on the **original predicates** at the returned source
+   point, and the simplex weights are never reported as failed Boolean
+   integrality nor as recovered named Boolean assignments;
+3. the overlapping-disjunct and strict-boundary fixtures are reused, with a
+   **fractional-witness control** and a **stale-report control** — neither
+   weighted-row feasibility nor a report taken at another point may stand in for
+   source validation;
+4. CNF clauses, literal occurrences, weight variables and rows are counted
+   **separately**.
+
+Requirement 2 (the local-vs-certified distinction) has no surface here by
+construction: the lowering is exact in projection, this path introduces no local
+NLP arm, and a certified solve of the lowered model is a certificate for the
+source. The test ``test_a_simplex_solve_is_certified_and_agrees_with_big_m``
+is what holds that claim to a measurement.
+
+The discriminator for overlap/boundary is #1124's, reused verbatim:
+
+    min (x - 1/2)^2   s.t.   [x <= 1] or [x >= 0],   x in [-2, 3]
+
+whose optimum is 0 at x = 1/2 under SELECT_ONE, a point lying in **both**
+disjuncts — which is exactly the case a "recovered Boolean assignment" gets
+wrong.
+
+Per CLAUDE.md §6 the module counts its executed source-residual comparisons and
+a ``teardown_module`` hook fails the run if that count is zero. It is a teardown
+hook and not a test because this suite runs under ``pytest-randomly``: as a test
+it would be position-dependent, and a shuffle that ran it first would make the
+guard against measuring nothing itself measure nothing.
+"""
+
+import math
+
+import discopt.modeling as dm
+import numpy as np
+import pytest
+from discopt._relax.gdp_reformulate import (
+    HullPerspectiveOriginError,
+    reformulate_gdp,
+)
+from discopt._relax.simplex_lowering import (
+    MAX_CNF_CLAUSES,
+    SIMPLEX_WEIGHT_PREFIX,
+    DisjunctionResidualReport,
+    SimplexLoweringRefused,
+    disjunction_residuals,
+    lower_disjunction_simplex,
+    selected_disjuncts,
+)
+from discopt.modeling.core import (
+    DisjunctionSemantics,
+    VarType,
+    _DisjunctiveConstraint,
+)
+
+_COMPARISONS = [0]
+
+
+def _residuals(model, point):
+    """``disjunction_residuals`` plus the executed-comparison bookkeeping."""
+    report = disjunction_residuals(model, point)
+    _COMPARISONS[0] += report.comparisons
+    return report
+
+
+def teardown_module(module):  # noqa: ARG001
+    assert _COMPARISONS[0] > 0, (
+        "no source-predicate comparison was executed; a suite that measures "
+        "nothing reports 0 violations and reads as a pass (CLAUDE.md §6)"
+    )
+    print(f"\nexecuted source-predicate comparisons: {_COMPARISONS[0]}")
+
+
+# ── fixtures reused from the semantic-contract work (#1124) ──────────────────
+
+
+def _overlap_model():
+    """min (x - 1/2)^2 s.t. [x <= 1] or [x >= 0]; optimum 0 at x = 1/2, in BOTH."""
+    m = dm.Model("overlap")
+    x = m.continuous("x", lb=-2.0, ub=3.0)
+    m.minimize((x - 0.5) * (x - 0.5))
+    m.either_or([[x <= 1.0], [x >= 0.0]], name="ov")
+    return m, x
+
+
+def _boundary_model():
+    """min x s.t. [x >= 1] or [x >= 2]; optimum 1 sits exactly ON the predicate."""
+    m = dm.Model("boundary")
+    x = m.continuous("x", lb=-5.0, ub=5.0)
+    m.minimize(x)
+    m.either_or([[x >= 1.0], [x >= 2.0]], name="bd")
+    return m, x
+
+
+def _disjunction(model):
+    return next(c for c in model._constraints if isinstance(c, _DisjunctiveConstraint))
+
+
+def _weights(model):
+    return [v for v in model._variables if v.name.startswith(SIMPLEX_WEIGHT_PREFIX)]
+
+
+# ── requirement 4: the four size quantities, counted separately ──────────────
+
+
+@pytest.mark.unit
+def test_size_quantities_are_reported_separately_not_summed():
+    """A J-way disjunction of EQUALITIES is 2**J clauses, not J rows.
+
+    Each ``h == 0`` is two predicates, and CNF distribution is multiplicative
+    over the disjuncts, so the clause count is what explodes while the *declared*
+    row count does not move. Requirement 4 exists because summing these hides
+    exactly that.
+    """
+    m = dm.Model("grid")
+    a = m.continuous("a", lb=-1.0, ub=1.0)
+    m.minimize(a)
+    m.either_or([[a == v] for v in (-0.5, 0.0, 0.5)], name="grid")
+
+    seen = []
+    record, rows = lower_disjunction_simplex(
+        _disjunction(m), lambda size: _fake_weight(m, size, seen)
+    )
+    assert record.sizes.cnf_clauses == 2**3 == 8
+    assert record.sizes.literal_occurrences == 8 * 3 == 24
+    assert record.sizes.weight_variables == 8 * 3 == 24
+    assert record.sizes.rows == 2 * 8 == 16
+    assert len(rows) == 16
+    # Four distinct numbers, deliberately not one "model size".
+    assert len({record.sizes.cnf_clauses, record.sizes.literal_occurrences, record.sizes.rows}) == 3
+
+
+def _fake_weight(model, size, seen):
+    from discopt.modeling.core import Variable
+
+    v = Variable(
+        f"{SIMPLEX_WEIGHT_PREFIX}t{len(seen)}", VarType.CONTINUOUS, (size,), 0.0, 1.0, model
+    )
+    model._variables.append(v)
+    seen.append(v)
+    return v
+
+
+@pytest.mark.unit
+def test_single_predicate_disjuncts_do_not_blow_up():
+    """The paper's optimal-control shape: one clause, J weights, 2 rows."""
+    m = dm.Model("single")
+    x = m.continuous("x", lb=-5.0, ub=5.0)
+    m.minimize(x * x)
+    m.either_or([[x <= -1.0], [x >= 1.0]], name="gap")
+    seen = []
+    record, rows = lower_disjunction_simplex(
+        _disjunction(m), lambda size: _fake_weight(m, size, seen)
+    )
+    assert (
+        record.sizes.cnf_clauses,
+        record.sizes.literal_occurrences,
+        record.sizes.weight_variables,
+        record.sizes.rows,
+    ) == (1, 2, 2, 2)
+    assert len(rows) == 2
+
+
+@pytest.mark.unit
+def test_clause_budget_refuses_loudly_and_names_the_cost():
+    """The blowup is refused, never silently expanded (CLAUDE.md §3)."""
+    m = dm.Model("blowup")
+    a = m.continuous("a", 12, lb=-1.0, ub=1.0)
+    m.minimize(a[0])
+    # 12 disjuncts of one equality each => 2**12 = 4096 clauses > MAX_CNF_CLAUSES.
+    m.either_or([[a[j] == 0.0] for j in range(12)], name="big")
+    seen = []
+    with pytest.raises(SimplexLoweringRefused) as exc:
+        lower_disjunction_simplex(_disjunction(m), lambda size: _fake_weight(m, size, seen))
+    message = str(exc.value)
+    assert "4096" in message and str(MAX_CNF_CLAUSES) in message
+    assert "big-m" in message  # names the alternative rather than just failing
+
+
+@pytest.mark.unit
+def test_the_budget_is_a_parameter_not_a_hidden_constant():
+    m = dm.Model("blowup2")
+    a = m.continuous("a", 12, lb=-1.0, ub=1.0)
+    m.minimize(a[0])
+    m.either_or([[a[j] == 0.0] for j in range(12)], name="big")
+    seen = []
+    record, _rows = lower_disjunction_simplex(
+        _disjunction(m), lambda size: _fake_weight(m, size, seen), max_clauses=4096
+    )
+    assert record.sizes.cnf_clauses == 4096
+
+
+# ── the refusals (contract boundaries) ───────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_reified_semantics_is_refused_not_approximated():
+    """§3.1's strict negation needs an existential exponential lift.
+
+    Serving EXACTLY_ONE_TRUE with these rows would silently return the *union*,
+    which is a different feasible set (#1124's discriminator makes the gap a
+    whole interval), so the lowering refuses.
+    """
+    m = dm.Model("reified")
+    x = m.continuous("x", lb=-2.0, ub=3.0)
+    m.minimize(x)
+    dc = _DisjunctiveConstraint(
+        disjuncts=[[x <= 1.0], [x >= 0.0]],
+        name="tv",
+        semantics=DisjunctionSemantics.EXACTLY_ONE_TRUE,
+    )
+    with pytest.raises(SimplexLoweringRefused) as exc:
+        lower_disjunction_simplex(dc, lambda size: _fake_weight(m, size, []))
+    assert "EXACTLY_ONE_TRUE" in str(exc.value)
+    assert "REIFIED" in str(exc.value)
+
+
+@pytest.mark.unit
+def test_a_nested_disjunction_is_refused():
+    m = dm.Model("nested")
+    x = m.continuous("x", lb=-2.0, ub=3.0)
+    m.minimize(x)
+    inner = _DisjunctiveConstraint(disjuncts=[[x <= 0.0], [x >= 2.0]], name="inner")
+    outer = _DisjunctiveConstraint(disjuncts=[[inner], [x >= 1.0]], name="outer")
+    with pytest.raises(SimplexLoweringRefused, match="nested disjunction"):
+        lower_disjunction_simplex(outer, lambda size: _fake_weight(m, size, []))
+
+
+@pytest.mark.unit
+def test_an_empty_disjunct_is_refused_rather_than_read_as_always_true():
+    m = dm.Model("empty")
+    x = m.continuous("x", lb=-2.0, ub=3.0)
+    m.minimize(x)
+    dc = _DisjunctiveConstraint(disjuncts=[[x <= 0.0], []], name="e")
+    with pytest.raises(SimplexLoweringRefused, match="declares no rows"):
+        lower_disjunction_simplex(dc, lambda size: _fake_weight(m, size, []))
+
+
+@pytest.mark.unit
+def test_a_vector_disjunct_row_is_refused_with_the_shape_named():
+    m = dm.Model("vec")
+    x = m.continuous("x", 3, lb=-2.0, ub=3.0)
+    m.minimize(x[0])
+    dc = _DisjunctiveConstraint(disjuncts=[[x <= 1.0], [x >= 2.0]], name="v")
+    with pytest.raises(SimplexLoweringRefused) as exc:
+        lower_disjunction_simplex(dc, lambda size: _fake_weight(m, size, []))
+    assert "(3,)" in str(exc.value)
+
+
+@pytest.mark.unit
+def test_mip_nlp_plus_simplex_is_refused_as_contradictory():
+    """No selector binary is emitted, so there is nothing for MIP-NLP to branch on."""
+    m, _x = _overlap_model()
+    with pytest.raises(ValueError, match="no selector binary"):
+        m.solve(time_limit=5, solver="mip-nlp", gdp_method="simplex")
+
+
+# ── requirement 1: the weights are witnesses, not selectors ──────────────────
+
+
+@pytest.mark.unit
+def test_the_weights_are_continuous_so_a_fraction_is_not_failed_integrality():
+    m, _x = _overlap_model()
+    lowered = reformulate_gdp(m, method="simplex")
+    weights = _weights(lowered)
+    assert weights, "the lowering emitted no weight variable"
+    for w in weights:
+        assert w.var_type is VarType.CONTINUOUS
+        assert float(np.max(w.lb)) == 0.0 and float(np.max(w.ub)) == 1.0
+    # and no selector binary was emitted at all
+    assert not [v for v in lowered._variables if v.var_type is VarType.BINARY]
+
+
+@pytest.mark.unit
+def test_the_lowering_record_exposes_no_boolean_assignment():
+    """Requirement 1: a witness must not be exposed as a named Boolean value."""
+    m, _x = _overlap_model()
+    lowered = reformulate_gdp(m, method="simplex")
+    (record,) = lowered._simplex_lowerings
+    for forbidden in ("selectors", "booleans", "assignment", "y", "binary"):
+        assert not hasattr(record, forbidden), (
+            f"SimplexLoweringRecord.{forbidden} would invite reading a Boolean "
+            "assignment off an existential witness"
+        )
+    assert all(n.startswith(SIMPLEX_WEIGHT_PREFIX) for n in record.weight_names)
+
+
+@pytest.mark.unit
+def test_a_fractional_witness_satisfies_the_weighted_row_while_a_disjunct_fails():
+    """The control that makes the weighted row unusable as a source report.
+
+    At ``x = 1.4`` in the #1124 fixture, disjunct 0 (``x <= 1``) is violated by
+    ``0.4`` and disjunct 1 (``x >= 0``) holds. A *fractional* witness still
+    satisfies the weighted row, so a caller reading truth off that row would
+    conclude both literals hold. The source report says otherwise.
+    """
+    m, _x = _overlap_model()
+    point = {"x": np.array([1.4])}
+
+    report = _residuals(m, point)
+    (res,) = report.residuals
+    assert res.per_disjunct[0] == pytest.approx(0.4)  # x - 1 = 0.4 > 0, fails
+    assert res.per_disjunct[1] == pytest.approx(-1.4)  # -x <= 0 holds
+    assert res.violation == pytest.approx(-1.4)  # the disjunction holds
+
+    # A fractional witness that satisfies the weighted row at the same point.
+    lam = np.array([0.5, 0.5])
+    weighted = lam[0] * res.per_disjunct[0] + lam[1] * res.per_disjunct[1]
+    assert weighted <= 0.0
+    # ... yet disjunct 0 is genuinely violated, and the source report says so.
+    assert selected_disjuncts(m, point) == {"ov": [1]}
+    _COMPARISONS[0] += 2
+
+
+@pytest.mark.unit
+def test_overlapping_disjuncts_report_every_disjunct_that_holds():
+    """Requirement 3's overlap fixture: the answer is a SET, not a choice."""
+    m, _x = _overlap_model()
+    point = {"x": np.array([0.5])}
+    assert selected_disjuncts(m, point) == {"ov": [0, 1]}
+    report = _residuals(m, point)
+    assert report.max_violation < 0.0
+
+
+@pytest.mark.unit
+def test_a_point_exactly_on_the_boundary_is_inside_the_closed_predicate():
+    """Requirement 3's strict-boundary fixture: residual 0 is satisfied, not violated."""
+    m, _x = _boundary_model()
+    point = {"x": np.array([1.0])}
+    report = _residuals(m, point)
+    (res,) = report.residuals
+    assert res.per_disjunct[0] == pytest.approx(0.0)
+    assert res.violation == pytest.approx(0.0)
+    assert selected_disjuncts(m, point) == {"bd": [0]}
+
+
+# ── requirement 3: no stale report, no empty report ──────────────────────────
+
+
+@pytest.mark.unit
+def test_a_report_from_another_point_cannot_stand_in_for_source_validation():
+    """The report is a pure function of the point handed in; there is no cache."""
+    m, _x = _overlap_model()
+    good = _residuals(m, {"x": np.array([0.5])})
+    bad = _residuals(m, {"x": np.array([-3.0])})  # violates x >= 0 only... see below
+    # x = -3 satisfies x <= 1, so the disjunction still holds; use a point that
+    # violates BOTH disjuncts of a disjoint fixture instead.
+    assert good.max_violation < 0.0
+    assert bad.max_violation < 0.0
+
+    m2 = dm.Model("disjoint")
+    y = m2.continuous("y", lb=-5.0, ub=5.0)
+    m2.minimize(y)
+    m2.either_or([[y <= -1.0], [y >= 1.0]], name="gap")
+    feasible = _residuals(m2, {"y": np.array([2.0])})
+    infeasible = _residuals(m2, {"y": np.array([0.0])})
+    assert feasible.max_violation == pytest.approx(-1.0)
+    assert infeasible.max_violation == pytest.approx(1.0)
+    assert selected_disjuncts(m2, {"y": np.array([0.0])}) == {"gap": []}
+
+
+@pytest.mark.unit
+def test_a_report_that_measured_nothing_refuses_to_read_as_a_pass():
+    m = dm.Model("nodisj")
+    x = m.continuous("x", lb=0.0, ub=1.0)
+    m.minimize(x)
+    with pytest.raises(ValueError, match="declares no disjunction"):
+        disjunction_residuals(m, {"x": np.array([0.0])})
+    with pytest.raises(ValueError, match="no disjunction was measured"):
+        DisjunctionResidualReport().max_violation
+
+
+@pytest.mark.unit
+def test_a_missing_source_variable_is_refused_not_defaulted():
+    m, _x = _overlap_model()
+    with pytest.raises(KeyError, match="absent from the point"):
+        disjunction_residuals(m, {})
+
+
+# ── exactness, against the exact GDP references ──────────────────────────────
+
+
+@pytest.mark.smoke
+def test_a_simplex_solve_is_certified_and_agrees_with_big_m():
+    """Exact in projection: the certified optimum is the big-M optimum.
+
+    This is also the whole of requirement 2's surface on this path — the result
+    is a genuine certificate, so no local/certified distinction arises.
+    """
+    m_ref, _ = _overlap_model()
+    reference = m_ref.solve(time_limit=30, gdp_method="big-m")
+    m_sx, _ = _overlap_model()
+    result = m_sx.solve(time_limit=30, gdp_method="simplex")
+
+    assert reference.status == "optimal" and result.status == "optimal"
+    assert result.gap_certified is True
+    assert result.objective == pytest.approx(reference.objective, abs=1e-5)
+    assert result.objective == pytest.approx(0.0, abs=1e-5)
+
+    source, _ = _overlap_model()
+    assert _residuals(source, result.x).max_violation <= 1e-6
+
+
+@pytest.mark.smoke
+def test_the_disjunction_is_enforced_not_merely_relaxed_away():
+    """A disjoint gap the optimum would otherwise fall into stays excluded."""
+    m = dm.Model("enforced")
+    x = m.continuous("x", lb=-5.0, ub=5.0)
+    m.minimize(x * x)  # unconstrained optimum x = 0, inside the gap
+    m.either_or([[x <= -1.0], [x >= 1.0]], name="gap")
+    result = m.solve(time_limit=30, gdp_method="simplex")
+    assert result.status == "optimal"
+    assert result.objective == pytest.approx(1.0, rel=1e-4)
+
+    source = dm.Model("enforced")
+    xs = source.continuous("x", lb=-5.0, ub=5.0)
+    source.minimize(xs * xs)
+    source.either_or([[xs <= -1.0], [xs >= 1.0]], name="gap")
+    assert _residuals(source, result.x).max_violation <= 1e-6
+
+
+# ── the capability this lowering exists for (#1182 entry condition) ──────────
+
+
+def _both_refuse_model():
+    """``1/x <= 1`` on a box straddling 0: unbounded enclosure AND undefined at 0.
+
+    big-M cannot bound the body; the Furman-Sawaya-Grossmann perspective needs
+    ``g(0)``, which divides by zero. This is the shape of the 18 ``stranded_gas``
+    disjunct rows the #1182 corpus scan found (``log`` of a capacity sum whose
+    box includes 0), reduced to its smallest reproducer.
+    """
+    m = dm.Model("both_refuse")
+    x = m.continuous("x", lb=-10.0, ub=10.0)
+    m.minimize((x - 5.0) * (x - 5.0))
+    m.either_or([[1.0 / x <= 1.0], [x >= 3.0]], name="recip")
+    return m
+
+
+@pytest.mark.smoke
+def test_big_m_and_hull_both_refuse_the_row_the_simplex_lowering_certifies():
+    with pytest.raises(ValueError, match="cannot bound the body"):
+        reformulate_gdp(_both_refuse_model(), method="big-m")
+    with pytest.raises(HullPerspectiveOriginError):
+        reformulate_gdp(_both_refuse_model(), method="hull")
+
+    lowered = reformulate_gdp(_both_refuse_model(), method="simplex")
+    assert lowered._simplex_lowerings[0].sizes.cnf_clauses == 1
+
+    result = _both_refuse_model().solve(time_limit=60, gdp_method="simplex")
+    assert result.status == "optimal"
+    assert result.objective == pytest.approx(0.0, abs=1e-6)
+    source = _both_refuse_model()
+    assert _residuals(source, result.x).max_violation <= 1e-6
+    # At x = 5 BOTH disjuncts hold (1/5 <= 1 and 5 >= 3) — the overlap case a
+    # recovered Boolean assignment would have to pick one of, wrongly.
+    assert selected_disjuncts(source, result.x) == {"recip": [0, 1]}
+
+
+@pytest.mark.unit
+def test_the_lowered_model_carries_its_size_accounting():
+    """``auto`` never routes to simplex, and every method leaves the list present."""
+    for method in ("big-m", "hull", "auto"):
+        lowered = reformulate_gdp(_overlap_model()[0], method=method)
+        assert lowered._simplex_lowerings == []
+    lowered = reformulate_gdp(_overlap_model()[0], method="simplex")
+    assert len(lowered._simplex_lowerings) == 1
+    assert lowered._simplex_lowerings[0].sizes.disjunctions == 1
+    assert not math.isnan(float(lowered._simplex_lowerings[0].sizes.cnf_clauses))
+
+
+@pytest.mark.unit
+def test_the_helpers_are_reachable_without_importing_a_private_module():
+    """``docs/disjunction_semantics.md`` §7 points users at these two names."""
+    import discopt
+
+    assert discopt.disjunction_residuals is disjunction_residuals
+    assert discopt.selected_disjuncts is selected_disjuncts
+
+
+@pytest.mark.relaxation
+def test_the_lifted_row_is_exact_in_projection_over_a_sampled_box():
+    """Theorem 1's exactness, asserted as the identity it actually is.
+
+    For a fixed ``z`` the best simplex weight makes the weighted row equal
+    ``min_j p_j(z)`` — a linear program over the simplex, whose optimum is at a
+    vertex. So "some ``lambda`` in the simplex satisfies the clause row" holds
+    exactly when the source disjunction holds, with no gap in either direction:
+    no feasible point is cut, and no infeasible point is admitted.
+
+    Sampled over both fixtures rather than argued, and the executed comparison
+    count is asserted so a sampler that generated nothing cannot read as a pass.
+    """
+    fixtures = []
+
+    m1, _ = _overlap_model()
+    fixtures.append((m1, "x", np.linspace(-2.0, 3.0, 101)))
+
+    m2 = dm.Model("disjoint")
+    y = m2.continuous("y", lb=-5.0, ub=5.0)
+    m2.minimize(y)
+    m2.either_or([[y <= -1.0], [y >= 1.0]], name="gap")
+    fixtures.append((m2, "y", np.linspace(-5.0, 5.0, 101)))
+
+    checked = 0
+    for model, name, grid in fixtures:
+        for value in grid:
+            report = _residuals(model, {name: np.array([value])})
+            (res,) = report.residuals
+            predicates = np.asarray(res.per_disjunct, dtype=float)
+            # The simplex minimum of a linear function is attained at a vertex.
+            best_weighted = float(predicates.min())
+            assert best_weighted == pytest.approx(res.violation, abs=1e-12)
+            # Both directions of "exact in projection", stated separately.
+            holds = bool((predicates <= 1e-12).any())
+            assert holds == (best_weighted <= 1e-12)
+            checked += 1
+
+    assert checked == 202, f"the sampler covered {checked} points, expected 202"

--- a/python/tests/test_1182_simplex_lowering.py
+++ b/python/tests/test_1182_simplex_lowering.py
@@ -523,3 +523,33 @@ def test_the_lifted_row_is_exact_in_projection_over_a_sampled_box():
             checked += 1
 
     assert checked == 202, f"the sampler covered {checked} points, expected 202"
+
+
+@pytest.mark.unit
+def test_jacobian_nonzeros_is_the_fourth_size_quantity_and_refuses_a_gdp_row():
+    """Requirement 4's fourth quantity, measured on the lowered model.
+
+    It is a whole-model number, so it lives beside ``LoweringSizes`` rather than
+    on it, and it refuses a model still carrying a disjunction — counting that
+    row as zero would understate the pattern it exists to compare.
+    """
+    from discopt._relax.simplex_lowering import structural_jacobian_nonzeros
+
+    def build():
+        m = dm.Model("nnz")
+        x = m.continuous("x", lb=-5.0, ub=5.0)
+        m.minimize(x * x)
+        m.either_or([[x <= -1.0], [x >= 1.0]], name="g")
+        return m
+
+    counts = {
+        method: structural_jacobian_nonzeros(reformulate_gdp(build(), method=method))
+        for method in ("big-m", "hull", "simplex")
+    }
+    # Three different sparsity patterns for the same disjunction — which is the
+    # whole point of measuring this separately from clause and row counts.
+    assert len(set(counts.values())) == 3
+    assert counts["simplex"] < counts["big-m"] < counts["hull"]
+
+    with pytest.raises(ValueError, match="unlowered disjunction"):
+        structural_jacobian_nonzeros(build())

--- a/scratchpad/issue1182/E1_entry_experiment.py
+++ b/scratchpad/issue1182/E1_entry_experiment.py
@@ -1,0 +1,175 @@
+"""#1182 entry experiment (CLAUDE.md section 4): does the Theorem-1 simplex/CNF
+lowering beat the exact GDP/SOS1 path on real corpus instances?
+
+Hypothesis under test (from RFC #1123 / arXiv:2601.03906v1): replacing each
+disjunction by its exact continuous simplex lowering removes the binaries and so
+gives a *faster certified* solve than discopt's big-M / hull lowering.
+
+Kill criterion, fixed before running: on the in-repo native GDP corpus
+(``benchmarks.gdplib_native``, whose optima are SCIP/BARON-certified), the
+simplex arm must reach the same certified optimum as big-M/hull on at least one
+instance with strictly less wall time or fewer nodes. If it certifies *nothing*
+that big-M/hull certifies, or returns an objective better than the certified
+optimum (a false primal), the hypothesis is falsified for this class and the
+lowering must not ship as a solve path.
+
+Every arm reports the four size quantities separately (requirement 4 of #1182)
+and validates the returned point against the ORIGINAL predicates (requirement 1),
+never against the weighted rows.
+
+Per CLAUDE.md section 6 this script prints an executed-comparison count and exits
+non-zero if it is zero.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+import time
+
+from benchmarks.gdplib_native import NATIVE_BUILDERS
+from benchmarks.gdplib_runner import reference_optima
+from simplex_proto import reformulate_simplex
+from source_check import predicate_report
+
+
+def _count_jacobian_nonzeros(model) -> int:
+    """Structural nonzeros: sum over rows of the number of distinct variables."""
+    from discopt.modeling.core import Constraint
+    from source_check import variables_in
+
+    nnz = 0
+    for c in model._constraints:
+        if isinstance(c, Constraint):
+            nnz += len(variables_in(c.body))
+    return nnz
+
+
+def _n_binaries(model) -> int:
+    from discopt.modeling.core import VarType
+
+    n = 0
+    for v in model._variables:
+        if v.var_type is VarType.BINARY:
+            n += int(_size(v))
+    return n
+
+
+def _size(v) -> int:
+    n = 1
+    for d in v.shape:
+        n *= d
+    return n
+
+
+def _solve(model, *, time_limit, **kw):
+    t0 = time.perf_counter()
+    res = model.solve(time_limit=time_limit, **kw)
+    return res, time.perf_counter() - t0
+
+
+def run(names, time_limit: float) -> int:
+    optima = reference_optima()
+    comparisons = 0
+    rows = []
+    for name in names:
+        source = NATIVE_BUILDERS[name]()
+        ref = optima[name]
+
+        for arm in ("big-m", "hull", "simplex"):
+            model = NATIVE_BUILDERS[name]()
+            if arm == "simplex":
+                lowered, records, counts = reformulate_simplex(model)
+                counts.jacobian_nonzeros = _count_jacobian_nonzeros(lowered)
+                target = lowered
+            else:
+                from discopt._relax.gdp_reformulate import reformulate_gdp
+
+                lowered = reformulate_gdp(model, method=arm)
+                from simplex_proto import SizeCounts
+
+                counts = SizeCounts(
+                    disjunctions=sum(
+                        1
+                        for c in model._constraints
+                        if type(c).__name__ == "_DisjunctiveConstraint"
+                    ),
+                    cnf_clauses=0,
+                    literal_occurrences=0,
+                    aux_variables=_n_binaries(lowered),
+                    rows=len(lowered._constraints),
+                )
+                counts.jacobian_nonzeros = _count_jacobian_nonzeros(lowered)
+                target = lowered
+
+            print(f"[{name}/{arm}] solving ({len(target._constraints)} rows, "
+                  f"{sum(_size(v) for v in target._variables)} vars)...", flush=True)
+            try:
+                if arm == "simplex":
+                    res, wall = _solve(target, time_limit=time_limit)
+                else:
+                    # solve the ORIGINAL model so discopt's own gdp pass runs
+                    res, wall = _solve(
+                        NATIVE_BUILDERS[name](), time_limit=time_limit, gdp_method=arm
+                    )
+            except Exception as exc:  # a crash is a result, not something to hide
+                print(f"[{name}/{arm}] RAISED {type(exc).__name__}: {exc}", flush=True)
+                rows.append((name, arm, "raised", None, None, None, None, counts))
+                comparisons += 1
+                continue
+
+            status = str(getattr(res, "status", "?"))
+            obj = getattr(res, "objective", None)
+            bound = getattr(res, "bound", None)
+            nodes = getattr(res, "node_count", None)
+            gap_certified = getattr(res, "gap_certified", None)
+
+            # Requirement 1: validate against the SOURCE predicates.
+            point = getattr(res, "x", None)
+            rep = predicate_report(source, point) if point else None
+            comparisons += 0 if rep is None else rep.comparisons
+
+            rows.append((name, arm, status, obj, bound, nodes, wall, counts, rep,
+                         gap_certified))
+            print(
+                f"[{name}/{arm}] status={status} obj={obj} bound={bound} "
+                f"nodes={nodes} wall={wall:.2f}s certified={gap_certified} "
+                f"ref={ref} src_disj_violation="
+                f"{None if rep is None else rep.max_disjunction_violation}",
+                flush=True,
+            )
+            comparisons += 1
+
+    print("\n=== summary ===")
+    hdr = ("instance", "arm", "status", "objective", "bound", "nodes", "wall",
+           "clauses", "lits", "aux", "rows", "nnz", "src_viol")
+    print(" | ".join(f"{h:>12}" for h in hdr))
+    for r in rows:
+        name, arm, status, obj, bound, nodes, wall, counts = r[:8]
+        rep = r[8] if len(r) > 8 else None
+        cells = [
+            name, arm, status,
+            "-" if obj is None else f"{obj:.6g}",
+            "-" if bound is None else f"{bound:.6g}",
+            "-" if nodes is None else str(nodes),
+            "-" if wall is None else f"{wall:.2f}",
+            str(counts.cnf_clauses), str(counts.literal_occurrences),
+            str(counts.aux_variables), str(counts.rows),
+            str(counts.jacobian_nonzeros),
+            "-" if rep is None else f"{rep.max_disjunction_violation:.3g}",
+        ]
+        print(" | ".join(f"{c:>12}" for c in cells))
+
+    print(f"\nexecuted comparisons: {comparisons}")
+    if comparisons == 0:
+        print("FAIL: the probe measured nothing (CLAUDE.md section 6)")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--instances", default=",".join(NATIVE_BUILDERS))
+    ap.add_argument("--time-limit", type=float, default=60.0)
+    args = ap.parse_args()
+    sys.exit(run([n for n in args.instances.split(",") if n], args.time_limit))

--- a/scratchpad/issue1182/E2_paper_class.py
+++ b/scratchpad/issue1182/E2_paper_class.py
@@ -1,0 +1,156 @@
+"""#1182 entry experiment, part 2: the paper's OWN class.
+
+E1 measured the in-repo native GDP corpus and found the Theorem-1 lowering slower
+and less often certified than big-M/hull. Before recording that as a
+falsification it is worth asking whether the three corpus models are simply not
+the class arXiv:2601.03906v1 targets: its section 5 is *optimal control with
+obstacle avoidance*, where each disjunct is a single linear predicate, so the CNF
+distribution is a no-op (1 clause per disjunction) and the lowering is at its
+smallest and most favourable.
+
+This probe builds exactly that: a discrete-time double integrator that must stay
+outside a rectangular obstacle at every step,
+
+    OR( x_t <= xa,  x_t >= xb,  y_t <= ya,  y_t >= yb )
+
+which is a 4-way disjunction of single predicates -- one CNF clause, four
+weights, no blowup. If the lowering loses here too, it loses on the class it was
+designed for, and the falsification is not an artefact of instance selection.
+
+Both arms are solved by the SAME certified global path (``Model.solve``), which
+is the comparison #1182 says the paper does not make: its section 5 uses local
+Ipopt on both sides.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+import time
+
+from discopt import Model
+from simplex_proto import reformulate_simplex
+from source_check import predicate_report
+
+# Obstacle: the box [XA, XB] x [YA, YB], to be avoided.
+XA, XB, YA, YB = 2.0, 4.0, 2.0, 4.0
+START = (0.0, 0.0)
+GOAL = (6.0, 6.0)
+
+
+def build_avoidance(n_steps: int) -> Model:
+    """Minimum-effort double integrator from START to GOAL avoiding the box."""
+    m = Model(f"avoid{n_steps}")
+    x = m.continuous("x", n_steps + 1, lb=-1.0, ub=8.0)
+    y = m.continuous("y", n_steps + 1, lb=-1.0, ub=8.0)
+    vx = m.continuous("vx", n_steps + 1, lb=-5.0, ub=5.0)
+    vy = m.continuous("vy", n_steps + 1, lb=-5.0, ub=5.0)
+    ax = m.continuous("ax", n_steps, lb=-3.0, ub=3.0)
+    ay = m.continuous("ay", n_steps, lb=-3.0, ub=3.0)
+    dt = 1.0
+
+    m.subject_to(x[0] == START[0])
+    m.subject_to(y[0] == START[1])
+    m.subject_to(vx[0] == 0.0)
+    m.subject_to(vy[0] == 0.0)
+    m.subject_to(x[n_steps] == GOAL[0])
+    m.subject_to(y[n_steps] == GOAL[1])
+
+    for t in range(n_steps):
+        m.subject_to(x[t + 1] == x[t] + dt * vx[t])
+        m.subject_to(y[t + 1] == y[t] + dt * vy[t])
+        m.subject_to(vx[t + 1] == vx[t] + dt * ax[t])
+        m.subject_to(vy[t + 1] == vy[t] + dt * ay[t])
+
+    # Obstacle avoidance at every step: one 4-way disjunction of single predicates.
+    for t in range(n_steps + 1):
+        m.either_or(
+            [
+                [x[t] <= XA],
+                [x[t] >= XB],
+                [y[t] <= YA],
+                [y[t] >= YB],
+            ],
+            name=f"avoid_{t}",
+        )
+
+    m.minimize(sum(ax[t] * ax[t] + ay[t] * ay[t] for t in range(n_steps)))
+    return m
+
+
+def _nnz(model) -> int:
+    from discopt.modeling.core import Constraint
+    from source_check import variables_in
+
+    return sum(len(variables_in(c.body)) for c in model._constraints if isinstance(c, Constraint))
+
+
+def run(steps: list[int], time_limit: float, reps: int) -> int:
+    comparisons = 0
+    table = []
+    # Interleave arms within a repetition (CLAUDE.md section 9) rather than
+    # running one arm to completion and then the other.
+    for rep in range(reps):
+        for n in steps:
+            for arm in ("big-m", "hull", "simplex"):
+                source = build_avoidance(n)
+                if arm == "simplex":
+                    target, _records, counts = reformulate_simplex(build_avoidance(n))
+                    counts.jacobian_nonzeros = _nnz(target)
+                    t0 = time.perf_counter()
+                    res = target.solve(time_limit=time_limit)
+                    wall = time.perf_counter() - t0
+                else:
+                    from simplex_proto import SizeCounts
+
+                    counts = SizeCounts()
+                    t0 = time.perf_counter()
+                    res = build_avoidance(n).solve(time_limit=time_limit, gdp_method=arm)
+                    wall = time.perf_counter() - t0
+
+                rep_src = predicate_report(source, res.x) if res.x else None
+                comparisons += 1 + (0 if rep_src is None else rep_src.comparisons)
+                table.append(
+                    (
+                        rep, n, arm, str(res.status),
+                        res.objective, res.bound, res.node_count, wall,
+                        getattr(res, "gap_certified", None),
+                        None if rep_src is None else rep_src.max_disjunction_violation,
+                    )
+                )
+                print(
+                    f"[rep{rep} n={n} {arm}] status={res.status} obj={res.objective} "
+                    f"bound={res.bound} nodes={res.node_count} wall={wall:.2f}s "
+                    f"certified={getattr(res, 'gap_certified', None)} "
+                    f"src_viol={None if rep_src is None else rep_src.max_disjunction_violation}",
+                    flush=True,
+                )
+
+    print("\n=== summary ===")
+    hdr = ("rep", "steps", "arm", "status", "objective", "bound", "nodes", "wall",
+           "certified", "src_viol")
+    print(" | ".join(f"{h:>11}" for h in hdr))
+    for row in table:
+        cells = [
+            str(row[0]), str(row[1]), row[2], row[3],
+            "-" if row[4] is None else f"{row[4]:.6g}",
+            "-" if row[5] is None else f"{row[5]:.6g}",
+            str(row[6]), f"{row[7]:.2f}", str(row[8]),
+            "-" if row[9] is None else f"{row[9]:.3g}",
+        ]
+        print(" | ".join(f"{c:>11}" for c in cells))
+
+    print(f"\nexecuted comparisons: {comparisons}")
+    if comparisons == 0:
+        print("FAIL: the probe measured nothing (CLAUDE.md section 6)")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--steps", default="3,5,8")
+    ap.add_argument("--time-limit", type=float, default=60.0)
+    ap.add_argument("--reps", type=int, default=1)
+    args = ap.parse_args()
+    sys.exit(run([int(s) for s in args.steps.split(",")], args.time_limit, args.reps))

--- a/scratchpad/issue1182/E3_bigm_refusal.py
+++ b/scratchpad/issue1182/E3_bigm_refusal.py
@@ -1,0 +1,133 @@
+"""#1182 entry experiment, part 3: is there a CLASS big-M/hull cannot lower at all?
+
+E1/E2 measured speed and certification and found the Theorem-1 lowering behind on
+both. That only kills the *performance* motive. A separate, non-performance motive
+would justify the lowering anyway: big-M lowering needs a finite M, and discopt
+refuses (``_unbounded_big_m_error``) when a disjunct row has no finite bound in
+the relevant direction; hull needs finite disjunct bounds for its perspective
+variables. Theorem 1 needs neither -- its lifted weights are bounded in [0, 1] by
+construction.
+
+So: on a GDP whose disjunct rows are unbounded, does big-M refuse where the
+simplex lowering solves? That would be a capability gap, not a speed claim, and
+it is the strongest remaining case for building this.
+
+Prints the executed-assertion count and exits non-zero if nothing was measured.
+"""
+
+from __future__ import annotations
+
+import sys
+
+from discopt import Model
+from simplex_proto import reformulate_simplex
+from source_check import predicate_report
+
+
+def build_unbounded_gdp() -> Model:
+    """``x`` has no finite bounds, so ``x <= 1`` has no finite big-M."""
+    m = Model("unbounded_disjunct")
+    x = m.continuous("x")  # default +/-9.999e19 sentinel == unbounded
+    z = m.continuous("z", lb=0.0, ub=10.0)
+    m.minimize((x - 5.0) * (x - 5.0) + z)
+    m.subject_to(z >= x - 100.0)
+    m.either_or([[x <= 1.0], [x >= 3.0]], name="gap")
+    return m
+
+
+def build_bounded_control() -> Model:
+    """Same model with a finite box, as the control: big-M must succeed here."""
+    m = Model("bounded_disjunct")
+    x = m.continuous("x", lb=-50.0, ub=50.0)
+    z = m.continuous("z", lb=0.0, ub=10.0)
+    m.minimize((x - 5.0) * (x - 5.0) + z)
+    m.subject_to(z >= x - 100.0)
+    m.either_or([[x <= 1.0], [x >= 3.0]], name="gap")
+    return m
+
+
+def build_log_unbounded_gdp() -> Model:
+    """Both classical lowerings refuse: no finite big-M *and* ``g(0) = log(0)``.
+
+    ``x`` is bounded below but not above, so ``log(x) <= 0`` has no finite big-M;
+    and the Furman-Sawaya-Grossmann perspective needs ``g(0)``, which is ``-inf``
+    here, so hull refuses too (:class:`HullPerspectiveOriginError`). If the
+    Theorem-1 lowering solves this it covers a class neither classical lowering
+    reaches -- a capability argument that survives E1/E2's speed falsification.
+    """
+    from discopt.modeling import log
+
+    m = Model("log_unbounded")
+    x = m.continuous("x", lb=0.1)  # unbounded above
+    m.minimize((x - 5.0) * (x - 5.0))
+    m.either_or([[log(x) <= 0.0], [x >= 3.0]], name="loggap")
+    return m
+
+
+def build_both_refuse_gdp() -> Model:
+    """The decisive case: BOTH classical lowerings refuse.
+
+    ``1.0 / x`` on a box straddling 0 has an unbounded interval enclosure (so
+    big-M cannot bound the row) and is undefined at the origin (so the
+    Furman-Sawaya-Grossmann perspective cannot be formed). This is the reduced
+    form of the 18 ``stranded_gas`` disjunct rows E5 finds in GDPlib, where the
+    row is ``log`` of a capacity sum whose box includes 0.
+
+    True optimum 0 at ``x = 5``, which satisfies BOTH disjuncts (1/5 <= 1 and
+    5 >= 3) -- so it is also an overlap fixture.
+    """
+    m = Model("both_refuse")
+    x = m.continuous("x", lb=-10.0, ub=10.0)
+    m.minimize((x - 5.0) * (x - 5.0))
+    m.either_or([[1.0 / x <= 1.0], [x >= 3.0]], name="recip")
+    return m
+
+
+def attempt(builder, arm, time_limit=30.0):
+    from discopt._relax.gdp_reformulate import reformulate_gdp
+
+    model = builder()
+    try:
+        if arm == "simplex":
+            target, _rec, _counts = reformulate_simplex(model)
+            res = target.solve(time_limit=time_limit)
+        else:
+            reformulate_gdp(builder(), method=arm)  # the lowering itself may refuse
+            res = builder().solve(time_limit=time_limit, gdp_method=arm)
+    except Exception as exc:
+        return ("refused", f"{type(exc).__name__}: {str(exc)[:140]}", None, None, None)
+    src = predicate_report(builder(), res.x) if res.x else None
+    return (
+        str(res.status),
+        "",
+        res.objective,
+        res.bound,
+        None if src is None else src.max_disjunction_violation,
+    )
+
+
+def main() -> int:
+    assertions = 0
+    for label, builder in (
+        ("unbounded", build_unbounded_gdp),
+        ("bounded-control", build_bounded_control),
+        ("log-unbounded", build_log_unbounded_gdp),
+        ("both-refuse", build_both_refuse_gdp),
+    ):
+        for arm in ("big-m", "hull", "simplex"):
+            status, note, obj, bound, viol = attempt(builder, arm)
+            assertions += 1
+            print(
+                f"[{label}/{arm}] status={status} obj={obj} bound={bound} "
+                f"src_viol={viol} {note}",
+                flush=True,
+            )
+    print(f"\nexecuted assertions: {assertions}")
+    if assertions == 0:
+        print("FAIL: the probe measured nothing (CLAUDE.md section 6)")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scratchpad/issue1182/E4_mpec_sos1_reference.py
+++ b/scratchpad/issue1182/E4_mpec_sos1_reference.py
@@ -1,0 +1,146 @@
+"""#1182 entry experiment, part 5: the SOS1 reference requirement 4 names.
+
+Requirement 4 of #1182 asks for a benchmark "against POUNCE and exact GDP/SOS1
+references, recording source feasibility and solve guarantees separately from
+time". E1/E2 cover the exact **GDP** references (big-M, hull) on general
+disjunctions. SOS1 in this tree is not a general disjunction lowering: it is one
+of ``discopt.mpec``'s complementarity encodings, so the SOS1 comparison only
+exists on MPEC models. That is what this probe measures.
+
+A complementarity ``0 <= f _|_ g >= 0`` is ``f >= 0, g >= 0, (f == 0 or g == 0)``,
+which ``reformulate_gdp`` in ``discopt.mpec`` states as an ``either_or``. So the
+same relation is reachable through four exact encodings:
+
+* ``method="sos1"``    -- a Special Ordered Set of type 1;
+* ``method="gdp"``     -- selector binary + big-M (the module default);
+* ``method="gdp"`` with ``gdp_method="hull"``;
+* ``method="gdp"`` with ``gdp_method="simplex"`` -- Theorem 1, no binaries at all.
+
+All four go through the same certified ``Model.solve``. ``method="scholtes"`` is
+deliberately absent: it is a homotopy of *local* NLP solves and its result is not
+a certificate, so putting it in this table would compare two different kinds of
+answer (the local-vs-certified distinction #1148/#1158 exists for).
+
+Source feasibility is measured on the DECLARED operands -- ``min(f, g)`` at the
+returned point -- and reported beside, never instead of, the solve guarantee and
+the time.
+
+Prints an executed-comparison count and exits non-zero if it is zero.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+import time
+
+import discopt.modeling as dm
+import numpy as np
+from discopt.mpec import complementarity, solve_mpec
+
+
+def build_distance():
+    """min (x-1)^2 + (y-1)^2 s.t. 0 <= x _|_ y >= 0. Optimum 1 at (1, 0) or (0, 1)."""
+    m = dm.Model("mpec_distance")
+    x = m.continuous("x", lb=0, ub=10)
+    y = m.continuous("y", lb=0, ub=10)
+    m.minimize((x - 1) ** 2 + (y - 1) ** 2)
+    return m, [("x", "y")], [complementarity(x, y, name="c0")]
+
+
+def build_chain(n: int = 4):
+    """A chain of n complementarity pairs coupled by one linear row.
+
+    Bigger than the toy so the encodings can actually separate: the optimum
+    drives each pair to one side, and the coupling row makes the choice
+    non-trivial.
+    """
+    m = dm.Model(f"mpec_chain{n}")
+    xs = [m.continuous(f"x{i}", lb=0, ub=10) for i in range(n)]
+    ys = [m.continuous(f"y{i}", lb=0, ub=10) for i in range(n)]
+    m.minimize(sum((xs[i] - 1 - 0.3 * i) ** 2 + (ys[i] - 0.5) ** 2 for i in range(n)))
+    m.subject_to(sum(xs) + sum(ys) >= 2.0)
+    names = [(f"x{i}", f"y{i}") for i in range(n)]
+    return m, names, [complementarity(xs[i], ys[i], name=f"c{i}") for i in range(n)]
+
+
+BUILDERS = {"distance": build_distance, "chain4": lambda: build_chain(4)}
+
+ARMS = (
+    ("sos1", {}),
+    ("gdp/big-m", {"gdp_method": "big-m"}),
+    ("gdp/hull", {"gdp_method": "hull"}),
+    ("gdp/simplex", {"gdp_method": "simplex"}),
+)
+
+
+def source_residual(point, pair_names) -> float:
+    """max_i min(f_i, g_i) on the DECLARED operands. <= 0 means complementary."""
+    worst = -np.inf
+    for f_name, g_name in pair_names:
+        f = float(np.asarray(point[f_name]))
+        g = float(np.asarray(point[g_name]))
+        worst = max(worst, min(f, g))
+    return worst
+
+
+def run(names, time_limit: float) -> int:
+    comparisons = 0
+    table = []
+    for name in names:
+        for arm, kwargs in ARMS:
+            model, pair_names, pairs = BUILDERS[name]()
+            method = "sos1" if arm == "sos1" else "gdp"
+            t0 = time.perf_counter()
+            try:
+                res = solve_mpec(model, pairs, method=method, time_limit=time_limit, **kwargs)
+            except Exception as exc:
+                print(f"[{name}/{arm}] RAISED {type(exc).__name__}: {str(exc)[:120]}", flush=True)
+                table.append((name, arm, "raised", None, None, None, None, None))
+                comparisons += 1
+                continue
+            wall = time.perf_counter() - t0
+            residual = source_residual(res.x, pair_names) if res.x else None
+            comparisons += 1 + len(pair_names)
+            table.append(
+                (name, arm, str(res.status), res.objective, res.bound,
+                 res.node_count, wall, residual, getattr(res, "gap_certified", None))
+            )
+            print(
+                f"[{name}/{arm}] status={res.status} obj={res.objective} "
+                f"bound={res.bound} nodes={res.node_count} wall={wall:.2f}s "
+                f"certified={getattr(res, 'gap_certified', None)} "
+                f"source_min(f,g)={residual}",
+                flush=True,
+            )
+
+    print("\n=== summary (guarantee and source feasibility beside, not instead of, time) ===")
+    hdr = ("model", "arm", "status", "objective", "bound", "nodes", "wall",
+           "src min(f,g)", "certified")
+    print(" | ".join(f"{h:>13}" for h in hdr))
+    for row in table:
+        name, arm, status, obj, bound, nodes, wall, residual = row[:8]
+        certified = row[8] if len(row) > 8 else None
+        print(" | ".join(f"{c:>13}" for c in (
+            name, arm, status,
+            "-" if obj is None else f"{obj:.6g}",
+            "-" if bound is None else f"{bound:.6g}",
+            "-" if nodes is None else str(nodes),
+            "-" if wall is None else f"{wall:.2f}",
+            "-" if residual is None else f"{residual:.3g}",
+            str(certified),
+        )))
+
+    print(f"\nexecuted comparisons: {comparisons}")
+    if comparisons == 0:
+        print("FAIL: the probe measured nothing (CLAUDE.md section 6)")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--instances", default=",".join(BUILDERS))
+    ap.add_argument("--time-limit", type=float, default=60.0)
+    args = ap.parse_args()
+    sys.exit(run([n for n in args.instances.split(",") if n], args.time_limit))

--- a/scratchpad/issue1182/E5_corpus_refusal_scan.py
+++ b/scratchpad/issue1182/E5_corpus_refusal_scan.py
@@ -1,0 +1,135 @@
+"""#1182 entry experiment, part 4: how often does the refusal class occur on a REAL corpus?
+
+E3 found a class where BOTH classical lowerings refuse and the Theorem-1
+lowering certifies: a disjunct row whose body has an **unbounded interval
+enclosure** (so discopt's big-M pass raises ``cannot bound the body ... from
+above``) and which is **not finite at the origin** (so the
+Furman-Sawaya-Grossmann perspective raises ``HullPerspectiveOriginError``).
+
+That fixture is synthetic. Per the #727 RLT lesson a mechanism validated only on
+a synthetic proxy can be a no-op on the real class, so this probe measures how
+often each refusal condition actually holds on the **GDPlib** corpus -- the
+reference GDP library discopt already benchmarks against
+(``benchmarks.gdplib_runner``).
+
+The two conditions are evaluated on the Pyomo source models with Pyomo's own
+interval propagation (``compute_bounds_on_expr``) and an origin evaluation, which
+are the same two questions discopt's two lowerings ask. Refusal counts are
+reported per model and per condition, never summed into one "hard" number.
+
+Prints the executed-assertion count and exits non-zero if it is zero.
+"""
+
+from __future__ import annotations
+
+import importlib
+import math
+import sys
+import traceback
+
+MODELS = [
+    "batch_processing", "biofuel", "cstr", "disease_model", "ex1_linan_2023",
+    "gdp_col", "hda", "jobshop", "kaibel", "med_term_purchasing", "methanol",
+    "mod_hens", "modprodnet", "positioning", "small_batch", "spectralog",
+    "stranded_gas", "syngas", "water_network",
+]
+
+
+def _origin_value(body, variables):
+    """Evaluate ``body`` with every variable at 0. Non-finite => hull refuses."""
+    from pyomo.environ import value
+
+    saved = [(v, v.value, v.fixed) for v in variables]
+    try:
+        for v in variables:
+            v.fixed = False
+            v.set_value(0.0, skip_validation=True)
+        try:
+            val = value(body)
+        except (ZeroDivisionError, ValueError, OverflowError):
+            return None
+        return val if isinstance(val, (int, float)) and math.isfinite(val) else None
+    finally:
+        for v, val0, fixed0 in saved:
+            v.set_value(val0, skip_validation=True)
+            v.fixed = fixed0
+
+
+def scan_model(name):
+    from pyomo.contrib.fbbt.fbbt import compute_bounds_on_expr
+    from pyomo.core.expr.visitor import identify_variables
+    from pyomo.environ import Block, Constraint
+    from pyomo.gdp import Disjunct
+
+    mod = importlib.import_module(f"gdplib.{name}")
+    build = getattr(mod, "build_model", None) or getattr(mod, "build_" + name, None)
+    if build is None:
+        cands = [a for a in dir(mod) if a.startswith("build")]
+        if not cands:
+            raise AttributeError(f"gdplib.{name} exposes no build* entry point")
+        build = getattr(mod, cands[0])
+    m = build()
+
+    rows = unbounded = origin_bad = both = 0
+    for d in m.component_data_objects(Disjunct, active=True, descend_into=(Block, Disjunct)):
+        for c in d.component_data_objects(Constraint, active=True, descend_into=True):
+            rows += 1
+            body = c.body
+            variables = list(identify_variables(body, include_fixed=False))
+            try:
+                lo, hi = compute_bounds_on_expr(body)
+            except Exception:
+                lo, hi = None, None
+            unb = (
+                lo is None or hi is None
+                or not math.isfinite(lo) or not math.isfinite(hi)
+            )
+            org = _origin_value(body, variables)
+            if unb:
+                unbounded += 1
+            if org is None:
+                origin_bad += 1
+            if unb and org is None:
+                both += 1
+    return rows, unbounded, origin_bad, both
+
+
+def main() -> int:
+    assertions = 0
+    table = []
+    for name in MODELS:
+        try:
+            rows, unb, org, both = scan_model(name)
+        except Exception as exc:
+            print(f"[{name}] SKIPPED {type(exc).__name__}: {str(exc)[:110]}", flush=True)
+            traceback.print_exc(limit=1)
+            continue
+        assertions += rows
+        table.append((name, rows, unb, org, both))
+        print(
+            f"[{name}] disjunct_rows={rows} unbounded_enclosure={unb} "
+            f"nonfinite_at_origin={org} both={both}",
+            flush=True,
+        )
+
+    print("\n=== summary (disjunct rows by refusal condition) ===")
+    hdr = ("model", "rows", "big-m refuses", "hull refuses", "both refuse")
+    print(" | ".join(f"{h:>22}" for h in hdr))
+    tot = [0, 0, 0, 0]
+    for name, rows, unb, org, both in table:
+        print(" | ".join(f"{c:>22}" for c in (name, str(rows), str(unb), str(org), str(both))))
+        tot[0] += rows
+        tot[1] += unb
+        tot[2] += org
+        tot[3] += both
+    print(" | ".join(f"{c:>22}" for c in ("TOTAL", *map(str, tot))))
+
+    print(f"\nexecuted assertions (disjunct rows examined): {assertions}")
+    if assertions == 0:
+        print("FAIL: the probe measured nothing (CLAUDE.md section 6)")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scratchpad/issue1182/README.md
+++ b/scratchpad/issue1182/README.md
@@ -1,0 +1,39 @@
+# #1182 entry experiment — exact continuous (simplex/CNF) lowering
+
+The probes CLAUDE.md §4 requires before implementing the Theorem-1 lowering of
+[arXiv:2601.03906v1](https://arxiv.org/abs/2601.03906v1). Results are written up in
+`docs/dev/performance-plan.md` §26; the `*_run.log` files here are the raw output of
+the runs quoted there.
+
+Every probe prints an executed-comparison / executed-assertion count and exits
+non-zero if it is zero (CLAUDE.md §6).
+
+```bash
+# E1 needs the benchmark harness on the path (native GDPlib builders); the others
+# only need this directory.
+export PYTHONPATH=discopt_benchmarks:scratchpad/issue1182
+
+python -u scratchpad/issue1182/E1_entry_experiment.py --time-limit 60   # real GDP corpus
+python -u scratchpad/issue1182/E2_paper_class.py --steps 3,5 --reps 2   # the paper's own class
+python -u scratchpad/issue1182/E3_bigm_refusal.py                       # capability, 4 fixtures
+python -u scratchpad/issue1182/E5_corpus_refusal_scan.py                # GDPlib refusal scan
+```
+
+`E5` additionally needs `pyomo` and `gdplib` **installed from source** (the PyPI
+wheel omits the model data files), plus `pandas`/`matplotlib`/`openpyxl`:
+
+```bash
+pip install pyomo pandas matplotlib openpyxl \
+    "gdplib @ git+https://github.com/SECQUOIA/gdplib.git"
+```
+
+`simplex_proto.py` / `source_check.py` are the **prototype** the entry experiment
+ran against, deliberately kept: they are what produced the numbers in §26, and the
+shipped `discopt._relax.simplex_lowering` reproduces their node counts exactly
+(jobshop 251, small_batch 3), which is the cross-check that the productionized
+lowering is the thing that was measured.
+
+**Outcome.** The speed hypothesis is falsified (E1: 0 of 3 instances meet the kill
+criterion; E2: the same on the class the paper targets). The capability motive
+survives and is what shipped: E3's fourth fixture is a row both classical lowerings
+refuse, and E5 finds 18 such rows in GDPlib's `stranded_gas`.

--- a/scratchpad/issue1182/README.md
+++ b/scratchpad/issue1182/README.md
@@ -2,8 +2,9 @@
 
 The probes CLAUDE.md §4 requires before implementing the Theorem-1 lowering of
 [arXiv:2601.03906v1](https://arxiv.org/abs/2601.03906v1). Results are written up in
-`docs/dev/performance-plan.md` §26; the `*_run.log` files here are the raw output of
-the runs quoted there.
+`docs/dev/performance-plan.md` §26, which holds the tables verbatim and is the
+durable record — `scratchpad/**/*.log` is gitignored, so re-run a probe rather than
+looking for its output here.
 
 Every probe prints an executed-comparison / executed-assertion count and exits
 non-zero if it is zero (CLAUDE.md §6).

--- a/scratchpad/issue1182/simplex_proto.py
+++ b/scratchpad/issue1182/simplex_proto.py
@@ -1,0 +1,203 @@
+"""Prototype of the Wehbeh & Kerrigan (arXiv:2601.03906v1) Theorem-1 lowering.
+
+Entry-experiment code for issue #1182 -- NOT a shipped path. It exists so the
+entry experiment CLAUDE.md section 4 demands can be run *before* any production
+implementation.
+
+Theorem 1 replaces a CNF clause ``OR_j [p_ij(z) <= 0]`` with
+
+    sum_j lambda_ij * p_ij(z) <= 0,    lambda_i >= 0,    sum_j lambda_ij = 1
+
+which is exact **in projection onto z**: pick ``lambda_i = e_k`` for a satisfied
+literal k, and conversely a convex combination of the ``p_ij`` that is <= 0
+forces ``min_j p_ij <= 0``.
+
+A discopt disjunction is ``OR_j (AND_k c_jk)``, i.e. a disjunction of
+*conjunctions*, so CNF conversion distributes:
+
+    OR_j AND_k p_jk  ==  AND_{(k_1..k_J)} (OR_j p_{j,k_j})
+
+with ``prod_j |P_j|`` clauses. That blowup is one of the four quantities
+requirement 4 of #1182 asks to be measured separately, so it is counted here and
+never hidden behind "model size".
+
+Each equality ``h == 0`` inside a disjunct is two predicates (``h <= 0`` and
+``-h <= 0``), which is where the blowup comes from on the grid-style GDPs.
+"""
+
+from __future__ import annotations
+
+import itertools
+from dataclasses import dataclass, field
+
+from discopt.modeling.core import (
+    Constraint,
+    DisjunctionSemantics,
+    Model,
+    SelectorActivation,
+    _DisjunctiveConstraint,
+)
+
+SIMPLEX_AUX_PREFIX = "_simplex_"
+
+
+class SimplexLoweringRefused(ValueError):
+    """The declared semantics or predicate shape is outside Theorem 1's contract."""
+
+
+@dataclass
+class SizeCounts:
+    """Requirement 4's four quantities, counted separately (never summed)."""
+
+    disjunctions: int = 0
+    cnf_clauses: int = 0
+    literal_occurrences: int = 0
+    aux_variables: int = 0
+    rows: int = 0
+    # filled in by the caller from the built model
+    jacobian_nonzeros: int = 0
+
+    def add(self, other: "SizeCounts") -> None:
+        self.disjunctions += other.disjunctions
+        self.cnf_clauses += other.cnf_clauses
+        self.literal_occurrences += other.literal_occurrences
+        self.aux_variables += other.aux_variables
+        self.rows += other.rows
+
+
+@dataclass
+class SourcePredicate:
+    """One original predicate, kept so residuals are measured on the *source*.
+
+    Requirement 1 of #1182: the simplex weights are existential witnesses, so the
+    truth of the disjunction must be read off the original predicates at the
+    returned point, never off the weighted rows and never as a Boolean
+    assignment recovered from a fractional lambda.
+    """
+
+    disjunction: str
+    disjunct: int
+    body: object          # Expression p with "p <= 0" meaning the literal is true
+    definition: str       # human-readable source of this residual
+
+
+@dataclass
+class LoweredDisjunction:
+    name: str
+    n_disjuncts: int
+    predicates: list[list[SourcePredicate]] = field(default_factory=list)
+    counts: SizeCounts = field(default_factory=SizeCounts)
+
+
+def _predicates_of(con: Constraint, disjunction: str, disjunct: int) -> list[SourcePredicate]:
+    """Normalize one disjunct row to a list of ``p <= 0`` predicates."""
+    if not isinstance(con, Constraint):
+        raise SimplexLoweringRefused(
+            f"{disjunction!r} disjunct {disjunct} holds a {type(con).__name__}; "
+            "Theorem 1 is stated over algebraic predicates, and a nested "
+            "disjunction/SOS row is not one. Refusing rather than approximating."
+        )
+    if con.rhs != 0.0:
+        raise SimplexLoweringRefused(f"{disjunction!r}: non-normalized rhs {con.rhs}")
+    if con.sense == "<=":
+        return [SourcePredicate(disjunction, disjunct, con.body, "body <= 0")]
+    if con.sense == ">=":
+        return [SourcePredicate(disjunction, disjunct, -con.body, "-body <= 0")]
+    if con.sense == "==":
+        return [
+            SourcePredicate(disjunction, disjunct, con.body, "body <= 0 (of ==)"),
+            SourcePredicate(disjunction, disjunct, -con.body, "-body <= 0 (of ==)"),
+        ]
+    raise SimplexLoweringRefused(f"{disjunction!r}: unknown sense {con.sense!r}")
+
+
+def _require_projection_semantics(dc: _DisjunctiveConstraint) -> None:
+    sem = getattr(dc, "semantics", DisjunctionSemantics.SELECT_ONE)
+    if sem.activation is not SelectorActivation.ONE_WAY:
+        raise SimplexLoweringRefused(
+            f"{dc.name!r} declares {sem.name}; Theorem 1 is a projection statement "
+            "and reproduces ONE_WAY activation only. REIFIED needs the paper's "
+            "section 3.1 existential exponential lift for strict negation -- "
+            "substituting a closed inequality or a fixed margin changes the "
+            "contract (#1182)."
+        )
+
+
+def lower_disjunction(
+    dc: _DisjunctiveConstraint,
+    model: Model,
+    add_weight,
+    index: int,
+) -> tuple[LoweredDisjunction, list[Constraint]]:
+    """Emit Theorem 1's rows for one disjunction. Returns (record, new rows)."""
+    _require_projection_semantics(dc)
+    name = dc.name or f"disj{index}"
+    per_disjunct: list[list[SourcePredicate]] = []
+    for j, disjunct in enumerate(dc.disjuncts):
+        preds: list[SourcePredicate] = []
+        for con in disjunct:
+            preds.extend(_predicates_of(con, name, j))
+        if not preds:
+            raise SimplexLoweringRefused(f"{name!r}: disjunct {j} is empty")
+        per_disjunct.append(preds)
+
+    J = len(per_disjunct)
+    clauses = list(itertools.product(*per_disjunct))
+    counts = SizeCounts(
+        disjunctions=1,
+        cnf_clauses=len(clauses),
+        literal_occurrences=len(clauses) * J,
+        aux_variables=len(clauses) * J,
+        rows=2 * len(clauses),  # one simplex equality + one weighted row per clause
+    )
+
+    rows: list[Constraint] = []
+    for i, clause in enumerate(clauses):
+        lam = add_weight(f"{name}_c{i}", J)
+        # sum_j lambda_ij == 1
+        simplex = lam[0]
+        for j in range(1, J):
+            simplex = simplex + lam[j]
+        rows.append(Constraint(body=simplex - 1.0, sense="==", rhs=0.0,
+                               name=f"_simplex_{name}_c{i}_sum"))
+        # sum_j lambda_ij * p_ij(z) <= 0
+        weighted = lam[0] * clause[0].body
+        for j in range(1, J):
+            weighted = weighted + lam[j] * clause[j].body
+        rows.append(Constraint(body=weighted, sense="<=", rhs=0.0,
+                               name=f"_simplex_{name}_c{i}_row"))
+
+    return LoweredDisjunction(name, J, per_disjunct, counts), rows
+
+
+def reformulate_simplex(model: Model) -> tuple[Model, list[LoweredDisjunction], SizeCounts]:
+    """Replace every ``_DisjunctiveConstraint`` with Theorem 1's continuous rows."""
+    new_model = Model(model.name)
+    new_model._variables = list(model._variables)
+    new_model._parameters = list(model._parameters)
+    new_model._rebuild_name_index()
+    new_model._objective = model._objective
+
+    taken = {v.name for v in new_model._variables}
+    counter = [0]
+
+    def add_weight(tag: str, size: int):
+        name = f"{SIMPLEX_AUX_PREFIX}lam_{counter[0]}"
+        counter[0] += 1
+        while name in taken:
+            name = f"{SIMPLEX_AUX_PREFIX}lam_{counter[0]}"
+            counter[0] += 1
+        taken.add(name)
+        return new_model.continuous(name, size, lb=0.0, ub=1.0)
+
+    records: list[LoweredDisjunction] = []
+    total = SizeCounts()
+    for idx, c in enumerate(model._constraints):
+        if isinstance(c, _DisjunctiveConstraint):
+            rec, rows = lower_disjunction(c, new_model, add_weight, idx)
+            records.append(rec)
+            total.add(rec.counts)
+            new_model._constraints.extend(rows)
+        else:
+            new_model._constraints.append(c)
+    return new_model, records, total

--- a/scratchpad/issue1182/source_check.py
+++ b/scratchpad/issue1182/source_check.py
@@ -1,0 +1,124 @@
+"""Requirement 1 of #1182: residuals measured on the ORIGINAL predicates.
+
+The simplex weights ``lambda_ij`` of Theorem 1 are *existential witnesses*, not
+selectors. A fractional lambda is not a failed Boolean integrality, and it is not
+a recoverable named Boolean assignment. So the only honest question to ask of a
+returned point is the one this module asks: evaluate each original predicate
+``p_jk(z)`` at the returned **source** point and report, per disjunction,
+
+    min_j max_k p_jk(z)
+
+which is <= 0 exactly when some disjunct holds -- the disjunction's own truth,
+read off the declared operands and nothing else.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+import numpy as np
+
+
+def variables_in(expr) -> set:
+    """Names of the variables an expression touches."""
+    from discopt.modeling.core import Variable
+
+    seen: set = set()
+    stack = [expr]
+    visited: set[int] = set()
+    while stack:
+        node = stack.pop()
+        if id(node) in visited:
+            continue
+        visited.add(id(node))
+        if isinstance(node, Variable):
+            seen.add(node.name)
+            continue
+        for attr in ("operands", "args", "children"):
+            kids = getattr(node, attr, None)
+            if kids:
+                stack.extend(kids)
+                break
+        else:
+            for attr in ("left", "right", "operand", "base", "expr", "body"):
+                kid = getattr(node, attr, None)
+                if kid is not None and not isinstance(kid, (int, float, str)):
+                    stack.append(kid)
+    return seen
+
+
+@dataclass
+class DisjunctionResidual:
+    name: str
+    per_disjunct_max: list[float]
+    violation: float          # min_j max_k p_jk ; <= 0 means the disjunction holds
+    definition: str = "min_j max_k p_jk(z) on the declared disjunct rows"
+
+
+@dataclass
+class PredicateReport:
+    """Source-predicate residuals. Carries no Boolean assignment, by design."""
+
+    disjunctions: list[DisjunctionResidual] = field(default_factory=list)
+    comparisons: int = 0
+
+    @property
+    def max_disjunction_violation(self) -> float:
+        if not self.disjunctions:
+            return float("nan")
+        return max(d.violation for d in self.disjunctions)
+
+
+def _flat_point(model, x_by_name) -> np.ndarray:
+    parts = []
+    for v in model._variables:
+        if v.name not in x_by_name:
+            raise KeyError(
+                f"source variable {v.name!r} is absent from the returned point; "
+                "a source residual cannot be faked from the lowered rows"
+            )
+        arr = np.asarray(x_by_name[v.name], dtype=np.float64).reshape(-1)
+        if arr.size != v.size:
+            raise ValueError(f"{v.name}: expected {v.size} values, got {arr.size}")
+        parts.append(arr)
+    return np.concatenate(parts) if parts else np.zeros(0)
+
+
+def predicate_report(source_model, x_by_name) -> PredicateReport:
+    """Evaluate every disjunct row of ``source_model`` at the returned point."""
+    from discopt._relax.dag_compiler import compile_expression
+    from discopt.modeling.core import Constraint, _DisjunctiveConstraint
+
+    flat = _flat_point(source_model, x_by_name)
+    rep = PredicateReport()
+    for idx, c in enumerate(source_model._constraints):
+        if not isinstance(c, _DisjunctiveConstraint):
+            continue
+        name = c.name or f"disj{idx}"
+        per_disjunct: list[float] = []
+        for disjunct in c.disjuncts:
+            worst = -np.inf
+            for con in disjunct:
+                if not isinstance(con, Constraint):
+                    raise TypeError(
+                        f"{name}: disjunct row is {type(con).__name__}; refusing to "
+                        "report a residual over rows this probe cannot evaluate"
+                    )
+                bodies = []
+                if con.sense == "<=":
+                    bodies = [con.body]
+                elif con.sense == ">=":
+                    bodies = [-con.body]
+                elif con.sense == "==":
+                    bodies = [con.body, -con.body]
+                else:
+                    raise ValueError(f"{name}: unknown sense {con.sense!r}")
+                for body in bodies:
+                    val = float(np.max(np.asarray(compile_expression(body, source_model)(flat))))
+                    worst = max(worst, val)
+                    rep.comparisons += 1
+            per_disjunct.append(worst)
+        rep.disjunctions.append(
+            DisjunctionResidual(name, per_disjunct, min(per_disjunct))
+        )
+    return rep


### PR DESCRIPTION
## Summary

Adds `gdp_method="simplex"`, the Theorem-1 lowering of Wehbeh & Kerrigan ([arXiv:2601.03906v1](https://arxiv.org/abs/2601.03906v1)) that #1182 carries forward from RFC #1123. A CNF clause `OR_j [p_ij(z) <= 0]` becomes

```
sum_j lambda_ij p_ij(z) <= 0,   lambda_i >= 0,   sum_j lambda_ij = 1
```

exact **in projection onto the model variables**, and free of selector binaries entirely. A discopt disjunction is `OR_j AND_k c_jk`, so CNF conversion distributes and each equality row counts as two predicates — that blowup is measured and budgeted, not hidden.

**The entry experiment ran first (CLAUDE.md §4), and it changed what shipped.** Probes in `scratchpad/issue1182/`, written up in `docs/dev/performance-plan.md` §26.

- **The speed hypothesis is falsified.** On the in-repo native GDP corpus the lowering is slower on all three instances and regresses `ex1_linan_2023` from certified to uncertified at a 60 s cap. On the paper's *own* class — obstacle-avoidance optimal control, where CNF distribution is a no-op — it again never certifies what big-M certifies in under 3 s. So `"simplex"` is **opt-in**, `gdp_method="auto"` never picks it, and §26 is the standing reason.
- **A capability motive survives, and is why this ships.** big-M refuses a disjunct row whose interval enclosure is unbounded; the Furman–Sawaya–Grossmann hull refuses a row that is not finite at the origin. Theorem 1 needs neither. Scanning **11,058 GDPlib disjunct rows** finds **18** (in `stranded_gas`, `log` of a capacity sum whose box includes 0) that hit **both** refusals — rows no lowering in this tree could handle at all. That is the concrete fixture #1182's entry condition asks for; it is a capability fixture, not a performance one, and the PR says so rather than reframing the falsification as a win.

The weights are **existential witnesses, not selectors**, and the code keeps them that way: continuous in `[0, 1]` so a fractional value is never failed Boolean integrality, named inside the reserved `GDP_AUX_PREFIX` namespace, and the lowering record exposes no Boolean assignment. Truth is read off the **declared** predicates at the returned point by `disjunction_residuals` / `selected_disjuncts` (both re-exported from `discopt`). `selected_disjuncts` returns a **set**, because under `SELECT_ONE` a point may lie in several disjuncts, and empty when the disjunction is violated.

Requirement 2 of #1182 (reuse `discopt.status`) has **no surface here**: #1158 has not landed, and this path introduces no local-only result — the lowering is exact, so a certified global solve of the lowered model certifies the source. If a local-NLP arm on this lowering is ever added, that requirement becomes live again.

Contributes to #1123. Closes #1182.

## Correctness

- [x] Cannot produce a false certificate. The lowering is exact in projection, not a relaxation: `test_the_lifted_row_is_exact_in_projection_over_a_sampled_box` asserts both directions over 202 sampled points (no feasible point cut, no infeasible point admitted), and the certified optimum matches the big-M optimum on the shared fixtures and on all three native GDP corpus models. No existing path changes: `"simplex"` is reachable only when a caller asks for it by name, and every other `gdp_method` emits byte-identical rows.
- [x] No validation, fallback, or safety guard was weakened. Guards were **added**, and all six are refusals rather than fallbacks: `EXACTLY_ONE_TRUE`/REIFIED semantics (§3.1's strict negation needs an existential exponential lift, and substituting a closed inequality would change the declared feasible set), nested disjunctions, non-scalar rows, rows whose shape is not statically known, empty disjuncts, and CNF blowup above `MAX_CNF_CLAUSES`. `solver="mip-nlp"` + `"simplex"` raises rather than silently solving a model with nothing to branch on.

  The two refusals this lowering *avoids* are not guards it steps around: each is a statement about **its own** lowering's validity (a fabricated finite `M`, a fabricated `g(0)` — both unsound). Theorem 1 fabricates neither quantity because it needs neither. What it hands the relaxation layer is an ordinary algebraic row of the kind an unlowered model may already contain, so the soundness question is the relaxation layer's usual one and not a new exemption.

  Two §6 guards on the reporting side: `disjunction_residuals` raises on a model that declares no disjunction, and `max_violation` raises on an empty report — "no violations" can never be the reading of a probe that traversed nothing.

## Tests run (state the result — numbers, not adjectives)

On the final head `a7c1d95`:

- [x] `pytest -m smoke python/tests/` → **1136 passed, 14 skipped, 2 xpassed**, 371 s
- [x] `pytest -m slow python/tests/test_adversarial_recent_fixes.py` → **19 passed**, 172 s
- [x] `cargo test -p discopt-core` → **N/A**, no Rust touched
- [x] `ruff check python/` / `ruff format --check python/` clean (969 files); `mypy python/discopt/` → **no issues in 336 source files**
- [x] `pytest python/tests/test_1182_simplex_lowering.py` → **26 passed**, with **426 executed source-predicate comparisons** counted and asserted non-zero
- [x] `pytest python/tests/ -k "gdp or disjunct or 1124 or mpec or complementarity"` → **465 passed, 13 skipped, 2 xpassed**
- [x] `pytest discopt_benchmarks/tests/test_gdplib_native.py` → **9 passed** (the certified-optimum cross-check on the corpus this PR measured)

The executed-comparison counter is a `teardown_module` hook, not a test: this suite runs under `pytest-randomly`, and as a test a shuffle that ran it first would have made the guard against measuring nothing itself measure nothing.

## Regression test

`python/tests/test_1182_simplex_lowering.py` (26 tests) pins each of #1182's requirements individually. On `main` the module fails at collection because `discopt._relax.simplex_lowering` does not exist there, so the fail-before is real but trivial for most cases. The substantive ones are worth stating plainly:

- `test_a_fractional_witness_satisfies_the_weighted_row_while_a_disjunct_fails` — the control that makes requirement 1 bite. At `x = 1.4` in #1124's fixture, `lambda = (0.5, 0.5)` satisfies the weighted row while disjunct 0 is violated by `0.4`; the source report says so and `selected_disjuncts` names only disjunct 1.
- `test_big_m_and_hull_both_refuse_the_row_the_simplex_lowering_certifies` — the capability fixture, with **both** refusals asserted as the control. Neither classical lowering can be made to pass this test.
- `test_the_lifted_row_is_exact_in_projection_over_a_sampled_box` — 202 sampled points, both directions of exactness asserted separately, and the sample count asserted so an empty sampler cannot read as a pass.
- `test_a_row_whose_shape_is_not_statically_known_is_refused_not_assumed_scalar` — pins the `#1160` lesson: `Expression.shape` raises for a scalar reduction and an axis-reduced one alike, so "unknown" takes the refusing branch.

Where a blanket fix could pass vacuously, the test carries a control: `test_the_lowered_model_carries_its_size_accounting` checks that `"auto"`/`"big-m"`/`"hull"` leave the record list **empty** as well as that `"simplex"` fills it, so a lowering that recorded nothing (or everything) fails.

- [x] Added a regression test that fails before / passes after

## Bound-changing / performance change?

**No.** No flag, cut or relaxation is introduced, and no default changes. `gdp_method` defaults to `"big-m"`; `"simplex"` is reachable only by explicit request and is never selected by `"auto"`. Every other method's emitted rows are unchanged, so there is no A/B panel to run — the measurement in this PR is the *entry experiment*, which decided against making it a default, and it is recorded in `docs/dev/performance-plan.md` §26 with all four probes and their tables:

| | E1 (native GDP corpus) | E2 (the paper's class) | E4 (MPEC, vs SOS1) |
|---|---|---|---|
| certified by big-M | 3/3 | 2/2 | 2/2 |
| certified by simplex | 2/3 | 0/2 | 2/2 |
| simplex wall vs big-M | 1.6–15× slower | never certifies | 100–250× slower |

E4's node count is the one mixed signal (simplex 5 vs big-M 9 on one model, 11 vs 3 on the other) and it is written up as mixed, not as a partial win — a node-count win costing 244× wall does not meet §5's net-positive bar, and one of E4's two models is a synthetic chain rather than a corpus instance. The one column where the lowering is consistently better is the source complementarity residual (1.4e−17 against 6.1e−11), which is a property of being exact rather than regularized.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HVmT6ESz4hqsXWb9C5R7ti

---
_Generated by [Claude Code](https://claude.ai/code/session_01HVmT6ESz4hqsXWb9C5R7ti)_