### PR TITLE
fix(relax): #1197 decide crossed intervals in DefinedVariableForwardRule

### DIFF
--- a/python/discopt/_relax/nonlinear_bound_tightening.py
+++ b/python/discopt/_relax/nonlinear_bound_tightening.py
@@ -2861,9 +2861,12 @@ class DefinedVariableForwardRule(NonlinearBoundTighteningRule):
     subtree stay bounded, so the spatial dual bound becomes *certifiable* instead of
     being dropped as un-rigorous on an unbounded node (issue: nvs/gear unbounded
     auxiliaries). Sound: an interval enclosure of the defining expression is a valid
-    enclosure of the variable; bounds are only ever intersected, never loosened. The
-    fixpoint loop in :func:`tighten_nonlinear_bounds` resolves chained definitions
-    (``x7`` defined via ``x6`` resolves once ``x6`` is bounded).
+    enclosure of the variable; bounds are only ever intersected, never loosened --
+    the one exception being a sub-tolerance crossing, which is snapped *outward* to
+    the enclosure's own endpoint (see ``tighten``) so eps-scale rounding cannot
+    manufacture an empty box. The fixpoint loop in :func:`tighten_nonlinear_bounds`
+    resolves chained definitions (``x7`` defined via ``x6`` resolves once ``x6`` is
+    bounded).
     """
 
     name = "defined_variable_forward"
@@ -2940,7 +2943,29 @@ class DefinedVariableForwardRule(NonlinearBoundTighteningRule):
                 or upd_lo > out_lb[iso_idx] + 1e-12
                 or upd_hi < out_ub[iso_idx] - 1e-12
             )
-            if tightened and upd_lo <= upd_hi + _EMPTY_INTERVAL_FEAS_TOL:
+            # Decide here what a crossed (``upd_lo > upd_hi``) interval means,
+            # rather than constructing the ``Interval`` and letting its dataclass
+            # invariant raise out of the whole tightening pass (#1197).
+            if upd_lo > upd_hi + _EMPTY_INTERVAL_FEAS_TOL:
+                # Beyond any rounding slack the defining expression's enclosure
+                # and the variable's box share no point. That is a genuine empty
+                # interval, reported the way every sibling rule reports one --
+                # the caller turns it into ``stats.infeasible``.
+                _prove_infeasible(
+                    self.name,
+                    con,
+                    f"defining interval [{new_lo}, {new_hi}] for flat variable "
+                    f"{iso_idx} is disjoint from its box "
+                    f"[{out_lb[iso_idx]}, {out_ub[iso_idx]}]",
+                )
+            if upd_lo > upd_hi:
+                # Sub-tolerance crossing: floating-point noise on an effectively
+                # degenerate range (ex7_3_6 crosses by 3e-15 on a variable whose
+                # true range is the single point 1.0), not an infeasibility proof.
+                # Collapse to the degenerate box at the enclosure's endpoint, the
+                # same repair ``_snap_tolerant_crossovers`` applies box-wide.
+                upd_lo = upd_hi
+            if tightened:
                 out_lb[iso_idx] = upd_lo
                 out_ub[iso_idx] = upd_hi
                 var = idx_to_var.get(iso_idx)

--- a/python/tests/test_defined_variable_forward_fbbt.py
+++ b/python/tests/test_defined_variable_forward_fbbt.py
@@ -24,7 +24,13 @@ from pathlib import Path
 import discopt.modeling as dm
 import numpy as np
 import pytest
-from discopt._relax.nonlinear_bound_tightening import tighten_nonlinear_bounds
+from discopt._relax.nonlinear_bound_tightening import (
+    _EMPTY_INTERVAL_FEAS_TOL,
+    DefinedVariableForwardRule,
+    NonlinearBoundTighteningInfeasible,
+    _cached_flat_metadata,
+    tighten_nonlinear_bounds,
+)
 from discopt.modeling.core import from_nl
 from discopt.solver import _extract_variable_info
 
@@ -78,6 +84,66 @@ def test_nvs05_aux_vars_bounded():
     tl, tu, stats = tighten_nonlinear_bounds(m, lb.copy(), ub.copy())
     assert np.all(np.isfinite(tl)) and np.all(np.isfinite(tu)), "an nvs05 var stayed unbounded"
     assert stats.n_tightened >= 8  # four aux vars x two bounds
+
+
+def _crossing_model(fixed_value: float):
+    """``s == x/3`` with ``x`` fixed and ``s`` free above a declared ``lb = 1.0``.
+
+    The forward substitution derives ``s in [fixed_value/3, fixed_value/3]`` and
+    intersects it with ``[1.0, inf)``. Choosing ``fixed_value`` just below ``3.0``
+    makes that intersection *cross* (``lo > hi``) by a controlled amount.
+    """
+    m = dm.Model("crossing")
+    x = m.continuous("x", lb=fixed_value, ub=fixed_value)
+    s = m.continuous("s", lb=1.0, ub=float("inf"))
+    m.minimize(x)
+    m.subject_to(s == x / 3.0)
+    return m, [v.name for v in m._variables].index("s")
+
+
+def test_sub_tolerance_crossing_snaps_instead_of_raising():
+    """A rounding-scale ``lo > hi`` collapses to a degenerate box, not a ValueError.
+
+    ``2.999999999999991 / 3 == 0.999999999999997``, so the derived range crosses the
+    declared ``lb = 1.0`` by 3e-15 -- exactly the ex7_3_6 shape of #1197, where the
+    ``Interval(lo, hi)`` invariant used to raise straight out of
+    ``tighten_nonlinear_bounds`` and take the instance out of every panel.
+    """
+    m, s_idx = _crossing_model(2.999999999999991)
+    _, lb, ub, _, _ = _extract_variable_info(m)
+    metadata = _cached_flat_metadata(m)
+
+    rule_lb, rule_ub = DefinedVariableForwardRule().tighten(m, lb.copy(), ub.copy(), metadata)
+    # Degenerate, and snapped to the enclosure's own endpoint (outward, i.e. *below*
+    # the declared lb) rather than to the tighter declared bound.
+    assert rule_lb[s_idx] == rule_ub[s_idx]
+    # Assert the crossing this test exists for was actually exercised: strictly
+    # below 1.0, and by less than the empty-interval tolerance.
+    assert 0.0 < 1.0 - rule_ub[s_idx] < _EMPTY_INTERVAL_FEAS_TOL
+
+    tl, tu, stats = tighten_nonlinear_bounds(m, lb.copy(), ub.copy())
+    assert not stats.infeasible, stats.infeasibility_reason
+    assert tl[s_idx] <= tu[s_idx]
+    assert tu[s_idx] == pytest.approx(1.0, abs=1e-9)
+
+
+def test_beyond_tolerance_crossing_is_reported_as_infeasible():
+    """A crossing far past any rounding slack is a real proof, reported as one.
+
+    ``s == 2.7/3 == 0.9`` cannot hold with ``s >= 1``: the derived interval and the
+    box are genuinely disjoint (by 0.1, four orders above ``_EMPTY_INTERVAL_FEAS_TOL``).
+    That must surface through ``stats.infeasible``, not as an escaping ValueError and
+    not as a silently skipped row.
+    """
+    m, _ = _crossing_model(2.7)
+    _, lb, ub, _, _ = _extract_variable_info(m)
+
+    _, _, stats = tighten_nonlinear_bounds(m, lb.copy(), ub.copy())
+    assert stats.infeasible
+    assert "defined_variable_forward" in (stats.infeasibility_reason or "")
+
+    with pytest.raises(NonlinearBoundTighteningInfeasible):
+        DefinedVariableForwardRule().tighten(m, lb.copy(), ub.copy(), _cached_flat_metadata(m))
 
 
 @pytest.mark.slow


### PR DESCRIPTION
## Summary

`DefinedVariableForwardRule` intersected the forward-substituted enclosure of a defined
variable with its box and then built `Interval(upd_lo, upd_hi)` from the result. When the
two crossed by rounding noise the dataclass invariant raised a bare `ValueError` out of
`tighten_nonlinear_bounds` entirely, so any caller that tightened the model died rather
than getting a (possibly untightened) box back — `ex7_3_6` crosses by 3e-15 on a variable
whose true range is the single point 1.0. The old guard
`upd_lo <= upd_hi + _EMPTY_INTERVAL_FEAS_TOL` admitted exactly the sub-tolerance crossings
that then blew up in the constructor, and silently skipped the row for anything larger.

The rule now decides what a crossed interval means *before* constructing it:

- **crossing beyond `_EMPTY_INTERVAL_FEAS_TOL`** → `_prove_infeasible`, the first-class
  representation every sibling rule already uses, which the driver turns into
  `stats.infeasible`. This was previously a silent skip — inconsistent with the driver,
  which already classifies the same crossed box as infeasible when a rule returns one.
- **crossing within tolerance** → collapse to the degenerate box at the enclosure's own
  endpoint (the same outward repair `_snap_tolerant_crossovers` applies box-wide), and
  continue.

No `except ValueError` around the construction, per CLAUDE.md §3. `tightened` is still
computed from the pre-snap values, so non-crossing rows are byte-identical.

Closes #1197

## Correctness

The sub-tolerance repair snaps *outward* — to the enclosure's own endpoint, i.e. below the
declared lower bound — never to the tighter declared bound, so eps-scale rounding cannot
cut a feasible point. The new infeasibility path is an intersection of a valid interval
enclosure with the incumbent box, tested with the module's existing
`_EMPTY_INTERVAL_FEAS_TOL`, identical to how every sibling rule in the file proves
infeasibility; it is also the same verdict the driver already reaches on its own when a
rule returns a crossed box. The corpus panel below confirms no instance newly reports
infeasible.

- [x] Cannot produce a false certificate
- [x] No validation, fallback, or safety guard was weakened to make a check pass

## Tests run (state the result — numbers, not adjectives)

- [x] `pytest -m smoke python/tests` → 1209 passed, 21 skipped, 9445 deselected, 2 xpassed (315 s)
- [x] `pytest -m slow python/tests/test_adversarial_recent_fixes.py` → 19 passed (160 s)
- [x] `cargo test -p discopt-core` → N/A, no Rust touched
- [x] `ruff check` / `ruff format --check` → clean (ruff 0.14.6)

Also run: `test_defined_variable_forward_fbbt.py` → 5 passed; the FBBT-adjacent files
(`test_fbbt_aux_chain_bounds`, `test_fbbt_bindings`, `test_fbbt_bounds_suspect_parity`,
`test_issue_1066_fbbt_row_sweep`, `test_nonlinear_bound_tightening_tol`) → 26 passed.

**Differential panel.** `tighten_nonlinear_bounds` over all 66 `.nl` instances in
`python/tests/data/minlplib_nl/`, `main` vs this change, comparing the full returned
`(lb, ub)` arrays plus `infeasible`, `infeasibility_reason`, `n_tightened` and
`applied_rules`: **66 compared, 0 differing**. Bound-neutral, and no instance newly
reports infeasible. Each arm asserted `nbt.__file__` and the presence/absence of a marker
string unique to the patched version before measuring (CLAUDE.md §8), and the panel exits
non-zero on zero instances compared (§6).

## Regression test

Two tests in `python/tests/test_defined_variable_forward_fbbt.py`, both confirmed to fail
before the change and pass after (`git stash` on the source file alone; before → 2 failed,
3 passed with `ValueError: Interval lo > hi: lo=1.0, hi=0.9999999999999972`; after → 5
passed):

- `test_sub_tolerance_crossing_snaps_instead_of_raising` — the `ex7_3_6` shape returns a
  degenerate box instead of raising. It asserts the crossing was actually exercised
  (`0 < 1.0 - hi < _EMPTY_INTERVAL_FEAS_TOL`) so it cannot pass vacuously.
- `test_beyond_tolerance_crossing_is_reported_as_infeasible` — `s == 2.7/3` with `s >= 1`
  (genuinely infeasible) surfaces through `stats.infeasible` naming the rule, not as an
  escaping `ValueError` and not as a silently skipped row.

`ex7_3_6.nl` is not in the in-repo corpus and minlplib.org is blocked by this
environment's network policy (`CONNECT tunnel failed, 403`), so the reproducer is a
synthetic instance of the same shape — `s == x/3` with `x` fixed just below 3.0 and `s`
free above a declared `lb = 1.0`. It reproduces the issue's trace values exactly
(`lo=1.0, hi=0.999999999999997`). Confirming on the real `ex7_3_6` needs a machine with
the MINLPLib snapshot.

## Bound-changing / performance change?

N/A — the panel above shows the returned boxes are byte-identical on every corpus
instance; the only behavior change is on rows that previously raised or were silently
skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017ZQBztHoGuWEP4VS53o3Eg

---
_Generated by [Claude Code](https://claude.ai/code/session_017ZQBztHoGuWEP4VS53o3Eg)_