### PR TITLE
fix(relax): a deep body made the term classifier lose its whole catalog

### DIFF
--- a/python/discopt/_relax/term_classifier.py
+++ b/python/discopt/_relax/term_classifier.py
@@ -169,15 +169,8 @@ def _contains_expandable_square(model: Model) -> bool:
     # RecursionError on qap. With the memo each unique node is visited once -> O(nodes).
     _seen: dict[int, bool] = {}
 
-    def visit(expr: Expression) -> bool:
-        eid = id(expr)
-        hit = _seen.get(eid)
-        if hit is not None:
-            return hit
-        _seen[eid] = result = _visit_uncached(expr)
-        return result
-
-    def _visit_uncached(expr: Expression) -> bool:
+    def _decide_here(expr: Expression) -> bool | None:
+        """The node's own verdict, when it can be reached without its children."""
         if isinstance(expr, BinaryOp):
             if (
                 expr.op == "**"
@@ -190,20 +183,59 @@ def _contains_expandable_square(model: Model) -> bool:
                 _is_additive_composite(expr.left) or _is_additive_composite(expr.right)
             ):
                 return True
-            return visit(expr.left) or visit(expr.right)
+        return None
+
+    def _children(expr: Expression) -> tuple[Expression, ...]:
+        if isinstance(expr, BinaryOp):
+            return (expr.left, expr.right)
         if isinstance(expr, UnaryOp):
-            return visit(expr.operand)
+            return (expr.operand,)
         if isinstance(expr, FunctionCall):
-            return any(visit(arg) for arg in expr.args)
+            return tuple(expr.args)
         if isinstance(expr, IndexExpression):
-            return not isinstance(expr.base, Variable) and visit(expr.base)
+            # A plain ``v[i]`` is a variable reference, not a composite.
+            return () if isinstance(expr.base, Variable) else (expr.base,)
         if isinstance(expr, SumExpression):
-            return visit(expr.operand)
+            return (expr.operand,)
         if isinstance(expr, SumOverExpression):
-            return any(visit(term) for term in expr.terms)
+            return tuple(expr.terms)
         if isinstance(expr, MatMulExpression):
-            return visit(expr.left) or visit(expr.right)
-        return False
+            return (expr.left, expr.right)
+        return ()
+
+    def visit(root: Expression) -> bool:
+        """Iterative post-order walk.
+
+        The memo above bounds repeated WORK but not recursion DEPTH: a lifted
+        model's objective is a left-deep ``((a + b) + c) + ...`` chain as long as
+        its term count, so a recursive visitor needs one frame per term and dies
+        with RecursionError past ~1000 of them. That exception is an ``Exception``
+        subclass, so the reformulation-adoption guard in ``solve_model`` caught it
+        and silently reported "no reformulation available" -- the pass was skipped
+        on exactly the biggest models it was written for, with nothing but a
+        ``logger.debug`` to say so. An explicit stack removes the depth limit; the
+        memo keeps it O(unique nodes).
+        """
+        stack: list[tuple[Expression, bool]] = [(root, False)]
+        while stack:
+            expr, expanded = stack.pop()
+            eid = id(expr)
+            if eid in _seen:
+                continue
+            if expanded:
+                _seen[eid] = any(_seen.get(id(c), False) for c in _children(expr))
+                continue
+            here = _decide_here(expr)
+            if here is not None:
+                _seen[eid] = here
+                continue
+            kids = _children(expr)
+            if not kids:
+                _seen[eid] = False
+                continue
+            stack.append((expr, True))
+            stack.extend((c, False) for c in kids)
+        return _seen[id(root)]
 
     if model._objective is not None and visit(model._objective.expression):
         return True
@@ -606,18 +638,53 @@ def extract_reciprocal_power(expr: Expression, model: Model) -> tuple[int, float
 # ---------------------------------------------------------------------------
 
 
+def _classify_recursion_headroom(model: Model) -> int:
+    """Recursion-limit headroom the Python classifier walk may need on *model*.
+
+    Sized off the *deepest single expression*, not the constraint count: the
+    hazard is depth concentrated in one giant body (issues #266/#271 hit the
+    same shape).  Returns 0 when the default limit is safe; the estimate is a
+    deliberate over-approximation (depth is bounded by node count) and only
+    decides whether the deep-stack path engages, never what gets classified.
+    """
+    # Deferred: ``factorable_reform`` imports from this module at import time.
+    from .factorable_reform import _DEEP_RECURSION_SIZE_GATE, _max_expr_node_count
+
+    size = _max_expr_node_count(model)
+    if size <= _DEEP_RECURSION_SIZE_GATE:
+        return 0
+    # ``distribute_products`` enters a couple of frames per expression node along
+    # the deepest path, and ``_classify_node`` walks the rebuilt tree after it;
+    # cushion the surrounding stack and cap it as the sibling walks do.
+    return min(2000 + 6 * size, 600_000)
+
+
 def classify_nonlinear_terms(model: Model) -> NonlinearTerms:
     """Walk the model's expression DAG and catalog nonlinear term structure.
 
     Uses the Rust expression-arena classifier for polynomial/product models when
     available, falling back to the Python implementation for unsupported models
     and for cases that need concrete ``general_nl`` expression objects.
+
+    The Python fallback (``distribute_products`` → ``_classify_node``) recurses
+    per expression node, so a deep body blew the default 1000-frame limit and
+    raised ``RecursionError``.  Callers treat that as "no reformulation
+    available" rather than as the bug it is, so a model with a 53k-node body
+    silently lost its whole term catalog.  Run the walk with size-scaled
+    headroom on a large stack, reusing the runner proven for the convexity and
+    factorable walks (issues #266/#271).
     """
-    if not _contains_expandable_square(model):
-        rust_terms = _classify_nonlinear_terms_rust(model)
-        if rust_terms is not None:
-            return rust_terms
-    return _classify_nonlinear_terms_python(model)
+
+    def _classify() -> NonlinearTerms:
+        if not _contains_expandable_square(model):
+            rust_terms = _classify_nonlinear_terms_rust(model)
+            if rust_terms is not None:
+                return rust_terms
+        return _classify_nonlinear_terms_python(model)
+
+    from .convexity.rules import _run_with_deep_recursion
+
+    return _run_with_deep_recursion(_classify, depth_need=_classify_recursion_headroom(model))
 
 
 def _classify_nonlinear_terms_rust(model: Model) -> NonlinearTerms | None:

--- a/python/tests/test_term_classifier_deep_recursion.py
+++ b/python/tests/test_term_classifier_deep_recursion.py
@@ -1,0 +1,77 @@
+"""The nonlinear-term classifier must not RecursionError on a deep body.
+
+`classify_nonlinear_terms`'s Python fallback (`distribute_products` ->
+`_classify_node`) recurses once per expression node, so a model whose objective
+or a constraint is one deep chain blew the default 1000-frame limit. The caller
+in `solve_model` catches `Exception` and logs "reformulation skipped", so the
+blowup was read as "no reformulation available" and the model silently lost its
+whole term catalog -- measured on 14 corpus instances including the graphpart,
+unitcommit and acopf_*_qcqp families.
+
+The fix runs the walk with size-scaled recursion headroom on a large stack,
+reusing the runner proven for the convexity (#266) and factorable (#271) walks.
+"""
+
+from __future__ import annotations
+
+import sys
+
+import discopt.modeling as dm
+import pytest
+from discopt._relax.term_classifier import (
+    _classify_recursion_headroom,
+    classify_nonlinear_terms,
+)
+
+
+def _n_terms() -> int:
+    """Chain length, sized off the *ambient* recursion limit rather than a
+    constant: this repo's pytest config raises the limit to 3000, so a fixed
+    1500-term chain silently stopped being deep enough to reproduce anything.
+    The walk enters ~2 frames per node, so twice the limit is safely past it."""
+    return 2 * sys.getrecursionlimit()
+
+
+def _deep_bilinear_model(n_terms: int | None = None) -> dm.Model:
+    """A model whose objective is one left-deep `+` chain of `x_i * x_{i+1}`."""
+    n_terms = _n_terms() if n_terms is None else n_terms
+    m = dm.Model()
+    x = m.continuous("x", shape=(n_terms + 1,), lb=-1.0, ub=1.0)
+    expr = x[0] * x[1]
+    for i in range(1, n_terms):
+        expr = expr + x[i] * x[i + 1]
+    m.minimize(expr)
+    return m
+
+
+def test_shallow_model_takes_the_inline_path():
+    """Control: a small model must not pay for the deep-stack path."""
+    m = dm.Model()
+    x = m.continuous("x", shape=(3,), lb=-1.0, ub=1.0)
+    m.minimize(x[0] * x[1] + x[2] * x[2])
+    assert _classify_recursion_headroom(m) == 0
+
+
+def test_deep_model_requests_headroom_beyond_the_default_limit():
+    """Guard the guard: if the estimate stayed under the limit the next test
+    would pass without ever engaging the fix."""
+    m = _deep_bilinear_model()
+    assert _classify_recursion_headroom(m) > sys.getrecursionlimit()
+
+
+def test_deep_body_classifies_instead_of_raising():
+    """Before the fix this raised RecursionError (and was swallowed upstream)."""
+    m = _deep_bilinear_model()
+    terms = classify_nonlinear_terms(m)
+    assert terms.bilinear, "deep chain of x_i*x_{i+1} produced no bilinear terms"
+    assert len(terms.bilinear) == _n_terms()
+
+
+def test_deep_body_raises_without_the_headroom_runner():
+    """Pin the failure the fix removes: the same walk at the default limit still
+    blows up, so this test fails loudly if the deep path is ever bypassed."""
+    from discopt._relax.term_classifier import _classify_nonlinear_terms_python
+
+    m = _deep_bilinear_model()
+    with pytest.raises(RecursionError):
+        _classify_nonlinear_terms_python(m)


### PR DESCRIPTION
## The defect

`classify_nonlinear_terms` walks the expression DAG recursively in two places:
`_contains_expandable_square` (one frame per node) and, on the Python fallback,
`distribute_products` -> `_classify_node`. Past ~1000 frames both raise
`RecursionError`.

`RecursionError` is an `Exception`, so the reformulation-adoption guard at
`solver.py:9691` caught it and emitted `logger.debug("... reformulation
skipped: %s")`. The model then continued with **no nonlinear-term catalog at
all** — no partition candidates, no bilinear structure, nothing for the spatial
machinery — and nothing above debug level said so. It failed on exactly the
largest models the pass exists for.

This is the CLAUDE.md §3 "swallowed exception" failure mode: "this path is
broken" was rendered as "this path is fine".

## The fix

Two changes, one per traversal shape:

* **`_contains_expandable_square` becomes an explicit-stack post-order walk.**
  The memo it already had bounds repeated *work* but not *depth*: a left-deep
  `((a + b) + c) + ...` chain as long as the term count still needed one frame
  per term.
* **`classify_nonlinear_terms` runs under size-scaled recursion headroom on a
  large stack**, reusing `_run_with_deep_recursion` — the runner already proven
  for the convexity (#266) and factorable (#271) walks. This is what covers
  `distribute_products`, which rebuilds trees *while preserving node identity*
  for the linearizer's `id()`-keyed `composite_var_map`; converting it to an
  explicit stack would put those maps at risk for no gain the headroom runner
  does not already provide.

The headroom is sized off the **deepest single expression**, not the constraint
count — the hazard is depth concentrated in one body (a 53k-node body under
~280 constraints), which a constraint count misses entirely. This mirrors the
gate `factorable_reform.py` already uses for the same reason.

## Verification — bound-neutral regime (CLAUDE.md §5)

This is a refactor, so the classification must be **exactly unchanged**
everywhere the old code produced an answer at all. Differential of the old
recursive version (extracted with `git show`) against the new one, over the
32-instance MIQP failure set plus 120 corpus instances, in both raw and
integer-bilinear-lifted form, on the 8-field term signature
(`bilinear, trilinear, multilinear, monomial, fractional_power,
bilinear_with_fp, ratio_of_products, general_nl`):

```
identical=146  MISMATCHES=0  rescued_from_RecursionError=35  load_fail=0
EXECUTED_ASSERTIONS=181
```

Zero mismatches. The only differences are the **35 model forms where the old
code raised** — spanning the `graphpart_*`, `unitcommit*`, `autocorr_bern*` and
`acopf_*_qcqp` families, all of which were silently uncatalogued before this.

A measured downstream effect: `graphpart_3g-0444-0444` previously returned **no
incumbent** at a 15 s limit; with the catalog restored it returns
`status=feasible, obj=-6917581.0, gap=0.365, nodes=3`.

## Suites

* `pytest -m smoke` — 1255 passed, 1 skipped, 2 xpassed (identical to baseline).
* `pytest -m slow python/tests/test_adversarial_recent_fixes.py` — 19 passed.
* `cargo test -p discopt-core` — not required, no Rust touched.

## Tests

`python/tests/test_term_classifier_deep_recursion.py` — four tests: the raw walk
still raises at the ambient limit (pinning the failure the fix removes), the
headroom estimate exceeds the current limit (guarding the guard, so the next
assertion cannot pass without engaging the fix), a deep body classifies instead
of raising, and a shallow control still takes the inline path.

The chain length is sized off `sys.getrecursionlimit()` **at call time**: a
fixed 1500-term chain silently stopped reproducing anything under this repo's
pytest config, which raises the limit to 3000 — the §6 "prove the probe fired"
hazard, caught here by the deliberate negative control.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014E81XM1j2J5sydzj9nFFFp
