### PR TITLE
perf(modeling): answer pure-integer index shapes arithmetically (1.32-1.92x construction)

### DIFF
--- a/docs/dev/performance-plan.md
+++ b/docs/dev/performance-plan.md
@@ -5934,3 +5934,105 @@ adjacent to what the gate claims to prove:
 The lesson generalizes falsification 6's: *gate on the mechanism you can count* —
 and make sure the thing you count is the mechanism, not a downstream symptom of
 it. A counter one step off the channel reads as rigor while proving nothing.
+
+## 30. Model construction: the numpy shape probe was the win; `__slots__` was not (2026-09-07)
+
+Entry question: discopt's Python modeling layer builds a 40-form × 5,000 =
+200,000-instance model in ~5 s and ~1.74 M live Python objects. How much of that
+is recoverable *without* the template-IR representation change?
+
+**Attribution first** (20 000 instances of one form, min of 3 reps):
+
+| stage | wall | per instance |
+|---|---|---|
+| model setup (sets + vars) | 0.005 s | — |
+| expression tree only (`x*y`) | 0.254 s | 12.70 µs |
+| + `Constraint` wrapper (`<= 4.0`) | 0.329 s | 16.43 µs |
+| full `m.constraint(...)` | 0.375 s | 18.75 µs |
+
+**89% of construction is inside expression-node creation**, not the indexed-family
+bookkeeping around it (11%). So the target is the node constructors.
+
+### What worked: pure-integer index shapes (shipped)
+
+`Expression.__getitem__` → `IndexExpression.__init__` → `_index_result_shape`
+ran `np.broadcast_to(np.zeros(()), base_shape)` and indexed the resulting view —
+**once per `x[i]`, on every element of every indexed family** — purely to
+re-derive that a scalar index into a 1-D variable has shape `()`. Answering
+pure-integer indexing arithmetically (`k` integer axes consumed leaves
+`base_shape[k:]`) gave, interleaved in one process with a marker assertion:
+
+| model | before | after | |
+|---|---|---|---|
+| 20k-instance bilinear family, 9 reps | 18.49 µs/inst | 9.64 µs/inst | **1.92×** (pooled sd 0.016 s) |
+| 40 forms × 5 000 = 200k rows, 5 reps | 27.92 µs/inst | 21.21 µs/inst | **1.32×** |
+
+Bound-neutral (CLAUDE.md §5): paired LP/MILP/NLP/MINLP solves bit-identical on
+status, objective and `node_count`. `bool` is excluded from the fast path —
+`isinstance(True, int)` holds but numpy treats a scalar bool as a *mask*
+(`zeros((5,))[True].shape == (1, 5)`), so admitting it would return `()` and
+silently mis-shape the node, with no exception.
+
+### What did not work: `__slots__` (implemented, measured, reverted)
+
+**The hypothesis was built on a bad number and is retracted.** `__slots__` was
+scoped on "85% of every node is its instance `__dict__`", from
+`sys.getsizeof(inst.__dict__)` = 280 B against a 48 B object. That figure is
+wrong: CPython uses **key-sharing (split-table) instance dicts**, so the key
+table lives once on the class and `getsizeof` re-counts it for *every* instance.
+`tracemalloc` on a 3-attribute class puts the real cost at **96 B/instance with
+a dict, 64 B with slots — a 1.5× per-object ratio, not 5×.**
+
+Measured on the 200k model, 20 alternating rounds per arm, fresh process each,
+with a marker assertion that each arm loaded the code it claimed:
+
+| | no slots | slots | |
+|---|---|---|---|
+| retained RSS | 203.4 MB (sd 0.00) | 195.6 MB (sd 0.02) | **−3.8%** (7.8 MB) |
+| build wall | 4.078 s (sd 0.192) | 3.947 s (sd 0.275) | +3.2%, Welch t = 1.74, **95% CI [−0.4%, +6.8%]** |
+
+The time interval **crosses zero at n = 20 per arm** — no demonstrable speedup.
+The memory effect is real but small. Against that, `__slots__` imposes a
+permanent invariant on the hierarchy that fails *silently*: a future
+`Expression` subclass that omits it restores `__dict__` for its whole subtree
+with no error and no failing test. Sound but not helpful — the
+`DISCOPT_CUT_INHERIT` disposition — so it was **reverted**, measurement recorded
+here.
+
+One thing the attempt did earn: slot names were derived by running a
+`__setattr__` recorder over the smoke suite rather than by reading `__init__`,
+and that caught `Variable._builder_idx` (assigned from `Model`, never in
+`Variable.__init__`), which an AST pass over the class bodies had missed. If
+this is ever revisited, derive the attribute set empirically again.
+
+### Where the memory actually is (the durable finding)
+
+Retained allocation by site, 40 000-instance model, **944 B per constraint
+instance**:
+
+| B/inst | site | what |
+|---|---|---|
+| **182** | `core.py:841` | `Constant.value = np.asarray(value, dtype=np.float64)` |
+| 160 | `core.py:747` | `IndexExpression(self, idx)` |
+| 126 | `core.py:1286` | `Constant(x)` in `_wrap` |
+| 110 | `core.py:652` | `BinaryOp("-")` from `__le__` normalization |
+| 72 | `core.py:684` | `Constraint(...)` |
+| 49 | `core.py:3652` | `c.name = f"{name}[{key_label(member)}]"` |
+
+**Every scalar literal in a model becomes a numpy 0-d array** where a Python
+float is 24 B — 182 B/instance, 19% of retained memory, roughly 4× everything
+`__slots__` recovered. That is the next memory target, not slots. It is a wider
+change (consumers read `.value` expecting an ndarray) and needs its own scoping.
+The 49 B/instance of constraint *name strings* — debugging metadata materialized
+for all 200 000 rows — is a second, cheaper candidate.
+
+### Ceiling for this approach
+
+Construction cost is otherwise flat and diffuse across `_known_shape` (called 4×
+per `x[i]`), `_integer_index_out_of_range`, and the node constructors — no
+remaining single hotspot. Python-level work of this kind gets ~1.3–1.9× on time
+and a few percent on memory. For reference, `oximo` (Rust, arena-allocated
+expression nodes, same per-instance construction model) builds the identical
+200k-instance model in **0.132 s / 41 MB** against discopt's ~4 s / ~196 MB.
+That remaining gap is representational, not a constant factor, and is what the
+template IR would address.

--- a/python/discopt/modeling/core.py
+++ b/python/discopt/modeling/core.py
@@ -613,34 +613,12 @@ class Expression:
     # ``ValueError: Input operand 1 does not have enough dimensions``.
     __array_ufunc__ = None
 
-    # ``__slots__`` throughout the Expression hierarchy: ~85% of every node was
-    # its instance ``__dict__`` (measured: IndexExpression 48 B object + 272 B
-    # dict, BinaryOp 48 + 280, Constant 48 + 272), and a model holds ~6 nodes per
-    # constraint instance. Slots delete that dict. Every class below therefore
-    # declares ``__slots__``; a single un-slotted class anywhere in the chain
-    # silently restores ``__dict__`` for the whole subtree and gives the memory
-    # straight back, so a new subclass MUST declare one (empty is fine).
-    #
-    # The slot names were derived empirically, not by reading ``__init__``: a
-    # ``__setattr__`` recorder ran over the smoke suite and dumped every
-    # attribute ever set on each class. That is how ``Variable._builder_idx``
-    # (assigned from ``Model``, never in ``Variable.__init__``) got into the list.
-    #
-    # ``_shape`` is a slot rather than the class-level ``_UNSET_SHAPE`` default it
-    # replaces -- Python forbids a slot and a class variable of the same name.
-    # This is behaviour-preserving because every read goes through
-    # ``getattr(node, "_shape", _UNSET_SHAPE)`` (see ``_known_shape``), and
-    # ``getattr``-with-default swallows the ``AttributeError`` an unset slot
-    # raises, yielding the same sentinel the class default used to supply.
-    # ``_scalarize_shape`` (memoized by ``_relax/scalarize``) and
-    # ``Variable._builder_idx`` are read the same guarded way -- via
-    # ``getattr(..., default)`` and ``hasattr`` respectively -- so an unset slot
-    # is likewise indistinguishable from the previous "attribute absent" state.
-    #
-    # ``__weakref__`` is kept on the base: nothing in-tree weakrefs an
-    # Expression today, but these are public API objects and 8 bytes against
-    # ~276 saved is cheap insurance.
-    __slots__ = ("_shape", "_scalarize_shape", "__weakref__")
+    # Cached static shape for composite nodes (populated at construction by
+    # ``BinaryOp``/``UnaryOp`` where inferable; see M8). Class default of the
+    # ``_UNSET_SHAPE`` sentinel means "not computed" so a cached ``None``
+    # ("computed, unknown") is distinguishable. Leaf nodes (Variable/Constant/
+    # Parameter) carry their own ``.shape`` and are handled in ``_known_shape``.
+    _shape: Any = _UNSET_SHAPE
 
     def __add__(self, other):
         return BinaryOp("+", self, _wrap(other))
@@ -832,8 +810,6 @@ class Expression:
 class Constant(Expression):
     """A numeric constant in the expression DAG."""
 
-    __slots__ = ("value",)
-
     def __init__(self, value: Union[float, int, np.ndarray]):
         if isinstance(value, np.ndarray):
             self.value = value.astype(np.float64)
@@ -866,17 +842,6 @@ class Variable(Expression):
     ub : numpy.ndarray
         Element-wise upper bounds.
     """
-
-    __slots__ = (
-        "_index",
-        "_size",
-        "_builder_idx",
-        "lb",
-        "model",
-        "name",
-        "ub",
-        "var_type",
-    )
 
     # __array_ufunc__ = None is inherited from Expression.
 
@@ -1007,11 +972,6 @@ def _integer_index_out_of_range(base_shape: tuple[int, ...], idx):
 class IndexExpression(Expression):
     """Result of indexing into an array variable: x[i] or x[0, 1]."""
 
-    __slots__ = (
-        "base",
-        "index",
-    )
-
     def __init__(self, base: Expression, index):
         self.base = base
         self.index = index
@@ -1095,12 +1055,6 @@ def _broadcast_shapes(
 class BinaryOp(Expression):
     """Binary operation: a op b."""
 
-    __slots__ = (
-        "left",
-        "op",
-        "right",
-    )
-
     def __init__(self, op: str, left: Expression, right: Expression):
         self.op = op
         self.left = left
@@ -1122,11 +1076,6 @@ class BinaryOp(Expression):
 
 class UnaryOp(Expression):
     """Unary operation: op(a)."""
-
-    __slots__ = (
-        "op",
-        "operand",
-    )
 
     def __init__(self, op: str, operand: Expression):
         self.op = op
@@ -1178,11 +1127,6 @@ _ELEMENTWISE_FUNCS: frozenset = frozenset(
 
 class FunctionCall(Expression):
     """Named function call: exp(x), log(x), sin(x), etc."""
-
-    __slots__ = (
-        "args",
-        "func_name",
-    )
 
     def __init__(self, func_name: str, *args: Expression):
         self.func_name = func_name
@@ -1249,12 +1193,6 @@ class CustomCall(Expression):
     Built via :func:`custom`; do not instantiate directly in user code.
     """
 
-    __slots__ = (
-        "args",
-        "fn",
-        "name",
-    )
-
     def __init__(self, fn: Callable, *args: Expression, name: Optional[str] = None):
         self.fn = fn
         self.args = tuple(args)
@@ -1268,11 +1206,6 @@ class CustomCall(Expression):
 class MatMulExpression(Expression):
     """Matrix multiplication: A @ x."""
 
-    __slots__ = (
-        "left",
-        "right",
-    )
-
     def __init__(self, left: Expression, right: Expression):
         self.left = left
         self.right = right
@@ -1283,11 +1216,6 @@ class MatMulExpression(Expression):
 
 class SumExpression(Expression):
     """Summation over expressions."""
-
-    __slots__ = (
-        "axis",
-        "operand",
-    )
 
     def __init__(self, operand: Expression, axis: Optional[int] = None):
         self.operand = operand
@@ -1301,8 +1229,6 @@ class SumExpression(Expression):
 
 class SumOverExpression(Expression):
     """Sum of expr(i) for i in index_set — the indexed summation pattern."""
-
-    __slots__ = ("terms",)
 
     def __init__(self, terms: list[Expression]):
         self.terms = terms
@@ -2265,12 +2191,6 @@ class Parameter(Expression):
     >>> m.minimize(price * x[0] + cost * x[1])
     >>> result = m.solve()
     """
-
-    __slots__ = (
-        "model",
-        "name",
-        "value",
-    )
 
     def __init__(self, name: str, value: Union[float, np.ndarray], model: "Model"):
         self.name = name

--- a/python/discopt/modeling/core.py
+++ b/python/discopt/modeling/core.py
@@ -880,6 +880,29 @@ class Variable(Expression):
         return f"{self.name}{list(self.shape)}"
 
 
+def _pure_integer_index(index) -> Optional[tuple[int, ...]]:
+    """*index* as a tuple of plain ints when it is pure-integer indexing, else ``None``.
+
+    ``bool`` is deliberately excluded even though ``isinstance(True, int)`` holds:
+    numpy treats a scalar boolean as a *mask*, not an index, and adds an axis
+    (``zeros((5,))[True].shape == (1, 5)``). Letting a bool through here would
+    hand back ``()`` and silently mis-shape the node. ``np.bool_`` is not an
+    ``np.integer`` subclass, so it falls out on its own.
+    """
+    if isinstance(index, bool):
+        return None
+    if isinstance(index, (int, np.integer)):
+        return (int(index),)
+    if isinstance(index, tuple):
+        out = []
+        for i in index:
+            if isinstance(i, bool) or not isinstance(i, (int, np.integer)):
+                return None
+            out.append(int(i))
+        return tuple(out)
+    return None
+
+
 def _index_result_shape(base_shape: tuple[int, ...], index) -> Optional[tuple[int, ...]]:
     """Numpy result shape of ``base_shape[index]``, or ``None`` when static
     inference is not possible (issue #816).
@@ -892,7 +915,26 @@ def _index_result_shape(base_shape: tuple[int, ...], index) -> Optional[tuple[in
     index object) yields ``None`` = "unknown". The out-of-bounds *guard* that
     surfaces user typos lives in :meth:`Expression.__getitem__`, so that internal
     lazy ``IndexExpression`` construction stays conservative.
+
+    Pure-integer indexing -- a plain int, or an all-int tuple of arity <= ndim,
+    which is what ``x[i]`` produces on every element of every indexed family --
+    is answered arithmetically instead: consuming ``k`` integer axes leaves
+    ``base_shape[k:]``. That is the construction hot path: the numpy probe below
+    ran once per ``x[i]`` purely to re-derive ``()``. Interleaved A/B in one
+    process, 9 reps, 20k-instance bilinear family: 18.49 -> 9.64 us/instance
+    (1.92x, pooled sd 0.016 s); on a 40-form x 5,000 = 200k-instance model,
+    27.92 -> 21.21 us/instance (1.32x, 5 reps). Bound-neutral per CLAUDE.md §5 --
+    paired LP/MILP/NLP/MINLP solves are bit-identical on status, objective and
+    node_count. The fast path reproduces the probe's contract exactly, including
+    returning ``None`` for an out-of-range axis (where numpy raises) rather than
+    guessing a shape; ``test_index_shape_fast_path.py`` is the equivalence grid.
     """
+    ints = _pure_integer_index(index)
+    if ints is not None and len(ints) <= len(base_shape):
+        for i, n in zip(ints, base_shape):
+            if i < -n or i >= n:
+                return None  # numpy would raise IndexError -> "unknown"
+        return tuple(base_shape[len(ints) :])
     try:
         probe = np.broadcast_to(np.zeros((), dtype=np.int8), base_shape)
         return tuple(int(d) for d in np.shape(probe[index]))

--- a/python/discopt/modeling/core.py
+++ b/python/discopt/modeling/core.py
@@ -613,12 +613,34 @@ class Expression:
     # ``ValueError: Input operand 1 does not have enough dimensions``.
     __array_ufunc__ = None
 
-    # Cached static shape for composite nodes (populated at construction by
-    # ``BinaryOp``/``UnaryOp`` where inferable; see M8). Class default of the
-    # ``_UNSET_SHAPE`` sentinel means "not computed" so a cached ``None``
-    # ("computed, unknown") is distinguishable. Leaf nodes (Variable/Constant/
-    # Parameter) carry their own ``.shape`` and are handled in ``_known_shape``.
-    _shape: Any = _UNSET_SHAPE
+    # ``__slots__`` throughout the Expression hierarchy: ~85% of every node was
+    # its instance ``__dict__`` (measured: IndexExpression 48 B object + 272 B
+    # dict, BinaryOp 48 + 280, Constant 48 + 272), and a model holds ~6 nodes per
+    # constraint instance. Slots delete that dict. Every class below therefore
+    # declares ``__slots__``; a single un-slotted class anywhere in the chain
+    # silently restores ``__dict__`` for the whole subtree and gives the memory
+    # straight back, so a new subclass MUST declare one (empty is fine).
+    #
+    # The slot names were derived empirically, not by reading ``__init__``: a
+    # ``__setattr__`` recorder ran over the smoke suite and dumped every
+    # attribute ever set on each class. That is how ``Variable._builder_idx``
+    # (assigned from ``Model``, never in ``Variable.__init__``) got into the list.
+    #
+    # ``_shape`` is a slot rather than the class-level ``_UNSET_SHAPE`` default it
+    # replaces -- Python forbids a slot and a class variable of the same name.
+    # This is behaviour-preserving because every read goes through
+    # ``getattr(node, "_shape", _UNSET_SHAPE)`` (see ``_known_shape``), and
+    # ``getattr``-with-default swallows the ``AttributeError`` an unset slot
+    # raises, yielding the same sentinel the class default used to supply.
+    # ``_scalarize_shape`` (memoized by ``_relax/scalarize``) and
+    # ``Variable._builder_idx`` are read the same guarded way -- via
+    # ``getattr(..., default)`` and ``hasattr`` respectively -- so an unset slot
+    # is likewise indistinguishable from the previous "attribute absent" state.
+    #
+    # ``__weakref__`` is kept on the base: nothing in-tree weakrefs an
+    # Expression today, but these are public API objects and 8 bytes against
+    # ~276 saved is cheap insurance.
+    __slots__ = ("_shape", "_scalarize_shape", "__weakref__")
 
     def __add__(self, other):
         return BinaryOp("+", self, _wrap(other))
@@ -810,6 +832,8 @@ class Expression:
 class Constant(Expression):
     """A numeric constant in the expression DAG."""
 
+    __slots__ = ("value",)
+
     def __init__(self, value: Union[float, int, np.ndarray]):
         if isinstance(value, np.ndarray):
             self.value = value.astype(np.float64)
@@ -842,6 +866,17 @@ class Variable(Expression):
     ub : numpy.ndarray
         Element-wise upper bounds.
     """
+
+    __slots__ = (
+        "_index",
+        "_size",
+        "_builder_idx",
+        "lb",
+        "model",
+        "name",
+        "ub",
+        "var_type",
+    )
 
     # __array_ufunc__ = None is inherited from Expression.
 
@@ -972,6 +1007,11 @@ def _integer_index_out_of_range(base_shape: tuple[int, ...], idx):
 class IndexExpression(Expression):
     """Result of indexing into an array variable: x[i] or x[0, 1]."""
 
+    __slots__ = (
+        "base",
+        "index",
+    )
+
     def __init__(self, base: Expression, index):
         self.base = base
         self.index = index
@@ -1055,6 +1095,12 @@ def _broadcast_shapes(
 class BinaryOp(Expression):
     """Binary operation: a op b."""
 
+    __slots__ = (
+        "left",
+        "op",
+        "right",
+    )
+
     def __init__(self, op: str, left: Expression, right: Expression):
         self.op = op
         self.left = left
@@ -1076,6 +1122,11 @@ class BinaryOp(Expression):
 
 class UnaryOp(Expression):
     """Unary operation: op(a)."""
+
+    __slots__ = (
+        "op",
+        "operand",
+    )
 
     def __init__(self, op: str, operand: Expression):
         self.op = op
@@ -1127,6 +1178,11 @@ _ELEMENTWISE_FUNCS: frozenset = frozenset(
 
 class FunctionCall(Expression):
     """Named function call: exp(x), log(x), sin(x), etc."""
+
+    __slots__ = (
+        "args",
+        "func_name",
+    )
 
     def __init__(self, func_name: str, *args: Expression):
         self.func_name = func_name
@@ -1193,6 +1249,12 @@ class CustomCall(Expression):
     Built via :func:`custom`; do not instantiate directly in user code.
     """
 
+    __slots__ = (
+        "args",
+        "fn",
+        "name",
+    )
+
     def __init__(self, fn: Callable, *args: Expression, name: Optional[str] = None):
         self.fn = fn
         self.args = tuple(args)
@@ -1206,6 +1268,11 @@ class CustomCall(Expression):
 class MatMulExpression(Expression):
     """Matrix multiplication: A @ x."""
 
+    __slots__ = (
+        "left",
+        "right",
+    )
+
     def __init__(self, left: Expression, right: Expression):
         self.left = left
         self.right = right
@@ -1216,6 +1283,11 @@ class MatMulExpression(Expression):
 
 class SumExpression(Expression):
     """Summation over expressions."""
+
+    __slots__ = (
+        "axis",
+        "operand",
+    )
 
     def __init__(self, operand: Expression, axis: Optional[int] = None):
         self.operand = operand
@@ -1229,6 +1301,8 @@ class SumExpression(Expression):
 
 class SumOverExpression(Expression):
     """Sum of expr(i) for i in index_set — the indexed summation pattern."""
+
+    __slots__ = ("terms",)
 
     def __init__(self, terms: list[Expression]):
         self.terms = terms
@@ -2191,6 +2265,12 @@ class Parameter(Expression):
     >>> m.minimize(price * x[0] + cost * x[1])
     >>> result = m.solve()
     """
+
+    __slots__ = (
+        "model",
+        "name",
+        "value",
+    )
 
     def __init__(self, name: str, value: Union[float, np.ndarray], model: "Model"):
         self.name = name

--- a/python/tests/test_index_shape_fast_path.py
+++ b/python/tests/test_index_shape_fast_path.py
@@ -1,0 +1,90 @@
+"""Differential test for the pure-integer fast path in ``_index_result_shape``.
+
+The fast path replaces a ``np.broadcast_to`` probe on the construction hot path
+(``x[i]`` on every element of every indexed family). It is a pure constant-factor
+change, so the gate is *exact* agreement with the numpy oracle it replaces --
+including the "unknown" (``None``) answer for indices numpy rejects.
+
+Per CLAUDE.md §6 the equivalence test counts its executed comparisons and fails
+if the grid ever degrades to zero, so a refactor that stops exercising the fast
+path cannot pass silently.
+"""
+
+import itertools
+
+import numpy as np
+import pytest
+from discopt.modeling.core import _index_result_shape, _pure_integer_index
+
+
+def _numpy_oracle(base_shape, index):
+    """The original implementation, verbatim -- the behavior being preserved."""
+    try:
+        probe = np.broadcast_to(np.zeros((), dtype=np.int8), base_shape)
+        return tuple(int(d) for d in np.shape(probe[index]))
+    except Exception:
+        return None
+
+
+SHAPES = [(1,), (5,), (4, 3), (2, 3, 4), (3, 1, 2)]
+
+
+def _index_grid(ndim):
+    """Indices spanning the fast path, its boundaries, and the fallback."""
+    scalars = [0, 1, 2, -1, -3, 4, 5, 99, -99, np.int64(1), np.int32(-1), np.uint8(2)]
+    # bools must route to the numpy mask semantics, never the integer fast path
+    masks = [True, False, np.bool_(True)]
+    exotic = [slice(None), slice(0, 2), Ellipsis, None, np.array([0, 1]), "nope", 1.5]
+    out = list(scalars) + masks + exotic
+    for k in range(1, ndim + 2):  # includes an over-long tuple (arity > ndim)
+        for combo in itertools.product([0, 1, -1, 7], repeat=k):
+            out.append(combo)
+    out.append((0, slice(None)))
+    out.append((True, 0))
+    out.append((0, 1.5))
+    return out
+
+
+def test_fast_path_matches_numpy_oracle_exactly():
+    compared = 0
+    mismatches = []
+    for base_shape in SHAPES:
+        for index in _index_grid(len(base_shape)):
+            got = _index_result_shape(base_shape, index)
+            want = _numpy_oracle(base_shape, index)
+            compared += 1
+            if got != want:
+                mismatches.append((base_shape, index, got, want))
+    assert not mismatches, f"fast path diverged from numpy on: {mismatches[:10]}"
+    # §6: prove the probe fired, and fired on a grid worth trusting.
+    assert compared > 500, f"equivalence grid degraded to {compared} comparisons"
+
+
+def test_fast_path_actually_engages_on_the_hot_case():
+    """The whole point: `x[i]` on a 1-D base must not touch numpy."""
+    assert _pure_integer_index(3) == (3,)
+    assert _pure_integer_index((1, 2)) == (1, 2)
+    assert _index_result_shape((5,), 3) == ()
+    assert _index_result_shape((4, 3), (1, 2)) == ()
+    assert _index_result_shape((4, 3), 1) == (3,)
+    assert _index_result_shape((2, 3, 4), (1,)) == (3, 4)
+
+
+@pytest.mark.parametrize("flag", [True, False, np.bool_(True), np.bool_(False)])
+def test_bool_is_a_mask_not_an_index(flag):
+    """`isinstance(True, int)` is True; numpy still treats it as a mask."""
+    assert _pure_integer_index(flag) is None
+    assert _index_result_shape((5,), flag) == _numpy_oracle((5,), flag)
+
+
+def test_out_of_range_reports_unknown_not_a_guessed_shape():
+    """Where numpy raises, both paths must answer "unknown" (None)."""
+    for shape, idx in [((5,), 5), ((5,), -6), ((4, 3), (0, 3)), ((4, 3), (4, 0))]:
+        assert _index_result_shape(shape, idx) is None
+        assert _numpy_oracle(shape, idx) is None
+
+
+def test_overlong_integer_tuple_falls_back():
+    """Arity > ndim is numpy's error, not a shape the fast path may invent."""
+    assert _index_result_shape((5,), (0, 0)) is None
+    assert _numpy_oracle((5,), (0, 0)) is None


### PR DESCRIPTION
## Summary

Model construction in the Python modeling layer ran a numpy shape probe once per
`x[i]` — on every element of every indexed family — purely to re-derive that a
scalar index into a 1-D variable has shape `()`:

```python
probe = np.broadcast_to(np.zeros((), dtype=np.int8), base_shape)
return tuple(int(d) for d in np.shape(probe[index]))
```

`_index_result_shape` now answers pure-integer indexing arithmetically —
consuming `k` integer axes leaves `base_shape[k:]` — and falls through to the
existing numpy probe for everything else (slices, ellipsis, newaxis, boolean
masks, arrays, symbolic/exotic index objects).

`bool` is excluded from the fast path even though `isinstance(True, int)` holds:
numpy treats a scalar boolean as a *mask*, not an index
(`zeros((5,))[True].shape == (1, 5)`), so admitting it would return `()` and
silently mis-shape the node with no exception. `np.bool_` is not an `np.integer`
subclass and falls out on its own.

Also adds `docs/dev/performance-plan.md` §30, recording the investigation in the
§6 house style: the attribution that located the cost, this win, and one
falsified hypothesis (below).

No linked issue — this came out of a construction-cost review.

### Why the cost was here

Attribution over 20 000 instances of one form (min of 3 reps):

| stage | wall | per instance |
|---|---|---|
| model setup (sets + vars) | 0.005 s | — |
| expression tree only (`x*y`) | 0.254 s | 12.70 µs |
| + `Constraint` wrapper (`<= 4.0`) | 0.329 s | 16.43 µs |
| full `m.constraint(...)` | 0.375 s | 18.75 µs |

89% of construction is inside expression-node creation; the indexed-family
bookkeeping around it is 11%.

### A hypothesis this branch falsified and reverted

`__slots__` across the `Expression` hierarchy (62ebd70) was implemented, passed
every gate, and was **reverted** in 1957bb5. It was scoped on a bad number of
mine — "85% of every node is its `__dict__`", from
`sys.getsizeof(inst.__dict__)` = 280 B. That figure is wrong: CPython uses
key-sharing (split-table) instance dicts, so `getsizeof` re-counts the shared key
table per instance. `tracemalloc` puts the real cost at 96 B → 64 B, a **1.5×
per-object ratio, not 5×**.

Measured on a 40-form × 5 000 = 200 000-instance model, 20 alternating rounds per
arm, fresh process each, with a marker assertion that each arm loaded the code it
claimed:

| | no slots | slots | |
|---|---|---|---|
| retained RSS | 203.4 MB (sd 0.00) | 195.6 MB (sd 0.02) | −3.8% |
| build wall | 4.078 s (sd 0.192) | 3.947 s (sd 0.275) | +3.2%, Welch t = 1.74, **95% CI [−0.4%, +6.8%]** |

The timing interval crosses zero — no demonstrable speedup — and `__slots__` buys
its 3.8% with an invariant that fails *silently*: a future `Expression` subclass
that omits it restores `__dict__` for its whole subtree with no error and no
failing test. Sound but not helpful, the `DISCOPT_CUT_INHERIT` disposition, so it
does not ship and the measurement is recorded instead. The net diff of this PR
contains no `__slots__`.

The attempt did earn one thing: slot names were derived by running a
`__setattr__` recorder over the smoke suite rather than by reading `__init__`,
which caught `Variable._builder_idx` (assigned from `Model`, never in
`Variable.__init__`) that an AST pass over the class bodies had missed.

### The durable finding

Retained allocation by site on a 40 000-instance model, **944 B per constraint
instance**:

| B/inst | site | what |
|---|---|---|
| **182** | `core.py:841` | `Constant.value = np.asarray(value, dtype=np.float64)` |
| 160 | `core.py:747` | `IndexExpression(self, idx)` |
| 126 | `core.py:1286` | `Constant(x)` in `_wrap` |
| 110 | `core.py:652` | `BinaryOp("-")` from `__le__` normalization |
| 72 | `core.py:684` | `Constraint(...)` |
| 49 | `core.py:3652` | `c.name = f"{name}[{key_label(member)}]"` |

Every scalar literal in a model becomes a numpy 0-d array where a Python float is
24 B — 19% of retained memory, ~4× everything `__slots__` recovered. That is the
next memory target; it is wider than it looks (consumers read `.value` expecting
an ndarray) and is **not** attempted here.

## Correctness

Pure refactor of a *best-effort shape query* that never raises. The fast path
reproduces the numpy probe's contract exactly, including returning `None`
("unknown") where numpy would raise `IndexError` — an out-of-range axis or an
integer tuple of arity > ndim — rather than inventing a shape. No solver math,
bound, cut, or relaxation is touched.

- [x] Cannot produce a false certificate (no solver-math change)
- [x] No validation, fallback, or safety guard was weakened to make a check pass

Bound-neutrality verified directly (CLAUDE.md §5, bound-neutral regime): paired
LP/MILP/NLP/MINLP solves with the fast path live vs monkeypatched back to the
numpy oracle, in one process, **bit-identical** on status, objective and
`node_count`:

```
case     status     objective              nodes
LP       optimal    56.999999955               0   IDENTICAL
MILP     optimal    91.5                       1   IDENTICAL
NLP      optimal    1.79628908561e-07          3   IDENTICAL
MINLP    optimal    1.2871872058             595   IDENTICAL
```

## Tests run (state the result — numbers, not adjectives)

- [x] `pytest -m smoke` → **1209 passed, 21 skipped, 2 xpassed** (9518 deselected)
- [x] `pytest -m slow python/tests/test_adversarial_recent_fixes.py` → **19 passed**
- [x] `cargo test -p discopt-core` → N/A, no Rust touched
- [x] `ruff check` / `ruff format --check` clean

Also: 90 existing indexing/shape/customcall tests pass, and the 8 new ones below.

## Regression test

`python/tests/test_index_shape_fast_path.py` — a **differential grid** asserting
the fast path agrees exactly with the numpy oracle it replaces, across 5 shapes ×
~100 indices: integers, negatives, out-of-range, `np.int64`/`int32`/`uint8`,
`bool` and `np.bool_`, slices, ellipsis, `None`, arrays, strings, floats, and
integer tuples up to arity > ndim. Per CLAUDE.md §6 it counts its executed
comparisons and fails if the grid degrades to zero, so a refactor that stops
exercising the fast path cannot pass silently.

This is a bound-neutral refactor, so the honest gate is exact equivalence to the
prior implementation plus the bound-neutrality run above — **not**
fail-before/pass-after, which for an equivalence test would only ever fail on the
import of the new helper. Flagging that rather than ticking the box as written.

- [x] Added a regression test — differential equivalence + bound-neutrality (see note)

## Bound-changing / performance change?

Performance only; not bound-changing, so no flag and no graduation panel.

Interleaved A/B in one process, marker assertion that the fast path is loaded:

| model | before | after | |
|---|---|---|---|
| 20k-instance bilinear family, 9 reps | 18.49 µs/inst | 9.64 µs/inst | **1.92×** (pooled sd 0.016 s) |
| 40 forms × 5 000 = 200k rows, 5 reps | 27.92 µs/inst | 21.21 µs/inst | **1.32×** |

The 40-form model gains less because `exp`, `**2` and `log` add nodes that do not
go through indexing. No effect on POUNCE tape build, as the mechanism predicts —
8 000 rows, 8 interleaved reps with a discarded warm-up: 0.309 s ± 0.006 vs
0.312 s ± 0.008, a difference of 0.48 pooled sd.

- Measurement: see the two tables above; method is interleaved same-process A/B
  with a `__file__` + marker assertion, on a quiet machine, reporting spreads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WqjFgW9GYpUQafJiaMsYrs

---
_Generated by [Claude Code](https://claude.ai/code/session_01WqjFgW9GYpUQafJiaMsYrs)_