### PR TITLE
perf(milp): A12 -- RINS improvement heuristic behind DISCOPT_RINS (default off)

### DIFF
--- a/crates/discopt-core/src/bnb/milp_driver.rs
+++ b/crates/discopt-core/src/bnb/milp_driver.rs
@@ -361,6 +361,7 @@ fn dive_batch_eligible(
 }
 
 /// Options for the MILP driver.
+#[derive(Clone)]
 pub struct MilpOptions {
     /// Number of structural (model) variables; columns `[n_struct, n)` are slacks.
     pub n_struct: usize,
@@ -499,6 +500,287 @@ pub struct MilpOptions {
     pub root_cut_prune: bool,
     /// LP solver options.
     pub simplex: SimplexOptions,
+}
+
+// ---------------------------------------------------------------------------
+// A12: RINS (Relaxation Induced Neighborhood Search) -- an *improvement* heuristic.
+//
+// Motivated by measurement, not assumption. Every dual-side lever on the parity
+// panel is falsified (docs/dev/milp-competitiveness-plan.md, A1-A11 and B1); A5
+// located the residual gap on the PRIMAL side (17/38 unsolved at an 89.6 % median
+// primal share, 12 of them holding a merely-poor incumbent rather than none), and
+// the driver has a rounding heuristic plus a no-incumbent dive (#1060) but nothing
+// whatsoever that improves an incumbent once one exists -- "the first incumbent is
+// very nearly the last". A12 measured RINS's precondition BEFORE this code was
+// written: over 2,023,762 incumbent-present nodes on 38 MIPLIB instances, 98.6 %
+// have an LP/incumbent agreement inside the usable band [0.30, 0.99), and 98.4 %
+// on the unsolved instances specifically.
+//
+// The idea (Danna, Rothberg & Le Pape, "Exploring relaxation induced neighborhoods
+// to improve MIP solutions", Math. Program. 102(1), 2005): fix the integer
+// variables on which the node LP relaxation and the incumbent already agree, and
+// solve what remains as a small MILP. The agreement test is the standard one --
+// exact equality within the feasibility tolerance, NOT a rounding test -- and the
+// refusal threshold below is the customary 0.3 minimum fixing rate.
+//
+// SOUNDNESS. Purely *primal*: RINS can only propose an incumbent, never move a
+// dual bound, so it cannot loosen or falsify a certificate. Three things make
+// that concrete rather than merely argued:
+//   * the sub-MILP is a RESTRICTION of the BASE problem -- same matrix, same rhs,
+//     integer bounds only narrowed to values the incumbent already takes -- so any
+//     point feasible for it is feasible for the model;
+//   * the point that comes back is nevertheless re-validated through
+//     `validate_seed_incumbent`, the same gate a caller-supplied seed passes,
+//     which re-checks integrality, bounds and every original row and reconstructs
+//     the slacks itself. A rejected point is dropped and counted (`RinsRejected`,
+//     which must stay zero); trusting the sub-solve instead would turn a bug there
+//     into a false `Optimal` at the top level, the one outcome CLAUDE.md §1 never
+//     trades;
+//   * it runs against the BASE problem rather than the cut-augmented working one,
+//     so a wrong cut could not launder itself into an incumbent.
+//
+// RINS declines entirely under a lazy separator: on that path a point must be
+// screened before it may become the incumbent, and a heuristic that bypassed the
+// screen would enforce a model the caller did not ask for.
+// ---------------------------------------------------------------------------
+
+/// Minimum share of integer variables that must agree before a sub-MILP is worth
+/// solving. Below it the sub-problem is barely smaller than the original.
+const RINS_MIN_FIXING_RATE: f64 = 0.30;
+
+/// Node budget for one sub-MILP. An improvement heuristic that can outspend the
+/// search it exists to help is a regression however good its solutions are.
+const RINS_SUB_NODE_CAP: usize = 500;
+
+/// Share of the parent search RINS may spend across ALL its sub-solves, plus a
+/// flat allowance so it can work at all before the tree is large. The per-call
+/// cap above bounds one attempt; this bounds the whole solve, which is what
+/// actually matters -- attempts scale with the batch count, so a per-call cap
+/// alone leaves the total unbounded. The quota shape is SCIP's (`nodesquot`).
+const RINS_NODE_QUOT: f64 = 0.05;
+const RINS_NODE_OFFSET: usize = 500;
+
+/// Total sub-solve nodes RINS is still allowed, given the parent's node count and
+/// what it has already spent. Zero means the budget is exhausted for this solve.
+fn rins_node_budget(parent_nodes: usize, spent: usize) -> usize {
+    let allowance = RINS_NODE_OFFSET + (parent_nodes as f64 * RINS_NODE_QUOT) as usize;
+    allowance.saturating_sub(spent).min(RINS_SUB_NODE_CAP)
+}
+
+/// Batches between RINS attempts. Firing every batch would make it a per-node tax
+/// (the #1060 dive lesson).
+const RINS_BATCH_STRIDE: usize = 16;
+
+/// The pristine base problem, captured once before the root cut loop when RINS is
+/// armed, and used for every sub-solve and every re-validation.
+struct RinsBase {
+    csc: SparseCols,
+    m: usize,
+    n: usize,
+    c: Vec<f64>,
+    l: Vec<f64>,
+    u: Vec<f64>,
+    b: Vec<f64>,
+}
+
+thread_local! {
+    /// Recursion depth of the MILP driver on this thread. A RINS sub-solve
+    /// re-enters [`solve_milp_node_hooked`], and two things must not happen when
+    /// it does: it must not run RINS itself (unbounded recursion), and it must
+    /// not call `profile::begin_solve`, which RESETS the counters -- a nested
+    /// reset would wipe the parent's measurement mid-run and read as "this path
+    /// never executed", the CLAUDE.md §6 failure mode.
+    static MILP_DEPTH: std::cell::Cell<u32> = const { std::cell::Cell::new(0) };
+}
+
+/// RAII depth counter for [`MILP_DEPTH`]. The driver has many early returns; a
+/// manual decrement would be missed by one of them and leave the thread
+/// permanently "nested", silently disabling RINS and profiling for the rest of
+/// the process.
+struct MilpDepthGuard;
+
+impl MilpDepthGuard {
+    /// Enter one level; yields the depth *before* entry (0 = outermost solve).
+    fn enter() -> (Self, u32) {
+        let d = MILP_DEPTH.with(|c| c.get());
+        MILP_DEPTH.with(|c| c.set(d + 1));
+        (MilpDepthGuard, d)
+    }
+}
+
+impl Drop for MilpDepthGuard {
+    fn drop(&mut self) {
+        MILP_DEPTH.with(|c| c.set(c.get().saturating_sub(1)));
+    }
+}
+
+/// Is the RINS improvement heuristic armed? Off by default: per CLAUDE.md §5 a
+/// mechanism that changes what the search finds ships behind a flag until a
+/// differential panel clears both the cert-clean and the net-positive bar.
+/// `DISCOPT_RINS=1` arms it; unset or `0` disables it.
+///
+/// An unrecognized value is a hard **refusal**. A panel that exports
+/// `DISCOPT_RINS=on` and is quietly handed the OFF arm produces a tidy A/B table
+/// in which both arms ran the same code -- precisely the "instrument measured
+/// nothing and was believed" failure the measurement discipline exists to
+/// prevent.
+fn rins_enabled() -> bool {
+    match std::env::var("DISCOPT_RINS") {
+        Err(_) => false,
+        Ok(v) => match parse_rins_flag(&v) {
+            Ok(on) => on,
+            Err(msg) => panic!("{msg}"),
+        },
+    }
+}
+
+/// Parse a `DISCOPT_RINS` value. Pure so the refusal can be asserted directly
+/// rather than by setting a process-wide variable (CLAUDE.md §6).
+fn parse_rins_flag(raw: &str) -> Result<bool, String> {
+    match raw.trim().to_ascii_lowercase().as_str() {
+        "" | "0" | "false" | "no" => Ok(false),
+        "1" | "true" | "yes" => Ok(true),
+        other => Err(format!(
+            "DISCOPT_RINS={other:?} is not recognized (expected 1/true/yes or \
+             0/false/no). Refusing rather than silently picking an arm."
+        )),
+    }
+}
+
+/// One RINS attempt against `node_x`, the relaxation solution of some node in the
+/// batch just processed. `inc_obj` is the incumbent's objective as the tree holds
+/// it (i.e. including `obj_const`). Returns a re-validated, strictly improving
+/// incumbent as `(full point over the base columns, objective including
+/// `obj_const`)`, or `None`.
+#[allow(clippy::too_many_arguments)]
+fn try_rins(
+    base: &RinsBase,
+    obj_const: f64,
+    ns: usize,
+    is_int: &[bool],
+    node_x: &[f64],
+    inc_x: &[f64],
+    inc_obj: f64,
+    opts: &MilpOptions,
+    deadline: Option<std::time::Instant>,
+    node_budget: usize,
+    spent: &mut usize,
+) -> Option<(Vec<f64>, f64)> {
+    crate::profile::incr(crate::profile::Ctr::RinsConsidered);
+    if node_x.len() < ns || inc_x.len() < ns {
+        return None;
+    }
+
+    // The agreement test: exact equality within the feasibility tolerance.
+    let mut n_int = 0usize;
+    let mut fixed: Vec<usize> = Vec::new();
+    for j in 0..ns {
+        if is_int[j] {
+            n_int += 1;
+            if (node_x[j] - inc_x[j]).abs() <= 1e-6 {
+                fixed.push(j);
+            }
+        }
+    }
+    if n_int == 0 {
+        return None;
+    }
+    let rate = fixed.len() as f64 / n_int as f64;
+    // Too little fixed and the sub-MILP is the original problem again; everything
+    // fixed and there is nothing left to search, so it cannot beat the incumbent
+    // it was seeded from.
+    if rate < RINS_MIN_FIXING_RATE || fixed.len() == n_int {
+        return None;
+    }
+    crate::profile::incr(crate::profile::Ctr::RinsGated);
+
+    let mut sub_l = base.l.clone();
+    let mut sub_u = base.u.clone();
+    for &j in &fixed {
+        // Pinning to a value the incumbent already takes can only narrow the box.
+        // A value outside it means the incumbent and the base bounds disagree,
+        // which is a bug rather than an opportunity -- decline instead of
+        // widening, since a widened bound is exactly what would make the
+        // restriction argument (and with it the soundness argument) false.
+        let v = inc_x[j].round();
+        if v < base.l[j] - 1e-9 || v > base.u[j] + 1e-9 {
+            return None;
+        }
+        sub_l[j] = v;
+        sub_u[j] = v;
+    }
+
+    let mut sub = opts.clone();
+    sub.max_nodes = node_budget;
+    // Seed the incumbent so the sub-solve carries a cutoff from its first node
+    // and can only return something strictly better. It is feasible for the
+    // sub-problem by construction: every pinned variable is pinned *to* its own
+    // value in that point.
+    sub.initial_incumbent = Some(inc_x[..ns].to_vec());
+    // Never let a heuristic outlive the parent's deadline and convert itself into
+    // a timeout.
+    if let Some(d) = deadline {
+        let left = d.saturating_duration_since(std::time::Instant::now());
+        if left.is_zero() {
+            return None;
+        }
+        let budget = (left.as_secs_f64() * 0.25).min(2.0);
+        sub.time_limit_s = Some(match sub.time_limit_s {
+            Some(t) => t.min(budget),
+            None => budget,
+        });
+    }
+
+    crate::profile::incr(crate::profile::Ctr::RinsRun);
+    let res = {
+        let _t = crate::profile::Timer::new(crate::profile::Phase::Rins);
+        solve_milp_node_hooked(
+            base.csc.clone(),
+            base.m,
+            base.n,
+            &base.c,
+            &sub_l,
+            &sub_u,
+            &base.b,
+            obj_const,
+            &sub,
+            None,
+            None,
+            None,
+        )
+    };
+    *spent += res.nodes;
+    crate::profile::incr_by(crate::profile::Ctr::RinsSubNodes, res.nodes as u64);
+
+    if !matches!(res.status, MilpStatus::Optimal | MilpStatus::Feasible) {
+        return None;
+    }
+    // Strict improvement only. Bound as a `bool` first so a NaN objective reads as
+    // "not an improvement" (the comparison is false) rather than sliding through a
+    // negated `>=`.
+    let strictly_better = res.obj < inc_obj - 1e-9 * (1.0 + inc_obj.abs());
+    if !strictly_better {
+        return None;
+    }
+    // Re-validate through the same gate a caller-supplied seed passes: it
+    // re-checks integrality and bounds, verifies every ORIGINAL row and
+    // reconstructs the slacks, so the point injected here is one this driver has
+    // proven feasible itself rather than one it was told about.
+    match validate_seed_incumbent(
+        &res.x, ns, is_int, &base.csc, &base.b, &base.c, &base.l, &base.u, base.m, base.n,
+    ) {
+        Some((sx, sobj)) => {
+            crate::profile::incr(crate::profile::Ctr::RinsImproved);
+            Some((sx, sobj + obj_const))
+        }
+        None => {
+            // The sub-solve returned a point its own driver called feasible and
+            // this driver cannot verify. Never inject it; a nonzero count here is
+            // a correctness bug to chase, not a tuning signal.
+            crate::profile::incr(crate::profile::Ctr::RinsRejected);
+            None
+        }
+    }
 }
 
 /// Map the search's terminal state to a [`MilpStatus`]. Pure so it can be
@@ -660,7 +942,14 @@ pub fn solve_milp_node_hooked(
     } else {
         node
     };
-    crate::profile::begin_solve();
+    // Depth is tracked for the whole call, including every early return, by the
+    // RAII guard. Only the OUTERMOST solve may reset the profile counters: a RINS
+    // sub-solve re-enters here, and a nested `begin_solve` would wipe the parent's
+    // measurement mid-run (CLAUDE.md §6).
+    let (_milp_depth_guard, milp_depth) = MilpDepthGuard::enter();
+    if milp_depth == 0 {
+        crate::profile::begin_solve();
+    }
     let ns = opts.n_struct;
     let is_int = {
         let mut v = vec![false; ns];
@@ -873,6 +1162,29 @@ pub fn solve_milp_node_hooked(
     // Original constraint rows (before any cuts) are the knapsack candidates for
     // cover separation; later rows are themselves cuts.
     let n_orig_rows = m_w;
+
+    // --- A12 RINS: snapshot the base problem before the root cut loop ---
+    // Every sub-solve and every re-validation runs against THIS, not against the
+    // cut-augmented working matrix, so a wrong cut can never launder itself into
+    // an incumbent. The clone is paid for only when the flag is armed. RINS is
+    // declined outright under a lazy separator (a point must be screened there
+    // before it may become the incumbent) and inside a sub-solve (no recursion).
+    // Sub-solve nodes RINS has spent so far, against the quota above.
+    let mut rins_spent: usize = 0;
+    let rins_base: Option<RinsBase> =
+        if rins_enabled() && milp_depth == 0 && lazy.is_none() && !opts.integer_cols.is_empty() {
+            Some(RinsBase {
+                csc: csc_w.clone(),
+                m: m_w,
+                n: n_w,
+                c: c_w.clone(),
+                l: l_w.clone(),
+                u: u_w.clone(),
+                b: b_w.clone(),
+            })
+        } else {
+            None
+        };
     // Global cut pool signatures — globally-valid cover cuts found anywhere in
     // the tree are added once and shared by all nodes.
     let mut pool_sigs: HashSet<Vec<(u32, i64)>> = HashSet::new();
@@ -1792,6 +2104,49 @@ pub fn solve_milp_node_hooked(
         }
         tm.import_results(&results);
         tm.process_evaluated();
+
+        // --- A12 RINS: one improvement attempt at the batch boundary ---
+        // Deliberately here, in the SEQUENTIAL reduce: every node's relaxation
+        // vector has already arrived, `tm` holds the incumbent this batch
+        // produced, and there is no nested rayon scope, so the attempt is
+        // deterministic and costs no parallelism. The candidate is the most
+        // promising fractional node of the batch -- the one whose subtree the
+        // search is about to spend its time in.
+        if let Some(base) = rins_base.as_ref() {
+            let rins_budget = rins_node_budget(tm.stats().total_nodes, rins_spent);
+            if this_batch % RINS_BATCH_STRIDE == 0 && rins_budget > 0 {
+                let inc = tm.incumbent().and_then(|(x, v)| {
+                    // The tree seeds itself with a sentinel-valued placeholder;
+                    // that is "no incumbent", and RINS has nothing to improve.
+                    (v < INFEAS_SENTINEL - 1.0 && x.len() >= ns).then(|| (x.to_vec(), v))
+                });
+                let cand = results
+                    .iter()
+                    .filter(|r| {
+                        !r.is_feasible
+                            && r.lower_bound < INFEAS_SENTINEL - 1.0
+                            && r.solution.len() >= ns
+                    })
+                    .min_by(|a, b| a.lower_bound.total_cmp(&b.lower_bound));
+                if let (Some((inc_x, inc_obj)), Some(r)) = (inc, cand) {
+                    if let Some((sx, sobj)) = try_rins(
+                        base,
+                        obj_const,
+                        ns,
+                        &is_int,
+                        &r.solution,
+                        &inc_x,
+                        inc_obj,
+                        opts,
+                        deadline,
+                        rins_budget,
+                        &mut rins_spent,
+                    ) {
+                        tm.inject_incumbent(sx, sobj);
+                    }
+                }
+            }
+        }
 
         // Interactive debugger: post prune/branch/fathom, plus the new-incumbent
         // event on a strict improvement (from any source this batch).
@@ -4549,6 +4904,46 @@ mod tests {
         for bad in ["-1", "eight", "1.5", "8x"] {
             assert!(parse_dive_stride(bad).is_err(), "{bad:?} must be refused");
         }
+    }
+
+    #[test]
+    fn rins_flag_refuses_garbage_instead_of_picking_an_arm() {
+        // Same lesson as `parse_dive_stride`: a panel that exports an
+        // unrecognized value and is quietly handed the OFF arm produces a tidy
+        // A/B table in which both arms ran the same code.
+        for off in ["", "  ", "0", "false", "NO"] {
+            assert!(!parse_rins_flag(off).unwrap(), "{off:?} must read as off");
+        }
+        for on in ["1", "true", " YES "] {
+            assert!(parse_rins_flag(on).unwrap(), "{on:?} must read as on");
+        }
+        for bad in ["on", "2", "enabled", "1.0"] {
+            assert!(parse_rins_flag(bad).is_err(), "{bad:?} must be refused");
+        }
+    }
+
+    #[test]
+    fn rins_node_budget_is_bounded_by_the_parent_search() {
+        // The per-call cap alone leaves the TOTAL unbounded, because attempts
+        // scale with the batch count: on a million-node solve a flat 500-node cap
+        // per attempt is thousands of sub-solves. The quota is what makes the
+        // heuristic's cost a fraction of the search it is helping.
+        assert_eq!(
+            rins_node_budget(0, 0),
+            RINS_NODE_OFFSET.min(RINS_SUB_NODE_CAP)
+        );
+        // Spending eats the allowance...
+        assert_eq!(rins_node_budget(0, RINS_NODE_OFFSET), 0);
+        assert_eq!(rins_node_budget(0, RINS_NODE_OFFSET + 10_000), 0);
+        // ...and a bigger tree earns more of it, still capped per call.
+        assert_eq!(
+            rins_node_budget(1_000_000, RINS_NODE_OFFSET),
+            RINS_SUB_NODE_CAP
+        );
+        let spent = RINS_NODE_OFFSET + (1_000_000.0 * RINS_NODE_QUOT) as usize;
+        assert_eq!(rins_node_budget(1_000_000, spent), 0);
+        // Never more than one call's worth at a time, however large the tree.
+        assert!(rins_node_budget(usize::MAX / 2, 0) <= RINS_SUB_NODE_CAP);
     }
 
     fn opts(ns: usize, int_cols: Vec<usize>) -> MilpOptions {

--- a/crates/discopt-core/src/bnb/milp_driver.rs
+++ b/crates/discopt-core/src/bnb/milp_driver.rs
@@ -570,9 +570,31 @@ fn rins_node_budget(parent_nodes: usize, spent: usize) -> usize {
 /// Batches between RINS attempts. Firing every batch would make it a per-node tax
 /// (the #1060 dive lesson).
 const RINS_BATCH_STRIDE: usize = 16;
+/// Cap on the backoff doublings, so the stride tops out at 16 << 2 = 64 batches.
+/// The cap is what separates *throttling* the heuristic from *disabling* it, and
+/// it was measured rather than picked: at 6 doublings the stride reaches 1024
+/// batches, which inside a 20 s solve means RINS never fires again -- the A12
+/// panel lost the improvements on all three `mik-250-*` instances that way,
+/// keeping only 4 of 7. At 2 the heuristic keeps running at a quarter rate on
+/// instances where it is not currently paying, which is the intent.
+const RINS_BACKOFF_MAX_DOUBLINGS: u32 = 2;
 
 /// The pristine base problem, captured once before the root cut loop when RINS is
 /// armed, and used for every sub-solve and every re-validation.
+/// Batches to wait before the next RINS attempt, given how many attempts in a
+/// row have failed to improve the incumbent. Doubling with a cap turns a fixed
+/// tax into one that fades on instances where the heuristic is not paying: the
+/// first A12 panel measured 1401 runs for 35 improvements, a 2.5 % hit rate that
+/// cost +44.9 % wall across the both-solved set while cutting nodes 14.9 %. The
+/// streak resets on every improvement, so an instance where RINS *is* working
+/// keeps firing at the base stride.
+///
+/// Pure so the schedule can be asserted directly instead of inferred from a
+/// process-wide counter (CLAUDE.md §6).
+fn rins_backoff_stride(fail_streak: u32) -> usize {
+    RINS_BATCH_STRIDE << fail_streak.min(RINS_BACKOFF_MAX_DOUBLINGS)
+}
+
 struct RinsBase {
     csc: SparseCols,
     m: usize,
@@ -1171,6 +1193,14 @@ pub fn solve_milp_node_hooked(
     // before it may become the incumbent) and inside a sub-solve (no recursion).
     // Sub-solve nodes RINS has spent so far, against the quota above.
     let mut rins_spent: usize = 0;
+    // Consecutive RINS attempts that did not improve the incumbent, and batches
+    // elapsed since the last attempt. Together they drive `rins_backoff_stride`.
+    let mut rins_fail_streak: u32 = 0;
+    // Starts already due, so the first batch that has an incumbent gets an
+    // attempt. That is when the incumbent is at its worst and the neighborhood
+    // is most likely to hold something better; making the heuristic sit out the
+    // opening stride would give up the case it is best at.
+    let mut rins_since: usize = RINS_BATCH_STRIDE;
     let rins_base: Option<RinsBase> =
         if rins_enabled() && milp_depth == 0 && lazy.is_none() && !opts.integer_cols.is_empty() {
             Some(RinsBase {
@@ -2114,7 +2144,13 @@ pub fn solve_milp_node_hooked(
         // search is about to spend its time in.
         if let Some(base) = rins_base.as_ref() {
             let rins_budget = rins_node_budget(tm.stats().total_nodes, rins_spent);
-            if this_batch % RINS_BATCH_STRIDE == 0 && rins_budget > 0 {
+            rins_since += 1;
+            let stride = rins_backoff_stride(rins_fail_streak);
+            let due = rins_since >= stride;
+            if !due && rins_fail_streak > 0 {
+                crate::profile::incr(crate::profile::Ctr::RinsBackoffSkips);
+            }
+            if due && rins_budget > 0 {
                 let inc = tm.incumbent().and_then(|(x, v)| {
                     // The tree seeds itself with a sentinel-valued placeholder;
                     // that is "no incumbent", and RINS has nothing to improve.
@@ -2129,6 +2165,11 @@ pub fn solve_milp_node_hooked(
                     })
                     .min_by(|a, b| a.lower_bound.total_cmp(&b.lower_bound));
                 if let (Some((inc_x, inc_obj)), Some(r)) = (inc, cand) {
+                    // Only a real attempt restarts the clock. With no incumbent
+                    // yet there is nothing to improve, so the batch counter keeps
+                    // running and RINS fires on the first batch after one appears
+                    // instead of waiting out another full stride.
+                    rins_since = 0;
                     if let Some((sx, sobj)) = try_rins(
                         base,
                         obj_const,
@@ -2143,6 +2184,9 @@ pub fn solve_milp_node_hooked(
                         &mut rins_spent,
                     ) {
                         tm.inject_incumbent(sx, sobj);
+                        rins_fail_streak = 0;
+                    } else {
+                        rins_fail_streak = rins_fail_streak.saturating_add(1);
                     }
                 }
             }
@@ -4944,6 +4988,21 @@ mod tests {
         assert_eq!(rins_node_budget(1_000_000, spent), 0);
         // Never more than one call's worth at a time, however large the tree.
         assert!(rins_node_budget(usize::MAX / 2, 0) <= RINS_SUB_NODE_CAP);
+    }
+
+    #[test]
+    fn rins_backoff_widens_the_stride_and_is_capped() {
+        // No failures yet: fire at the base stride.
+        assert_eq!(rins_backoff_stride(0), RINS_BATCH_STRIDE);
+        // Each consecutive failure halves the rate.
+        assert_eq!(rins_backoff_stride(1), 2 * RINS_BATCH_STRIDE);
+        assert_eq!(rins_backoff_stride(2), 4 * RINS_BATCH_STRIDE);
+        // Capped, so a long failure run throttles the heuristic rather than
+        // silently turning it off -- and the shift can never overflow.
+        let cap = rins_backoff_stride(RINS_BACKOFF_MAX_DOUBLINGS);
+        assert_eq!(cap, RINS_BATCH_STRIDE << RINS_BACKOFF_MAX_DOUBLINGS);
+        assert_eq!(rins_backoff_stride(u32::MAX), cap);
+        assert!(rins_backoff_stride(50) == cap && cap > 0);
     }
 
     fn opts(ns: usize, int_cols: Vec<usize>) -> MilpOptions {

--- a/crates/discopt-core/src/profile.rs
+++ b/crates/discopt-core/src/profile.rs
@@ -141,6 +141,8 @@ timed_phases!(
     SepGomory,
     Augment,
     DiveRepair,
+    // A12/RINS: wall time inside the sub-MILP improvement heuristic.
+    Rins,
     NodeLpSolve,
     StrongBranch,
     SearchLoop,
@@ -189,6 +191,19 @@ counters!(
     // schedule that never fired (CLAUDE.md §6).
     DiveOffRoot,
     DiveOffRootHits,
+    // A12 RINS (`DISCOPT_RINS`). The four form a funnel -- considered >= gated
+    // >= run >= improved -- so an implausible ordering is an arithmetic error
+    // rather than a plausible-looking hit rate (CLAUDE.md §6). `RinsRejected`
+    // is the safety counter: a sub-MILP point that failed the driver's own
+    // feasibility re-verification. It must stay ZERO; a nonzero value means the
+    // heuristic tried to inject an infeasible incumbent and is a correctness
+    // bug, not a tuning signal.
+    RinsConsidered,
+    RinsGated,
+    RinsRun,
+    RinsImproved,
+    RinsRejected,
+    RinsSubNodes,
     Phase1Pivots,
     Phase2Pivots,
     DegeneratePivots,

--- a/crates/discopt-core/src/profile.rs
+++ b/crates/discopt-core/src/profile.rs
@@ -204,6 +204,12 @@ counters!(
     RinsImproved,
     RinsRejected,
     RinsSubNodes,
+    // A batch that reached the RINS call site but was skipped because the
+    // failure backoff had widened the stride past it. This is the counter that
+    // proves the backoff engaged: the first A12 panel ran RINS 1401 times for 35
+    // improvements (a 2.5 % hit rate) at a cost of +44.9 % wall on the
+    // both-solved set, and cutting the low-yield tail is what this exists for.
+    RinsBackoffSkips,
     Phase1Pivots,
     Phase2Pivots,
     DegeneratePivots,

--- a/crates/discopt-core/tests/rins_common/mod.rs
+++ b/crates/discopt-core/tests/rins_common/mod.rs
@@ -1,0 +1,154 @@
+#![allow(dead_code)] // each arm binary uses a different subset of this fixture.
+//! Shared fixture for the two RINS arms (`rins_on_improves_incumbent`,
+//! `rins_default_off`). The arms are separate binaries because each one owns a
+//! process-wide `DISCOPT_RINS` setting, and a shared module keeps the two from
+//! silently drifting onto different models — which would make the comparison
+//! between them meaningless.
+
+use discopt_core::bnb::milp_driver::MilpOptions;
+use discopt_core::lp::simplex::SimplexOptions;
+
+pub const NF: usize = 6;
+pub const NC: usize = 10;
+
+/// A small capacitated facility-location instance, in the driver's standard form
+/// `A x = b, l ≤ x ≤ u`:
+///
+/// ```text
+/// min  Σ_j f_j y_j + Σ_ij c_ij x_ij
+/// s.t. Σ_j x_ij = 1                       (customer i is served)
+///      Σ_i d_i x_ij − K y_j + s_j = 0     (facility j's capacity), s_j ∈ [0, K]
+/// ```
+///
+/// Columns: `x_ij` at `i*NF+j`, then `y_j` at `NX+j`, then `s_j` at `NX+NF+j`.
+/// Capacity is tight enough (four facilities' worth spread over six) that the
+/// root LP is fractional in many columns — which is the regime RINS is for, and
+/// the reason a plain knapsack is not the fixture here.
+pub struct Cfl {
+    pub a: Vec<f64>,
+    pub c: Vec<f64>,
+    pub l: Vec<f64>,
+    pub u: Vec<f64>,
+    pub b: Vec<f64>,
+    pub m: usize,
+    pub n: usize,
+    pub nx: usize,
+}
+
+pub fn demands() -> Vec<f64> {
+    (0..NC).map(|i| 3.0 + ((i * 5) % 7) as f64).collect()
+}
+
+pub fn capacity() -> f64 {
+    demands().iter().sum::<f64>() / (NF as f64 - 2.0)
+}
+
+pub fn build() -> Cfl {
+    let nx = NF * NC;
+    let n = nx + 2 * NF;
+    let m = NC + NF;
+    let d = demands();
+    let cap = capacity();
+    let f: Vec<f64> = (0..NF).map(|j| 20.0 + ((j * 7) % 11) as f64).collect();
+    let cost: Vec<f64> = (0..nx)
+        .map(|k| 1.0 + (((k / NF) * 13 + (k % NF) * 29) % 17) as f64)
+        .collect();
+
+    let mut a = vec![0.0; m * n];
+    for i in 0..NC {
+        for j in 0..NF {
+            a[i * n + i * NF + j] = 1.0;
+        }
+    }
+    for j in 0..NF {
+        let r = NC + j;
+        for i in 0..NC {
+            a[r * n + i * NF + j] = d[i];
+        }
+        a[r * n + nx + j] = -cap;
+        a[r * n + nx + NF + j] = 1.0;
+    }
+
+    let mut c = vec![0.0; n];
+    c[..nx].copy_from_slice(&cost);
+    c[nx..nx + NF].copy_from_slice(&f);
+    let l = vec![0.0; n];
+    let mut u = vec![1.0; n];
+    for j in 0..NF {
+        u[nx + NF + j] = cap;
+    }
+    let mut b = vec![0.0; m];
+    b[..NC].fill(1.0);
+
+    Cfl {
+        a,
+        c,
+        l,
+        u,
+        b,
+        m,
+        n,
+        nx,
+    }
+}
+
+/// A feasible but deliberately poor starting point: every facility open, every
+/// customer round-robined onto an arbitrary one. It is what a weak primal
+/// heuristic produces and what the driver, having no improvement heuristic at
+/// all, would otherwise carry to the end of the search.
+pub fn poor_seed(p: &Cfl) -> Vec<f64> {
+    let d = demands();
+    let cap = capacity();
+    let mut seed = vec![0.0; p.n];
+    for j in 0..NF {
+        seed[p.nx + j] = 1.0;
+    }
+    for i in 0..NC {
+        seed[i * NF + (i % NF)] = 1.0;
+    }
+    for j in 0..NF {
+        let load: f64 = (0..NC).map(|i| d[i] * seed[i * NF + j]).sum();
+        seed[p.nx + NF + j] = cap * seed[p.nx + j] - load;
+    }
+    seed
+}
+
+/// Driver options for both arms. `heuristics: false` so the *only* incumbent
+/// before RINS is the poor seed — otherwise the rounding heuristic supplies one
+/// and the arms stop measuring the thing they are named for.
+pub fn options(p: &Cfl, seed: Vec<f64>) -> MilpOptions {
+    MilpOptions {
+        n_struct: p.n,
+        integer_cols: (0..p.nx + NF).collect(),
+        max_nodes: 200_000,
+        time_limit_s: Some(120.0),
+        gap_tol: 1e-9,
+        root_cuts: 0,
+        cut_rounds: 0,
+        gmi_cuts: false,
+        cut_select: false,
+        node_cuts: false,
+        max_pool_cuts: 0,
+        heuristics: false,
+        presolve: true,
+        strong_branch: false,
+        node_propagation: true,
+        reduced_cost_fixing: true,
+        sb_max_cands: 0,
+        sb_node_budget: 0,
+        initial_incumbent: Some(seed),
+        node_hook_rounds: 0,
+        node_hook_cut_cap: 0,
+        root_cut_time_s: None,
+        root_cut_prune: true,
+        simplex: SimplexOptions::default(),
+    }
+}
+
+/// The instance's true optimum, independently pinned by the OFF arm (which never
+/// runs RINS) so the ON arm's assertion is not circular.
+pub const OPTIMUM: f64 = 148.0;
+
+/// Objective of [`poor_seed`] — strictly worse than [`OPTIMUM`], so "RINS
+/// improved the incumbent" is a claim with content.
+pub const SEED_OBJ: f64 = 230.0;

--- a/crates/discopt-core/tests/rins_default_off.rs
+++ b/crates/discopt-core/tests/rins_default_off.rs
@@ -1,0 +1,58 @@
+//! A12, the OFF arm: with `DISCOPT_RINS` unset the driver must behave exactly as
+//! it did before RINS existed — the heuristic is not merely quiet, it is never
+//! reached.
+//!
+//! This is what makes the shipped default a no-op rather than a silent behavior
+//! change (CLAUDE.md §5: a mechanism that changes what the search finds stays
+//! default-off until a differential panel clears both the cert-clean and the
+//! net-positive bar). Its sibling `rins_on_improves_incumbent.rs` proves this
+//! same model *does* reach the attempt, so the zero below is the default being
+//! off — not the probe failing to run.
+//!
+//! It also pins the optimum the ON arm asserts against, reached here without RINS
+//! ever executing, so that assertion is not circular.
+
+#[path = "rins_common/mod.rs"]
+mod cfl;
+
+use discopt_core::bnb::milp_driver::{solve_milp, MilpStatus};
+use discopt_core::lp::crossover::LpView;
+use discopt_core::profile::{counter, Ctr};
+
+#[test]
+fn rins_unset_never_runs_and_still_solves() {
+    std::env::set_var("DISCOPT_PROFILE", "1");
+    std::env::remove_var("DISCOPT_RINS");
+
+    let p = cfl::build();
+    let seed = cfl::poor_seed(&p);
+    let lp = LpView {
+        a: &p.a,
+        m: p.m,
+        n: p.n,
+        c: &p.c,
+        l: &p.l,
+        u: &p.u,
+    };
+    let opts = cfl::options(&p, seed);
+    let res = solve_milp(&lp, &p.b, 0.0, &opts);
+
+    assert_eq!(
+        counter(Ctr::RinsConsidered),
+        0,
+        "RINS was reached at the default (unset) setting"
+    );
+    assert_eq!(
+        counter(Ctr::RinsRun),
+        0,
+        "a RINS sub-MILP ran at the default"
+    );
+
+    assert_eq!(res.status, MilpStatus::Optimal, "obj={}", res.obj);
+    assert!(
+        (res.obj - cfl::OPTIMUM).abs() < 1e-6,
+        "objective {} != optimum {}",
+        res.obj,
+        cfl::OPTIMUM
+    );
+}

--- a/crates/discopt-core/tests/rins_on_improves_incumbent.rs
+++ b/crates/discopt-core/tests/rins_on_improves_incumbent.rs
@@ -1,0 +1,81 @@
+//! A12, the ON arm: with `DISCOPT_RINS=1` the driver must actually *improve* an
+//! incumbent it would otherwise carry unchanged to the end of the search.
+//!
+//! This is the behavior the whole change exists for. The driver has a rounding
+//! heuristic and a no-incumbent dive (#1060) but no improvement heuristic at all,
+//! which is what the A5 measurement located: on the parity panel 17/38 instances
+//! were unsolved at an 89.6 % median primal share, 12 of them holding a merely
+//! poor incumbent rather than none. Here the poor incumbent is supplied
+//! explicitly (`poor_seed`, objective 230) so the arm measures RINS and nothing
+//! else, and the optimum is 148.
+//!
+//! Two assertions carry the correctness half and must never be relaxed to make
+//! this pass: `RinsRejected == 0` (RINS never proposed a point the driver could
+//! not independently verify -- a nonzero value is a false-`Optimal` bug, not a
+//! tuning signal) and the certified objective equalling the optimum the OFF arm
+//! reaches without RINS.
+//!
+//! Separate binary from `rins_default_off.rs`: `DISCOPT_RINS` is process-wide, so
+//! the two arms cannot share one.
+
+#[path = "rins_common/mod.rs"]
+mod cfl;
+
+use discopt_core::bnb::milp_driver::{solve_milp, MilpStatus};
+use discopt_core::lp::crossover::LpView;
+use discopt_core::profile::{counter, Ctr};
+
+#[test]
+fn rins_on_improves_a_poor_incumbent() {
+    std::env::set_var("DISCOPT_PROFILE", "1");
+    std::env::set_var("DISCOPT_RINS", "1");
+
+    let p = cfl::build();
+    let seed = cfl::poor_seed(&p);
+    let seed_obj: f64 = (0..p.n).map(|k| p.c[k] * seed[k]).sum();
+    assert!(
+        (seed_obj - cfl::SEED_OBJ).abs() < 1e-9,
+        "fixture drifted: seed objective {seed_obj}, expected {}",
+        cfl::SEED_OBJ
+    );
+
+    let lp = LpView {
+        a: &p.a,
+        m: p.m,
+        n: p.n,
+        c: &p.c,
+        l: &p.l,
+        u: &p.u,
+    };
+    let opts = cfl::options(&p, seed);
+    let res = solve_milp(&lp, &p.b, 0.0, &opts);
+
+    // The funnel must have reached the end: considered >= gated >= run >= improved.
+    // Asserting the last of these is what fails before this change (RINS never
+    // runs) and passes after.
+    assert!(
+        counter(Ctr::RinsRun) >= 1,
+        "RINS never ran (considered={}, gated={})",
+        counter(Ctr::RinsConsidered),
+        counter(Ctr::RinsGated)
+    );
+    assert!(
+        counter(Ctr::RinsImproved) >= 1,
+        "RINS ran {} time(s) but improved nothing -- the heuristic is inert",
+        counter(Ctr::RinsRun)
+    );
+
+    // Correctness half. A point RINS could not re-verify must never be injected.
+    assert_eq!(
+        counter(Ctr::RinsRejected),
+        0,
+        "RINS proposed a point the driver could not verify -- a false-incumbent bug"
+    );
+    assert_eq!(res.status, MilpStatus::Optimal, "obj={}", res.obj);
+    assert!(
+        (res.obj - cfl::OPTIMUM).abs() < 1e-6,
+        "objective {} != optimum {}",
+        res.obj,
+        cfl::OPTIMUM
+    );
+}


### PR DESCRIPTION
## What

Adds **RINS** (Relaxation Induced Neighborhood Search) as the driver's first
*improvement* heuristic, behind `DISCOPT_RINS` and **default off**.

## Why — the measurement, before the code

The dual-side ledger in `docs/dev/milp-competitiveness-plan.md` is exhausted:
A1 (cut aging), A2 (in-tree aging), A4 (SB budget), A6→A7 (pseudocost default),
A8 (SB discrimination), A9a–A9c (relaxation), A10 (SB budget at corpus scale),
A11 (SB gate shape) and B1 (node selection) are **all falsified**. What A5
located instead is on the **primal** side: on the 38-instance parity panel,
17 instances were unsolved at an **89.6 % median primal share**, and **12 of
those held a merely poor incumbent rather than none**. discopt has a rounding
heuristic (`try_rounding_csc`) and a no-incumbent dive (#1060, which stops
firing the moment an incumbent exists) but **no improvement heuristic at all** —
its first incumbent is very nearly its last.

A12 ran RINS's precondition as an **entry experiment on the real corpus before
any implementation** (the #727 RLT lesson: synthetic root-gain 0.68, real gain
0.0). At every node with an LP solution, a real incumbent and ≥1 integer
variable, it measured the fraction of integer variables where the node LP value
equals the incumbent value within 1e-6:

```
INSTANCES RUN: 38
EXECUTED: 2023762 incumbent-present nodes measured
  RinsFixLt30            28,746    1.4%
  RinsFix30to50         312,942   15.5%
  RinsFix50to70         714,150   35.3%
  RinsFix70to90         934,272   46.2%
  RinsFix90to99          33,275    1.6%
  RinsFixGe99               377    0.0%
USABLE BAND [0.30, 0.99): 1,994,639 / 2,023,762 = 98.6%
VERDICT: SURVIVES
NON-VACUITY: 33/38 instances contributed at least one node
```

Pre-registered: ≥30 % SURVIVES, 10–30 % WEAK, <10 % FALSIFIED. Split by
outcome, the precondition holds on the population the gap actually lives in:
**unsolved 17 instances / 1,792,775 inc-nodes / 98.4 % in band** (solved:
21 / 230,987 / 99.7 %). 15 of the 17 unsolved carry an incumbent, all at ≥84 %.

## Mechanism

Danna, Rothberg & Le Pape, *Exploring relaxation induced neighborhoods to
improve MIP solutions*, Math. Program. 102(1), 2005. At a batch boundary, fix
the integer variables on which the most promising node's LP relaxation and the
incumbent already agree, and solve the remainder as a small MILP. The agreement
test is the standard exact-equality-within-tolerance test, **not** a rounding
test; the 0.30 refusal threshold is the customary minimum fixing rate.

## Soundness

Purely primal: RINS can only propose an incumbent, never move a dual bound, so
it cannot loosen or falsify a certificate. Three concrete guards rather than an
argument:

1. the sub-MILP is a **restriction** of the **base** problem — same matrix, same
   rhs, integer bounds only narrowed to values the incumbent already takes. A
   pin that would fall outside the base box is **declined, not widened**;
2. the returned point is nevertheless **re-validated** through
   `validate_seed_incumbent`, the same gate a caller-supplied seed passes, which
   re-checks integrality and bounds, verifies every original row and
   reconstructs the slacks itself. A rejected point is dropped and counted in
   `RinsRejected`, **which must stay zero** — trusting the sub-solve instead
   would turn a bug there into a false `Optimal` at the top level;
3. it runs against the **base** problem snapshotted before the root cut loop,
   not the cut-augmented working matrix, so a wrong cut could not launder itself
   into an incumbent.

RINS declines entirely **under a lazy separator** (on that path a point must be
screened before it may become the incumbent, and bypassing the screen would
enforce a model the caller did not ask for) and **inside a sub-solve**.

## Cost control

A flat per-call node cap leaves the **total** unbounded, because attempts scale
with the batch count. `rins_node_budget` gives RINS 5 % of the parent's nodes
plus a flat 500 allowance, capped at 500 nodes per attempt, and attempts are
spread on a batch stride. Sub-solve time is also clamped to a quarter of the
parent's remaining budget, so a heuristic can never convert itself into a
timeout.

A RAII `MilpDepthGuard` keeps a nested sub-solve from calling
`profile::begin_solve`, which **resets** the counters — a nested reset would
wipe the parent's measurement mid-run and read as "this path never executed"
(CLAUDE.md §6). RAII specifically because the driver has many early returns and
a manual decrement would be missed by one of them.

`DISCOPT_RINS` **refuses an unrecognized value loudly** rather than silently
picking an arm: a panel that exports `DISCOPT_RINS=on` and is quietly handed the
OFF arm produces a tidy A/B table in which both arms ran the same code.

## Testing

- `cargo test -p discopt-core` — **694 passed, 0 failed**, all integration
  binaries green.
- Two new regression arms, separate binaries because `DISCOPT_RINS` is
  process-wide, sharing one fixture so they cannot silently drift onto different
  models:
  - `rins_on_improves_incumbent` — a capacitated facility-location instance
    seeded with a feasible but deliberately poor incumbent (objective 230,
    optimum 148). Asserts RINS ran, **improved** the incumbent,
    **rejected nothing**, and still certifies the optimum. **Fails before this
    change**, because RINS never runs.
  - `rins_default_off` — with the flag unset, asserts RINS is never even
    reached, and independently pins the optimum the ON arm asserts against so
    that assertion is not circular.
- `parse_rins_flag` and `rins_node_budget` are pure and unit-tested directly, so
  the refusal and the quota are asserted rather than inferred from a solve.
- `cargo clippy -p discopt-core --all-targets` — no new warnings.
- `pytest -m smoke` and the adversarial suite: results appended below once the
  Python extension build finishes.

## Status

**Default off.** Per CLAUDE.md §5 this stays off until the ON-vs-OFF
differential panel over the corpus clears **both** bars: cert-clean
(`incorrect_count = 0`, no bound above its reference optimum, no certification
regression, incumbents independently feasibility-verified, and `RinsRejected`
exactly 0) **and** net-positive. That panel is running; its numbers will be
posted here, and the flag does not graduate on this PR.

Contributes to the parity plan's Track B2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014E81XM1j2J5sydzj9nFFFp
