### PR TITLE
fix(relax): #1198 make _flatten_sum iterative so long rows don't blow the stack

### DIFF
--- a/python/discopt/_relax/nonlinear_bound_tightening.py
+++ b/python/discopt/_relax/nonlinear_bound_tightening.py
@@ -707,30 +707,49 @@ def _tighten_affine_upper_bound(
 
 
 def _flatten_sum(expr, scale: float, out: list[tuple[float, object]]) -> None:
-    if isinstance(expr, SumOverExpression):
-        for term in expr.terms:
-            _flatten_sum(term, scale, out)
-        return
+    """Flatten an additive expression into ``(scale, leaf)`` terms.
 
-    if isinstance(expr, BinaryOp) and expr.op == "+":
-        _flatten_sum(expr.left, scale, out)
-        _flatten_sum(expr.right, scale, out)
-        return
-    if isinstance(expr, BinaryOp) and expr.op == "-":
-        _flatten_sum(expr.left, scale, out)
-        _flatten_sum(expr.right, -scale, out)
-        return
-    # Distribute negation over its operand: neg(a + b) == (-a) + (-b) is an exact
-    # identity, so pushing the sign inward lets the additive walk see the full
-    # structure underneath a `neg` (e.g. a `neg(sum-of-squares)` term whose
-    # squares would otherwise be hidden inside one opaque leaf, invisible to the
-    # downstream quadratic/interval bounding rules). This mirrors the negation
-    # handling already in `_flatten_sum_terms` (convexity/patterns.py) and is a
-    # sound normalization — it never removes a feasible point (#777).
-    if isinstance(expr, UnaryOp) and expr.op == "neg":
-        _flatten_sum(expr.operand, -scale, out)
-        return
-    out.append((scale, expr))
+    The walk is iterative over an explicit ``(expr, scale)`` stack rather than
+    recursive: a long linear row parses to a left-deep ``((a+b)+c)+d…`` chain
+    whose depth equals the term count, so a recursive walk exhausted the Python
+    stack on models with a few thousand terms (``t1000``) and killed the whole
+    tightening pass with a ``RecursionError`` (#1198). Depth is now bounded only
+    by the heap.
+
+    Children are pushed in reverse so they pop left-to-right, which makes the
+    emitted term order identical to the recursive walk's; the scale carried on a
+    stack entry is the same value the recursion passed down (sign flips are
+    exact), so the term list is bit-for-bit unchanged.
+    """
+    stack: list[tuple[object, float]] = [(expr, scale)]
+    while stack:
+        node, node_scale = stack.pop()
+
+        if isinstance(node, SumOverExpression):
+            for term in reversed(node.terms):
+                stack.append((term, node_scale))
+            continue
+
+        if isinstance(node, BinaryOp) and node.op == "+":
+            stack.append((node.right, node_scale))
+            stack.append((node.left, node_scale))
+            continue
+        if isinstance(node, BinaryOp) and node.op == "-":
+            stack.append((node.right, -node_scale))
+            stack.append((node.left, node_scale))
+            continue
+        # Distribute negation over its operand: neg(a + b) == (-a) + (-b) is an
+        # exact identity, so pushing the sign inward lets the additive walk see
+        # the full structure underneath a `neg` (e.g. a `neg(sum-of-squares)`
+        # term whose squares would otherwise be hidden inside one opaque leaf,
+        # invisible to the downstream quadratic/interval bounding rules). This
+        # mirrors the negation handling already in `_flatten_sum_terms`
+        # (convexity/patterns.py) and is a sound normalization — it never removes
+        # a feasible point (#777).
+        if isinstance(node, UnaryOp) and node.op == "neg":
+            stack.append((node.operand, -node_scale))
+            continue
+        out.append((node_scale, node))
 
 
 def _min_univariate_quadratic(a: float, b: float, lb: float, ub: float) -> float:

--- a/python/tests/test_issue1198_flatten_sum_iterative.py
+++ b/python/tests/test_issue1198_flatten_sum_iterative.py
@@ -1,0 +1,159 @@
+"""Issue #1198 — `_flatten_sum` must not recurse once per additive term.
+
+A long linear row parses to a left-deep ``((a+b)+c)+d…`` chain whose depth
+equals its term count, so the recursive additive walk used by the nonlinear
+bound-tightening rules exhausted the Python stack on models with a few thousand
+terms (`t1000` in MINLPLib). The `RecursionError` escaped
+`tighten_nonlinear_bounds` and the instance dropped out of any panel touching
+this path — a silent size cliff, not a soundness bug.
+
+The walk is now iterative over an explicit ``(expr, scale)`` stack. These tests
+fail before that rewrite (`RecursionError` at ~1000 terms) and pass after. The
+equivalence test pins the rewrite to the recursive semantics it replaced: the
+same leaves, in the same order, with the same scales.
+"""
+
+from __future__ import annotations
+
+import os
+
+os.environ.setdefault("JAX_PLATFORMS", "cpu")
+os.environ.setdefault("JAX_ENABLE_X64", "1")
+
+import numpy as np
+import pytest
+from discopt._relax.model_utils import flat_variable_bounds
+from discopt._relax.nonlinear_bound_tightening import (
+    BinaryOp,
+    SumOverExpression,
+    UnaryOp,
+    _flatten_sum,
+    tighten_nonlinear_bounds,
+)
+from discopt.modeling.core import Model
+
+pytestmark = pytest.mark.unit
+
+# Comfortably past CPython's default recursion limit (1000), so the pre-fix walk
+# dies here regardless of how many frames the test harness already occupies.
+DEEP_N = 20_000
+
+
+def _left_deep_sum(terms):
+    """Build ``((t0 + t1) + t2) + …`` — the shape a long linear row parses to."""
+    expr = terms[0]
+    for term in terms[1:]:
+        expr = expr + term
+    return expr
+
+
+def _recursive_flatten_sum(expr, scale: float, out: list[tuple[float, object]]) -> None:
+    """The pre-#1198 recursive walk, kept here as the equivalence oracle."""
+    if isinstance(expr, SumOverExpression):
+        for term in expr.terms:
+            _recursive_flatten_sum(term, scale, out)
+        return
+    if isinstance(expr, BinaryOp) and expr.op == "+":
+        _recursive_flatten_sum(expr.left, scale, out)
+        _recursive_flatten_sum(expr.right, scale, out)
+        return
+    if isinstance(expr, BinaryOp) and expr.op == "-":
+        _recursive_flatten_sum(expr.left, scale, out)
+        _recursive_flatten_sum(expr.right, -scale, out)
+        return
+    if isinstance(expr, UnaryOp) and expr.op == "neg":
+        _recursive_flatten_sum(expr.operand, -scale, out)
+        return
+    out.append((scale, expr))
+
+
+def test_flatten_sum_handles_a_left_deep_sum_of_20000_terms():
+    """The additive walk's depth must be bounded by the heap, not the C stack."""
+    m = Model("deep_sum")
+    xs = [m.continuous(f"x{i}", lb=-1.0, ub=1.0) for i in range(DEEP_N)]
+
+    terms: list[tuple[float, object]] = []
+    _flatten_sum(_left_deep_sum(xs), 1.0, terms)  # pre-fix: RecursionError
+
+    assert len(terms) == DEEP_N
+    # Order and scale are preserved all the way down the chain.
+    assert [t is x for (_, t), x in zip(terms, xs)] == [True] * DEEP_N
+    assert all(scale == 1.0 for scale, _ in terms)
+
+
+def test_flatten_sum_handles_a_left_deep_difference():
+    """`-` alternates the carried scale; depth must not matter to that either."""
+    m = Model("deep_diff")
+    xs = [m.continuous(f"x{i}", lb=-1.0, ub=1.0) for i in range(DEEP_N)]
+
+    expr = xs[0]
+    for x in xs[1:]:
+        expr = expr - x
+
+    terms: list[tuple[float, object]] = []
+    _flatten_sum(expr, 1.0, terms)
+
+    assert len(terms) == DEEP_N
+    assert terms[0][0] == 1.0
+    assert all(scale == -1.0 for scale, _ in terms[1:])
+
+
+def test_flatten_sum_matches_the_recursive_walk_term_for_term():
+    """Bit-for-bit equivalence with the walk this replaced, on mixed structure.
+
+    Sums, differences, `neg`, `SumOverExpression`, non-additive leaves (squares,
+    products, scaled variables) and both signs of the incoming scale.
+    """
+    m = Model("mixed")
+    xs = [m.continuous(f"x{i}", lb=-2.0, ub=3.0) for i in range(6)]
+
+    exprs = [
+        xs[0] + xs[1] - xs[2],
+        -(xs[0] ** 2 + xs[1] ** 2),
+        (xs[0] - (xs[1] + xs[2])) - (-(xs[3] * xs[4])),
+        2.5 * xs[0] + (-1.25) * xs[1] - (xs[2] ** 2 - xs[3]),
+        sum(xs[1:], xs[0]),
+        -(-(xs[0] + xs[1]) - xs[2]) + xs[3] ** 2,
+        _left_deep_sum([x**2 for x in xs]) - _left_deep_sum(xs),
+    ]
+
+    comparisons = 0
+    for expr in exprs:
+        for scale in (1.0, -1.0, 0.75, -3.0):
+            expected: list[tuple[float, object]] = []
+            actual: list[tuple[float, object]] = []
+            _recursive_flatten_sum(expr, scale, expected)
+            _flatten_sum(expr, scale, actual)
+
+            assert len(actual) == len(expected)
+            for (exp_scale, exp_term), (act_scale, act_term) in zip(expected, actual):
+                assert act_term is exp_term  # same leaf, same position
+                assert act_scale == exp_scale  # exact, not approx: bounds move on a ulp
+                comparisons += 1
+
+    # §6: prove the probe fired — a silently empty comparison loop reads as a pass.
+    assert comparisons > 0
+
+
+def test_tighten_nonlinear_bounds_survives_a_deep_row():
+    """End to end: the rule that hit this on `t1000` now derives its bounds.
+
+    ``sum_i x_i^2 <= 9`` over a left-deep row of 20k squares implies
+    ``|x_i| <= 3``; pre-fix the `RecursionError` escaped the whole pass.
+    """
+    m = Model("deep_sos")
+    xs = [m.continuous(f"x{i}", lb=-100.0, ub=100.0) for i in range(DEEP_N)]
+    m.subject_to(_left_deep_sum([x**2 for x in xs]) <= 9.0)
+    m.minimize(xs[0])
+
+    lb0, ub0 = flat_variable_bounds(m)
+    tlb, tub, stats = tighten_nonlinear_bounds(m, lb0.copy(), ub0.copy())
+
+    assert not stats.infeasible
+    assert "sum_of_squares_upper_bound" in stats.applied_rules
+
+    # Nothing looser than the input box, and the radius-3 ball bounds are found.
+    assert np.all(tlb >= lb0 - 1e-12)
+    assert np.all(tub <= ub0 + 1e-12)
+    assert tub == pytest.approx(np.full(DEEP_N, 3.0))
+    assert tlb == pytest.approx(np.full(DEEP_N, -3.0))


### PR DESCRIPTION
## Summary

`_flatten_sum` in `python/discopt/_relax/nonlinear_bound_tightening.py` recursed once per additive node. A long linear row parses to a left-deep `((a+b)+c)+d…` chain whose depth equals its term count, so a few thousand terms exhausted the Python stack; the `RecursionError` escaped `tighten_nonlinear_bounds` and the instance (`t1000`) dropped out of any panel touching this path. A silent size cliff, not a soundness bug.

The walk is now an explicit `(expr, scale)` work stack. Children are pushed in reverse so they pop left-to-right, and each stack entry carries the same scale value the recursion passed down (sign flips are exact), so the emitted term list is bit-for-bit unchanged — the memoized `_cached_flat_terms` contract and the ulp sensitivity documented there are preserved.

Closes #1198

**Two caveats stated up front:**

1. **The issue's literal reproducer was never run.** The MINLPLib snapshot is not in this container and `minlplib.org` is blocked by the egress policy, so `t1000` itself was never loaded. The regression tests reproduce the exact reported shape (recursion entirely down `expr.left`, same rule path) synthetically, but confirming `t1000` against the corpus is left to a reviewer with it on disk.
2. **A sibling of the same cliff was deliberately left alone.** The nested `_flatten_sum` inside `_sum_of_affine_squares` (`python/discopt/_relax/convexity/patterns.py:578`) also recurses per `+` node. It is a different function on a different path and outside what #1198 scopes as done, so widening this PR to it seemed wrong — but it is the same size cliff and will bite the same way.

## Correctness

Mechanical rewrite of a traversal; no solver math changed. The flattened term list is bit-for-bit identical, verified two ways below, so no bound can move — a bound-neutral change under CLAUDE.md §5.

- [x] Cannot produce a false certificate (no solver-math change; term list proven byte-identical)
- [x] No validation, fallback, or safety guard was weakened to make a check pass

## Tests run (state the result — numbers, not adjectives)

- [x] `pytest -m smoke` → 1209 passed, 21 skipped, 9447 deselected, 2 xpassed (393.74s)
- [x] `pytest -m slow python/tests/test_adversarial_recent_fixes.py` → 19 passed (163.72s)
- [x] `cargo test -p discopt-core` → N/A, no Rust touched
- [x] `ruff check` / `ruff format --check` clean

Additional evidence beyond the required suites:

- **Bound-neutral differential** over the 66-instance in-repo MINLPLib corpus (`python/tests/data/minlplib_nl/`): tightened `flat_lb` and `flat_ub` compared as raw float64 bytes, plus applied-rule tuple and infeasible flag, before vs after — **66 compared, 0 differing**.
- **Randomized equivalence** against the recursive walk over mixed `+`/`-`/`neg`/`SumOverExpression` structure at four incoming scales — **4180 term comparisons**, same leaf objects in the same order with exactly equal scales.

Per the measurement discipline in CLAUDE.md §6/§8: every probe asserts a nonzero comparison count and exits non-zero otherwise, and each run asserts both `nbt.__file__` under the worktree and a marker string unique to the version under test — present on the "after" run, **absent** on the "before" run. Runs used a Python 3.12 venv with the maturin-built `_rust.abi3.so` placed in the worktree.

## Regression test

`python/tests/test_issue1198_flatten_sum_iterative.py` — four tests:

1. 20,000-term left-deep sum → asserts the term count, leaf order, and scales.
2. 20,000-term left-deep difference → asserts the alternating scale.
3. Equivalence oracle: the pre-fix recursive walk is kept in-test and compared term-for-term against the new walk on mixed structure (this one passes both before and after; it pins the rewrite's semantics rather than reproducing the bug).
4. End-to-end `tighten_nonlinear_bounds` over a 20k-square row → the `sum_of_squares_upper_bound` rule fires and derives the radius-3 ball bounds.

- [x] Added a regression test that fails before / passes after — **3 of the 4 fail with `RecursionError` on the pre-fix code**, verified by reverting the source file and re-running (`3 failed, 1 passed`); all 4 pass after.

## Bound-changing / performance change?

N/A — bound-neutral, no flag, no bound or cut touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X4AtGPdUFj8J4hqNohy1r4

---
_Generated by [Claude Code](https://claude.ai/code/session_01X4AtGPdUFj8J4hqNohy1r4)_