### PR TITLE
fix(primal): #1193 -- restore the integer primal escape on kernel-routed exits

### DIFF
--- a/discopt_benchmarks/scripts/issue1193_exit_polish_panel.py
+++ b/discopt_benchmarks/scripts/issue1193_exit_polish_panel.py
@@ -1,0 +1,468 @@
+"""Graduation panel for the #1193 integer primal escape.
+
+``DISCOPT_INTEGER_BOX_POLISH`` gates BOTH halves of the #1193 fix: the
+zero-continuous *direct path* in ``integer_box_search`` (which fires INSIDE the
+tree on the Python route) and the post-kernel *exit polish* on an uncertified
+native-kernel exit. So OFF is a true pre-#1193 baseline -- but the flag is NOT
+bound-neutral by construction: a better in-tree incumbent prunes differently and
+may legitimately move ``node_count`` and the bound. It sits in CLAUDE.md §5's
+heuristic-policy regime, where soundness is absolute and neutrality is not.
+
+**The determinism pre-check.** Asserting OFF-vs-ON neutrality is only meaningful
+where the instance is deterministic. Measured on ``ball_mk2_30`` with the flag
+PINNED OFF for six runs: node_count came back 7282 / 7629 / 7465 / 2029 / 7646 /
+7544 and the run alternated between two different (bound, incumbent) outcomes --
+so the panel's original "bound MOVED / node MOVED / ON lost the incumbent"
+verdict there was the solver's own run-to-run noise (tracked as #1187), not the
+flag. Every instance therefore runs a THIRD arm -- OFF again, after ON -- and any
+neutrality-class finding is charged to the flag only when the two OFF runs agree
+with each other. On a nondeterministic instance it is recorded as a note carrying
+the measured OFF-vs-OFF spread. The soundness bars below are asserted on every
+instance regardless, since they cannot be excused by noise.
+
+**The inertness proof.** The flag can influence a run through exactly one
+channel: an improving point out of ``integer_box_search`` (the in-tree direct
+path) or an adopted exit polish. Both are counted directly, so where neither
+produced a point in EITHER arm the two runs must be bit-identical and any drift
+is a plumbing bug -- that is where exact neutrality is asserted. Where one did,
+the search legitimately diverges (``gear``: 31 -> 3 nodes at a BETTER objective,
+8.6e-07 -> 3.8e-08 against a 0.0 oracle, certificate intact), and asserting
+neutrality there would be asserting the flag does nothing.
+
+  1. **cert-clean**
+     a. *(only where the flag is provably inert AND the instance is
+        deterministic)* exact ``bound`` / ``node_count`` / incumbent neutrality.
+     b. *(always)* an arm reporting ``optimal`` must be AT its oracle within
+        tolerance -- a false certificate is never excusable -- and certification
+        must not be lost OFF -> ON.
+     c. *(always)* no bound passes its oracle and no incumbent beats it, in
+        either arm, sense-aware.
+     d. *(always)* the ON incumbent independently re-verifies feasible whenever
+        the OFF one does.
+     e. *(always)* the polish is never ADOPTED on a certified-optimal exit.
+  2. **net-positive**: the ON objective is never worse on a deterministic
+     instance, and is strictly better on a measurable share.
+
+Firing is instrumented directly by wrapping ``_native_exit_primal_polish`` and
+counting adoptions, so "inert" is a proof rather than a node-count proxy
+(CLAUDE.md §6).
+
+Usage:
+    python -u discopt_benchmarks/scripts/issue1193_exit_polish_panel.py \
+        <corpus_dir> <max_nodes> <time_limit> out.json [inst1,inst2,...]
+"""
+
+from __future__ import annotations
+
+import glob
+import json
+import math
+import os
+import sys
+import time
+import warnings
+
+import numpy as np
+
+sys.path.insert(0, "python")
+
+SOLU = os.path.expanduser("~/Dropbox/projects/discopt-minlp-benchmark/minlplib.solu")
+FLAG = "DISCOPT_INTEGER_BOX_POLISH"
+
+
+def load_oracles():
+    """name -> value from the .solu; prefer ``=opt=``, else ``=best=``."""
+    best, opt = {}, {}
+    if not os.path.exists(SOLU):
+        return {}
+    with open(SOLU) as f:
+        for line in f:
+            p = line.split()
+            if len(p) >= 3:
+                if p[0] == "=opt=":
+                    opt[p[1]] = float(p[2])
+                elif p[0] == "=best=":
+                    best[p[1]] = float(p[2])
+    out = dict(best)
+    out.update(opt)
+    return out
+
+
+ORACLES = load_oracles()
+
+# ---- firing instrumentation (CLAUDE.md §6) --------------------------------- #
+_FIRE = {"calls": 0, "adopted": 0, "delta": 0.0, "box_hits": 0, "ibs_calls": 0, "direct": 0}
+
+
+def _install_fire_counter():
+    import discopt.solver as sv
+
+    orig = sv._native_exit_primal_polish
+
+    def wrapped(model, x_flat, obj_val, bound_val, n_orig, outer_deadline):
+        _FIRE["calls"] += 1
+        out = orig(model, x_flat, obj_val, bound_val, n_orig, outer_deadline)
+        if out is not None:
+            _FIRE["adopted"] += 1
+            _FIRE["delta"] += abs(float(out[1]) - float(obj_val))
+        return out
+
+    sv._native_exit_primal_polish = wrapped
+
+    # The flag can change a run ONLY by supplying a better incumbent, and the one
+    # gate every such point passes through is ``integer_box_search`` returning
+    # not-None. Counting those returns turns "the flag was inert here" into a
+    # proof rather than an inference (CLAUDE.md §6), which is what licenses the
+    # exact-neutrality assertion below.
+    import discopt._relax.primal_heuristics as ph
+
+    _orig_ibs = ph.integer_box_search
+
+    def _counting_ibs(*a, **k):
+        # ``ibs_calls`` is the call, ``box_hits`` the EFFECT (returned a point?), and
+        # ``direct`` the actual CHANNEL. Inertness must be proved on the CHANNEL: an
+        # enumeration that finds nothing still spends #912 work budget and can move the
+        # search, so a zero hit count proves nothing -- but a call on a model with any
+        # continuous slot cannot take the direct path and so behaves identically in
+        # both arms whatever the flag says. Measured: tspn12 has 24 continuous slots
+        # and one ibs call per solve, and flags 0/1/0 give bit-identical runs.
+        _FIRE["ibs_calls"] += 1
+        model = a[0] if a else k.get("model")
+        if model is not None and not bool(np.any(~ph._get_integer_mask(model))):
+            _FIRE["direct"] += 1
+        out = _orig_ibs(*a, **k)
+        if out is not None:
+            _FIRE["box_hits"] += 1
+        return out
+
+    ph.integer_box_search = _counting_ibs
+    # solver.py imports it lazily inside the polish, so the module attribute is
+    # the single interception point; assert that rather than assume it.
+    assert ph.integer_box_search is _counting_ibs
+
+
+def _incumbent_feasible(model, r) -> bool:
+    """Independently re-verify the returned incumbent against the model rows."""
+    if getattr(r, "x", None) is None:
+        return True
+    from discopt._relax.nlp_evaluator import cached_evaluator
+    from discopt._relax.primal_heuristics import _check_constraint_feasibility
+
+    ev = cached_evaluator(model)
+    flat = np.concatenate(
+        [np.atleast_1d(np.asarray(r.x[v.name], dtype=np.float64)).ravel() for v in model._variables]
+    )
+    return bool(_check_constraint_feasibility(ev, flat))
+
+
+def _f(x):
+    return None if x is None else float(x)
+
+
+def run(path, name, max_nodes, tl):
+    from discopt.modeling.core import from_nl
+
+    arms = {}
+    sense = "minimize"
+    # off -> on -> off again: the third arm brackets ON and measures this
+    # instance's own run-to-run spread, which is what licenses (or forbids)
+    # a neutrality assertion below.
+    for arm, flag in (("off", "0"), ("on", "1"), ("off2", "0")):
+        os.environ[FLAG] = flag
+        _FIRE["calls"] = _FIRE["adopted"] = _FIRE["box_hits"] = 0
+        _FIRE["ibs_calls"] = _FIRE["direct"] = 0
+        _FIRE["delta"] = 0.0
+        m = from_nl(path)
+        obj = getattr(m, "_objective", None)
+        s = getattr(obj, "sense", None)
+        if s is not None:
+            sense = "maximize" if "MAX" in str(s).upper() else "minimize"
+        t0 = time.time()
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            r = m.solve(max_nodes=max_nodes, time_limit=tl)
+        wall = time.time() - t0
+        arms[arm] = {
+            "obj": _f(r.objective),
+            "bound": _f(r.bound),
+            "status": str(r.status),
+            "gap_certified": bool(getattr(r, "gap_certified", False)),
+            "nodes": int(getattr(r, "node_count", -1)),
+            "wall": round(wall, 2),
+            "polish_calls": _FIRE["calls"],
+            "polish_adopted": _FIRE["adopted"],
+            "box_hits": _FIRE["box_hits"],
+            "ibs_calls": _FIRE["ibs_calls"],
+            "direct": _FIRE["direct"],
+            "incumbent_feasible": _incumbent_feasible(m, r),
+        }
+    o1, o2 = arms["off"], arms["off2"]
+    spread = [
+        f"{k} {o1[k]!r} vs {o2[k]!r}"
+        for k in ("bound", "nodes", "obj", "status", "gap_certified")
+        if o1[k] != o2[k]
+    ]
+    return {
+        "instance": name,
+        "oracle": ORACLES.get(name),
+        "sense": sense,
+        "deterministic": not spread,
+        "off_spread": spread,
+        **arms,
+    }
+
+
+def assess(rec):
+    """Per-instance cert-clean verdict + net-positive signal."""
+    opt = rec["oracle"]
+    off, on = rec["off"], rec["on"]
+    is_max = rec.get("sense") == "maximize"
+    tol = 1e-4 * (1 + abs(opt)) if opt is not None else 1e-4
+    problems, notes = [], []
+    fired = on["polish_adopted"] > 0
+
+    # A neutrality-class finding is charged to the flag only where the SAME
+    # protocol run twice with the flag OFF reproduces itself. Where it does not,
+    # the instance's own noise floor is larger than anything the flag could show,
+    # so the finding is recorded with that measured spread instead of asserted
+    # away (CLAUDE.md §9; the ball_mk2_30 measurement in the module docstring).
+    det = rec.get("deterministic", True)
+    spread = "; ".join(rec.get("off_spread") or []) or "none"
+    # The ONLY channel by which this flag can influence a run is an improving
+    # point out of ``integer_box_search`` (in-tree direct path) or an adopted
+    # polish. Where neither produced one in EITHER arm, the two runs must be
+    # bit-identical and any drift is a plumbing bug. Where one did, the search
+    # legitimately diverges -- that is what a primal heuristic is for -- and
+    # asserting neutrality would be asserting the flag does nothing.
+    inert = off.get("direct", 0) == 0 and on.get("direct", 0) == 0 and on["polish_calls"] == 0
+
+    def charge(msg):
+        if not det:
+            notes.append(f"{msg} -- NOT attributable: OFF-vs-OFF spread [{spread}]")
+        elif not inert:
+            notes.append(
+                f"{msg} -- EXPECTED: the flag had a live channel here "
+                f"(direct off={off.get('direct', 0)} on={on.get('direct', 0)}, "
+                f"box_hits on={on.get('box_hits', 0)}, polish_calls={on['polish_calls']})"
+            )
+        else:
+            problems.append(msg)
+
+    # --- 1a: neutrality, asserted only where the run is reproducible. -------
+    ob, nb = off["bound"], on["bound"]
+    both_finite = ob is not None and nb is not None and math.isfinite(ob) and math.isfinite(nb)
+    bound_moved = (
+        f"bound {ob:.12g} -> {nb:.12g}"
+        if (both_finite and abs(ob - nb) > 1e-12 * (1 + abs(ob)))
+        else (f"bound presence {ob} -> {nb}" if (ob is None) != (nb is None) else None)
+    )
+    node_moved = (
+        f"node_count {off['nodes']} -> {on['nodes']}" if off["nodes"] != on["nodes"] else None
+    )
+    for drift in (bound_moved, node_moved):
+        if drift is not None:
+            charge(f"{drift} MOVED")
+
+    # --- 1b: what a CERTIFIED exit must still guarantee. --------------------
+    # Not bit-identity: a better in-tree incumbent prunes harder, so a certified
+    # solve may legitimately certify in fewer nodes at a better objective (gear:
+    # 31 -> 3 nodes, 8.6e-07 -> 3.8e-08 against a 0.0 oracle). What may NOT happen
+    # is losing the certificate, or certifying an answer that is not the optimum.
+    for arm_name, a in (("off", off), ("on", on)):
+        if a["status"] != "optimal":
+            continue
+        if opt is None or a["obj"] is None:
+            continue
+        if abs(a["obj"] - opt) > tol:
+            # Unconditional: a FALSE certificate is never excusable by noise or
+            # by the flag having fired (CLAUDE.md §1).
+            problems.append(
+                f"{arm_name} certified OPTIMAL at {a['obj']:.12g} but the oracle is "
+                f"{opt:.12g} (FALSE CERTIFICATE)"
+            )
+    if off["status"] == "optimal" and on["status"] != "optimal":
+        problems.append(f"certification LOST: off=optimal -> on={on['status']}")
+    # The polish is gated on ``status != 'optimal'``; an adoption there is a
+    # plumbing bug and is never excusable.
+    if fired and "optimal" in (off["status"], on["status"]):
+        problems.append("polish ADOPTED on a certified-optimal exit (must be gated off)")
+
+    # --- 1c: certification never regresses. ---------------------------------
+    if off["gap_certified"] and not on["gap_certified"]:
+        charge("cert regression: OFF certified, ON not")
+
+    # --- 1d: soundness against the oracle, both arms, sense-aware. ----------
+    # Unconditional. Noise cannot excuse an invalid bound or a beaten optimum.
+    for arm_name, a in (("off", off), ("on", on), ("off2", rec["off2"])):
+        b, o = a["bound"], a["obj"]
+        if opt is not None and b is not None and math.isfinite(b):
+            if not is_max and b > opt + tol:
+                problems.append(f"{arm_name} lower bound {b:.6g} > oracle {opt:.6g} (UNSOUND)")
+            if is_max and b < opt - tol:
+                problems.append(f"{arm_name} upper bound {b:.6g} < oracle {opt:.6g} (UNSOUND)")
+        if opt is not None and o is not None:
+            if not is_max and o < opt - tol:
+                problems.append(f"{arm_name} obj {o:.6g} < oracle {opt:.6g} (beats optimum)")
+            if is_max and o > opt + tol:
+                problems.append(f"{arm_name} obj {o:.6g} > oracle {opt:.6g} (beats optimum)")
+
+    # --- 1e: an ON-only infeasible incumbent is charged to the flag. --------
+    # Failing in BOTH arms is a pre-existing condition of the instance (measured
+    # on nvs05 on main; tracked as #1199), not something this flag did.
+    if not on["incumbent_feasible"]:
+        if off["incumbent_feasible"]:
+            problems.append("ON incumbent INFEASIBLE (OFF feasible)")
+        else:
+            notes.append("incumbent fails re-verification in BOTH arms (pre-existing, #1199)")
+
+    # --- 2: net-positive, in the currency a PRIMAL flag is paid in. ---------
+    signal = "inert"
+    oo, no = off["obj"], on["obj"]
+    if oo is not None and no is not None:
+        delta = (no - oo) if is_max else (oo - no)  # > 0 == ON better
+        eps = 1e-9 * (1 + abs(oo))
+        if delta > eps:
+            signal = "ON better incumbent"
+        elif delta < -eps:
+            signal = "ON WORSE incumbent"
+            charge(f"ON incumbent WORSE {oo:.12g} -> {no:.12g}")
+        elif fired:
+            signal = "fired, no change"
+    elif no is not None and oo is None:
+        signal = "ON found an incumbent (OFF none)"
+    elif oo is not None and no is None:
+        signal = "ON LOST the incumbent"
+        charge("ON lost the incumbent OFF had")
+
+    rec["signal"] = signal
+    rec["problems"] = problems
+    rec["notes"] = notes
+    rec["fired"] = fired
+    return rec
+
+
+def escalate(path, name, max_nodes, tl, rec, extra=4):
+    """Re-measure a flagged instance with EXTRA OFF repeats before failing it.
+
+    Two OFF runs are a weak determinism test, and a false "deterministic" verdict
+    turns this corpus's own run-to-run noise (#1187) into a fabricated flag
+    regression. Measured on ``tls2``: the panel drew 171 twice and called it
+    deterministic, while a third OFF run gave 145 and a fourth 253 -- on an
+    instance where ``integer_box_search`` is never even CALLED (4 continuous
+    slots), so the flag has no channel to act through at all.
+
+    This is an escalation, not an exemption: it spends more samples exactly where
+    the verdict depends on them, and a drift that survives the wider sample stays
+    a hard problem.
+    """
+    neutrality = [q for q in rec["problems"] if "MOVED" in q or "lost the incumbent" in q]
+    if not neutrality:
+        return rec
+    print(f"    ~~ escalating: {extra} extra OFF runs to test the determinism claim", flush=True)
+    seen = [(rec["off"]["bound"], rec["off"]["nodes"], rec["off"]["obj"], rec["off"]["status"])]
+    for _ in range(extra):
+        os.environ[FLAG] = "0"
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            r = from_nl_cached(path).solve(max_nodes=max_nodes, time_limit=tl)
+        seen.append(
+            (_f(r.bound), int(getattr(r, "node_count", -1)), _f(r.objective), str(r.status))
+        )
+    rec["off_repeats"] = seen
+    if len(set(seen)) == 1:
+        print(f"    ~~ {name}: {len(seen)} OFF runs agree -- drift stands as a PROBLEM", flush=True)
+        return rec
+    rec["deterministic"] = False
+    rec["off_spread"] = [f"{len(set(seen))} distinct outcomes in {len(seen)} OFF runs: {seen}"]
+    rec["problems"] = [q for q in rec["problems"] if q not in neutrality]
+    rec["notes"] += [
+        f"{q} -- NOT attributable: {len(set(seen))} distinct outcomes across "
+        f"{len(seen)} flag-OFF runs {seen}"
+        for q in neutrality
+    ]
+    print(f"    ~~ {name}: OFF runs DISAGREE {seen} -- drift is noise, reclassified", flush=True)
+    return rec
+
+
+def from_nl_cached(path):
+    from discopt.modeling.core import from_nl
+
+    return from_nl(path)
+
+
+def main():
+    corpus, max_nodes, tl, out_path = sys.argv[1], int(sys.argv[2]), float(sys.argv[3]), sys.argv[4]
+    only = set(sys.argv[5].split(",")) if len(sys.argv) > 5 else None
+    paths = sorted(glob.glob(os.path.join(corpus, "*.nl")))
+    if only:
+        paths = [p for p in paths if os.path.basename(p)[:-3] in only]
+    _install_fire_counter()
+
+    records = []
+    for i, p in enumerate(paths, 1):
+        name = os.path.basename(p)[:-3]
+        print(f"[{i}/{len(paths)}] {name} ...", flush=True)
+        try:
+            rec = assess(run(p, name, max_nodes, tl))
+        except Exception as exc:
+            print(f"    ERROR {type(exc).__name__}: {exc}", flush=True)
+            records.append({"instance": name, "error": f"{type(exc).__name__}: {exc}"})
+            continue
+        rec = escalate(p, name, max_nodes, tl, rec)
+        records.append(rec)
+        flagmark = "FIRED" if rec["fired"] else "-"
+        print(
+            f"    {flagmark:5s} {rec['signal']:28s} "
+            f"obj {rec['off']['obj']} -> {rec['on']['obj']}  "
+            f"bound {rec['off']['bound']} nodes {rec['off']['nodes']}",
+            flush=True,
+        )
+        for pr in rec["problems"]:
+            print(f"    !! {pr}", flush=True)
+        for nt in rec["notes"]:
+            print(f"    .. {nt}", flush=True)
+        with open(out_path, "w") as f:
+            json.dump(records, f, indent=2)
+
+    scored = [r for r in records if "error" not in r]
+    problems = [(r["instance"], p) for r in scored for p in r["problems"]]
+    fired = [r for r in scored if r["fired"]]
+    better = [r for r in scored if r["signal"] == "ON better incumbent"]
+    worse = [r for r in scored if r["signal"] == "ON WORSE incumbent"]
+    print("\n" + "=" * 72)
+    print(f"instances scored     : {len(scored)}  (errors: {len(records) - len(scored)})")
+    print(f"polish ADOPTED on    : {len(fired)}")
+    print(f"ON better incumbent  : {len(better)}  {[r['instance'] for r in better]}")
+    print(f"ON worse incumbent   : {len(worse)}  {[r['instance'] for r in worse]}")
+    nondet = [r for r in scored if not r.get("deterministic", True)]
+    print(
+        f"nondeterministic     : {len(nondet)} of {len(scored)} (OFF vs OFF disagreed; "
+        f"neutrality asserted on the other {len(scored) - len(nondet)})"
+    )
+    for r in nondet:
+        print(f"     ~ {r['instance']}: {'; '.join(r['off_spread'])}")
+    # LIVE = the flag had a channel (a zero-continuous direct-path call, or an
+    # adopted exit polish). A ``box_hits`` on a call that was NOT direct-eligible
+    # happens identically in both arms and is not the flag acting.
+    active = [r for r in scored if r["on"].get("direct", 0) or r["on"]["polish_adopted"]]
+    print(
+        f"flag channel LIVE on : {len(active)} of {len(scored)} {[r['instance'] for r in active]}"
+    )
+    print(f"cert-clean problems  : {len(problems)}")
+    for inst, p in problems:
+        print(f"  !! {inst}: {p}")
+    print(f"EXECUTED_COMPARISONS={len(scored)}")
+    if not scored:
+        print("PANEL PROVED NOTHING -- zero instances scored")
+        sys.exit(2)
+    cert_clean = not problems
+    # A "worse" signal on a nondeterministic instance is that instance's noise,
+    # not a regression the flag caused; it is already reported as a note.
+    worse_det = [r for r in worse if r.get("deterministic", True)]
+    net_positive = len(better) > 0 and not worse_det
+    print(f"VERDICT: cert-clean={cert_clean}  net-positive={net_positive}")
+    sys.exit(0 if (cert_clean and net_positive) else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/dev/performance-plan.md
+++ b/docs/dev/performance-plan.md
@@ -5768,3 +5768,169 @@ this harness was written without it. Fixed, and the sense now prints per row.
 pass, twice (§18 and #1008); Bland at a reachable threshold (§18); unconditional
 (unarmed) cost perturbation, on wall median 1.044x; and perturbing *every*
 nonbasic cost, which makes an LP with free columns reject its own warm start.
+
+## 29. #1193 nvs19's primal stall: the dual side was never the problem, and two instruments lied (2026-09-06)
+
+`nvs19` returns **-1098.2** against a **-1098.4** optimum and exits on
+`max_nodes`, not the clock. The issue text proposed reading that as a *dual*
+symptom — "100k nodes with a 34% remaining gap on an 8-variable integer nonlinear
+problem suggests the bound is not tightening, which points at the relaxation
+rather than the search order". **The measurement says otherwise, and the issue's
+own step (1) is what falsified it.** Raising the budget reaches -1098.4
+(radius-1 box search, `obj=-1098.4`, `wall=72.8 s`), so the point is reachable
+and the defect is on the **primal** side: the incumbent search never gets there
+within budget. Everything below follows from taking that measurement first.
+
+**Falsification 1 — the planned fix was a no-op.** The entry plan was a sub-MIP
+escape hatch on the stalled incumbent. Measured on nvs19: it never executes.
+`INTEGER_BOX_SEARCH_CALLS=0`, and the instrumented kernel route reports
+`_try_native_spatial_kernel = 1, returned_None = 0`. No amount of tuning a
+heuristic that is never called can move this instance. Building it would have
+produced a flag that measured nothing and read as a pass — the §6 failure mode,
+reached by skipping §4's entry experiment.
+
+**Falsification 2 — #1153 removed the Python primal layer without measuring it.**
+`_try_native_spatial_kernel` was extended to accept `node_limit` alongside
+`optimal` and `time_limit`. That made an **uncertified** kernel exit *terminal*,
+which silently deleted the entire Python primal-heuristic layer from every
+kernel-routed model. The `_try_native_spatial_kernel` docstring still claimed
+"Node-limited or declined runs retain the established Python fallback" — false
+since #1153, and corrected in this change. A budget-exhausted solve is exactly
+the case where a primal improver is worth the most, and it was the case that lost
+one.
+
+**Falsification 3 — `integer_box_search`'s caps are priced in the wrong
+currency.** Its `max_int_vars=3` / `max_combos=128` caps were sized against a
+per-cell **sub-NLP solve**. On a model with no continuous slots that solve is
+zero-dimensional and the true cost per cell is an evaluation:
+
+| per-cell work | wall |
+|---|---|
+| `subnlp(...)` | 18.922 ms |
+| `_finalize_candidate(...)` | 0.014 ms |
+
+**1385×.** Priced correctly, nvs19's radius-1 grid (3^8 = 6561 cells) costs
+**0.09 s** where the sub-NLP pricing implies **124.1 s** — so the caps declined
+outright a search that is nearly free. End to end the box search went **72.8 s →
+0.352 s (207×)**, which is what makes it affordable at the default budget.
+
+**The fix, and what it is NOT.** Both halves — the zero-continuous *direct path*
+(budgeted in `EVAL`, not `NLP_SOLVE`) and a post-kernel *exit polish* on an
+uncertified exit — sit behind the single flag `DISCOPT_INTEGER_BOX_POLISH`
+(default ON, `=0` restores pre-#1193 behaviour on both). The direct path is gated
+on the *presence* of a continuous slot, not its width: a presolve-fixed
+continuous variable conservatively keeps the sub-NLP path. Acceptance on nvs19 at
+the **default** budget: **-1098.4 ON vs -1098.2 OFF, with an identical bound
+(-1472.35) and an identical node count (100 000)** — the change is purely primal
+on this instance.
+
+**Falsification 4 — gating one half of a two-half fix makes the A/B meaningless.**
+The first cut gated only the exit polish. The re-priced box search therefore
+stayed live in the panel's OFF arm, so "OFF" was a hybrid that was neither `main`
+nor the fix, and the panel measured neither half honestly. One flag now governs
+both call sites; `test_the_flag_gates_the_direct_path_too` pins it.
+
+**Falsification 5 — a neutrality gate on a nondeterministic instance measures
+noise (extends #1187).** The first all-integer panel reported three hard
+cert-clean problems on `ball_mk2_30`: `bound -27.8829 -> -26.8877 MOVED`,
+`node_count 2029 -> 7376 MOVED`, and `ON lost the incumbent OFF had`. All three
+were noise. With the flag **pinned OFF for six runs**, that instance produced
+both outcomes on its own and never repeated a node count:
+
+| run | nodes | bound | obj | status |
+|---|---|---|---|---|
+| 1 | 7282 | -26.8877 | None | node_limit |
+| 2 | 7629 | -26.8877 | None | node_limit |
+| 3 | 7465 | -26.8877 | None | node_limit |
+| 4 | **2029** | **-27.8829** | **0.0** | **feasible** |
+| 5 | 7646 | -26.8877 | None | node_limit |
+| 6 | 7544 | -26.8877 | None | node_limit |
+
+`polish_calls = 0` in all six and in both original panel arms — the hook provably
+never ran on this instance, so the flag could not have caused what it was charged
+with. The correction is **not** to exempt the instance: the panel now runs a
+**third arm (OFF again, after ON)** on every instance and charges a
+neutrality-class finding to the flag only when the two OFF runs agree with each
+other, recording the measured OFF-vs-OFF spread otherwise. Soundness bars — no
+bound past its oracle, no incumbent beating it, no ON-only infeasible incumbent,
+no adoption on a certified exit — stay unconditional, since noise cannot excuse
+them. The general lesson for every bound-neutrality gate in this repo: **an
+empirical per-instance determinism control, not a blanket assumption that a
+repeated run repeats.**
+
+**Falsification 6 — "a certified solve must not notice a primal flag" is false,
+and the bar that encoded it was measuring the wrong property.** The panel's rule
+1b asserted bit-identity on any `optimal` exit. `gear` violated it — and was
+right to:
+
+| arm | obj | bound | status | nodes |
+|---|---|---|---|---|
+| off | 8.606434189258208e-07 | 0.0 | optimal | 31 |
+| on | **3.778766482334665e-08** | 0.0 | optimal | **3** |
+| off2 | 8.606434189258208e-07 | 0.0 | optimal | 31 |
+
+Deterministic (both OFF arms bit-identical), oracle 0.0, certificate intact in
+both, ON strictly closer to the optimum in 10× fewer nodes. A better in-tree
+incumbent prunes harder; that is what a primal heuristic *is*. Rule 1b encoded
+the superseded premise that the flag only ran after the tree finished.
+
+The replacement is stronger, not weaker, and rests on a **measured** fact rather
+than an assumption. The flag can influence a run through exactly one channel: an
+improving point out of `integer_box_search`, or an adopted polish. The panel now
+counts both directly, and asserts exact `bound`/`node_count`/incumbent neutrality
+only where **neither produced a point in either arm** — where the flag is
+*provably* inert, drift is a plumbing bug and is charged as one. In its place, on
+any arm reporting `optimal` the panel now requires the objective to sit **at its
+oracle within tolerance** (a false-certificate detector the old bit-identity rule
+did not contain) and forbids losing certification OFF → ON; both are
+unconditional, since neither noise nor a firing heuristic can excuse them. The
+general rule this yields: **gate on the mechanism you can count, not on an
+invariant you assume the mechanism preserves.**
+
+**Falsification 7 — "the flag is changing these runs through a channel my counter
+misses" was my own hypothesis, and it is false; the counter was measuring the
+wrong thing, and the two-sample determinism control was too weak.** Panel 3 (66
+in-repo instances) failed cert-clean on three findings: `tls2 bound 5.29999995874
+-> 5.2999998753 MOVED`, `tls2 node_count 171 -> 209 MOVED`, and `tspn12
+node_count 159 -> 191 MOVED`. In each the two OFF arms had agreed exactly, so the
+determinism pre-check licensed charging the drift to the flag, and I wrote that
+the flag "really is changing these runs through a channel my `box_hits` counter
+misses." A direct probe (`scratchpad/issue1193/reach.py`, three solves at flags
+0/1/0 with the channel counted) falsified that:
+
+| instance | continuous vars | `ibs_calls` | direct-eligible | nodes at flags 0 / 1 / 0 |
+|---|---|---|---|---|
+| `tls2`   | 4  | 0 | 0 | 171 / 253 / 145 |
+| `tspn12` | 24 | 1 | 0 | 191 / 191 / 191 |
+
+On `tls2` `integer_box_search` is never called at all, so the flag has no channel
+whatever — yet two runs at the *same* flag value differ by 26 nodes. On `tspn12`
+it is called once per solve, but with 24 continuous slots the zero-continuous
+direct path can never engage, so the call behaves identically in both arms; the
+three runs are bit-identical (bound 203.37071810676102, obj 262.64739579632794),
+and the standalone flag=0 run returns **191** nodes — the exact value panel 3 had
+attributed to the flag's ON arm, while both of its OFF arms drew 159. Neither
+finding is the flag. Both are the pre-existing run-to-run nondeterminism of
+falsification 5 (#1187), and on `tspn12` it is process-state-dependent rather than
+per-solve, which is precisely what a two-sample OFF/OFF control cannot see.
+
+Two instrument defects, both of the §6 family — a counter that counts something
+adjacent to what the gate claims to prove:
+
+1. **Inertness was defined on the effect, not the channel.** `box_hits` counts
+   `integer_box_search` *returning a point*; but the flag can only act through a
+   *direct-path-eligible* call. A call on a model with any continuous slot takes
+   the identical route in both arms, and a direct-path call that finds nothing
+   still spends #912 work budget. The panel now counts `direct` — calls where
+   `not np.any(~_get_integer_mask(model))` — and defines `inert` on that, so
+   "the flag was inert here" is a proof rather than an inference.
+2. **Two samples cannot establish determinism.** Any instance carrying a
+   neutrality-class finding is now re-measured with four *additional* OFF runs
+   (`escalate()`); if every OFF outcome still agrees, the drift stays a hard
+   problem. This is an escalation, not an exemption — it widens the control
+   sample before a finding may be excused, and a drift that survives the wider
+   sample fails the panel exactly as before.
+
+The lesson generalizes falsification 6's: *gate on the mechanism you can count* —
+and make sure the thing you count is the mechanism, not a downstream symptom of
+it. A counter one step off the channel reads as rigor while proving nothing.

--- a/python/discopt/_relax/primal_heuristics.py
+++ b/python/discopt/_relax/primal_heuristics.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import itertools
 import logging
 import math
+import os
 import time
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Callable, Optional
@@ -1278,6 +1279,53 @@ def integer_local_search(
     return best
 
 
+def _box_work_budget(
+    kind: str,
+    limit: int,
+    time_budget: float,
+    deadline: Optional[float],
+) -> WorkBudget:
+    """A deterministic work budget of ``limit`` operations of ``kind``.
+
+    ``limit <= 0`` is the documented #912 escape hatch: it restores the legacy
+    wall-clock gate (``time_budget``), still clamped by the caller's ``deadline``.
+    """
+    if limit > 0:
+        return WorkBudget({kind: limit}, deadline=deadline, clock=_now)
+    _wall = _now() + max(0.0, time_budget)
+    _dl = _wall if deadline is None else min(_wall, deadline)
+    return WorkBudget(None, deadline=_dl, clock=_now)
+
+
+# Default caps for :func:`integer_box_search`, one pair per inner loop. They differ
+# because the per-cell cost does: a sub-NLP solve is 18.922 ms and a direct
+# evaluation 0.014 ms -- 1385x (#1193). These are DEFAULTS only; a caller that
+# passes ``max_int_vars``/``max_combos`` explicitly gets exactly that on either path.
+_SUBNLP_MAX_INT_VARS = 3
+_SUBNLP_MAX_COMBOS = 128
+_DIRECT_MAX_INT_VARS = 64
+_DIRECT_MAX_COMBOS = 20_000
+
+
+def integer_box_polish_enabled() -> bool:
+    """Whether the #1193 integer primal-escape is active
+    (``DISCOPT_INTEGER_BOX_POLISH``, **default ON**; ``=0`` restores pre-#1193
+    behaviour).
+
+    ONE flag deliberately governs BOTH halves of the #1193 fix: the zero-continuous
+    direct path in :func:`integer_box_search` (below) and the post-kernel exit polish
+    in :mod:`discopt.solver`. Gating only the polish made a graduation panel's OFF
+    arm a hybrid -- the re-priced box search stayed live in both arms, so the A/B
+    measured neither half honestly. Keep the two call sites on this one predicate.
+    """
+    return os.environ.get("DISCOPT_INTEGER_BOX_POLISH", "1").strip().lower() not in (
+        "0",
+        "false",
+        "no",
+        "off",
+    )
+
+
 def integer_box_search(
     model: Model,
     x_incumbent: np.ndarray,
@@ -1286,12 +1334,13 @@ def integer_box_search(
     backend: Optional[Callable] = None,
     nlp_options: Optional[dict] = None,
     evaluator: Optional[NLPEvaluator] = None,
-    max_int_vars: int = 3,
-    max_combos: int = 128,
+    max_int_vars: Optional[int] = None,
+    max_combos: Optional[int] = None,
     integer_tol: float = 1e-5,
     feas_tol: float = 1e-6,
     time_budget: float = 4.0,
     solve_budget: Optional[int] = None,
+    eval_budget: Optional[int] = None,
     deadline: Optional[float] = None,
 ) -> Optional[tuple[np.ndarray, float]]:
     """Objective-improving integer *box* search around an incumbent.
@@ -1323,6 +1372,30 @@ def integer_box_search(
     stops at the same cell on every machine. ``deadline`` is the caller's
     ``time_limit`` backstop. ``solve_budget=0`` restores the legacy
     ``time_budget`` wall gate.
+
+    **Zero-continuous models take the direct path (issue #1193).** When the model
+    has no continuous slots at all, fixing every integer leaves the per-cell sub-NLP
+    zero-dimensional: :func:`subnlp` degenerates to "round, verify, evaluate",
+    which is exactly :func:`_finalize_candidate` — same acceptance arbiter, same
+    integer snap, same objective. Measured on nvs19 (8 integers, 0 continuous):
+    **18.922 ms/cell via subnlp vs 0.014 ms/cell direct, a 1385x gap** — the
+    radius-1 grid costs 124.1 s one way and 0.09 s the other. ``max_int_vars`` and
+    ``max_combos`` exist only to price that NLP solve, so on this path the *default*
+    caps are re-priced against the operation actually performed
+    (``_DIRECT_MAX_INT_VARS`` / ``_DIRECT_MAX_COMBOS`` instead of
+    ``_SUBNLP_MAX_INT_VARS`` / ``_SUBNLP_MAX_COMBOS``), budgeted in ``EVAL`` rather
+    than ``NLP_SOLVE``. nvs19's 3^8 = 6561-cell radius-1 grid is unreachable under
+    the 3-variable/128-cell defaults and is enumerated in full under the direct ones.
+
+    Only the *defaults* move. Both parameters default to ``None`` meaning "pick the
+    cap that matches the inner loop"; a caller that passes either explicitly gets
+    exactly that number on either path, because silently overriding a caller's cap
+    would be a silent approximation (CLAUDE.md §3).
+
+    The test is the *presence* of a continuous slot, not its width: a continuous
+    variable that presolve has fixed still routes to the sub-NLP path. That is the
+    conservative direction — it can only decline a speedup, never take one that is
+    not warranted.
     """
     # As in ``one_hot_swap_search``: a non-positive ``time_budget`` is the caller
     # saying there is no budget at all, and #912's deterministic cell budget must
@@ -1332,7 +1405,20 @@ def integer_box_search(
     int_mask = _get_integer_mask(model)
     int_idx = np.where(int_mask)[0]
     n_int = int(int_idx.size)
-    if n_int == 0 or n_int > max_int_vars:
+    if n_int == 0:
+        return None
+    # #1193: see the "direct path" paragraph above. The cost of a cell, not the
+    # number of integers, is what the caps were sized against, so the DEFAULT caps
+    # differ by path. An *explicitly passed* cap is honoured on either path --
+    # silently overriding a caller's cap because we happened to pick a cheaper
+    # inner loop would be a silent approximation (CLAUDE.md §3).
+    direct = not bool(np.any(~int_mask)) and integer_box_polish_enabled()
+    eff_max_int_vars = (
+        max_int_vars
+        if max_int_vars is not None
+        else (_DIRECT_MAX_INT_VARS if direct else _SUBNLP_MAX_INT_VARS)
+    )
+    if n_int > eff_max_int_vars:
         return None
 
     lb, ub = _get_variable_bounds(model)
@@ -1354,7 +1440,12 @@ def integer_box_search(
     for ax in axes:
         n_combos *= len(ax)
     # A single-cell grid means the incumbent is pinned with no neighbours to try.
-    if n_combos <= 1 or n_combos > max_combos:
+    cell_cap = int(
+        max_combos
+        if max_combos is not None
+        else (_DIRECT_MAX_COMBOS if direct else _SUBNLP_MAX_COMBOS)
+    )
+    if n_combos <= 1 or n_combos > cell_cap:
         return None
 
     if evaluator is None:
@@ -1387,46 +1478,64 @@ def integer_box_search(
     # ``max_combos``, so this only ever trims a large box — but it trims it at the
     # same cell on every machine. ``deadline`` (the caller's ``time_limit``) stays
     # as a backstop. Both budgets off => the legacy ``time_budget`` wall gate.
-    if solve_budget is None:
-        from discopt import solver_tuning as _st
+    # #1193: the direct path spends *evaluations*, not NLP solves, so it is
+    # budgeted in the cheap currency. #912 keeps the two separate on purpose --
+    # their cost ratio varies 27x across the corpus and one number cannot price
+    # both -- so charging a 0.014 ms cell against the 128-solve budget would
+    # throttle it by a factor of ~1000 for no reason.
+    if direct:
+        if eval_budget is None:
+            from discopt import solver_tuning as _st
 
-        solve_budget = max(1, round(_BOX_BUDGET_RATIO * _st.current().ils_solve_budget))
-    if int(solve_budget) > 0:
-        budget = WorkBudget({NLP_SOLVE: int(solve_budget)}, deadline=deadline, clock=_now)
+            eval_budget = max(2, round(_BOX_BUDGET_RATIO * _st.current().ils_eval_budget))
+        budget = _box_work_budget(EVAL, int(eval_budget), time_budget, deadline)
     else:
-        _wall = _now() + max(0.0, time_budget)
-        budget = WorkBudget(
-            None, deadline=_wall if deadline is None else min(_wall, deadline), clock=_now
-        )
+        if solve_budget is None:
+            from discopt import solver_tuning as _st
+
+            solve_budget = max(1, round(_BOX_BUDGET_RATIO * _st.current().ils_solve_budget))
+        budget = _box_work_budget(NLP_SOLVE, int(solve_budget), time_budget, deadline)
     best: Optional[tuple[np.ndarray, float]] = None
     for combo in combos:
         if budget.exhausted():
             break
         if combo == center_key:
             continue  # the incumbent's own cell — nothing to improve on
-        # Seed from the nearest already-solved feasible neighbour (smallest L1
-        # gap), falling back to the incumbent's continuous values.
-        seed_src = x_inc
-        best_gap = None
-        for key, cont in cont_at.items():
-            gap = sum(abs(combo[k] - key[k]) for k in range(n_int))
-            if best_gap is None or gap < best_gap:
-                best_gap, seed_src = gap, cont
-        seed = seed_src.copy()
+        if direct:
+            # No continuous slots, so ``cont_at`` propagates nothing and its
+            # nearest-feasible scan would cost O(cells) per cell — quadratic over a
+            # grid whose whole point is that it is large.
+            seed = x_inc.copy()
+        else:
+            # Seed from the nearest already-solved feasible neighbour (smallest L1
+            # gap), falling back to the incumbent's continuous values.
+            seed_src = x_inc
+            best_gap = None
+            for key, cont in cont_at.items():
+                gap = sum(abs(combo[k] - key[k]) for k in range(n_int))
+                if best_gap is None or gap < best_gap:
+                    best_gap, seed_src = gap, cont
+            seed = seed_src.copy()
         for k, j in enumerate(int_idx):
             seed[j] = float(combo[k])
-        budget.charge(NLP_SOLVE)
-        found = subnlp(
-            model,
-            seed,
-            backend=backend,
-            nlp_options=nlp_options,
-            evaluator=evaluator,
-            integer_tol=integer_tol,
-            feas_tol=feas_tol,
-        )
+        if direct:
+            # One constraint-vector evaluation plus one objective evaluation.
+            budget.charge(EVAL, 2)
+            found = _finalize_candidate(evaluator, seed, int_mask, integer_tol, feas_tol)
+        else:
+            budget.charge(NLP_SOLVE)
+            found = subnlp(
+                model,
+                seed,
+                backend=backend,
+                nlp_options=nlp_options,
+                evaluator=evaluator,
+                integer_tol=integer_tol,
+                feas_tol=feas_tol,
+            )
         if found is not None:
-            cont_at[combo] = np.asarray(found[0]).copy()
+            if not direct:
+                cont_at[combo] = np.asarray(found[0]).copy()
             if best is None or found[1] < best[1]:
                 best = (np.asarray(found[0]).copy(), float(found[1]))
     return best

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -1408,6 +1408,113 @@ def _native_kernel_seed(model, lb, ub, sign, off, n_orig, outer_deadline=None):
     return best_internal, best_point
 
 
+def _native_exit_polish_enabled() -> bool:
+    """Whether an uncertified native-kernel exit gets a primal-improvement pass.
+
+    Delegates to the single #1193 predicate (``DISCOPT_INTEGER_BOX_POLISH``,
+    **default ON**) so that this pass and the zero-continuous direct path in
+    :func:`~discopt._relax.primal_heuristics.integer_box_search` switch together;
+    ``=0`` restores pre-#1193 behaviour on both. Sound either way: the pass is a
+    pure incumbent finder on a run that has already given up its certificate, so it
+    can only change *which* feasible point is reported, never the dual bound, the
+    status, or ``gap_certified``.
+    """
+    from discopt._relax.primal_heuristics import integer_box_polish_enabled
+
+    return integer_box_polish_enabled()
+
+
+def _native_exit_primal_polish(model, x_flat, obj_val, bound_val, n_orig, outer_deadline):
+    """Improve an UNCERTIFIED native-kernel incumbent before reporting it (#1193).
+
+    Returns ``(x_new, obj_new)`` — a strictly better, independently re-verified point
+    — or ``None`` to keep the kernel's own incumbent unchanged.
+
+    Why this exists. #1153 put ``node_limit`` on the kernel's accepted-status list,
+    which was right (the alternative threw away a sound result and restarted the
+    Python engine with the budget already spent) but had an unmeasured consequence:
+    the kernel now *terminates* the solve on those exits, so the Python engine's
+    primal heuristic layer — ``integer_local_search``, ``integer_box_search``, the
+    LNS scheduler — never runs on a kernel-routed model at all. Measured on nvs19:
+    ``integer_box_search`` fired **0 times** on a default solve, while
+    ``_try_native_spatial_kernel`` fired once and returned a result every time. The
+    kernel docstring still claimed node-limited runs "retain the established Python
+    fallback"; that has not been true since #1153 and is corrected there.
+
+    What it does. On an uncertified exit that carries an incumbent, run one bounded
+    ``integer_box_search`` over the unit integer box around it. nvs19's stalled
+    ``(2,6,3,2,8,6,6,2)`` = -1098.2 is a strict 2-opt local optimum — an exhaustive
+    scan of its L-inf <= 2 box found 98,429 feasible points and exactly ONE improving
+    one, the global optimum ``(2,6,3,2,8,5,7,1)`` = -1098.4, three coordinates away —
+    so no unit-move descent reaches it and only a box enumeration does.
+
+    Soundness. Three independent gates, each at least as strict as the one the
+    reported incumbent already passed: (1) ``integer_box_search`` returns only points
+    its own acceptance arbiter certifies integer- and constraint-feasible; (2) the
+    candidate is re-verified against the ORIGINAL model by the same
+    ``_native_kernel_verify_point`` guard (#789) that vetted the kernel's incumbent,
+    which also supplies the true model-units objective; (3) it is adopted only on
+    strict improvement in the model's own sense. Nothing here touches ``bound``,
+    ``status`` or ``gap_certified`` — the exit was already uncertified and stays so.
+    """
+    if not _native_exit_polish_enabled():
+        return None
+    from discopt.modeling.core import ObjectiveSense as _ObjSensePP
+
+    is_max = model._objective is not None and model._objective.sense == _ObjSensePP.MAXIMIZE
+
+    try:
+        from discopt._relax.nlp_evaluator import cached_evaluator as _cached_ev
+        from discopt._relax.primal_heuristics import integer_box_search as _ibs
+
+        evaluator = _cached_ev(model)
+        x_full = np.asarray(x_flat, dtype=np.float64)
+        found = _ibs(model, x_full, radius=1, evaluator=evaluator, deadline=outer_deadline)
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.debug("native-exit primal polish raised: %s", exc)
+        return None
+    if found is None:
+        return None
+
+    x_new = np.asarray(found[0], dtype=np.float64)
+    if x_new.shape[0] < n_orig:
+        return None
+    ok, obj_new = _native_kernel_verify_point(model, x_new[:n_orig])
+    if not ok or obj_new is None:
+        # The box search's arbiter accepted a point the original-model verifier
+        # rejects. Keep the reported incumbent; never widen an acceptance to make a
+        # heuristic pay off (CLAUDE.md §1).
+        logger.debug("native-exit primal polish: candidate failed original-model verification")
+        return None
+
+    improved = (obj_new > obj_val + 1e-9) if is_max else (obj_new < obj_val - 1e-9)
+    if not improved:
+        return None
+
+    # A verified feasible point cannot beat a VALID global bound. If it does, the
+    # bound is wrong — a pre-existing soundness defect this pass has surfaced, not
+    # caused. Say so at ERROR and decline, leaving the run bit-identical to what it
+    # would have reported anyway (CLAUDE.md §1/§3: surface, never paper over).
+    if math.isfinite(bound_val):
+        crosses = (obj_new > bound_val + 1e-6) if is_max else (obj_new < bound_val - 1e-6)
+        if crosses:
+            logger.error(
+                "native-exit primal polish found a VERIFIED feasible point %.12g beyond "
+                "the reported dual bound %.12g — the bound is invalid; declining the "
+                "polish and reporting the original incumbent (#1193)",
+                obj_new,
+                bound_val,
+            )
+            return None
+
+    logger.info(
+        "native-exit primal polish (#1193): incumbent %.6g -> %.6g on an uncertified exit",
+        obj_val,
+        obj_new,
+    )
+    return x_new, float(obj_new)
+
+
 def _try_native_spatial_kernel(
     model,
     lb,
@@ -1432,10 +1539,13 @@ def _try_native_spatial_kernel(
     Soundness: the producer declines (``None``) any model it cannot reproduce
     bound-neutrally. A fully-certified native solve (``status == 'optimal'``) is
     returned as optimal; a wall-clock-limited native solve returns its rigorous
-    partial incumbent/bound with ``status == 'time_limit'``. Node-limited or declined
-    runs retain the established Python fallback. The kernel's incumbent satisfies the
-    model's linear rows (they are fixed rows in its LP) and every lifted term to
-    ``mccormick_tol``.
+    partial incumbent/bound with ``status == 'time_limit'``. Since #1153 a NODE-limited
+    solve is accepted on the same terms (see the note at the ``native_status`` gate
+    below); only declined or otherwise incomplete runs retain the established Python
+    fallback -- so an accepted uncertified exit is TERMINAL, which is why #1193's
+    primal polish runs here as the last chance to improve its incumbent. The kernel's
+    incumbent satisfies the model's linear rows (they are fixed rows in its LP) and
+    every lifted term to ``mccormick_tol``.
     The internal minimize-convention objective/bound are mapped to model units via the
     producer's ``sign*(value + offset)`` metadata.
 
@@ -1683,6 +1793,20 @@ def _try_native_spatial_kernel(
                 _fb_bound,
             )
             bound_val = _fb_bound
+
+    # #1193: an uncertified exit ends the solve here, so this is the LAST place the
+    # incumbent can still be improved — #1153 made the kernel terminal on
+    # ``node_limit``, which silently removed the Python primal-heuristic layer from
+    # every kernel-routed model. Purely primal: bound, status and certification below
+    # are untouched.
+    if native_status != "optimal" and x_flat is not None and obj_val is not None:
+        _t_phase = time.perf_counter()
+        _polished = _native_exit_primal_polish(
+            model, x_flat, obj_val, bound_val, n_orig, outer_deadline
+        )
+        _native_jax_s += time.perf_counter() - _t_phase
+        if _polished is not None:
+            x_flat, obj_val = _polished
 
     x_dict = _unpack_solution(model, x_flat) if x_flat is not None else None
     wall_time = time.perf_counter() - t_start

--- a/python/tests/test_issue_1193_native_exit_polish.py
+++ b/python/tests/test_issue_1193_native_exit_polish.py
@@ -1,0 +1,323 @@
+"""Regression tests for the #1193 native-exit primal polish.
+
+Issue #1193: ``nvs19`` returns -1098.2 against a -1098.4 optimum at the default
+budget and exits on ``max_nodes``. The measured cause is *primal*, in two parts:
+
+1. **The Python heuristic layer never runs.** #1153 put ``node_limit`` on the
+   native kernel's accepted-status list, which made an uncertified kernel exit
+   *terminal*. Measured on nvs19: ``integer_box_search`` fired **0 times** on a
+   default solve while ``_try_native_spatial_kernel`` fired once and returned a
+   result. So no primal heuristic could ever see that incumbent.
+2. **The heuristic that would fix it was priced for the wrong operation.**
+   ``integer_box_search`` re-solves a continuous sub-NLP per cell, so its caps
+   are ``max_int_vars=3`` / ``max_combos=128``. On a model with **no free
+   continuous variables** that sub-NLP is zero-dimensional and reduces exactly to
+   "round, verify, evaluate". Measured on nvs19 (8 integers, 0 continuous):
+   18.922 ms/cell via ``subnlp`` vs 0.014 ms/cell direct — 1385x — so the whole
+   3^8 = 6561-cell radius-1 grid costs 0.09 s, not 124.1 s.
+
+nvs19's incumbent is a **strict 2-opt local optimum**: an exhaustive scan of its
+L-inf <= 2 box found 98,429 feasible points and exactly ONE improving one, the
+global optimum, three coordinates away. So no unit-move descent reaches it and
+only a box enumeration does.
+
+nvs19 is not in the in-repo corpus and a full solve is minutes long, so the class
+is exercised here by the smallest model that exhibits it (CLAUDE.md §2: the fix
+is for the class, not the instance) -- ``_two_opt_trap`` below is verified to BE
+a strict 2-opt local optimum by :func:`test_trap_is_a_strict_two_opt_local_optimum`,
+so these tests cannot quietly degrade into passing against a model that no longer
+poses the problem.
+"""
+
+from __future__ import annotations
+
+import itertools
+import logging
+
+import numpy as np
+import pytest
+from discopt._relax.nlp_evaluator import cached_evaluator
+from discopt._relax.primal_heuristics import (
+    _check_constraint_feasibility,
+    _finalize_candidate,
+    _get_integer_mask,
+    integer_box_search,
+    subnlp,
+)
+from discopt.modeling.core import Model
+from discopt.solver import _native_exit_polish_enabled, _native_exit_primal_polish
+
+pytestmark = pytest.mark.unit
+
+FLAG = "DISCOPT_INTEGER_BOX_POLISH"
+
+
+def _two_opt_trap(*, with_continuous: bool = False, maximize: bool = False) -> Model:
+    """5 integers, no continuous slots; the origin is a strict 2-opt local optimum.
+
+    ``-(x0*x1*x2) + 0.1*sum(x)``: every 1-step move costs +0.1 and every 2-step
+    move +0.2, while the 3-step ``(1,1,1,0,0)`` pays -0.7. The trilinear term is
+    the general shape that makes the improving move invisible to unit descent --
+    no proper subset of ``{x0,x1,x2}`` earns anything.
+    """
+    m = Model("two_opt_trap")
+    xs = [m.integer(f"x{i}", lb=0, ub=4) for i in range(5)]
+    if with_continuous:
+        c = m.continuous("c", lb=0.0, ub=1.0)
+        m.subject_to(c <= 1.0)
+    m.subject_to(sum(xs) <= 3)
+    body = -(xs[0] * xs[1] * xs[2]) + 0.1 * sum(xs)
+    if maximize:
+        m.maximize(-body)
+    else:
+        m.minimize(body)
+    return m
+
+
+ORIGIN = np.zeros(5)
+ESCAPE = np.array([1.0, 1.0, 1.0, 0.0, 0.0])
+
+
+# ---------------------------------------------------------------------------
+# The test instance really does pose the problem (CLAUDE.md §6)
+# ---------------------------------------------------------------------------
+
+
+def test_trap_is_a_strict_two_opt_local_optimum():
+    """Guards every other test here: if this fails they are all vacuous."""
+    m = _two_opt_trap()
+    ev = cached_evaluator(m)
+    base = float(ev.evaluate_objective(ORIGIN))
+    assert base == pytest.approx(0.0)
+
+    moves = 0
+    for k in (1, 2):
+        for combo in itertools.combinations(range(5), k):
+            for vals in itertools.product((1.0, 2.0, 3.0, 4.0), repeat=k):
+                x = ORIGIN.copy()
+                for idx, v in zip(combo, vals):
+                    x[idx] = v
+                if not _check_constraint_feasibility(ev, x):
+                    continue
+                moves += 1
+                assert float(ev.evaluate_objective(x)) > base - 1e-12, (
+                    f"{combo}={vals} improves on the origin — not a 2-opt local optimum"
+                )
+    assert moves > 0, "no feasible 1-/2-opt neighbour was examined; the scan proved nothing"
+    # ...and the 3-step escape really is strictly better and feasible.
+    assert _check_constraint_feasibility(ev, ESCAPE)
+    assert float(ev.evaluate_objective(ESCAPE)) == pytest.approx(-0.7)
+
+
+# ---------------------------------------------------------------------------
+# integer_box_search: the zero-free-continuous direct path
+# ---------------------------------------------------------------------------
+
+
+def test_direct_path_reaches_the_three_step_optimum_at_default_caps():
+    """The #1193 fix. Before it, 5 integers > ``max_int_vars=3`` declined outright."""
+    m = _two_opt_trap()
+    out = integer_box_search(m, ORIGIN, radius=1, evaluator=cached_evaluator(m))
+    assert out is not None, "declined — the direct path did not fire"
+    x, obj = out
+    np.testing.assert_allclose(x, ESCAPE)
+    assert obj == pytest.approx(-0.7)
+
+
+def test_the_flag_gates_the_direct_path_too(monkeypatch):
+    """ONE flag governs BOTH halves of the #1193 fix.
+
+    Regression test for a real defect in the first cut: only the exit polish was
+    gated, so the re-priced box search stayed live in a graduation panel's OFF
+    arm and the A/B measured neither half honestly. With the flag off, this
+    5-integer zero-continuous model must fall back to the pre-#1193 caps
+    (``max_int_vars=3``) and decline.
+    """
+    m = _two_opt_trap()
+    ev = cached_evaluator(m)
+    monkeypatch.setenv(FLAG, "0")
+    assert integer_box_search(m, ORIGIN, radius=1, evaluator=ev) is None
+    monkeypatch.setenv(FLAG, "1")
+    out = integer_box_search(m, ORIGIN, radius=1, evaluator=ev)
+    assert out is not None
+    np.testing.assert_allclose(out[0], ESCAPE)
+
+
+def test_direct_path_returns_only_feasible_integral_points():
+    m = _two_opt_trap()
+    ev = cached_evaluator(m)
+    out = integer_box_search(m, ORIGIN, radius=1, evaluator=ev)
+    assert out is not None
+    x = out[0]
+    int_mask = _get_integer_mask(m)
+    np.testing.assert_allclose(x[int_mask], np.round(x[int_mask]))
+    assert _check_constraint_feasibility(ev, x)
+    assert float(ev.evaluate_objective(x)) == pytest.approx(out[1])
+
+
+def test_a_free_continuous_variable_keeps_the_sub_nlp_caps():
+    """The direct path is gated on the *cost* of a cell, not on the model's name.
+
+    One free continuous slot restores the per-cell NLP solve, so the NLP-priced
+    caps apply again and 5 integers is over ``max_int_vars=3``.
+    """
+    m = _two_opt_trap(with_continuous=True)
+    out = integer_box_search(m, np.zeros(6), radius=1, evaluator=cached_evaluator(m))
+    assert out is None
+
+
+def test_direct_path_still_honours_its_own_cell_cap():
+    """The cap is re-priced, not removed: a grid past it is declined, not run."""
+    m = _two_opt_trap()
+    out = integer_box_search(m, ORIGIN, radius=1, evaluator=cached_evaluator(m), max_combos=10)
+    assert out is None, "3^5 = 243 cells must not run under a 10-cell cap"
+
+
+def test_an_explicit_cap_is_never_silently_overridden(monkeypatch):
+    """An explicitly passed cap binds on the DIRECT path too.
+
+    Regression test for a real defect in the first cut: the direct path read a
+    separate ``max_combos_direct`` and ignored ``max_combos``/``max_int_vars``
+    entirely, so a caller who asked for a 2-cell search silently got a 20,000-cell
+    one. Two pre-existing tests in ``test_gdpopt_heuristics_core_units.py`` caught
+    it in CI. Only the DEFAULTS are re-priced by path; an explicit number is
+    obeyed verbatim on either.
+    """
+    m = _two_opt_trap()
+    ev = cached_evaluator(m)
+    # Defaults: the direct path runs and escapes.
+    assert integer_box_search(m, ORIGIN, radius=1, evaluator=ev) is not None
+    # Explicit caps: each one alone must veto it.
+    assert integer_box_search(m, ORIGIN, radius=1, evaluator=ev, max_combos=2) is None
+    assert integer_box_search(m, ORIGIN, radius=1, evaluator=ev, max_int_vars=1) is None
+
+
+def test_direct_path_is_bounded_by_its_eval_budget():
+    """The extent is a deterministic operation count, not a wall clock (#912)."""
+    m = _two_opt_trap()
+    ev = cached_evaluator(m)
+    # Two EVAL charges per cell, so a 4-charge budget buys 2 cells of a 243-cell
+    # grid — far too few to reach a 3-step escape.
+    starved = integer_box_search(m, ORIGIN, radius=1, evaluator=ev, eval_budget=4)
+    assert starved is None or starved[1] > -0.7 + 1e-9
+    full = integer_box_search(m, ORIGIN, radius=1, evaluator=ev, eval_budget=100_000)
+    assert full is not None and full[1] == pytest.approx(-0.7)
+
+
+def test_zero_time_budget_still_means_no_budget_at_all():
+    m = _two_opt_trap()
+    out = integer_box_search(m, ORIGIN, radius=1, evaluator=cached_evaluator(m), time_budget=0.0)
+    assert out is None
+
+
+def test_finalize_candidate_matches_subnlp_when_there_are_no_continuous_slots():
+    """The substitution the direct path rests on, checked directly.
+
+    With every integer fixed and no continuous variable left, ``subnlp``'s inner
+    solve has zero degrees of freedom, so it must agree with the direct
+    "round, verify, evaluate" on both the point and the objective.
+    """
+    m = _two_opt_trap()
+    ev = cached_evaluator(m)
+    int_mask = _get_integer_mask(m)
+    compared = 0
+    for combo in itertools.product((0.0, 1.0), repeat=3):
+        seed = np.array([*combo, 0.0, 0.0])
+        direct = _finalize_candidate(ev, seed, int_mask, 1e-5, 1e-6)
+        viasub = subnlp(m, seed, evaluator=ev, integer_tol=1e-5, feas_tol=1e-6)
+        assert (direct is None) == (viasub is None), f"{combo}: disagreement on acceptance"
+        if direct is None:
+            continue
+        compared += 1
+        np.testing.assert_allclose(direct[0], viasub[0], atol=1e-9)
+        assert direct[1] == pytest.approx(viasub[1], abs=1e-9)
+    assert compared > 0, "no cell was accepted by either path; the comparison proved nothing"
+
+
+# ---------------------------------------------------------------------------
+# _native_exit_primal_polish
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def polish_on(monkeypatch):
+    monkeypatch.setenv(FLAG, "1")
+
+
+def test_polish_adopts_a_strictly_improving_verified_point(polish_on):
+    m = _two_opt_trap()
+    out = _native_exit_primal_polish(m, ORIGIN, 0.0, -10.0, 5, None)
+    assert out is not None
+    np.testing.assert_allclose(out[0][:5], ESCAPE)
+    assert out[1] == pytest.approx(-0.7)
+
+
+def test_polish_declines_when_nothing_improves(polish_on):
+    """An incumbent already better than anything in the box is left alone."""
+    m = _two_opt_trap()
+    assert _native_exit_primal_polish(m, ORIGIN, -1e6, -1e9, 5, None) is None
+
+
+def test_polish_declines_a_candidate_that_crosses_the_reported_bound(polish_on, caplog):
+    """A verified point beyond a *valid* bound means the BOUND is wrong.
+
+    The polish must surface that loudly and decline, leaving the run identical to
+    what it would have reported anyway — never silently ship a negative gap, and
+    never weaken the check to let the improvement through (CLAUDE.md §1/§3).
+    """
+    m = _two_opt_trap()
+    with caplog.at_level(logging.ERROR, logger="discopt.solver"):
+        out = _native_exit_primal_polish(m, ORIGIN, 0.0, -0.1, 5, None)
+    assert out is None
+    assert any("bound is invalid" in r.getMessage() for r in caplog.records)
+
+
+def test_polish_respects_maximize_sense(polish_on):
+    """Improvement is 'better in the model's own sense', not 'numerically smaller'."""
+    m = _two_opt_trap(maximize=True)
+    out = _native_exit_primal_polish(m, ORIGIN, 0.0, 10.0, 5, None)
+    assert out is not None
+    np.testing.assert_allclose(out[0][:5], ESCAPE)
+    assert out[1] == pytest.approx(0.7)
+    # And the same point must NOT be adopted against an already-better incumbent.
+    assert _native_exit_primal_polish(m, ORIGIN, 1e6, 1e9, 5, None) is None
+
+
+def test_polish_is_off_when_the_flag_is_off(monkeypatch):
+    monkeypatch.setenv(FLAG, "0")
+    assert not _native_exit_polish_enabled()
+    m = _two_opt_trap()
+    assert _native_exit_primal_polish(m, ORIGIN, 0.0, -10.0, 5, None) is None
+
+
+def test_polish_defaults_on(monkeypatch):
+    monkeypatch.delenv(FLAG, raising=False)
+    assert _native_exit_polish_enabled()
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: the polish is bound-, node- and certificate-neutral
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("max_nodes", [1, 50, 5000])
+def test_solve_is_bound_and_node_neutral_across_the_flag(max_nodes, monkeypatch):
+    """CLAUDE.md §5 bound-neutral regime: the polish runs AFTER the tree, so it
+    cannot move the dual bound or the node count. Any drift is a plumbing bug."""
+    results = {}
+    for flag in ("0", "1"):
+        monkeypatch.setenv(FLAG, flag)
+        r = _two_opt_trap().solve(max_nodes=max_nodes, time_limit=30.0)
+        results[flag] = r
+    off, on = results["0"], results["1"]
+    assert off.node_count == on.node_count, "node count moved"
+    if off.bound is not None and on.bound is not None:
+        assert off.bound == pytest.approx(on.bound, rel=1e-12, abs=1e-12), "dual bound moved"
+    assert off.gap_certified == on.gap_certified, "certification changed"
+    # A certified exit must not notice the flag at all.
+    if off.status == "optimal":
+        assert on.status == "optimal"
+        assert off.objective == pytest.approx(on.objective, rel=1e-12, abs=1e-12)
+    # The incumbent may only ever get BETTER (minimize sense).
+    if off.objective is not None and on.objective is not None:
+        assert on.objective <= off.objective + 1e-9


### PR DESCRIPTION
Fixes the actual symptom in #1193: `nvs19` returns **-1098.2** against a
**-1098.4** optimum at the default budget and exits on `max_nodes`.

## The issue's own step (1) falsified its step (2)

#1193 read the stall as a *dual* symptom -- "the bound is not tightening, which
points at the relaxation rather than the search order". Running the entry
experiment first (CLAUDE.md §4) said otherwise: -1098.4 **is** reachable, so the
defect is primal. Two measured root causes, neither of which is the relaxation:

**1. #1153 silently deleted the Python primal layer from kernel-routed models.**
It put `node_limit` on `_try_native_spatial_kernel`'s accepted-status list --
correct in itself, but it made an *uncertified* kernel exit **terminal**, so
`integer_local_search` / `integer_box_search` / the LNS scheduler never run.
Measured on nvs19: `integer_box_search` fired **0 times** on a default solve,
while `_try_native_spatial_kernel` fired once and returned a result every time.
The kernel docstring still claimed node-limited runs "retain the established
Python fallback"; false since #1153, corrected here.

**2. `integer_box_search`'s caps are priced in the wrong currency.** Its
`max_int_vars=3` / `max_combos=128` were sized against a per-cell **sub-NLP
solve**. With no continuous slots that solve is zero-dimensional and a cell is
really one evaluation:

| per-cell work | wall |
|---|---|
| `subnlp(...)` | 18.922 ms |
| `_finalize_candidate(...)` | 0.014 ms |

**1385x.** nvs19's radius-1 grid (3^8 = 6561 cells) costs **0.09 s** priced
correctly and **124.1 s** priced as sub-NLPs -- so the caps declined outright a
search that is nearly free. End to end the box search went **72.8 s -> 0.352 s
(207x)**.

nvs19's stalled `(2,6,3,2,8,6,6,2)` is a strict 2-opt local optimum: an
exhaustive scan of its L-inf <= 2 box found 98,429 feasible points and exactly
**one** improving one -- the global optimum, three coordinates away. No unit-move
descent reaches it; only a box enumeration does.

## The change

Both halves sit behind **one** flag, `DISCOPT_INTEGER_BOX_POLISH` (default ON,
`=0` restores pre-#1193 behaviour on both):

- `_relax/primal_heuristics.py` -- a **direct path** for models with no
  continuous slots: `_finalize_candidate` instead of `subnlp`, budgeted in `EVAL`
  rather than `NLP_SOLVE` (#912 keeps the currencies separate because their cost
  ratio varies 27x; charging a 0.014 ms cell against the 128-solve budget
  throttles it ~1000x for nothing), cell cap `max_combos_direct=20_000`, and no
  per-cell nearest-neighbour seed scan (it is O(cells) per cell -- quadratic --
  and propagates nothing when there are no continuous slots). Gated on the
  *presence* of a continuous slot, not its width: a presolve-fixed continuous
  variable conservatively keeps the sub-NLP path.
- `solver.py` -- a **post-kernel primal polish** on an uncertified exit, the last
  point at which that incumbent can still be improved.

**Soundness -- three independent gates, each at least as strict as the one the
reported incumbent already passed:** the box search returns only points its own
arbiter certifies integer- and constraint-feasible; the candidate is re-verified
against the ORIGINAL model by the same `_native_kernel_verify_point` guard (#789)
that vetted the kernel's incumbent; and it is adopted only on strict improvement
in the model's own sense. `bound`, `status` and `gap_certified` are untouched. A
verified point that lands beyond the reported dual bound means the *bound* is
wrong -- that logs at ERROR and declines the polish rather than papering over it.

## Acceptance -- the #1193 symptom, at the DEFAULT budget

```
flag=0  obj=-1098.2  bound=-1472.3500000001088  nodes=100000  status=node_limit
flag=1  obj=-1098.4  bound=-1472.3500000001088  nodes=100000  status=node_limit
```

Identical bound, identical node count -- purely primal on this instance.

## Graduation panels

`discopt_benchmarks/scripts/issue1193_exit_polish_panel.py`, 2000 nodes / 30 s,
three arms **OFF / ON / OFF** so neutrality is only charged to the flag where the
two OFF runs agree, plus a **4-extra-OFF-run escalation** on any instance
carrying a neutrality finding. Inertness is proved on the *channel* -- calls
where `not np.any(~_get_integer_mask(model))`, i.e. the direct path could
actually engage -- not on whether a point came back. Run against merged `main`.

| panel | n | cert-clean | net-positive | adopted | ON better | ON worse | channel live | problems |
|---|---|---|---|---|---|---|---|---|
| all-integer (MINLPLib `probtype` `I*`) | 34 | **True** | **True** | 2 | 3 (`gear`, `nvs19`, `nvs23`) | 0 | 7 | 0 |
| in-repo `minlplib_nl` | 66 | **True** | False | 0 | 0 | 0 | 1 | 0 |

The in-repo `net-positive=False` is **0 better and 0 worse** with the channel
live on 1 of 66 -- 65 of those instances have continuous variables, so the direct
path can never engage and the flag is inert by construction. That panel is the
*soundness* gate; helpfulness is measured on the population where the mechanism
can act, and that panel passes both bars. Reported here rather than only the
favourable one.

`gear` is the clearest single result: 31 -> 3 nodes at a strictly better
objective (8.606e-07 -> 3.779e-08 against a 0.0 oracle, neither beating it),
certificate intact -- an in-tree direct-path incumbent that prunes harder.

## Three of my own instruments measured nothing and were believed

Recorded in `docs/dev/performance-plan.md` §29 (7 falsifications). Briefly:

1. Only the exit polish was flagged at first, so the panel's OFF arm was a
   hybrid -- the re-priced box search stayed live in both arms and the A/B
   measured neither half. One flag now governs both, pinned by a regression test.
2. "A certified solve must not notice a primal flag" was falsified by `gear`.
   Replaced with an unconditional false-certificate detector.
3. Inertness was defined on the *effect* (`box_hits`) rather than the *channel*,
   and a two-sample OFF/OFF control produced a false "deterministic" verdict.
   A probe then falsified my own published claim that the flag was acting through
   a channel the counter missed: `tls2` never calls `integer_box_search` at all
   yet moves 171/253/145 nodes across flags 0/1/0, and `tspn12` (24 continuous
   slots, never direct-eligible) returns **bit-identical** runs at 0/1/0 while
   its standalone flag=0 run gives the exact node count the panel had blamed on
   the flag. Both were pre-existing nondeterminism (#1187).

## CI caught a fourth defect of mine

`test_gdpopt_heuristics_core_units.py::TestIntegerBoxSearchEdges::{test_combo_cap,
test_too_many_integers}` failed on the first push. They were right: the direct
path read a separate `max_combos_direct` and ignored `max_combos` /
`max_int_vars` entirely, so a caller asking for a 2-cell search silently got a
20,000-cell one. Only the *defaults* should be re-priced by path. Both
parameters now default to `None` ("the cap matching the inner loop") and an
explicit value binds on either path; a new regression test pins that, and the
two pre-existing tests pass unmodified -- they were not the thing to change.
All panel numbers above were re-measured after this fix and are unchanged.

## Verification

- `pytest -m smoke` -- 1255 passed, 1 skipped, 2 xpassed
- `pytest -m slow python/tests/test_adversarial_recent_fixes.py` -- 19 passed
- `python/tests/test_issue_1193_native_exit_polish.py` -- 19 new tests, and
  #1199's `test_polish_feasibility_gate_1199.py` + #1153's
  `test_1153_node_limit_kernel_accept.py` pass alongside
- `ruff check` / `ruff format --check` / `mypy` -- clean, no new errors
- No Rust touched, so `cargo test` is not required

Closes #1193

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014E81XM1j2J5sydzj9nFFFp
