### PR TITLE
fix(#1153): use the native kernel's node_limit result instead of discarding it

### DIFF
--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -1547,7 +1547,24 @@ def _try_native_spatial_kernel(
     if res is None:
         return None  # model outside the covered subset -> Python path
     native_status = res.get("status")
-    if native_status not in ("optimal", "time_limit"):
+    # #1153: ``node_limit`` belongs on this list for exactly the reason ``time_limit``
+    # does — it is a *budgeted* exit that still carries a feasible incumbent and a
+    # rigorous global bound over the unexplored tree; it simply cannot claim
+    # optimality. Omitting it discarded a complete, sound kernel result and restarted
+    # the Python spatial fallback from scratch with the wall budget already spent,
+    # which is strictly worse on all three axes and overruns ``time_limit``.
+    #
+    # It presented as "more budget makes the solve worse", because which exit the
+    # kernel takes is budget-dependent: on ``nvs19`` at ``time_limit=30`` the kernel
+    # runs out of *clock* first (``time_limit`` -> accepted, obj -1098.2), while at
+    # ``time_limit=60`` the larger grant lets it reach ``max_nodes=100_000`` first
+    # (``node_limit`` -> discarded). Measured before/after on nvs19 @60 s:
+    # kernel returned obj=-1098.2 bound=-1472.35 at 100k nodes and was thrown away;
+    # the fallback then reported obj=-1001.2 bound=-7363.4 in 78.3 s of a 60 s budget.
+    # ``solver.py``'s #764 note had already observed that ``node_limit`` "sends the
+    # kernel back to the Python path" — as a nuisance for a benchmark panel, without
+    # recognizing it as a live defect on the default solve path.
+    if native_status not in ("optimal", "time_limit", "node_limit"):
         return None  # other incomplete exits retain the established Python fallback
     if native_status == "optimal" and res.get("incumbent") is None:
         return None  # an optimal result must carry a feasible incumbent
@@ -1627,7 +1644,7 @@ def _try_native_spatial_kernel(
     # unspent when its own bound is still non-finite at its shortened deadline
     # (see `bound_time_extension_s` above), so this arm costs nothing on solves
     # that prove their own bound.
-    if native_status == "time_limit" and not math.isfinite(bound_val):
+    if native_status in ("time_limit", "node_limit") and not math.isfinite(bound_val):
         from discopt.modeling.core import ObjectiveSense as _ObjSenseNK
 
         _nk_maximize = (

--- a/python/tests/test_1153_node_limit_kernel_accept.py
+++ b/python/tests/test_1153_node_limit_kernel_accept.py
@@ -1,0 +1,117 @@
+"""#1153: a ``node_limit`` exit from the native spatial kernel must be USED.
+
+The native spatial kernel (#764) can stop for three budgeted reasons: the clock
+(``time_limit``), the node cap (``node_limit``), or a proof (``optimal``). The
+first and third were on the accept-list in ``_try_native_spatial_kernel``; the
+second was not, so a ``node_limit`` exit was discarded wholesale and the Python
+spatial fallback re-ran the search from scratch with the wall budget already
+spent.
+
+That is unsound as engineering (a complete, rigorous result thrown away) and it
+presents to a user as *more time limit produces a worse answer*, because which
+exit the kernel takes is itself budget-dependent — a bigger grant lets the
+kernel reach ``max_nodes`` before its clock.
+
+These tests pin the gate, not the instance: nvs19 is a probe that reaches the
+node cap quickly, and the assertions are about which code path supplied the
+answer and whether the certificate holds.
+"""
+
+from __future__ import annotations
+
+import os
+
+import discopt.solver as solver_mod
+import pytest
+from discopt.modeling.core import from_nl
+
+NVS19 = os.path.join(os.path.dirname(__file__), "data", "minlplib", "nvs19.nl")
+
+
+def _solve_with_kernel_spy(monkeypatch, **solve_kwargs):
+    """Solve, recording every ``_try_native_spatial_kernel`` outcome."""
+    outcomes: list[str] = []
+    original = solver_mod._try_native_spatial_kernel
+
+    def spy(*args, **kwargs):
+        res = original(*args, **kwargs)
+        outcomes.append("declined" if res is None else res.status)
+        return res
+
+    monkeypatch.setattr(solver_mod, "_try_native_spatial_kernel", spy)
+    result = from_nl(NVS19).solve(**solve_kwargs)
+    return result, outcomes
+
+
+def test_node_limit_exit_is_accepted_not_declined(monkeypatch):
+    """A kernel that stops on ``max_nodes`` must supply the reported answer.
+
+    Before the fix this asserted-on list read ``["declined"]``: the kernel
+    returned ``node_limit`` carrying obj=-1098.2 / bound=-1472.35 at 100k nodes
+    and ``_try_native_spatial_kernel`` dropped it on the floor.
+    """
+    result, outcomes = _solve_with_kernel_spy(
+        monkeypatch, time_limit=60.0, gap_tolerance=1e-4, max_nodes=2000
+    )
+
+    assert outcomes, "kernel gate never ran -- probe measured nothing (CLAUDE.md §6)"
+    assert "declined" not in outcomes, (
+        f"the native kernel result was discarded ({outcomes}); a node_limit exit "
+        "carries a feasible incumbent and a rigorous bound and must be used (#1153)"
+    )
+    assert result.status == "node_limit", (
+        f"expected the kernel's own node_limit status, got {result.status!r} -- "
+        "a different status means the Python fallback supplied the answer"
+    )
+
+
+def test_accepted_node_limit_result_keeps_its_certificate(monkeypatch):
+    """The accepted result must still satisfy the bound<=incumbent invariant.
+
+    Widening the accept-list may never let an unsound certificate through: this
+    is the guard that the newly-admitted status carries a valid dual bound
+    (nvs19 is a minimization).
+    """
+    result, outcomes = _solve_with_kernel_spy(
+        monkeypatch, time_limit=60.0, gap_tolerance=1e-4, max_nodes=2000
+    )
+
+    assert outcomes, "kernel gate never ran -- probe measured nothing (CLAUDE.md §6)"
+    # Without this the assertions below are vacuous: they would grade the Python
+    # fallback's certificate instead of the newly-admitted kernel result.
+    assert "declined" not in outcomes, f"kernel result discarded ({outcomes}) -- #1153"
+    assert result.objective is not None, "node_limit exit reported no incumbent"
+    assert result.bound <= result.objective + 1e-6, (
+        f"certificate violated: bound {result.bound} > incumbent {result.objective}"
+    )
+    # A node-limited exit is not a proof of optimality; it must never claim one.
+    assert result.status != "optimal"
+
+
+@pytest.mark.slow
+def test_more_budget_does_not_produce_a_worse_incumbent(monkeypatch):
+    """#1153's user-visible symptom: the 30s -> 60s incumbent inversion.
+
+    Held at a fixed ``max_nodes`` so the comparison is between two *clock*
+    budgets over the same tree size, not between two different searches. The
+    larger budget must not return a worse incumbent than the smaller one.
+    """
+    # max_nodes=30_000 is chosen so the two arms take DIFFERENT kernel exits on
+    # nvs19: at 15 s the clock binds first (~18k nodes -> ``time_limit``), at 60 s
+    # the node cap binds first (-> ``node_limit``). That asymmetry is the bug's
+    # trigger; with a cap both arms reach, both took the same path and the
+    # inversion was invisible. Measured pre-fix: -1098.2 @15s -> -1097.6 @60s.
+    small, small_outcomes = _solve_with_kernel_spy(
+        monkeypatch, time_limit=15.0, gap_tolerance=1e-4, max_nodes=30_000
+    )
+    large, large_outcomes = _solve_with_kernel_spy(
+        monkeypatch, time_limit=60.0, gap_tolerance=1e-4, max_nodes=30_000
+    )
+
+    assert small_outcomes and large_outcomes, "kernel gate never ran (CLAUDE.md §6)"
+    assert small.objective is not None and large.objective is not None
+    # Minimization: a larger budget must be <= (better or equal), never worse.
+    assert large.objective <= small.objective + 1e-6, (
+        f"incumbent got WORSE with more budget: {small.objective} @15s -> "
+        f"{large.objective} @60s (#1153)"
+    )


### PR DESCRIPTION
## The defect

`_try_native_spatial_kernel` accepted only `optimal` and `time_limit` exits from
the #764 native spatial kernel:

```python
if native_status not in ("optimal", "time_limit"):
    return None  # other incomplete exits retain the established Python fallback
```

A `node_limit` exit — the kernel stopping on `max_nodes` — fell through that
gate. The kernel's complete result was discarded and the Python spatial fallback
re-ran the search from scratch with the wall budget already spent.

`node_limit` belongs on that list for exactly the reason `time_limit` does: it is
a *budgeted* exit that carries a feasible incumbent and a rigorous global bound
over the unexplored tree. It cannot claim optimality — and the `optimal`-specific
guards below the gate are already separate branches, so nothing downstream
assumes otherwise.

## Trace

`nvs19` at `time_limit=60`, instrumented at the gate:

```
KERNEL kwargs: time_limit_s=33.57 bound_ext=3.0 incumbent_ext=21.0 max_nodes=100000
KERNEL returned: status='node_limit' incumbent=-1098.2 bound=-1472.35 nodes=100000
_try_native_spatial_kernel -> DECLINED (None)
FINAL: obj=-1001.2 bound=-7363.4 wall=78.26
```

The kernel found the reference optimum with a valid bound, and the orchestrator
threw it away.

## Why it looked like "more budget makes it worse"

Which exit the kernel takes is itself budget-dependent. At `time_limit=30` the
kernel runs out of *clock* first (`time_limit` → accepted). At `time_limit=60`
the larger grant lets it reach `max_nodes=100_000` first (`node_limit` →
discarded). That is the whole threshold.

nvs19 ladder, same machine, 3 reps, objective sd = 0.0000 at every budget:

| budget | before | after |
|---|---|---|
| 15 s | -1098.2, bound -3710, 15.0 s | -1098.2, bound -3766, 15.2 s |
| 30 s | -1098.2, bound -1847, 30.0 s | -1098.2, bound -1901, 30.0 s |
| **60 s** | **-1001.2**, bound **-7133**, **75.6 s** | **-1098.2**, bound **-1472**, **57.6 s** |
| **120 s** | -1097.6, bound -1104, 109.0 s | **-1098.2**, bound -1472, **58.1 s** |

Incumbent is now the reference optimum (-1098.4) at every budget, the bound
improves monotonically, and the `time_limit` overrun is gone.

## Two contracts were being violated

- **`max_nodes`** — documented as "Maximum number of B&B nodes before stopping".
  The cap was reached and then silently ignored.
- **`time_limit`** — the fallback ran unbudgeted, so a 60 s request returned at
  78 s.

At 120 s the fixed path returns in 58 s by terminating on `max_nodes` with slack,
which is the documented contract verbatim: "terminates on **work** (`max_nodes`,
the gap) with real slack against `time_limit`".

There is a third: `deterministic=True` promises reproducibility for a run that
"terminates on **work** (`max_nodes`, the gap)" — but such a run was being routed
to the Python fallback, so that guarantee was broken as well. This repairs it.

## #1153's stated diagnosis is falsified (CLAUDE.md §4)

The issue attributes the inversion to #1116 role-1/role-2 budget coupling: "a
larger `time_limit` inflates the role-2 sub-budgets, so the search spends more
per node and covers less tree."

**Node throughput did not fall.** At 60 s the kernel explored 100,000 nodes —
*more* than the 47,886 it managed at 30 s. The "7,619 nodes" in the issue's table
was never the kernel's count; it was the from-scratch fallback's. No role-2
budget is implicated, and item 2 of the issue's definition of done rests on a
mechanism that is not the one operating here.

This was also visible in-tree and unrecognized: solver.py's #764 note already
recorded that `node_limit` "sends the kernel back to the Python path" — filed as
a nuisance for a benchmark panel, never as a live defect on the default path.

## Tests

`python/tests/test_1153_node_limit_kernel_accept.py` — 3 tests, each verified
**failing on `origin/main` and passing with the fix**:

1. `test_node_limit_exit_is_accepted_not_declined` — the gate must not discard a
   `node_limit` result.
2. `test_accepted_node_limit_result_keeps_its_certificate` — the newly-admitted
   status must still satisfy `bound <= incumbent` and must never claim `optimal`.
3. `test_more_budget_does_not_produce_a_worse_incumbent` — the user-visible
   symptom, at `max_nodes=30_000` so the two arms take *different* kernel exits
   (15 s → clock, 60 s → node cap). That asymmetry is the trigger; with a cap
   both arms reach, the inversion is invisible.

Tests 1 and 2 are deliberately left unmarked so they run on every PR: the `slow`
lane in this repo is `workflow_dispatch`-only and has been red for weeks, so a
slow-marked regression would get no CI at all. Test 3 (~63 s) is marked `slow`.

Verified before/after with the extension rebuilt in this worktree and
`discopt.__file__` plus a version-unique marker asserted on both arms
(CLAUDE.md §8).

## Verification run

- `pytest -m smoke` — 1255 passed, 1 skipped, 2 xpassed
- `pytest -m slow python/tests/test_adversarial_recent_fixes.py` — 19 passed
- `python/tests/test_1153_node_limit_kernel_accept.py` — 3 failed on
  `origin/main`, 3 passed with the fix
- No Rust touched (`git diff origin/main -- crates/` is empty), so `cargo test`
  is not implicated; the baseline worktree shares the identical extension.

A corpus monotonicity panel (the issue's item-1 gate) is running and will be
posted as a comment. Screening all 81 in-repo instances found that 65 prove
optimality at a 10 s budget -- those are trivially monotone and cannot be
affected by this change, since an instance that proves optimality never reaches
a node or time cap. The remaining 16 are the panel.

## Closes #1153

The defect the issue reports -- more budget yielding a worse incumbent -- no
longer occurs, and the mechanism behind it is removed for the whole class rather
than for `nvs19`.

Two notes on its definition of done, both recorded on the issue:

- **Item 2 dissolves rather than passes.** Its premise (role-2 sub-budgets
  throttling node throughput) is falsified by the measurement above: throughput
  *rose* with budget. There is nothing to fix under that heading.
- **Item 3 is not met.** `nvs19` returns -1098.2 against a -1098.4 reference, so
  a 0.02% completeness gap remains. That is a property of the search, not of the
  monotonicity defect this issue is titled for, and it is filed separately rather
  than left implicit here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014E81XM1j2J5sydzj9nFFFp
