### PR TITLE
fix(correctness): #1199 the terminal polish must not adopt a point it moved off the rows

### DIFF
--- a/python/discopt/_relax/primal_heuristics.py
+++ b/python/discopt/_relax/primal_heuristics.py
@@ -497,6 +497,8 @@ def _check_constraint_feasibility(
     x: np.ndarray,
     tol: float = 1e-6,
     rtol: float = 1e-9,
+    cl: Optional[np.ndarray] = None,
+    cu: Optional[np.ndarray] = None,
 ) -> bool:
     """Check that ``x`` satisfies the model's constraints to within tolerance.
 
@@ -518,24 +520,99 @@ def _check_constraint_feasibility(
     real consequence is still rejected. The absolute test is tried first and the
     Jacobian (the only added cost) is evaluated only for rows that fail it, so
     well-scaled feasible points keep the original cheap path unchanged.
+
+    ``cl``/``cu`` override the evaluator's own inferred row bounds, for a caller
+    that already holds the bounds its rows were built with (see
+    :func:`row_violations`); :func:`scaled_violation_ratio` reports the same test
+    as a magnitude, for a caller that must RANK two points rather than judge one.
     """
     if evaluator.n_constraints == 0:
         return True
-    g = np.asarray(evaluator.evaluate_constraints(x))
-    from discopt.solvers.nlp_ipopt import _infer_constraint_bounds
-
-    cl, cu = (np.asarray(b, dtype=np.float64) for b in _infer_constraint_bounds(evaluator))
-    viol = np.maximum(np.maximum(cl - g, 0.0), np.maximum(g - cu, 0.0))
-    if bool(np.all(viol <= tol)):
+    viol = row_violations(evaluator, x, cl, cu)
+    if viol.size == 0 or bool(np.all(viol <= tol)):
         return True
     # Some row exceeds the absolute tolerance: re-test those rows against a
     # term-magnitude-scaled tolerance before declaring infeasibility.
     try:
-        jac = np.abs(np.asarray(evaluator.evaluate_jacobian(x), dtype=np.float64))
-        scale = jac @ np.abs(np.asarray(x, dtype=np.float64))
+        scale = row_term_scale(evaluator, x)
     except Exception:
         return False
-    return bool(np.all(viol <= tol + rtol * scale))
+    return bool(np.all(viol <= combined_tolerance(scale, tol, rtol)))
+
+
+def row_violations(
+    evaluator: NLPEvaluator,
+    x: np.ndarray,
+    cl: Optional[np.ndarray] = None,
+    cu: Optional[np.ndarray] = None,
+) -> np.ndarray:
+    """Per-row constraint violation of ``x`` (``0`` on every satisfied row).
+
+    ``cl``/``cu`` default to the evaluator's own inferred row bounds; pass them
+    explicitly when the caller already holds the bounds the rows were built with.
+    An evaluator carrying MORE rows than the bounds describe (a cut-augmented one)
+    is truncated to the described rows: cuts are valid for the original feasible
+    set, so they do not define feasibility of a point.
+    """
+    g = np.asarray(evaluator.evaluate_constraints(x), dtype=np.float64)
+    if cl is None or cu is None:
+        from discopt.solvers.nlp_ipopt import _infer_constraint_bounds
+
+        cl, cu = _infer_constraint_bounds(evaluator)
+    cl = np.asarray(cl, dtype=np.float64)
+    cu = np.asarray(cu, dtype=np.float64)
+    n = min(g.size, cl.size, cu.size)
+    if n == 0:
+        return np.zeros(0, dtype=np.float64)
+    g, cl, cu = g[:n], cl[:n], cu[:n]
+    return np.maximum(np.maximum(cl - g, 0.0), np.maximum(g - cu, 0.0))
+
+
+def row_term_scale(evaluator: NLPEvaluator, x: np.ndarray) -> np.ndarray:
+    """Per-row absolute linearized magnitude ``sum_j |J_ij| * |x_j|``.
+
+    The size of the row's additive terms, taken from the Jacobian and NOT from the
+    (possibly +/-1e20 sentinel) bound values, so an unbounded row cannot inflate a
+    tolerance built on it.
+    """
+    jac = np.abs(np.asarray(evaluator.evaluate_jacobian(x), dtype=np.float64))
+    return jac @ np.abs(np.asarray(x, dtype=np.float64))
+
+
+def combined_tolerance(scale: np.ndarray, tol: float = 1e-6, rtol: float = 1e-9) -> np.ndarray:
+    """The per-row threshold ``tol + rtol*scale`` of the combined feasibility test.
+
+    One definition, used by every site that decides or reports against that test,
+    so a threshold and the number compared to it can never drift apart.
+    """
+    return tol + rtol * np.asarray(scale, dtype=np.float64)
+
+
+def scaled_violation_ratio(
+    evaluator: NLPEvaluator,
+    x: np.ndarray,
+    cl: Optional[np.ndarray] = None,
+    cu: Optional[np.ndarray] = None,
+    tol: float = 1e-6,
+    rtol: float = 1e-9,
+) -> float:
+    """How far outside the rows ``x`` sits, as a MULTIPLE of the combined tolerance.
+
+    ``max_i viol_i / (tol + rtol*scale_i)``: the same quantity
+    :func:`_check_constraint_feasibility` decides with, reported as a number rather
+    than a bool. ``<= 1.0`` holds exactly when that function accepts, so two points
+    can be RANKED by feasibility on the arbiter's own scale -- which is what a
+    caller choosing between an incumbent and a candidate replacement needs, and
+    what a bool cannot express. Raises rather than degrading to a verdict if the
+    Jacobian cannot be evaluated (CLAUDE.md §7).
+    """
+    if evaluator.n_constraints == 0:
+        return 0.0
+    viol = row_violations(evaluator, x, cl, cu)
+    if viol.size == 0 or not bool(np.any(viol > 0.0)):
+        return 0.0
+    scale = row_term_scale(evaluator, x)
+    return float(np.max(viol / combined_tolerance(scale, tol, rtol)))
 
 
 # --- The false-primal screen (#772 / #815 / #1061) ---------------------------

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -2992,6 +2992,60 @@ def _nonlinear_point_excess(
     return float(excess), where, n_compared
 
 
+def _polish_preserves_feasibility(evaluator, x_new, x_old, cl_list, cu_list) -> bool:
+    """May the terminal polish's point replace the incumbent, on FEASIBILITY grounds?
+
+    The terminal KKT polish (see its call site) re-solves the incumbent's
+    continuous completion and adopts the result when the objective is unchanged
+    ("purification") or improved. Neither of those tests looks at the rows, and an
+    objective that did not move says nothing about whether the point still
+    satisfies them: the NLP backend reports its OWN convergence status, not the
+    model's feasibility. Measured on nvs05 (#1199): the tree incumbent -- max row
+    violation 9.0e-6, i.e. 3.5e-7 of the acceptance tolerance, objective
+    5.470934109, the ``minlplib.solu`` oracle to 9 digits -- was replaced by a
+    polish output violating one row by 132.4, whose objective had moved 3.3e-8,
+    far inside the 1e-4 relative window the purification arm treats as unchanged.
+    The solve then reported ``optimal`` with ``gap_certified``, at an objective
+    BELOW the true optimum, on a point the repo's own acceptance arbiter rejects.
+
+    The bar here is NEVER-DEGRADE, not simply "feasible": the polished point is
+    admissible when it clears
+    :func:`_relax.primal_heuristics._check_constraint_feasibility` (the repo's
+    single acceptance arbiter, scale-aware in both legs), or -- when the incumbent
+    it would replace does not clear it either -- when it sits no further outside
+    the rows than that incumbent does. A purification is therefore never blocked
+    by a bar its own input could not meet, and the polish can only ever move the
+    reported point toward the feasible set, never away from it.
+
+    Ranking two points needs the arbiter's MAGNITUDE, not its verdict, hence
+    ``scaled_violation_ratio``; both points are measured against the same rows and
+    the same evaluator, so the comparison is like-for-like.
+    """
+    # ``len(...) == 0``, never ``not cl_list``: on a one-row numpy bound array the
+    # latter evaluates the ELEMENT's truthiness, so a single row at bound 0.0 --
+    # an ordinary equality -- reads as "no rows" and silently disables this gate.
+    if cl_list is None or len(cl_list) == 0:
+        return True
+    from discopt._relax.primal_heuristics import _check_constraint_feasibility as _accept_cc
+    from discopt._relax.primal_heuristics import scaled_violation_ratio
+
+    cl_arr = np.asarray(cl_list, dtype=np.float64)
+    cu_arr = np.asarray(cu_list, dtype=np.float64)
+    if _accept_cc(evaluator, x_new, cl=cl_arr, cu=cu_arr):
+        return True
+    ratio_new = scaled_violation_ratio(evaluator, x_new, cl_arr, cu_arr)
+    ratio_old = scaled_violation_ratio(evaluator, x_old, cl_arr, cu_arr)
+    if ratio_new <= ratio_old:
+        return True
+    logger.debug(
+        "#1199: rejecting the terminal polish -- it moves the incumbent further "
+        "outside the rows (%.4g -> %.4g times the acceptance tolerance).",
+        ratio_old,
+        ratio_new,
+    )
+    return False
+
+
 def _is_integer_feasible_solution(x, int_offsets, int_sizes, tol=1e-5):
     """Return True if all discrete variables are integral within tolerance."""
     for off, sz in zip(int_offsets, int_sizes):
@@ -15420,16 +15474,28 @@ def solve_model(
                 # fractional power of a ratio jumped 176.17 -> 0.0). There we keep
                 # only the always-safe purification (unchanged objective).
                 _improved = _model_is_convex and _pobj < obj_val - 1e-9 * (1.0 + abs(obj_val))
+                # #1199: feasibility gates BOTH arms. The comment above calls the
+                # unchanged-objective arm "always safe" purification; it is not --
+                # on nvs05 that arm adopted a point 132.4 outside a row and
+                # certified an objective below the true optimum. See
+                # ``_polish_preserves_feasibility`` for the measurement and for why
+                # the bar is never-degrade rather than plain feasibility.
                 _accept = (
-                    _unchanged
-                    or (
-                        _improved
-                        and (
-                            not cl_list
-                            or _check_constraint_feasibility(evaluator, _refined, cl_list, cu_list)
+                    _polish_preserves_feasibility(evaluator, _refined, sol_flat, cl_list, cu_list)
+                    and (
+                        _unchanged
+                        or (
+                            _improved
+                            and (
+                                not cl_list
+                                or _check_constraint_feasibility(
+                                    evaluator, _refined, cl_list, cu_list
+                                )
+                            )
                         )
                     )
-                ) and _pobj >= _min_accept_obj
+                    and _pobj >= _min_accept_obj
+                )
                 if _accept:
                     sol_flat = _refined
                     x_dict = _unpack_solution(model, sol_flat)
@@ -17775,25 +17841,50 @@ def _solve_nlp_bb(
                 # cannot admit a point the gate below refuses. When the two
                 # points agree to within the window, the original branch still
                 # applies and nothing moves.
+                #
+                # #1199: the window is row-blind in the OTHER direction too. When
+                # the two objectives agree it adopted the refined point without
+                # ever asking whether that point still satisfies the rows -- the
+                # same blind spot the spatial path's terminal polish had, where a
+                # 3.3e-8 objective move hid a point 132 outside a row and the solve
+                # certified an objective below the true optimum (nvs05). Here the
+                # exit gate below would catch it, but only by REFUSING the result:
+                # adopting a refine that walked off the rows turns a good solve
+                # into a withheld incumbent. So both arms are now judged on the
+                # same excess, against the same declared rows and box the exit gate
+                # uses, and the rule is never-degrade: a refined point is adopted
+                # when it would clear that gate, or when it is no further outside
+                # than the incumbent it replaces.
                 _ref_obj = float(nlp_refined.objective)
-                _adopt = abs(_ref_obj - obj_val) <= 1e-4 * (1.0 + abs(obj_val))
-                if not _adopt:
-                    _inc_exc, _, _ = _nonlinear_point_excess(
-                        evaluator,
-                        sol_flat,
-                        cl_list,
-                        cu_list,
-                        n_rows=_declared_rows,
-                        box=_declared_box,
-                    )
-                    _ref_exc, _, _ = _nonlinear_point_excess(
-                        evaluator,
-                        refined,
-                        cl_list,
-                        cu_list,
-                        n_rows=_declared_rows,
-                        box=_declared_box,
-                    )
+                _inc_exc, _, _ = _nonlinear_point_excess(
+                    evaluator,
+                    sol_flat,
+                    cl_list,
+                    cu_list,
+                    n_rows=_declared_rows,
+                    box=_declared_box,
+                )
+                _ref_exc, _, _ = _nonlinear_point_excess(
+                    evaluator,
+                    refined,
+                    cl_list,
+                    cu_list,
+                    n_rows=_declared_rows,
+                    box=_declared_box,
+                )
+                if abs(_ref_obj - obj_val) <= 1e-4 * (1.0 + abs(obj_val)):
+                    _adopt = _ref_exc <= _NLPBB_EXIT_ABS_TOL or _ref_exc <= _inc_exc
+                    if not _adopt:
+                        logger.debug(
+                            "NLP-BB: rejecting the refined incumbent (#1199) — its "
+                            "objective matches (%.6g vs %.6g) but it sits further "
+                            "outside the declared rows (excess %.3e -> %.3e).",
+                            _ref_obj,
+                            obj_val,
+                            _inc_exc,
+                            _ref_exc,
+                        )
+                else:
                     _adopt = _ref_exc < _inc_exc and _ref_exc <= _NLPBB_EXIT_ABS_TOL
                     if _adopt:
                         logger.info(

--- a/python/tests/test_polish_feasibility_gate_1199.py
+++ b/python/tests/test_polish_feasibility_gate_1199.py
@@ -1,0 +1,200 @@
+"""#1199 — the terminal KKT polish must never adopt a point it moved off the rows.
+
+``solve_model``'s terminal polish re-solves the incumbent's continuous completion
+with the integers fixed and adopts the result when the objective is *unchanged*
+(the arm its own comment called "the always-safe purification") or, on convex
+models, *improved*. Only the improving arm ever looked at the constraints. An
+objective that did not move says nothing about whether the point still satisfies
+the rows -- the NLP backend reports its own convergence status, not the model's.
+
+Measured on ``nvs05`` before this fix (``max_nodes=5000, time_limit=300``):
+
+    tree incumbent      max row violation 9.0e-6   objective 5.470934109
+    polish output       max row violation 1.3e+2   objective 5.4709340754
+
+The polish output was adopted -- its objective had moved 3.3e-8, deep inside the
+1e-4 relative window ``_unchanged`` accepts -- and the solve reported
+``status="optimal"``, ``gap_certified=True`` at an objective BELOW the
+``minlplib.solu`` oracle (5.470934108), on a point the repo's own acceptance
+arbiter (``_check_constraint_feasibility``) rejects. The tree incumbent it
+replaced matched that oracle to nine digits.
+"""
+
+from __future__ import annotations
+
+import pathlib
+
+import discopt.modeling as dm
+import discopt.solver as solver_mod
+import numpy as np
+import pytest
+from discopt._relax import primal_heuristics as ph
+from discopt._relax.nlp_evaluator import cached_evaluator
+from discopt.modeling.core import from_nl
+from discopt.solvers.nlp_ipopt import _infer_constraint_bounds
+
+
+class _LinearRows:
+    """Minimal evaluator over equality rows ``A x == 0``.
+
+    Enough surface for the arbiter and the ratio: ``n_constraints``,
+    ``evaluate_constraints`` and ``evaluate_jacobian``.
+    """
+
+    def __init__(self, A):
+        self.A = np.asarray(A, dtype=float)
+
+    @property
+    def n_constraints(self):
+        return int(self.A.shape[0])
+
+    def evaluate_constraints(self, x):
+        return self.A @ np.asarray(x, dtype=float)
+
+    def evaluate_jacobian(self, x):
+        return self.A
+
+
+# One row ``x0 - x1 == 0`` evaluated near 1e5: the large-magnitude regime the
+# scale-aware test exists for. scale = |1|*1e5 + |-1|*(1e5) ~ 2e5, so the
+# combined tolerance is 1e-6 + 1e-9*2e5 ~ 2.01e-4.
+_BIG = 1.0e5
+_ROWS = _LinearRows([[1.0, -1.0]])
+_CL = np.zeros(1)
+_CU = np.zeros(1)
+
+
+def _pt(resid):
+    return np.array([_BIG + resid, _BIG])
+
+
+def test_ratio_and_arbiter_agree_at_the_boundary():
+    """``scaled_violation_ratio(...) <= 1`` exactly when the arbiter accepts.
+
+    The gate ranks two points by this number, so it may not be a second, drifting
+    definition of the same test.
+    """
+    compared = 0
+    for resid in (0.0, 1e-9, 1e-4, 2.0e-4, 2.1e-4, 1e-3, 1.0):
+        x = _pt(resid)
+        accepts = ph._check_constraint_feasibility(x=x, evaluator=_ROWS, cl=_CL, cu=_CU)
+        ratio = ph.scaled_violation_ratio(_ROWS, x, _CL, _CU)
+        assert accepts == (ratio <= 1.0), f"resid={resid:g}: accepts={accepts} ratio={ratio:g}"
+        compared += 1
+    assert compared == 7, f"only {compared} comparisons executed"
+
+
+def test_ratio_is_scale_aware_not_absolute():
+    """A residual accepted at scale 1e5 is refused on the same row at scale 1."""
+    big = ph.scaled_violation_ratio(_ROWS, _pt(1.0e-4), _CL, _CU)
+    small = ph.scaled_violation_ratio(_ROWS, np.array([1.0e-4, 0.0]), _CL, _CU)
+    assert big <= 1.0 < small, f"big={big:g} small={small:g}"
+
+
+def test_gate_rejects_a_polish_that_moves_the_point_off_the_rows():
+    """The nvs05 signature, at unit scale: feasible incumbent, degraded candidate."""
+    x_old = _pt(0.0)
+    x_new = _pt(1.0e-2)  # ~50x the combined tolerance
+    assert not solver_mod._polish_preserves_feasibility(_ROWS, x_new, x_old, _CL, _CU)
+
+
+def test_gate_accepts_a_feasible_polish():
+    x_old = _pt(1.0e-4)
+    x_new = _pt(1.0e-9)
+    assert solver_mod._polish_preserves_feasibility(_ROWS, x_new, x_old, _CL, _CU)
+
+
+def test_gate_accepts_a_polish_that_improves_an_already_infeasible_incumbent():
+    """Never-degrade, not "feasible": a purification of a marginal point must not
+    be blocked by a bar its own input could not clear."""
+    x_old = _pt(1.0)
+    x_new = _pt(1.0e-2)  # still outside the arbiter, but 100x closer
+    assert solver_mod._polish_preserves_feasibility(_ROWS, x_new, x_old, _CL, _CU)
+    assert not solver_mod._polish_preserves_feasibility(_ROWS, x_old, x_new, _CL, _CU)
+
+
+def test_gate_is_a_no_op_without_row_bounds():
+    assert solver_mod._polish_preserves_feasibility(_ROWS, _pt(1.0), _pt(0.0), [], [])
+
+
+def _pinned_model():
+    """``min n  s.t.  x**3 - 1000 == 0``, x continuous, n integer.
+
+    The row pins ``x = 10`` and involves no objective variable, so perturbing
+    ``x`` moves the point off the row while leaving the objective EXACTLY
+    unchanged — the purification arm's own condition, met perfectly.
+    """
+    m = dm.Model()
+    x = m.continuous("x", lb=0.0, ub=100.0)
+    n = m.integer("n", lb=1, ub=3)
+    m.subject_to(x * x * x - 1000.0 == 0.0)
+    m.minimize(n)
+    return m
+
+
+# Row scale at the solution: |d/dx (x**3)| * |x| = 3*10**2 * 10 = 3000, so the
+# acceptance tolerance there is 1e-6 + 1e-9*3000 = 4e-6 and the deliberately loose
+# false-primal screen is 1e-3 + 1e-6*3000 = 4e-3. The injected 1e-4 violation sits
+# between them: only the polish gate can refuse this point.
+_INJECTED_VIOLATION = 1.0e-4
+
+
+def test_a_degrading_polish_is_not_reported(monkeypatch):
+    """End to end: an off-manifold polish output with an IDENTICAL objective.
+
+    Fails before the fix — the purification arm adopts any point whose objective
+    did not move — and passes after. Route-agnostic on purpose: both terminal
+    re-solves (spatial-B&B polish, NLP-BB refine) go through
+    ``_solve_node_nlp_kkt``, and the invariant asserted is the one the issue is
+    about: the point that leaves satisfies the rows it is reported against.
+    """
+    calls = {"n": 0}
+    real = solver_mod._solve_node_nlp_kkt
+
+    def _degrading(evaluator, x0, node_lb, node_ub, constraint_bounds, options, *a, **k):
+        res = real(evaluator, x0, node_lb, node_ub, constraint_bounds, options, *a, **k)
+        if res.x is not None and len(res.x) >= 2:
+            calls["n"] += 1
+            bad = np.asarray(res.x, dtype=float).copy()
+            bad[0] = float((1000.0 + _INJECTED_VIOLATION) ** (1.0 / 3.0))
+            res.x = bad
+        return res
+
+    monkeypatch.setattr(solver_mod, "_solve_node_nlp_kkt", _degrading)
+
+    r = _pinned_model().solve(time_limit=30)
+    assert calls["n"] > 0, "no terminal re-solve ran — this test asserted nothing"
+    assert r.x is not None, f"no incumbent (status={r.status})"
+    x_rep = float(np.asarray(r.x["x"]).ravel()[0])
+    resid = abs(x_rep**3 - 1000.0)
+    threshold = 1.0e-6 + 1.0e-9 * (3.0 * x_rep**2 * abs(x_rep))
+    assert resid <= threshold, (
+        f"the reported point sits {resid:.3e} off the row it must satisfy "
+        f"(tolerance {threshold:.3e}, x={x_rep!r}): a re-solve that moved the "
+        f"incumbent off the manifold was adopted because its objective had not moved"
+    )
+
+
+@pytest.mark.slow
+def test_nvs05_incumbent_passes_the_acceptance_arbiter():
+    """The issue's own instance, verified against a freshly parsed ORIGINAL model."""
+    path = pathlib.Path(__file__).parent / "data" / "minlplib_nl" / "nvs05.nl"
+    r = from_nl(str(path)).solve(max_nodes=5000, time_limit=180.0)
+    assert r.x is not None, f"no incumbent (status={r.status})"
+
+    fresh = from_nl(str(path))
+    ev = cached_evaluator(fresh)
+    assert ev.n_constraints > 0, "fixture has no rows — the assertion below is vacuous"
+    x = np.concatenate(
+        [np.atleast_1d(np.asarray(r.x[v.name], dtype=float)).ravel() for v in fresh._variables]
+    )
+    cl, cu = (np.asarray(b, dtype=float) for b in _infer_constraint_bounds(ev))
+    ratio = ph.scaled_violation_ratio(ev, x, cl, cu)
+    assert ph._check_constraint_feasibility(ev, x), (
+        f"the reported nvs05 incumbent (objective={r.objective!r}) is "
+        f"{ratio:.3g}x the acceptance tolerance outside the rows — the arbiter that "
+        f"decides whether a primal heuristic may offer a point rejects the point the "
+        f"solve returns"
+    )
+    # The oracle: 5.470934108 (minlplib.solu). Below it means off the manifold.
+    assert r.objective is not None and r.objective >= 5.470934108 - 1e-6

--- a/scratchpad/i1199/compare_1199.py
+++ b/scratchpad/i1199/compare_1199.py
@@ -1,0 +1,60 @@
+"""Before/after comparison for #1199 over the in-repo MINLPLib corpus."""
+
+import json
+import sys
+
+before = {r["name"]: r for r in json.load(open("scratchpad/i1199/panel_1199_before.json"))}
+after = {r["name"]: r for r in json.load(open("scratchpad/i1199/panel_1199_after.json"))}
+names = sorted(set(before) & set(after))
+assert names, "no instances in common — nothing was compared"
+
+
+def close(a, b, rel=1e-9):
+    if a is None or b is None:
+        return a is b
+    return abs(a - b) <= rel * (1.0 + max(abs(a), abs(b)))
+
+
+rows_status, rows_obj, rows_nodes, rows_ratio, rows_err = [], [], [], [], []
+compared = 0
+for n in names:
+    b, a = before[n], after[n]
+    compared += 1
+    if b.get("error") or a.get("error"):
+        rows_err.append((n, b.get("error"), a.get("error")))
+        continue
+    if b["status"] != a["status"]:
+        rows_status.append((n, b["status"], a["status"]))
+    if not close(b.get("obj"), a.get("obj"), 1e-9):
+        rows_obj.append((n, b.get("obj"), a.get("obj")))
+    if b.get("nodes") != a.get("nodes"):
+        rows_nodes.append((n, b.get("nodes"), a.get("nodes")))
+    if b.get("ratio") is not None and a.get("ratio") is not None:
+        if not close(b["ratio"], a["ratio"], 1e-6):
+            rows_ratio.append((n, b["ratio"], a["ratio"]))
+
+print(f"instances compared: {compared}")
+
+
+def dump(title, rows):
+    print(f"\n{title}: {len(rows)}")
+    for r in rows:
+        print("   ", r)
+
+
+dump("status changed (before -> after)", rows_status)
+dump("objective changed", rows_obj)
+dump("node_count changed", rows_nodes)
+dump("acceptance ratio changed", rows_ratio)
+dump("errors", rows_err)
+
+bad_b = [r["name"] for r in before.values() if r.get("accepts") is False]
+bad_a = [r["name"] for r in after.values() if r.get("accepts") is False]
+print(f"\nincumbents FAILING the acceptance arbiter — before: {bad_b}  after: {bad_a}")
+
+# certification: no instance may lose a certificate it had
+lost = [n for n in names if before[n].get("cert") and not after[n].get("cert")]
+gained = [n for n in names if after[n].get("cert") and not before[n].get("cert")]
+print(f"certificates lost: {lost}   gained: {gained}")
+if compared == 0:
+    sys.exit(1)

--- a/scratchpad/i1199/panel_1199.py
+++ b/scratchpad/i1199/panel_1199.py
@@ -1,0 +1,82 @@
+"""Panel for #1199: does the reported incumbent pass the repo's ACCEPTANCE arbiter?
+
+For every in-repo MINLPLib instance: solve, then re-verify the reported point
+against a freshly parsed ORIGINAL model with
+``primal_heuristics._check_constraint_feasibility``'s own combined test, and
+report the normalized ratio  max_i viol_i / (tol + rtol*scale_i)  (<= 1 passes).
+
+Prints per-instance progress (CLAUDE.md §10) and an executed-comparison count,
+exiting non-zero if nothing was actually compared (§6).
+"""
+
+import glob
+import json
+import os
+import sys
+import time
+
+import numpy as np
+from discopt._relax.nlp_evaluator import cached_evaluator
+from discopt.modeling.core import from_nl
+from discopt.solvers.nlp_ipopt import _infer_constraint_bounds
+
+MARKER_EXPECTED = os.environ.get("PANEL_MARKER")  # §8: assert the code under test
+if MARKER_EXPECTED is not None:
+    import discopt.solver as _S
+
+    src = open(_S.__file__).read()
+    present = MARKER_EXPECTED in src
+    want = os.environ.get("PANEL_MARKER_PRESENT", "1") == "1"
+    print(f"# {_S.__file__}  marker={MARKER_EXPECTED!r} present={present} want={want}", flush=True)
+    assert present is want, "wrong code loaded"
+
+TL = float(os.environ.get("PANEL_TL", "20"))
+MAXN = int(os.environ.get("PANEL_NODES", "5000"))
+out_path = sys.argv[1]
+
+files = sorted(glob.glob("python/tests/data/minlplib_nl/*.nl"))
+rows = []
+compared = 0
+for k, f in enumerate(files, 1):
+    name = os.path.basename(f)[:-3]
+    rec = {"name": name}
+    try:
+        m = from_nl(f)
+        t0 = time.perf_counter()
+        r = m.solve(max_nodes=MAXN, time_limit=TL)
+        rec["wall"] = round(time.perf_counter() - t0, 3)
+        rec["status"] = r.status
+        rec["obj"] = None if r.objective is None else float(r.objective)
+        rec["bound"] = None if getattr(r, "bound", None) is None else float(r.bound)
+        rec["nodes"] = getattr(r, "node_count", None)
+        rec["cert"] = bool(getattr(r, "gap_certified", False))
+        if r.x:
+            om = from_nl(f)
+            ev = cached_evaluator(om)
+            if ev.n_constraints:
+                cl, cu = (np.asarray(b, float) for b in _infer_constraint_bounds(ev))
+                x = np.concatenate(
+                    [np.atleast_1d(np.asarray(r.x[v.name], float)).ravel() for v in om._variables]
+                )
+                g = np.asarray(ev.evaluate_constraints(x))
+                viol = np.maximum(np.maximum(cl - g, 0.0), np.maximum(g - cu, 0.0))
+                jac = np.abs(np.asarray(ev.evaluate_jacobian(x), float))
+                scale = jac @ np.abs(x)
+                thr = 1e-6 + 1e-9 * scale
+                ratio = float(np.max(viol / thr))
+                rec["ratio"] = ratio
+                rec["maxviol"] = float(np.max(viol))
+                rec["accepts"] = ratio <= 1.0
+                compared += 1
+    except Exception as exc:  # recorded, never swallowed
+        rec["error"] = f"{type(exc).__name__}: {exc}"
+    rows.append(rec)
+    print(f"[{k}/{len(files)}] {name}: {json.dumps(rec)}", flush=True)
+
+json.dump(rows, open(out_path, "w"), indent=1)
+bad = [r for r in rows if r.get("accepts") is False]
+print(f"\nincumbents compared: {compared}")
+print(f"FAIL acceptance arbiter: {len(bad)} -> {[(r['name'], round(r['ratio'], 2)) for r in bad]}")
+if compared == 0:
+    print("PANEL MEASURED NOTHING")
+    sys.exit(1)


### PR DESCRIPTION
## Summary

`nvs05` returned an incumbent the repo's own acceptance arbiter
(`_relax.primal_heuristics._check_constraint_feasibility`) rejects. The root cause is
not a tolerance: **`solve_model`'s terminal KKT polish adopts its re-solve on objective
proximity alone.** Its `_unchanged` arm — whose own comment called it "the always-safe
purification" — never looked at the constraints; only the `_improved` arm did.

Measured by spying on the single `_solve_node_nlp_kkt` call `nvs05` makes
(`max_nodes=5000, time_limit=300`):

| point | max row violation (original model) | objective |
|---|---|---|
| tree incumbent (polish **input**) | 9.0e-6 | 5.470934109 |
| polish **output** (adopted) | **1.3e+2** | 5.4709340754 |

The output's objective had moved 3.3e-8 — deep inside the `1e-4` relative window
`_unchanged` accepts — so it was adopted. The incumbent it replaced matched the
`minlplib.solu` oracle (5.470934108) to nine digits.

This answers the issue's either/or: **option 1**. The acceptance threshold is right and
this point should never have been returned; `rtol=1e-9` is not miscalibrated. Nothing in
the arbiter changed.

**Correction to the issue's "Not a false certificate" section.** The issue observed
`status=feasible` at a 30 s limit. At 300 s the same solve terminates
`status="optimal"`, `gap_certified=True`, at an objective **below** the true optimum, on
that same rejected point — because the polish walked it off the row manifold. So this was
a certificate on an infeasible point, not only an incumbent-quality issue. After the fix:
`optimal`, obj `5.470934109134` (oracle **+1.1e-9**, was −3.3e-8 below it), acceptance
ratio 2.96e-7, `node_count` 153 unchanged.

**The rule is never-degrade, not merely "feasible".** A re-solve's point is adopted when
it clears the acceptance arbiter, or — when the incumbent it would replace does not clear
it either — when it sits no further outside the rows. So a purification of an
already-marginal point is never blocked by a bar its own input could not meet, and a
polish can only ever move the reported point toward the feasible set.

**Both sites of the class are fixed, not just the instance:**
- `solve_model`'s terminal polish (spatial B&B), via the new module-level
  `_polish_preserves_feasibility` — extracted from the inline expression so it is
  unit-testable.
- `_solve_nlp_bb`'s refine adoption (#1061), whose matching-objective arm was row-blind
  the same way. There the #954 exit gate would catch the degraded point, but only by
  **refusing** the result — so adopting it turned a good solve into a withheld incumbent.
  Both arms now judge the same `_nonlinear_point_excess` against the same declared rows
  and box that gate uses.

Ranking two points needs the arbiter's *magnitude*, not its verdict, so
`primal_heuristics` grows `scaled_violation_ratio`
(`max_i viol_i / (tol + rtol*scale_i)`, `<= 1` exactly when
`_check_constraint_feasibility` accepts), built from shared
`row_violations` / `row_term_scale` / `combined_tolerance` helpers so the threshold and
the number compared against it cannot drift.

Closes #1199

## Correctness

The change only ever **withholds** a replacement point; it can never introduce one. Both
gates are one-directional: a candidate that fails is discarded and the pre-existing
incumbent stands. No tolerance, arbiter, bound, cut, or relaxation was altered — the dual
bound path is untouched — and the acceptance arbiter's own thresholds are unchanged. It
removes a false certificate rather than creating one: `nvs05` stops reporting an
objective below its true optimum.

- [x] Cannot produce a false certificate (or: N/A — no solver-math change)
- [x] No validation, fallback, or safety guard was weakened to make a check pass

## Tests run (state the result — numbers, not adjectives)

- [x] `pytest -m smoke` → 1209 passed, 21 skipped, 2 xpassed (379 s)
- [x] `pytest -m slow python/tests/test_adversarial_recent_fixes.py` → 19 passed (164 s)
- [x] `cargo test -p discopt-core` → N/A, no Rust touched
- [x] `ruff check` / `ruff format --check` clean over `python/`; `mypy` clean on the
      touched module

Also: the #952 / #954 / #1043 / #1061 incumbent and primal-heuristic suites →
41 passed, 1 skipped.

**Corpus panel** — all 66 in-repo MINLPLib instances at `time_limit=20`, every incumbent
independently re-verified against a **freshly parsed original model**
(script + before/after JSON and logs in `scratchpad/i1199/`):

| | before | after |
|---|---|---|
| status changed | — | **0** |
| objective changed | — | **0** |
| acceptance ratio changed | — | **0** |
| certificates lost | — | **0** |
| incumbents failing the acceptance arbiter | 0 | 0 |
| errors | — | 0 |

Two node counts moved (`tanksize` 2497→2828, `tls2` 245→251). Both hit the 20 s wall
clock and vary run-to-run on **identical** code (2753/2797/2787 and 245/251/245 over
three reps), and this change is post-search, so it cannot alter a node count.

## Regression test

`python/tests/test_polish_feasibility_gate_1199.py` — 7 fast + 1 slow. Verified
fail-before / pass-after by stashing the source change: all 7 fail before, all pass
after. The end-to-end case
(`test_a_degrading_polish_is_not_reported`) fails pre-fix on the **behaviour**, not on a
missing import:

```
AssertionError: the reported point sits 1.000e-04 off the row it must satisfy
(tolerance 4.000e-06, x=10.00000033333332)
```

It injects an off-manifold point with an *exactly* unchanged objective (the perturbed
variable does not appear in the objective) whose violation sits between the acceptance
tolerance and the deliberately-loose false-primal screen — so only the polish gate can
refuse it. The slow case is the issue's own `nvs05`, verified against a freshly parsed
original model. Boundary test asserts `scaled_violation_ratio(...) <= 1` iff the arbiter
accepts, so the ranking number cannot become a second, drifting definition of the test.

- [x] Added a regression test that fails before / passes after

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GY2xx74Tncg44Tu3kCmSS5

---
_Generated by [Claude Code](https://claude.ai/code/session_01GY2xx74Tncg44Tu3kCmSS5)_