### PR TITLE
perf(classifier): read quadratic/linear coefficients off the DAG, not by probing

### DIFF
--- a/crates/discopt-core/src/expr.rs
+++ b/crates/discopt-core/src/expr.rs
@@ -915,6 +915,375 @@ impl ExprArena {
         }
     }
 
+    // ── Symbolic quadratic-form extraction ────────────────────────────────
+    //
+    // `is_quadratic` above walks the entire DAG to decide a *degree*, then
+    // throws away everything it learned and returns a bool. The Python QP
+    // extractor, left with only that bool, recovered the coefficients by
+    // finite-difference PROBING -- one full model evaluation per variable
+    // *pair*, O(|support|^2) (`_relax/problem_classifier.py`,
+    // `_extract_qp_data_from_repr`). Measured over the 150-instance MINLPLib
+    // MIQP family (BQP/IQP/MBQP/MIQP): 29 instances need more than 60 s of
+    // probing before the search can start, 71,330 s in total, worst case
+    // `unitcommit_200_100_1_mod_8` at 28,288 s. That instance's objective DAG
+    // has 56,299 nodes and 330,262,150 variable pairs -- the structure is
+    // ~5,900x smaller than the space the probe searches.
+    //
+    // Worse, the probe is not merely slow. Its off-diagonal identity
+    // `f(e_i + e_j) - f(e_i) - f(e_j) + f(0)` is a difference of nearly-equal
+    // floats, so it loses precision to cancellation: on `chimera_mis-01` the
+    // sweep costs 275 s and then fails its own #866 verification (recovers
+    // -171.42 against a true -174.09), and all 275 s is discarded.
+    //
+    // This walk emits the coefficients the degree walk already sees. Every
+    // output coefficient is a sum of products of literals that appear in the
+    // DAG, so there is no subtractive cancellation and no step size. It is
+    // O(nodes), it is iterative (a `.nl` objective is a left-nested chain --
+    // 18,499 `+` nodes deep on `unitcommit_200_100_1_mod_8` -- which would
+    // blow a recursive walk's stack), and it either succeeds exactly or
+    // DECLINES. It never approximates: any form it cannot represent returns
+    // `None` and the caller falls back to the existing ladder.
+    //
+    // The output is the same sparse COO triplet that `set_quadratic_objective`
+    // (crates/discopt-python/src/expr_bindings.rs) already accepts in the
+    // other direction; this is that function's missing inverse.
+
+    /// Build the flat-offset map for every variable in the arena, in one pass.
+    ///
+    /// Reproduces [`Self::var_offset`] exactly (distinct `index`, sorted,
+    /// prefix-summed `size`), but computes it once instead of re-scanning
+    /// every node per variable occurrence -- which would itself be quadratic
+    /// on a model with many variables.
+    fn var_offset_map(&self) -> std::collections::HashMap<usize, usize> {
+        let mut vars: Vec<(usize, usize)> = Vec::new();
+        let mut seen = std::collections::HashSet::new();
+        for node in &self.nodes {
+            if let ExprNode::Variable { index, size, .. } = node {
+                if seen.insert(*index) {
+                    vars.push((*index, *size));
+                }
+            }
+        }
+        vars.sort_by_key(|(idx, _)| *idx);
+        let mut map = std::collections::HashMap::with_capacity(vars.len());
+        let mut off = 0usize;
+        for (idx, sz) in vars {
+            map.insert(idx, off);
+            off += sz;
+        }
+        map
+    }
+
+    /// The direct children of a node, in no particular order.
+    fn quad_children(&self, id: ExprId) -> Vec<ExprId> {
+        match self.get(id) {
+            ExprNode::BinaryOp { left, right, .. } | ExprNode::MatMul { left, right } => {
+                vec![*left, *right]
+            }
+            ExprNode::UnaryOp { operand, .. } | ExprNode::Sum { operand, .. } => vec![*operand],
+            ExprNode::FunctionCall { args, .. } => args.clone(),
+            ExprNode::SumOver { terms } => terms.clone(),
+            // `Index` deliberately does NOT descend: the base is consumed
+            // structurally below (only a Variable / ConstantArray / Parameter
+            // base is representable), never as a polynomial value.
+            _ => Vec::new(),
+        }
+    }
+
+    /// Extract the objective/constraint body `id` as an exact sparse quadratic
+    /// form over the arena's flat variable space.
+    ///
+    /// Returns `None` -- decline, never an approximation -- when the
+    /// expression is not a quadratic form, when it uses a construct this walk
+    /// does not represent, or when the accumulated coefficient count would
+    /// exceed `max_terms` *live* coefficients (a dense `Q` on a large model
+    /// is exactly the
+    /// materialization this is meant to avoid; the caller keeps its fallback).
+    ///
+    /// The semantics mirror [`Self::evaluate`] / [`Self::collect_array_values`]
+    /// node for node, including the `Sum { axis: Some(_) }` refusal (#1160) and
+    /// the `abs`-of-a-variable refusal (#739). A caller that wants belt and
+    /// braces can evaluate the returned form against `evaluate` at a random
+    /// point; they agree to machine precision by construction.
+    pub fn quadratic_form(&self, id: ExprId, max_terms: usize) -> Option<QuadForm> {
+        let offsets = self.var_offset_map();
+        let mut memo: std::collections::HashMap<ExprId, Option<std::rc::Rc<Vec<QuadForm>>>> =
+            std::collections::HashMap::new();
+
+        // In-degree over the reachable sub-DAG, counting multiplicity (`x * x`
+        // consumes `x` twice). A memo entry is dropped the moment its last
+        // parent has consumed it, which is what keeps peak memory proportional
+        // to the *live* frontier rather than to the whole DAG: a left-nested
+        // `+` chain accumulating a dense form would otherwise memoize every
+        // prefix, at O(terms^2).
+        let mut indeg: std::collections::HashMap<ExprId, usize> = std::collections::HashMap::new();
+        let mut seen = std::collections::HashSet::new();
+        seen.insert(id);
+        let mut walk = vec![id];
+        while let Some(cur) = walk.pop() {
+            for c in self.quad_children(cur) {
+                *indeg.entry(c).or_insert(0) += 1;
+                if seen.insert(c) {
+                    walk.push(c);
+                }
+            }
+        }
+
+        let mut live = 0usize;
+
+        // Iterative post-order: push (node, children_done). A `.nl` objective
+        // is a deeply left-nested chain, so this must not recurse.
+        let mut stack: Vec<(ExprId, bool)> = vec![(id, false)];
+        while let Some((cur, done)) = stack.pop() {
+            if memo.contains_key(&cur) {
+                continue;
+            }
+            if !done {
+                stack.push((cur, true));
+                // Push children in REVERSE so they pop left-to-right. A `.nl`
+                // objective is a left-nested `+` chain, and popping the right
+                // operand first would compute and hold every term on the way
+                // down -- peak live memory O(chain length) instead of O(1).
+                for c in self.quad_children(cur).into_iter().rev() {
+                    if !memo.contains_key(&c) {
+                        stack.push((c, false));
+                    }
+                }
+            } else {
+                let v = self.quad_combine(cur, &offsets, &memo);
+                if let Some(rc) = v.as_ref() {
+                    live += rc.iter().map(|q| q.n_terms()).sum::<usize>();
+                    // Declining here keeps a would-be dense `Q` from ever being
+                    // materialized; the caller keeps its fallback.
+                    if live > max_terms {
+                        return None;
+                    }
+                }
+                memo.insert(cur, v);
+
+                // Release every child whose last parent was this node. The
+                // entry is tombstoned rather than removed so the
+                // `contains_key` guards above stay valid; a stale read would
+                // see `None` and decline, never a wrong answer.
+                for c in self.quad_children(cur) {
+                    if c == id {
+                        continue;
+                    }
+                    if let Some(rem) = indeg.get_mut(&c) {
+                        *rem -= 1;
+                        if *rem == 0 {
+                            if let Some(Some(rc)) = memo.get(&c) {
+                                live -= rc.iter().map(|q| q.n_terms()).sum::<usize>();
+                            }
+                            memo.insert(c, None);
+                        }
+                    }
+                }
+            }
+        }
+
+        let vals = memo.get(&id)?.clone()?;
+        if vals.len() != 1 {
+            // An array-valued objective is not a scalar quadratic form.
+            return None;
+        }
+        let mut out = vals[0].clone();
+        // Drop exact zeros once, at the end. Pruning inside the accumulation
+        // loop would re-scan the whole accumulator per term and reintroduce
+        // the quadratic behaviour this function exists to remove.
+        out.linear.retain(|_, v| *v != 0.0);
+        out.quadratic.retain(|_, v| *v != 0.0);
+
+        // Refuse a non-finite coefficient rather than emit one. `scaled(0.0)`
+        // collapses `0 * x` to the constant 0, which differs from `evaluate`'s
+        // `0 * inf = NaN`; division by an infinite constant is the reachable
+        // route to that divergence. Checking the output once (O(nnz)) is
+        // cheaper and more general than case-analysing every operator, and a
+        // decline costs only the caller's fallback -- never a wrong model.
+        if !out.is_finite() {
+            return None;
+        }
+        Some(out)
+    }
+
+    /// Combine a node's already-computed children into its polynomial value.
+    fn quad_combine(
+        &self,
+        id: ExprId,
+        offsets: &std::collections::HashMap<usize, usize>,
+        memo: &std::collections::HashMap<ExprId, Option<std::rc::Rc<Vec<QuadForm>>>>,
+    ) -> Option<std::rc::Rc<Vec<QuadForm>>> {
+        let child = |c: &ExprId| -> Option<std::rc::Rc<Vec<QuadForm>>> { memo.get(c)?.clone() };
+
+        let vals: Vec<QuadForm> = match self.get(id) {
+            ExprNode::Constant(v) => vec![QuadForm::constant(*v)],
+            ExprNode::ConstantArray(data, _) => {
+                data.iter().map(|v| QuadForm::constant(*v)).collect()
+            }
+            ExprNode::Parameter { value, .. } => {
+                value.iter().map(|v| QuadForm::constant(*v)).collect()
+            }
+            ExprNode::Variable { index, size, .. } => {
+                let off = *offsets.get(index)?;
+                (0..*size).map(|k| QuadForm::variable(off + k)).collect()
+            }
+            ExprNode::BinaryOp { op, left, right } => {
+                let l = child(left)?;
+                let r = child(right)?;
+                match op {
+                    BinOp::Add => broadcast(&l, &r, |a, b| {
+                        let mut o = a.clone();
+                        o.add_assign_scaled(b, 1.0);
+                        Some(o)
+                    })?,
+                    BinOp::Sub => broadcast(&l, &r, |a, b| {
+                        let mut o = a.clone();
+                        o.add_assign_scaled(b, -1.0);
+                        Some(o)
+                    })?,
+                    BinOp::Mul => broadcast(&l, &r, |a, b| a.mul(b))?,
+                    BinOp::Div => broadcast(&l, &r, |a, b| {
+                        // A variable in the denominator is not polynomial;
+                        // a zero denominator is not representable either.
+                        //
+                        // A non-finite denominator is refused for a subtler
+                        // reason: `1.0 / inf` is `0.0`, and scaling by zero
+                        // would report `x / inf` as the exact constant 0 while
+                        // `evaluate` yields 0 only for finite `x` and NaN for
+                        // `inf / inf`. Declining costs the caller its probe
+                        // fallback; collapsing would hand back a coefficient
+                        // the walk cannot stand behind.
+                        if b.degree() != 0 || !b.constant.is_finite() || b.constant == 0.0 {
+                            None
+                        } else {
+                            Some(a.scaled(1.0 / b.constant))
+                        }
+                    })?,
+                    BinOp::Pow => broadcast(&l, &r, |a, e| {
+                        if e.degree() != 0 {
+                            return None; // variable exponent
+                        }
+                        let p = e.constant;
+                        if a.degree() == 0 {
+                            return Some(QuadForm::constant(a.constant.powf(p)));
+                        }
+                        // Non-constant base: only integer powers 0, 1, 2, and
+                        // only when the result stays within degree 2.
+                        let n = p as i64;
+                        if (p - n as f64).abs() != 0.0 || n < 0 {
+                            return None;
+                        }
+                        match n {
+                            0 => Some(QuadForm::constant(1.0)),
+                            1 => Some(a.clone()),
+                            2 => a.mul(a),
+                            _ => None,
+                        }
+                    })?,
+                }
+            }
+            ExprNode::UnaryOp { op, operand } => {
+                let v = child(operand)?;
+                match op {
+                    UnOp::Neg => v.iter().map(|a| a.scaled(-1.0)).collect(),
+                    // `abs` of anything variable-dependent is piecewise, not
+                    // polynomial. Treating it as degree 1 is what certified a
+                    // false optimum in #739; `max_degree` refuses it too.
+                    UnOp::Abs => {
+                        let mut out = Vec::with_capacity(v.len());
+                        for a in v.iter() {
+                            if a.degree() != 0 {
+                                return None;
+                            }
+                            out.push(QuadForm::constant(a.constant.abs()));
+                        }
+                        out
+                    }
+                }
+            }
+            // Every named function is transcendental or piecewise; none is a
+            // quadratic form of its argument.
+            ExprNode::FunctionCall { .. } => return None,
+            ExprNode::Index { base, index } => match self.get(*base) {
+                ExprNode::Variable {
+                    shape,
+                    index: vi,
+                    size,
+                    ..
+                } => {
+                    let off = *offsets.get(vi)?;
+                    let flat = index_spec_collect_flat(index, shape);
+                    let mut out = Vec::with_capacity(flat.len());
+                    for f in flat {
+                        if f >= *size {
+                            return None;
+                        }
+                        out.push(QuadForm::variable(off + f));
+                    }
+                    out
+                }
+                ExprNode::ConstantArray(data, shape) => {
+                    let mut out = Vec::new();
+                    for f in index_spec_collect_flat(index, shape) {
+                        out.push(QuadForm::constant(*data.get(f)?));
+                    }
+                    out
+                }
+                ExprNode::Parameter { value, shape, .. } => {
+                    let mut out = Vec::new();
+                    for f in index_spec_collect_flat(index, shape) {
+                        out.push(QuadForm::constant(*value.get(f)?));
+                    }
+                    out
+                }
+                // Indexing a compound expression needs shape inference the
+                // arena does not carry; `evaluate` returns NaN here.
+                _ => return None,
+            },
+            ExprNode::MatMul { left, right } => {
+                let l = child(left)?;
+                let r = child(right)?;
+                // `evaluate_matmul` contracts the two flat vectors. Equal
+                // lengths only: zipping mismatched lengths would silently
+                // answer a different model.
+                if l.len() != r.len() {
+                    return None;
+                }
+                let mut acc = QuadForm::default();
+                for (a, b) in l.iter().zip(r.iter()) {
+                    acc.add_assign_scaled(&a.mul(b)?, 1.0);
+                }
+                vec![acc]
+            }
+            ExprNode::Sum { operand, axis } => {
+                if axis.is_some() {
+                    // An axis reduction is array-valued; collapsing it to a
+                    // full sum answers a DIFFERENT model (#1160).
+                    return None;
+                }
+                let v = child(operand)?;
+                let mut acc = QuadForm::default();
+                for a in v.iter() {
+                    acc.add_assign_scaled(a, 1.0);
+                }
+                vec![acc]
+            }
+            ExprNode::SumOver { terms } => {
+                let mut acc = QuadForm::default();
+                for t in terms {
+                    let v = child(t)?;
+                    if v.len() != 1 {
+                        return None; // `evaluate` treats each term as scalar
+                    }
+                    acc.add_assign_scaled(&v[0], 1.0);
+                }
+                vec![acc]
+            }
+        };
+
+        Some(std::rc::Rc::new(vals))
+    }
+
     /// Compute the maximum polynomial degree of an expression.
     ///
     /// Returns `usize::MAX` for transcendental functions (exp, log, sin, ...).
@@ -1738,6 +2107,279 @@ impl ModelRepr {
 mod tests {
     use super::*;
 
+    // ── Symbolic quadratic-form extraction ────────────────────────────────
+
+    /// Evaluate a [`QuadForm`] at `x`, for cross-checking against
+    /// [`ExprArena::evaluate`].
+    fn qf_eval(q: &QuadForm, x: &[f64]) -> f64 {
+        let mut v = q.constant;
+        for (i, c) in &q.linear {
+            v += c * x[*i];
+        }
+        for ((i, j), c) in &q.quadratic {
+            v += c * x[*i] * x[*j];
+        }
+        v
+    }
+
+    fn var(arena: &mut ExprArena, name: &str, index: usize, size: usize) -> ExprId {
+        let shape = if size == 1 { vec![] } else { vec![size] };
+        arena.add(ExprNode::Variable {
+            name: name.into(),
+            index,
+            size,
+            shape,
+        })
+    }
+
+    fn bin(arena: &mut ExprArena, op: BinOp, l: ExprId, r: ExprId) -> ExprId {
+        arena.add(ExprNode::BinaryOp {
+            op,
+            left: l,
+            right: r,
+        })
+    }
+
+    #[test]
+    fn test_quadratic_form_declines_non_finite_coefficients() {
+        // x / inf: `scaled` would collapse this to the constant 0, but the
+        // constant term inf/inf is NaN under `evaluate`. The walk must decline
+        // rather than hand a coefficient it cannot stand behind to the caller.
+        let mut a = ExprArena::new();
+        let x = var(&mut a, "x0", 0, 1);
+        let inf = a.add(ExprNode::Constant(f64::INFINITY));
+        let q = bin(&mut a, BinOp::Div, inf, inf);
+        let e = bin(&mut a, BinOp::Add, x, q);
+        assert!(
+            a.quadratic_form(e, 1_000).is_none(),
+            "a non-finite coefficient must be declined, not emitted"
+        );
+
+        // The finite twin still extracts, so the guard is not a blanket refusal.
+        let mut b = ExprArena::new();
+        let x2 = var(&mut b, "x0", 0, 1);
+        let two = b.add(ExprNode::Constant(2.0));
+        let ok = bin(&mut b, BinOp::Div, x2, two);
+        let f = b
+            .quadratic_form(ok, 1_000)
+            .expect("x/2 is a quadratic form");
+        assert_eq!(f.linear.get(&0).copied(), Some(0.5));
+    }
+
+    #[test]
+    fn test_quadratic_form_coefficients() {
+        // 2*x0*x0 + 3*x0*x1 - x1 + 5
+        let mut a = ExprArena::new();
+        let x0 = var(&mut a, "x0", 0, 1);
+        let x1 = var(&mut a, "x1", 1, 1);
+        let c2 = a.add(ExprNode::Constant(2.0));
+        let c3 = a.add(ExprNode::Constant(3.0));
+        let c5 = a.add(ExprNode::Constant(5.0));
+        let sq = bin(&mut a, BinOp::Mul, x0, x0);
+        let t1 = bin(&mut a, BinOp::Mul, c2, sq);
+        let x0x1 = bin(&mut a, BinOp::Mul, x0, x1);
+        let t2 = bin(&mut a, BinOp::Mul, c3, x0x1);
+        let s1 = bin(&mut a, BinOp::Add, t1, t2);
+        let s2 = bin(&mut a, BinOp::Sub, s1, x1);
+        let root = bin(&mut a, BinOp::Add, s2, c5);
+
+        let q = a.quadratic_form(root, 1_000).expect("should extract");
+        assert_eq!(q.constant, 5.0);
+        assert_eq!(q.linear.len(), 1);
+        assert_eq!(q.linear[&1], -1.0);
+        assert_eq!(q.quadratic.len(), 2);
+        assert_eq!(q.quadratic[&(0, 0)], 2.0);
+        assert_eq!(q.quadratic[&(0, 1)], 3.0);
+        // The (i, j) key carries the FULL cross coefficient, not a half.
+        assert!(!q.quadratic.contains_key(&(1, 0)));
+    }
+
+    #[test]
+    fn test_quadratic_form_matches_evaluate() {
+        // Cross-check the symbolic walk against the arena's own evaluator on a
+        // mix of forms: powers, negation, division by a constant, nested sums.
+        let mut a = ExprArena::new();
+        let x0 = var(&mut a, "x0", 0, 1);
+        let x1 = var(&mut a, "x1", 1, 1);
+        let x2 = var(&mut a, "x2", 2, 1);
+        let two = a.add(ExprNode::Constant(2.0));
+        let seven = a.add(ExprNode::Constant(7.0));
+        let four = a.add(ExprNode::Constant(4.0));
+
+        let p = bin(&mut a, BinOp::Pow, x0, two); // x0^2
+        let neg = a.add(ExprNode::UnaryOp {
+            op: UnOp::Neg,
+            operand: x1,
+        });
+        let prod = bin(&mut a, BinOp::Mul, x1, x2);
+        let div = bin(&mut a, BinOp::Div, prod, four); // x1*x2/4
+        let s = bin(&mut a, BinOp::Add, p, neg);
+        let s = bin(&mut a, BinOp::Add, s, div);
+        let root = bin(&mut a, BinOp::Sub, s, seven);
+
+        let q = a.quadratic_form(root, 1_000).expect("should extract");
+        let mut checked = 0;
+        for pt in [
+            [0.0, 0.0, 0.0],
+            [1.0, 2.0, 3.0],
+            [-1.5, 0.25, 4.0],
+            [1e3, -1e3, 1e-3],
+        ] {
+            let want = a.evaluate(root, &pt);
+            let got = qf_eval(&q, &pt);
+            assert!(
+                (want - got).abs() <= 1e-9 * want.abs().max(1.0),
+                "point {pt:?}: evaluate={want} quadratic_form={got}"
+            );
+            checked += 1;
+        }
+        assert_eq!(checked, 4);
+    }
+
+    #[test]
+    fn test_quadratic_form_declines_non_quadratic() {
+        // Every arm here must DECLINE, not approximate. `is_quadratic` agrees.
+        let mut a = ExprArena::new();
+        let x0 = var(&mut a, "x0", 0, 1);
+        let x1 = var(&mut a, "x1", 1, 1);
+        let three = a.add(ExprNode::Constant(3.0));
+
+        let exp = a.add(ExprNode::FunctionCall {
+            func: MathFunc::Exp,
+            args: vec![x0],
+        });
+        assert!(
+            a.quadratic_form(exp, 1_000).is_none(),
+            "exp(x) is not quadratic"
+        );
+
+        let ratio = bin(&mut a, BinOp::Div, x0, x1);
+        assert!(
+            a.quadratic_form(ratio, 1_000).is_none(),
+            "x0/x1 is not polynomial"
+        );
+
+        // |x| is piecewise, not degree 1 -- treating it as linear certified a
+        // false optimum in #739.
+        let abs = a.add(ExprNode::UnaryOp {
+            op: UnOp::Abs,
+            operand: x0,
+        });
+        assert!(
+            a.quadratic_form(abs, 1_000).is_none(),
+            "abs(x) is not quadratic"
+        );
+        assert!(!a.is_quadratic(abs));
+
+        let cube = bin(&mut a, BinOp::Pow, x0, three);
+        assert!(
+            a.quadratic_form(cube, 1_000).is_none(),
+            "x^3 exceeds degree 2"
+        );
+
+        // Degree 3 as a product of a square and a variable.
+        let sq = bin(&mut a, BinOp::Mul, x0, x0);
+        let cubed = bin(&mut a, BinOp::Mul, sq, x1);
+        assert!(
+            a.quadratic_form(cubed, 1_000).is_none(),
+            "x0^2*x1 exceeds degree 2"
+        );
+
+        // An axis reduction is array-valued; collapsing it answers a different
+        // model (#1160), so it is refused here as it is in `evaluate`.
+        let axis_sum = a.add(ExprNode::Sum {
+            operand: x0,
+            axis: Some(0),
+        });
+        assert!(
+            a.quadratic_form(axis_sum, 1_000).is_none(),
+            "axis sum is refused"
+        );
+    }
+
+    #[test]
+    fn test_quadratic_form_deep_chain_does_not_overflow() {
+        // A `.nl` objective is a left-nested chain -- 18,499 `+` nodes deep on
+        // `unitcommit_200_100_1_mod_8`. A recursive walk blows the stack here.
+        let mut a = ExprArena::new();
+        let n = 100_000usize;
+        let x = var(&mut a, "x", 0, 1);
+        let mut acc = a.add(ExprNode::Constant(0.0));
+        for k in 0..n {
+            let c = a.add(ExprNode::Constant((k % 7) as f64));
+            let t = bin(&mut a, BinOp::Mul, c, x);
+            acc = bin(&mut a, BinOp::Add, acc, t);
+        }
+        // A budget of 16 live coefficients proves the walk holds only the
+        // frontier: the chain has 100,000 terms but never more than a handful
+        // alive at once.
+        let q = a
+            .quadratic_form(acc, 16)
+            .expect("deep chain should extract");
+        let want: f64 = (0..n).map(|k| (k % 7) as f64).sum();
+        assert_eq!(q.linear[&0], want);
+        assert_eq!(q.constant, 0.0);
+    }
+
+    #[test]
+    fn test_quadratic_form_array_matmul() {
+        // x' x for a 3-vector, via MatMul -- the array path.
+        let mut a = ExprArena::new();
+        let x = var(&mut a, "x", 0, 3);
+        let root = a.add(ExprNode::MatMul { left: x, right: x });
+        let q = a.quadratic_form(root, 1_000).expect("should extract");
+        assert_eq!(q.quadratic.len(), 3);
+        for i in 0..3 {
+            assert_eq!(q.quadratic[&(i, i)], 1.0);
+        }
+        let pt = [1.0, -2.0, 3.0];
+        assert_eq!(qf_eval(&q, &pt), a.evaluate(root, &pt));
+    }
+
+    #[test]
+    fn test_quadratic_form_respects_term_budget() {
+        // The budget exists so a would-be dense `Q` is never materialized.
+        // A 200-variable dense form is 20,100 coefficients.
+        let mut a = ExprArena::new();
+        let x = var(&mut a, "x", 0, 200);
+        let root = a.add(ExprNode::MatMul { left: x, right: x });
+        assert!(
+            a.quadratic_form(root, 10).is_none(),
+            "should decline under budget"
+        );
+        assert!(
+            a.quadratic_form(root, 1_000_000).is_some(),
+            "should extract with budget"
+        );
+    }
+
+    #[test]
+    fn test_quadratic_form_coo_is_sorted_and_deterministic() {
+        // COO output must be byte-reproducible: iterating the hash maps
+        // directly would not be.
+        let mut a = ExprArena::new();
+        let x = var(&mut a, "x", 0, 40);
+        let root = a.add(ExprNode::MatMul { left: x, right: x });
+        let q = a.quadratic_form(root, 1_000_000).unwrap();
+        let first = q.to_coo();
+        for _ in 0..5 {
+            let again = a.quadratic_form(root, 1_000_000).unwrap().to_coo();
+            assert_eq!(first, again);
+        }
+        let (qi, qj, _, _, _, _) = &first;
+        let mut keys: Vec<(usize, usize)> = qi.iter().copied().zip(qj.iter().copied()).collect();
+        let sorted = {
+            let mut k = keys.clone();
+            k.sort();
+            k
+        };
+        assert_eq!(keys, sorted, "COO entries must be in ascending key order");
+        keys.dedup();
+        assert_eq!(keys.len(), qi.len(), "no duplicate COO keys");
+        // i <= j for every entry.
+        assert!(qi.iter().zip(qj.iter()).all(|(i, j)| i <= j));
+    }
+
     #[test]
     fn test_arena_add_get() {
         let mut arena = ExprArena::new();
@@ -2355,4 +2997,188 @@ mod tests {
             );
         }
     }
+}
+
+/// An exact sparse quadratic form over an [`ExprArena`]'s flat variable space:
+///
+/// ```text
+/// constant + sum_i linear[i] * x_i + sum_{i <= j} quadratic[(i, j)] * x_i * x_j
+/// ```
+///
+/// `quadratic` is keyed by an ordered pair, so `(i, i)` carries the full
+/// coefficient of `x_i^2` and `(i, j)` with `i < j` the full coefficient of the
+/// cross term -- NOT the symmetric-matrix halves. A caller building a `Q` with
+/// the `0.5 x' Q x` convention must double the off-diagonals; one building the
+/// COO triplet that `set_quadratic_objective` consumes can use these directly.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct QuadForm {
+    /// The constant term.
+    pub constant: f64,
+    /// Linear coefficients, keyed by flat variable index.
+    pub linear: std::collections::HashMap<usize, f64>,
+    /// Quadratic coefficients, keyed by `(i, j)` with `i <= j`.
+    pub quadratic: std::collections::HashMap<(usize, usize), f64>,
+    /// Structural degree (0, 1 or 2), carried explicitly.
+    ///
+    /// It is tracked incrementally rather than read off the maps for two
+    /// reasons. It keeps [`Self::degree`] O(1): deriving it from map emptiness
+    /// would require pruning cancelled coefficients after every operation,
+    /// which re-scans the whole accumulator per term and restores the
+    /// quadratic cost this module exists to remove. And it keeps the answer
+    /// consistent with [`ExprArena::max_degree`], which likewise counts a term
+    /// whose coefficient happens to cancel to zero.
+    deg: usize,
+}
+
+impl QuadForm {
+    /// A degree-0 form holding a single constant.
+    pub fn constant(v: f64) -> Self {
+        Self {
+            constant: v,
+            ..Default::default()
+        }
+    }
+
+    /// The degree-1 form `x_i`.
+    pub fn variable(i: usize) -> Self {
+        let mut linear = std::collections::HashMap::with_capacity(1);
+        linear.insert(i, 1.0);
+        Self {
+            constant: 0.0,
+            linear,
+            quadratic: std::collections::HashMap::new(),
+            deg: 1,
+        }
+    }
+
+    /// Structural polynomial degree: 0, 1 or 2.
+    pub fn degree(&self) -> usize {
+        self.deg
+    }
+
+    /// Number of stored linear + quadratic coefficients.
+    pub fn n_terms(&self) -> usize {
+        self.linear.len() + self.quadratic.len()
+    }
+
+    /// True when every coefficient of this form is finite.
+    pub fn is_finite(&self) -> bool {
+        self.constant.is_finite()
+            && self.linear.values().all(|v| v.is_finite())
+            && self.quadratic.values().all(|v| v.is_finite())
+    }
+
+    /// This form scaled by a constant.
+    ///
+    /// Scaling by exactly zero collapses the degree: `0 * x` is the constant 0,
+    /// and keeping it at degree 1 would make an otherwise-representable
+    /// product (`(0 * x) * y`) decline for no reason.
+    pub fn scaled(&self, s: f64) -> Self {
+        // `0 * x` is the constant 0 -- but only when the coefficients of `x`
+        // are finite, since `evaluate` gives `0 * inf = NaN`. Short-circuiting
+        // unconditionally would erase a non-finite before the walk's output
+        // check can decline it, so a non-finite operand falls through to the
+        // ordinary multiply and propagates the NaN the caller must see.
+        if s == 0.0 && self.is_finite() {
+            return Self::constant(0.0);
+        }
+        Self {
+            constant: self.constant * s,
+            linear: self.linear.iter().map(|(k, v)| (*k, v * s)).collect(),
+            quadratic: self.quadratic.iter().map(|(k, v)| (*k, v * s)).collect(),
+            deg: self.deg,
+        }
+    }
+
+    /// `self += other * s`, in place.
+    pub fn add_assign_scaled(&mut self, other: &Self, s: f64) {
+        self.constant += other.constant * s;
+        if s == 0.0 {
+            return;
+        }
+        for (k, v) in &other.linear {
+            *self.linear.entry(*k).or_insert(0.0) += v * s;
+        }
+        for (k, v) in &other.quadratic {
+            *self.quadratic.entry(*k).or_insert(0.0) += v * s;
+        }
+        self.deg = self.deg.max(other.deg);
+    }
+
+    /// The product `self * other`, or `None` when it would exceed degree 2.
+    pub fn mul(&self, other: &Self) -> Option<Self> {
+        if self.deg + other.deg > 2 {
+            return None;
+        }
+        let mut out = Self::constant(self.constant * other.constant);
+        out.deg = self.deg + other.deg;
+        // constant x (linear, quadratic), both directions.
+        for (i, a) in &self.linear {
+            *out.linear.entry(*i).or_insert(0.0) += a * other.constant;
+        }
+        for (i, b) in &other.linear {
+            *out.linear.entry(*i).or_insert(0.0) += b * self.constant;
+        }
+        for (k, a) in &self.quadratic {
+            *out.quadratic.entry(*k).or_insert(0.0) += a * other.constant;
+        }
+        for (k, b) in &other.quadratic {
+            *out.quadratic.entry(*k).or_insert(0.0) += b * self.constant;
+        }
+        // linear x linear -> quadratic. Degree 3 and 4 products are excluded
+        // by the guard above, so there is nothing else to form.
+        for (i, a) in &self.linear {
+            for (j, b) in &other.linear {
+                let key = if i <= j { (*i, *j) } else { (*j, *i) };
+                *out.quadratic.entry(key).or_insert(0.0) += a * b;
+            }
+        }
+        Some(out)
+    }
+
+    /// The form as sparse COO plus linear and constant parts, ready for the
+    /// Python boundary: `(qi, qj, qd, ci, cd, constant)`.
+    ///
+    /// Entries are emitted in ascending key order so the output is
+    /// deterministic and byte-reproducible across runs, which iterating the
+    /// hash maps directly would not be.
+    pub fn to_coo(&self) -> (Vec<usize>, Vec<usize>, Vec<f64>, Vec<usize>, Vec<f64>, f64) {
+        let mut q: Vec<((usize, usize), f64)> =
+            self.quadratic.iter().map(|(k, v)| (*k, *v)).collect();
+        q.sort_by_key(|(k, _)| *k);
+        let mut l: Vec<(usize, f64)> = self.linear.iter().map(|(k, v)| (*k, *v)).collect();
+        l.sort_by_key(|(k, _)| *k);
+        (
+            q.iter().map(|((i, _), _)| *i).collect(),
+            q.iter().map(|((_, j), _)| *j).collect(),
+            q.iter().map(|(_, v)| *v).collect(),
+            l.iter().map(|(i, _)| *i).collect(),
+            l.iter().map(|(_, v)| *v).collect(),
+            self.constant,
+        )
+    }
+}
+
+/// Apply a binary operation elementwise over two flat polynomial arrays,
+/// broadcasting a length-1 operand against a longer one.
+///
+/// Any other length pairing is refused rather than zipped: truncating to the
+/// shorter operand would silently answer a different model.
+fn broadcast<F>(l: &[QuadForm], r: &[QuadForm], f: F) -> Option<Vec<QuadForm>>
+where
+    F: Fn(&QuadForm, &QuadForm) -> Option<QuadForm>,
+{
+    let n = match (l.len(), r.len()) {
+        (a, b) if a == b => a,
+        (1, b) => b,
+        (a, 1) => a,
+        _ => return None,
+    };
+    let mut out = Vec::with_capacity(n);
+    for k in 0..n {
+        let a = if l.len() == 1 { &l[0] } else { &l[k] };
+        let b = if r.len() == 1 { &r[0] } else { &r[k] };
+        out.push(f(a, b)?);
+    }
+    Some(out)
 }

--- a/crates/discopt-core/src/expr.rs
+++ b/crates/discopt-core/src/expr.rs
@@ -3142,7 +3142,7 @@ impl QuadForm {
     /// Entries are emitted in ascending key order so the output is
     /// deterministic and byte-reproducible across runs, which iterating the
     /// hash maps directly would not be.
-    pub fn to_coo(&self) -> (Vec<usize>, Vec<usize>, Vec<f64>, Vec<usize>, Vec<f64>, f64) {
+    pub fn to_coo(&self) -> QuadFormCoo {
         let mut q: Vec<((usize, usize), f64)> =
             self.quadratic.iter().map(|(k, v)| (*k, *v)).collect();
         q.sort_by_key(|(k, _)| *k);
@@ -3158,6 +3158,12 @@ impl QuadForm {
         )
     }
 }
+
+/// The COO payload of [`QuadForm::to_coo`]: `(qi, qj, qd, ci, cd, constant)`,
+/// i.e. the quadratic row/col/value triple, the linear index/value pair, and
+/// the constant term. Named so the tuple stays one thing at every call site
+/// rather than six positional vectors clippy has to read as a type.
+pub type QuadFormCoo = (Vec<usize>, Vec<usize>, Vec<f64>, Vec<usize>, Vec<f64>, f64);
 
 /// Apply a binary operation elementwise over two flat polynomial arrays,
 /// broadcasting a length-1 operand against a longer one.

--- a/crates/discopt-python/src/expr_bindings.rs
+++ b/crates/discopt-python/src/expr_bindings.rs
@@ -172,6 +172,65 @@ impl PyModelRepr {
         self.inner.arena.is_bilinear(self.inner.objective)
     }
 
+    /// The objective as an exact sparse quadratic form, or `None` to decline.
+    ///
+    /// Returns `(qi, qj, qd, ci, cd, constant)`: the quadratic coefficients as
+    /// a COO triplet with `qi <= qj`, the linear coefficients as
+    /// `(index, value)` arrays, and the constant -- the same layout
+    /// `set_quadratic_objective` consumes in the other direction. Indices are
+    /// in this repr's flat variable space (`n_vars`).
+    ///
+    /// `qd[k]` is the FULL coefficient of `x[qi[k]] * x[qj[k]]`, not a
+    /// symmetric-matrix half: a caller assembling `Q` under the `0.5 x' Q x`
+    /// convention must double the off-diagonals.
+    ///
+    /// `None` means the walk declined -- the body is not a quadratic form, it
+    /// uses a construct the walk does not represent, or it would need more
+    /// than `max_terms` live coefficients (which is how a would-be dense `Q`
+    /// is refused before it is materialized). It is never an approximation, so
+    /// a caller may use the result directly without a verification pass.
+    ///
+    /// This exists because the Python QP extractor previously recovered these
+    /// coefficients by finite-difference probing at O(|support|^2) model
+    /// evaluations -- 71,330 s over the 150-instance MINLPLib MIQP family,
+    /// 28,288 s on `unitcommit_200_100_1_mod_8` alone, whose objective DAG has
+    /// only 56,299 nodes.
+    #[pyo3(signature = (max_terms = 20_000_000))]
+    #[allow(clippy::type_complexity)]
+    fn objective_quadratic_form(
+        &self,
+        max_terms: usize,
+    ) -> Option<(Vec<usize>, Vec<usize>, Vec<f64>, Vec<usize>, Vec<f64>, f64)> {
+        self.inner
+            .arena
+            .quadratic_form(self.inner.objective, max_terms)
+            .map(|q| q.to_coo())
+    }
+
+    /// Constraint `i`'s body as an exact sparse quadratic form, or `None`.
+    ///
+    /// Same layout and same decline semantics as
+    /// [`Self::objective_quadratic_form`].
+    #[pyo3(signature = (i, max_terms = 20_000_000))]
+    #[allow(clippy::type_complexity)]
+    fn constraint_quadratic_form(
+        &self,
+        i: usize,
+        max_terms: usize,
+    ) -> PyResult<Option<(Vec<usize>, Vec<usize>, Vec<f64>, Vec<usize>, Vec<f64>, f64)>> {
+        let c = self.inner.constraints.get(i).ok_or_else(|| {
+            PyErr::new::<pyo3::exceptions::PyIndexError, _>(format!(
+                "constraint index {i} out of range (model has {})",
+                self.inner.constraints.len()
+            ))
+        })?;
+        Ok(self
+            .inner
+            .arena
+            .quadratic_form(c.body, max_terms)
+            .map(|q| q.to_coo()))
+    }
+
     /// Is constraint i linear?
     fn is_constraint_linear(&self, i: usize) -> bool {
         self.inner.arena.is_linear(self.inner.constraints[i].body)

--- a/docs/dev/certification-gap-plan.md
+++ b/docs/dev/certification-gap-plan.md
@@ -603,7 +603,7 @@ Reading the arena is both faster and *exact*.
 |---|---|---|---|---|---|
 | **P0** | `_extract_qcp_data_from_repr` (`_relax/problem_classifier.py`) | every QCP/MIQCP model (265 MINLPLib instances) | `m*2n` evaluations for the diagonal sweep **plus** `sum_rows |support|^2/2` pair probes — the O(n^2) probe runs **once per constraint** | `constraint_quadratic_form(i)` reads each row's coefficients off the arena in O(nodes) | **fixed** (#1209) |
 | **P1** | `_extract_lp_data_from_repr` | first path for any model with a `_builder`; the only path for `from_nl` LP/MILP | `m*n` full constraint evaluations + `m*n` dense `(n,)` allocations. Static census over the 415 LP/MILP-family MINLPLib instances: **1.11e11 evaluations**, median 3,996/instance | a row is linear exactly when its quadratic COO is empty, and then its linear map *is* the row | **fixed** (#1209) |
-| **P2** | `_AugmentedEvaluator` (`solver.py`) | `cutting_planes=True` and lazy constraints — **not** the default path (`cutting_planes: bool = False`) | it enumerates its members explicitly and omits `has_sparse_structure`, so every POUNCE derivative callback densifies to `(m,n)`/`(n,n)` and `jacobianstructure` builds an `m*n` meshgrid — even though the tape already returns analytical sparse COO Hessians | forward `has_sparse_structure` (as the sibling `_BoundOverrideEvaluator` already does via `__getattr__`) | **open** |
+| **P2** | `_AugmentedEvaluator` (`solver.py`) | `cutting_planes=True` and lazy constraints — **not** the default path (`cutting_planes: bool = False`) | it enumerates its members explicitly and omits `has_sparse_structure`, so every POUNCE derivative callback densifies to `(m,n)`/`(n,n)` and `jacobianstructure` builds an `m*n` meshgrid — even though the tape already returns analytical sparse COO Hessians | implement the sparse protocol: answer `has_sparse_structure` with the wrapped evaluator's answer, and **append the cut block to the COO structure**. Forwarding the flag alone is *unsound*, not merely incomplete — the augmented constraint vector has `n_cuts` rows the wrapped pattern does not describe, so the solver would receive a Jacobian silently missing every cut row | **fixed** (#1210) |
 | **P3** | `_estimate_alpha_fd` (`solver.py`) | never — zero production callers | O(n^2) evaluations + an O(n^3) eigendecomposition, with a `4e-12` divisor | delete it | **fixed** (#1209, deleted) |
 
 Falsified while auditing, and recorded here per §4: the hypothesis that *the
@@ -612,6 +612,25 @@ per-node NLP densifies its Hessian every iteration* is **wrong**.
 `nlp_ipopt.py:174` takes the sparse branch, so the default solve path already
 feeds POUNCE analytical sparse Hessians. P2 is the exception, and only because
 one wrapper drops the capability flag — not because the tape lacks it.
+
+**Retraction (§11), 2026-09-07.** The P2 row of this table first said the fix
+was to *forward* `has_sparse_structure`, "as the sibling
+`_BoundOverrideEvaluator` already does via `__getattr__`". That was wrong and
+the row has been corrected. Forwarding the flag alone would have been a
+**soundness** bug: the augmented constraint vector carries `n_cuts` rows beyond
+what the wrapped evaluator's pattern describes, so POUNCE would have been handed
+a Jacobian silently missing every cut row. The shipped fix (#1210) extends the
+COO structure with the cut block, whose pattern is exact and constant because
+the cut pool is snapshotted at construction and a cut `a^T x - b` has gradient
+`a`.
+
+Measured there (structural census, `scratchpad/1193/p2_census.py` — counts, not
+timings, so load-independent), 10 cuts on a root pool: `crudeoil_lee1_09`
+(n=963) Jacobian 2,274,606 -> 12,488 entries and Hessian 464,166 -> 1,397;
+`carton9` 325,080 -> 4,935 and 64,980 -> 400. `elec100` is the counter-case in
+the same output: its Hessian is genuinely dense (45,150 either way) while its
+Jacobian still drops 33,000 -> 350. These are per-callback counts, paid every
+IPM iteration of every cut-augmented node NLP.
 
 Standing rule this class implies: **an extractor that wants coefficients reads
 the arena; only an evaluator evaluates.** A new `evaluate_*` call inside

--- a/docs/dev/certification-gap-plan.md
+++ b/docs/dev/certification-gap-plan.md
@@ -583,6 +583,43 @@ heuristic suite (incumbents are not the problem — the *proof* is).
 
 ---
 
+## 2b. The numerical-probing defect class (audit, 2026-09-07)
+
+An audit prompted by #1193 found that four code paths recovered coefficients the
+model **already holds exactly** by evaluating it numerically at unit vectors.
+This is one defect with four instances, not four defects, and it is worth stating
+as a class because the shape recurs: an extractor written against
+`ModelRepr.evaluate_*` when it should have been written against the expression
+arena.
+
+Two costs, and the second is the one that matters. The probe is O(n) or O(n^2)
+*model evaluations* where the arena answers in O(nodes) — and the probe
+identities are differences of nearly-equal floats, so they lose precision
+catastrophically on badly-scaled data. On `min (x - 1e10)^2` the off-diagonal
+identity returns `Q = 0` and the solver certifies a false optimum (#866).
+Reading the arena is both faster and *exact*.
+
+| | path | fires on | cost | mechanism of the fix | status |
+|---|---|---|---|---|---|
+| **P0** | `_extract_qcp_data_from_repr` (`_relax/problem_classifier.py`) | every QCP/MIQCP model (265 MINLPLib instances) | `m*2n` evaluations for the diagonal sweep **plus** `sum_rows |support|^2/2` pair probes — the O(n^2) probe runs **once per constraint** | `constraint_quadratic_form(i)` reads each row's coefficients off the arena in O(nodes) | **fixed** (#1209) |
+| **P1** | `_extract_lp_data_from_repr` | first path for any model with a `_builder`; the only path for `from_nl` LP/MILP | `m*n` full constraint evaluations + `m*n` dense `(n,)` allocations. Static census over the 415 LP/MILP-family MINLPLib instances: **1.11e11 evaluations**, median 3,996/instance | a row is linear exactly when its quadratic COO is empty, and then its linear map *is* the row | **fixed** (#1209) |
+| **P2** | `_AugmentedEvaluator` (`solver.py`) | `cutting_planes=True` and lazy constraints — **not** the default path (`cutting_planes: bool = False`) | it enumerates its members explicitly and omits `has_sparse_structure`, so every POUNCE derivative callback densifies to `(m,n)`/`(n,n)` and `jacobianstructure` builds an `m*n` meshgrid — even though the tape already returns analytical sparse COO Hessians | forward `has_sparse_structure` (as the sibling `_BoundOverrideEvaluator` already does via `__getattr__`) | **open** |
+| **P3** | `_estimate_alpha_fd` (`solver.py`) | never — zero production callers | O(n^2) evaluations + an O(n^3) eigendecomposition, with a `4e-12` divisor | delete it | **fixed** (#1209, deleted) |
+
+Falsified while auditing, and recorded here per §4: the hypothesis that *the
+per-node NLP densifies its Hessian every iteration* is **wrong**.
+`_tape_nlp_evaluator.has_sparse_structure()` returns `True` and
+`nlp_ipopt.py:174` takes the sparse branch, so the default solve path already
+feeds POUNCE analytical sparse Hessians. P2 is the exception, and only because
+one wrapper drops the capability flag — not because the tape lacks it.
+
+Standing rule this class implies: **an extractor that wants coefficients reads
+the arena; only an evaluator evaluates.** A new `evaluate_*` call inside
+`_relax/problem_classifier.py` should be treated as a defect until shown
+otherwise.
+
+---
+
 ## 3. Design principles
 
 1. **Correctness is a gate with zero slack.** Every phase ships behind a flag and must

--- a/docs/dev/certification-gap-plan.md
+++ b/docs/dev/certification-gap-plan.md
@@ -520,6 +520,32 @@ From `scip-gap-closing-plan.md` (all measured):
 
 ### C4 — Structure is lost before the relaxation is ever built (multiplier on C1–C3)
 
+> **CLOSED (2026-09-07). All three items below are stale; C4 is no longer a gap.**
+> Verified against the current tree:
+> (1) *CSE/hash-consing* — `ExprArena` is content-addressed via `StructuralKey`
+> (`expr.rs:299-395`) and interning is **enabled on both production build paths**:
+> the `.nl` parser (`nl_parser.rs:788`) and the Python model → `ModelRepr` bridge
+> (`expr_bindings.rs:1284`). The `expr.rs:266` citation below predates it.
+> (2) *AMPL defined variables* — V segments are **inlined, not discarded**
+> (C-7; `nl_parser.rs:1137,1686,3349`, with regression tests
+> `test_defined_variable_inlined_and_evaluated` / `..._chained_reference`).
+> (3) *Quadratic/structure extraction in the IR* — closed by
+> `ExprArena::quadratic_form` (`expr.rs`), which emits the symbolic
+> constant/linear/quadratic coefficients the `max_degree` walk already computes,
+> in `O(nodes)`, exposed as `objective_quadratic_form` /
+> `constraint_quadratic_form` and consumed by `_relax/problem_classifier.py`.
+> It replaced a finite-difference probe costing one model evaluation per variable
+> *pair*: over the 150-instance MINLPLib MIQP family (BQP/IQP/MBQP/MIQP)
+> extraction goes from **71,330 s to 5.99 s**, with zero declines and worst
+> relative error 6.9e-14 over 750 point checks. It also removes the #866
+> cancellation class at its source — the probe identity
+> `f(e_i+e_j) - f(e_i) - f(e_j) + f(0)` is a difference of nearly-equal floats,
+> and on `min (x-1e10)^2` it returns `Q = 0` and certifies a false optimum.
+> Convexity detection remains Python-side; that is unchanged and is not what
+> C4's "only degree checks" referred to.
+
+*Original text, superseded (kept per §0.4):*
+
 - **No CSE/hash-consing** in the Rust expression arena (`expr.rs:266` — `add` never
   dedups); the `.nl` parser **discards AMPL defined variables** (V segments — AMPL's
   own DAG sharing), so shared subexpressions are duplicated into the DAG, the JAX
@@ -550,8 +576,8 @@ heuristic suite (incumbents are not the problem — the *proof* is).
 | Per-node cheap reduction (FBBT+cutoff, DBBT/marginals) | every node                          | components exist, mostly root-only | **wiring**            |
 | Aggregation / c-MIR cuts                               | workhorse (97–169× nodes)           | absent (current cuts net-negative) | **missing + quality** |
 | Cut pool w/ aging on default path                      | yes                                 | opt-in path only                   | wiring                |
-| CSE / defined-variable sharing                         | preserved & exploited               | discarded                          | **missing**           |
-| Quadratic/structure recognition in core                | yes                                 | Python-side convexity only         | missing               |
+| CSE / defined-variable sharing                          | preserved & exploited               | preserved (interned + V inlined)   | closed (see C4)       |
+| Quadratic/structure recognition in core                | yes                                 | `quadratic_form` in the arena      | closed (see C4)       |
 | Root-gap instrumentation                               | n/a (internal)                      | schema exists, never populated     | missing               |
 | Parallel tree search                                   | partial                             | no                                 | out of scope here     |
 

--- a/python/discopt/_relax/problem_classifier.py
+++ b/python/discopt/_relax/problem_classifier.py
@@ -9,6 +9,8 @@ to classify problems, then extracts standard-form data using the JAX DAG compile
 from __future__ import annotations
 
 import logging
+import os
+import time
 from enum import Enum
 from typing import TYPE_CHECKING, NamedTuple, cast
 
@@ -128,6 +130,31 @@ _QP_DENSE_Q_MAX_BYTES = 256 * 1024 * 1024
 # is 91.5 GB, an equal-sized wall to the 91 GB dense Q above. Above this budget the
 # extractors emit scipy CSR and consumers densify through ``dense_A()``.
 _DENSE_A_MAX_BYTES = 256 * 1024 * 1024
+
+# Wall-clock budget for the pairwise probe sweep in ``_extract_qp_data_from_repr``
+# and ``_extract_quadratic_coefficients_from_values``, in seconds. 0 disables the
+# gate and restores the pre-#1208 behaviour exactly.
+#
+# Those extractors recover the objective Hessian by finite differences: one full
+# model evaluation per SUPPORT PAIR, i.e. O(|support|^2) evaluations. #863 already
+# restricted the sweep to the objective's support, which is decisive for a wide
+# model with a narrow objective (watercontamination0202: 101 of 106,711 variables).
+# It buys nothing for a QUBO, where the support IS every variable -- and that is the
+# whole BQP/MBQP class.
+#
+# Measured on ``chimera_mis-01`` (n = 2,032, |support| = 1,818): 1,651,653 probes at
+# 166.5 us = 275.0 s predicted, 275.3 s measured end-to-end -- on a solve whose
+# ``time_limit`` was 60 s. The search never started; the solve returned no incumbent
+# with zero nodes explored. Worse, the #866 verification below then rejects that
+# Q as unrecovered and the answer is discarded, so all 275 s were spent on work
+# that was thrown away.
+#
+# Sweeping the whole MIQP family of MINLPLib (148 instances readable here): 58 spend
+# over 1 s here, 42 over 10 s, and 29 over 60 s -- 71,330 s in total, up to 28,288 s
+# on a single instance (unitcommit_200_100_1_mod_8, n = 25,700). Six of those
+# overlap the tracked MIQP failure set, including all four instances that were
+# observed overrunning a 60 s limit by up to 4.8x.
+_QP_PROBE_MAX_SECONDS = float(os.environ.get("DISCOPT_QP_PROBE_BUDGET", "0") or 0.0)
 
 
 def _sp_issparse(x) -> bool:
@@ -320,6 +347,16 @@ class _NotLinearError(Exception):
 
 class _NotQuadraticError(Exception):
     """Raised when an expression is not quadratic (at most degree 2)."""
+
+
+class _ProbeBudgetExceeded(Exception):
+    """Raised when the O(|support|^2) probe sweep would exceed its time budget.
+
+    Distinct from :class:`_NotQuadraticError` because it says nothing about the
+    model: the probe *could* have produced an answer, it would just have cost more
+    than the budget allows. The dispatcher treats the two differently -- a model
+    declined on cost is never allowed to end up with no extraction at all.
+    """
 
 
 def _extract_linear_coefficients(expr, model: Model, n: int):
@@ -1409,7 +1446,7 @@ def _extract_lp_data_from_repr(model: Model) -> LPData:
     )
 
 
-def _extract_qp_data_from_repr(model: Model) -> QPData:
+def _extract_qp_data_from_repr(model: Model, probe_budget_s: float | None = None) -> QPData:
     """Extract QP data by evaluating the Rust ModelRepr numerically.
 
     For the quadratic objective 0.5 x'Qx + c'x + d:
@@ -1429,7 +1466,9 @@ def _extract_qp_data_from_repr(model: Model) -> QPData:
     x_zero = np.zeros(n_orig, dtype=np.float64)
     d = repr_.evaluate_objective(x_zero)
 
-    # Evaluate at all unit vectors
+    # Evaluate at all unit vectors. Timed, because the per-probe cost measured here
+    # is what prices the O(|support|^2) sweep below -- see the budget check.
+    _probe_t0 = time.perf_counter()
     f_ej = np.zeros(n_orig, dtype=np.float64)
     f_neg_ej = np.zeros(n_orig, dtype=np.float64)
     for j in range(n_orig):
@@ -1438,6 +1477,7 @@ def _extract_qp_data_from_repr(model: Model) -> QPData:
         f_ej[j] = repr_.evaluate_objective(ej)
         ej[j] = -1.0
         f_neg_ej[j] = repr_.evaluate_objective(ej)
+    _probe_per_call = (time.perf_counter() - _probe_t0) / max(1, 2 * n_orig)
 
     # Q diagonal: Q[j,j] = f(e_j) + f(-e_j) - 2*d  (kept 1-D; see the note below on
     # why the dense (n, n) is not materialised until the very end)
@@ -1454,6 +1494,25 @@ def _extract_qp_data_from_repr(model: Model) -> QPData:
     # the unrestricted sweep issues 5.69e9 probes to discover ~1e4 possibly-nonzero
     # entries, and a dense (n, n) Q there is 91 GB.
     support = [j for j in range(n_orig) if f_ej[j] != d or f_neg_ej[j] != d or diag[j] != 0.0]
+
+    # Budget gate (#1208). |support| is now known exactly, and the diagonal sweep
+    # above just measured what one probe costs on THIS model, so the pair sweep can
+    # be priced before it is paid for -- a prediction validated at ratio 1.00
+    # (275.0 s predicted vs 275.3 s measured on chimera_mis-01). Refuse loudly
+    # rather than silently spending a multiple of the caller's whole time limit;
+    # ``extract_qp_data`` routes a declined model to the tape extractor, which gets
+    # the same Hessian from one AD evaluation instead of |support|^2 probes.
+    _budget = _QP_PROBE_MAX_SECONDS if probe_budget_s is None else probe_budget_s
+    _pairs = len(support) * (len(support) - 1) // 2
+    _predicted = _pairs * _probe_per_call
+    if _budget > 0.0 and _predicted > _budget:
+        raise _ProbeBudgetExceeded(
+            f"pairwise probe sweep would cost ~{_predicted:.1f}s "
+            f"({_pairs:,} probes over a support of {len(support)} of {n_orig} "
+            f"variables at {_probe_per_call * 1e6:.1f}us each), over the "
+            f"{_budget:.1f}s budget (DISCOPT_QP_PROBE_BUDGET)"
+        )
+
     off_i: list[int] = []
     off_j: list[int] = []
     off_v: list[float] = []
@@ -2100,8 +2159,21 @@ def extract_qp_data(model: Model) -> QPData:
     # ``classify_problem``), so ``from_nl`` / repr-only models — where the
     # algebraic DAG walk can't run — skip the per-primitive eager-JAX autodiff
     # path (orders of magnitude faster on small instances; see #330).
+    #
+    # "On small instances" is load-bearing and was not enforced until #1208. The
+    # probe is O(|support|^2) model evaluations against the tape's O(1), so the
+    # ordering inverts as the objective's support grows: measured on ``du-opt``
+    # (n = 20) the probe wins 0.02s to 0.16s, and on ``chimera_mis-01``
+    # (n = 2,032, |support| = 1,818) it loses 275.3s to a fraction of a second.
+    # The two agree to 6.65e-16 relative where both succeed. ``_ProbeBudgetExceeded``
+    # is the probe declining on that basis; it is handled separately below because
+    # it is a statement about cost, not about the model.
+    _declined: _ProbeBudgetExceeded | None = None
     try:
         return _extract_qp_data_from_repr(model)
+    except _ProbeBudgetExceeded as exc:
+        _declined = exc
+        logger.info("QP repr probe declined on cost, using the tape extractor: %s", exc)
     except Exception as exc:  # noqa: BLE001 - falls through to the autodiff extractor
         logger.debug(
             "QP repr extraction (probe) failed, falling back to autodiff: %s: %s",
@@ -2109,7 +2181,24 @@ def extract_qp_data(model: Model) -> QPData:
             exc,
         )
 
-    return _extract_qp_data_autodiff(model)
+    if _declined is None:
+        return _extract_qp_data_autodiff(model)
+
+    # The probe was declined on cost, not on correctness -- it would have produced
+    # an answer eventually. So a declined model must never end up with NO extraction:
+    # if the tape and JAX arms both fail to represent it, pay the cost we skipped
+    # rather than propagate a failure the unbudgeted code would not have had.
+    try:
+        return _extract_qp_data_autodiff(model)
+    except Exception as exc:  # noqa: BLE001 - re-runs the probe it declined
+        logger.warning(
+            "QP autodiff extraction failed after the repr probe was declined on cost "
+            "(%s); re-running the probe without its budget: %s: %s",
+            _declined,
+            type(exc).__name__,
+            exc,
+        )
+        return _extract_qp_data_from_repr(model, probe_budget_s=0.0)
 
 
 def extract_qcp_data(model: Model) -> QCPData:

--- a/python/discopt/_relax/problem_classifier.py
+++ b/python/discopt/_relax/problem_classifier.py
@@ -10,7 +10,6 @@ from __future__ import annotations
 
 import logging
 import os
-import time
 from enum import Enum
 from typing import TYPE_CHECKING, NamedTuple, cast
 
@@ -154,7 +153,19 @@ _DENSE_A_MAX_BYTES = 256 * 1024 * 1024
 # on a single instance (unitcommit_200_100_1_mod_8, n = 25,700). Six of those
 # overlap the tracked MIQP failure set, including all four instances that were
 # observed overrunning a 60 s limit by up to 4.8x.
-_QP_PROBE_MAX_SECONDS = float(os.environ.get("DISCOPT_QP_PROBE_BUDGET", "0") or 0.0)
+# Denominated in PROBES, not seconds, and deliberately so. An earlier revision
+# priced the sweep by timing the diagonal pass and multiplying:
+# ``(perf_counter() - t0) / (2 * n_orig) * pairs``. That made *which extractor
+# runs* a function of machine speed -- the construction #1187 exists to stop,
+# and ``test_912_wall_budget_inventory`` caught it. The two extractors agree to
+# ~1e-16 but not bitwise, so a slow machine could take the tape arm, a fast one
+# the probe, and the two Q matrices could branch differently at identical node
+# counts under ``deterministic=True``. The pair count is exactly the quantity
+# the timing was estimating, is known exactly before the sweep starts, and is
+# identical on every machine -- so the deterministic gate is also the more
+# precise one. Conversion is free here (no seconds-valued tuning to re-derive),
+# which is why this is a conversion and not a ``KNOWN_SLICES`` entry.
+_QP_PROBE_MAX_PROBES = int(float(os.environ.get("DISCOPT_QP_PROBE_MAX_PROBES", "0") or 0))
 
 
 # Read the objective's quadratic coefficients off the expression DAG instead of
@@ -364,7 +375,7 @@ class _NotQuadraticError(Exception):
 
 
 class _ProbeBudgetExceeded(Exception):
-    """Raised when the O(|support|^2) probe sweep would exceed its time budget.
+    """Raised when the O(|support|^2) probe sweep would exceed its probe budget.
 
     Distinct from :class:`_NotQuadraticError` because it says nothing about the
     model: the probe *could* have produced an answer, it would just have cost more
@@ -1496,7 +1507,7 @@ def _extract_lp_data_from_repr(model: Model) -> LPData:
     )
 
 
-def _extract_qp_data_from_repr(model: Model, probe_budget_s: float | None = None) -> QPData:
+def _extract_qp_data_from_repr(model: Model, probe_budget: int | None = None) -> QPData:
     """Extract QP data by evaluating the Rust ModelRepr numerically.
 
     For the quadratic objective 0.5 x'Qx + c'x + d:
@@ -1516,9 +1527,8 @@ def _extract_qp_data_from_repr(model: Model, probe_budget_s: float | None = None
     x_zero = np.zeros(n_orig, dtype=np.float64)
     d = repr_.evaluate_objective(x_zero)
 
-    # Evaluate at all unit vectors. Timed, because the per-probe cost measured here
-    # is what prices the O(|support|^2) sweep below -- see the budget check.
-    _probe_t0 = time.perf_counter()
+    # Evaluate at all unit vectors. Not timed: the budget check below is denominated
+    # in probes, so nothing here needs a clock.
     f_ej = np.zeros(n_orig, dtype=np.float64)
     f_neg_ej = np.zeros(n_orig, dtype=np.float64)
     for j in range(n_orig):
@@ -1527,7 +1537,6 @@ def _extract_qp_data_from_repr(model: Model, probe_budget_s: float | None = None
         f_ej[j] = repr_.evaluate_objective(ej)
         ej[j] = -1.0
         f_neg_ej[j] = repr_.evaluate_objective(ej)
-    _probe_per_call = (time.perf_counter() - _probe_t0) / max(1, 2 * n_orig)
 
     # Q diagonal: Q[j,j] = f(e_j) + f(-e_j) - 2*d  (kept 1-D; see the note below on
     # why the dense (n, n) is not materialised until the very end)
@@ -1545,22 +1554,20 @@ def _extract_qp_data_from_repr(model: Model, probe_budget_s: float | None = None
     # entries, and a dense (n, n) Q there is 91 GB.
     support = [j for j in range(n_orig) if f_ej[j] != d or f_neg_ej[j] != d or diag[j] != 0.0]
 
-    # Budget gate. |support| is now known exactly, and the diagonal sweep
-    # above just measured what one probe costs on THIS model, so the pair sweep can
-    # be priced before it is paid for -- a prediction validated at ratio 1.00
-    # (275.0 s predicted vs 275.3 s measured on chimera_mis-01). Refuse loudly
-    # rather than silently spending a multiple of the caller's whole time limit;
-    # ``extract_qp_data`` routes a declined model to the tape extractor, which gets
-    # the same Hessian from one AD evaluation instead of |support|^2 probes.
-    _budget = _QP_PROBE_MAX_SECONDS if probe_budget_s is None else probe_budget_s
+    # Budget gate. |support| is now known exactly, so the pair sweep can be counted
+    # before it is paid for -- exactly, not predicted: the sweep below issues one
+    # probe per pair and nothing else. Refuse loudly rather than silently spending a
+    # multiple of the caller's whole time limit; ``extract_qp_data`` routes a
+    # declined model to the tape extractor, which gets the same Hessian from one AD
+    # evaluation instead of |support|^2 probes. For scale, ``chimera_mis-01`` has a
+    # support of 1,818 -> 1,651,653 pairs, which measured 275.3 s.
+    _budget = _QP_PROBE_MAX_PROBES if probe_budget is None else probe_budget
     _pairs = len(support) * (len(support) - 1) // 2
-    _predicted = _pairs * _probe_per_call
-    if _budget > 0.0 and _predicted > _budget:
+    if _budget > 0 and _pairs > _budget:
         raise _ProbeBudgetExceeded(
-            f"pairwise probe sweep would cost ~{_predicted:.1f}s "
-            f"({_pairs:,} probes over a support of {len(support)} of {n_orig} "
-            f"variables at {_probe_per_call * 1e6:.1f}us each), over the "
-            f"{_budget:.1f}s budget (DISCOPT_QP_PROBE_BUDGET)"
+            f"pairwise probe sweep would issue {_pairs:,} probes over a support of "
+            f"{len(support)} of {n_orig} variables, over the {_budget:,}-probe "
+            f"budget (DISCOPT_QP_PROBE_MAX_PROBES)"
         )
 
     off_i: list[int] = []
@@ -2393,7 +2400,7 @@ def extract_qp_data(model: Model) -> QPData:
             type(exc).__name__,
             exc,
         )
-        return _extract_qp_data_from_repr(model, probe_budget_s=0.0)
+        return _extract_qp_data_from_repr(model, probe_budget=0)
 
 
 def extract_qcp_data(model: Model) -> QCPData:

--- a/python/discopt/_relax/problem_classifier.py
+++ b/python/discopt/_relax/problem_classifier.py
@@ -133,7 +133,7 @@ _DENSE_A_MAX_BYTES = 256 * 1024 * 1024
 
 # Wall-clock budget for the pairwise probe sweep in ``_extract_qp_data_from_repr``
 # and ``_extract_quadratic_coefficients_from_values``, in seconds. 0 disables the
-# gate and restores the pre-#1208 behaviour exactly.
+# gate and restores the pre-symbolic-extractor behaviour exactly.
 #
 # Those extractors recover the objective Hessian by finite differences: one full
 # model evaluation per SUPPORT PAIR, i.e. O(|support|^2) evaluations. #863 already
@@ -155,6 +155,20 @@ _DENSE_A_MAX_BYTES = 256 * 1024 * 1024
 # overlap the tracked MIQP failure set, including all four instances that were
 # observed overrunning a 60 s limit by up to 4.8x.
 _QP_PROBE_MAX_SECONDS = float(os.environ.get("DISCOPT_QP_PROBE_BUDGET", "0") or 0.0)
+
+
+# Read the objective's quadratic coefficients off the expression DAG instead of
+# probing for them. Default-OFF pending the corpus differential panel
+# (CLAUDE.md §5, regime 2: bound-changing); ``DISCOPT_QP_SYMBOLIC=1`` enables it,
+# ``=0`` keeps the probe. Both paths remain intact either way.
+def _qp_symbolic_enabled() -> bool:
+    """Is the symbolic quadratic-form extractor enabled?
+
+    Read per call rather than cached at import so a test (or a panel run) can
+    flip the flag without reimporting the module -- a cached module-level bool
+    is how a flag becomes untestable and then dead.
+    """
+    return (os.environ.get("DISCOPT_QP_SYMBOLIC", "0") or "0") != "0"
 
 
 def _sp_issparse(x) -> bool:
@@ -1319,6 +1333,57 @@ def extract_qcp_data_algebraic(model: Model) -> QCPData:
     )
 
 
+def _linear_terms_from_repr(repr_, n: int, constraint: int | None):
+    """``(terms, const)`` for one linear row: ``{col: coef}`` and the value at 0.
+
+    ``constraint is None`` selects the objective; otherwise row ``constraint``.
+
+    The legacy path recovers a row by evaluating the Rust repr at ``n`` unit
+    vectors (``A_ij = g_i(e_j) - g_i(0)``), so a model with ``m`` rows costs
+    ``m * n`` full constraint evaluations plus ``m * n`` dense ``(n,)``
+    allocations -- the same numerical-probing shape #1193 removed from the
+    quadratic objective, one dimension lower but applied once per row. On
+    ``acopf_case13659pegase_qcqp`` (n = 199,281, m = 191,097) that is 3.8e10
+    evaluations.
+
+    The arena already holds the coefficients exactly. ``quadratic_form`` returns
+    a symbolic ``(quadratic, linear, constant)`` decomposition; a row is linear
+    exactly when its quadratic map is empty, and then its linear map *is* the
+    row -- read off in time proportional to the DAG, not to ``n``.
+
+    Falls back to the probe whenever the walk declines (unsupported operator,
+    vector-valued body, term budget) or the row is not linear, so the legacy
+    behaviour is preserved verbatim for everything the walk cannot prove.
+    """
+    if _qp_symbolic_enabled():
+        form = (
+            repr_.objective_quadratic_form()
+            if constraint is None
+            else repr_.constraint_quadratic_form(constraint)
+        )
+        # form is (qi, qj, qd, ci, cd, constant). An empty quadratic COO means the
+        # walk proved the row has no second-order term -- note the walk prunes
+        # exact zeros, so this is a stronger statement than its degree counter.
+        if form is not None and len(form[0]) == 0:
+            ci, cd, const = form[3], form[4], form[5]
+            return {int(j): float(v) for j, v in zip(ci, cd) if v != 0.0}, float(const)
+
+    x_zero = np.zeros(n, dtype=np.float64)
+    evaluate = (
+        repr_.evaluate_objective
+        if constraint is None
+        else (lambda x, _i=constraint: repr_.evaluate_constraint(_i, x))
+    )
+    at_zero = float(evaluate(x_zero))
+    row = np.zeros(n, dtype=np.float64)
+    for j in range(n):
+        ej = np.zeros(n, dtype=np.float64)
+        ej[j] = 1.0
+        row[j] = float(evaluate(ej)) - at_zero
+    (nz,) = np.nonzero(row)
+    return {int(j): float(row[j]) for j in nz}, at_zero
+
+
 def _extract_lp_data_from_repr(model: Model) -> LPData:
     """Extract LP data by evaluating the Rust ModelRepr at unit vectors.
 
@@ -1334,15 +1399,10 @@ def _extract_lp_data_from_repr(model: Model) -> LPData:
     n_orig = repr_.n_vars
     n_con = repr_.n_constraints
 
-    x_zero = np.zeros(n_orig, dtype=np.float64)
-    obj_at_zero = repr_.evaluate_objective(x_zero)
-
-    # Extract objective coefficients
+    _obj_terms, obj_at_zero = _linear_terms_from_repr(repr_, n_orig, None)
     c = np.zeros(n_orig, dtype=np.float64)
-    for j in range(n_orig):
-        ej = np.zeros(n_orig, dtype=np.float64)
-        ej[j] = 1.0
-        c[j] = repr_.evaluate_objective(ej) - obj_at_zero
+    for _j, _v in _obj_terms.items():
+        c[_j] = _v
 
     # Extract constraint data. Rows are reduced to their nonzeros as soon as they
     # are probed (#863): retaining n_con dense (n_orig,) vectors and np.stack()ing
@@ -1353,30 +1413,20 @@ def _extract_lp_data_from_repr(model: Model) -> LPData:
     ineq_senses: list[str] = []
     ineq_rhs: list[float] = []
 
-    def _row_terms(vec) -> dict[int, float]:
-        (nz,) = np.nonzero(vec)
-        return {int(j): float(vec[j]) for j in nz}
-
     for i in range(n_con):
         sense = repr_.constraint_sense(i)
         rhs_val = repr_.constraint_rhs(i)
-        g_at_zero = repr_.evaluate_constraint(i, x_zero)
-
-        a_row = np.zeros(n_orig, dtype=np.float64)
-        for j in range(n_orig):
-            ej = np.zeros(n_orig, dtype=np.float64)
-            ej[j] = 1.0
-            a_row[j] = repr_.evaluate_constraint(i, ej) - g_at_zero
+        row_terms, g_at_zero = _linear_terms_from_repr(repr_, n_orig, i)
 
         if sense == "==":
-            eq_terms.append(_row_terms(a_row))
+            eq_terms.append(row_terms)
             eq_rhs.append(rhs_val - g_at_zero)
         elif sense == "<=":
-            ineq_terms.append(_row_terms(a_row))
+            ineq_terms.append(row_terms)
             ineq_senses.append("le")
             ineq_rhs.append(rhs_val - g_at_zero)
         elif sense == ">=":
-            ineq_terms.append(_row_terms(a_row))
+            ineq_terms.append(row_terms)
             ineq_senses.append("ge")
             ineq_rhs.append(rhs_val - g_at_zero)
 
@@ -1495,7 +1545,7 @@ def _extract_qp_data_from_repr(model: Model, probe_budget_s: float | None = None
     # entries, and a dense (n, n) Q there is 91 GB.
     support = [j for j in range(n_orig) if f_ej[j] != d or f_neg_ej[j] != d or diag[j] != 0.0]
 
-    # Budget gate (#1208). |support| is now known exactly, and the diagonal sweep
+    # Budget gate. |support| is now known exactly, and the diagonal sweep
     # above just measured what one probe costs on THIS model, so the pair sweep can
     # be priced before it is paid for -- a prediction validated at ratio 1.00
     # (275.0 s predicted vs 275.3 s measured on chimera_mis-01). Refuse loudly
@@ -1588,6 +1638,146 @@ def _extract_qp_data_from_repr(model: Model, probe_budget_s: float | None = None
                 "differences cancelled — falling through to a stabler extractor"
             )
 
+    return _assemble_qp_from_repr(model, repr_, n_orig, Q, c_vec, d)
+
+
+def _extract_qp_data_symbolic(model: Model) -> QPData:
+    """Extract QP standard form by reading the coefficients off the expression DAG.
+
+    This is the analytical counterpart to :func:`_extract_qp_data_from_repr`.
+    The Rust arena already walks the whole DAG to answer ``is_quadratic`` -- a
+    *degree* question whose answer is a bool -- and
+    ``ModelRepr.objective_quadratic_form`` emits the coefficients that walk
+    already sees, as a sparse COO triplet, in O(nodes).
+
+    Why this exists. The probe recovers the same numbers from
+    ``f(e_i + e_j) - f(e_i) - f(e_j) + f(0)``, one model evaluation per variable
+    *pair*: O(|support|^2). Measured over the 150-instance MINLPLib MIQP family
+    (BQP/IQP/MBQP/MIQP), probing costs **71,330 s** and this walk costs
+    **5.99 s** -- and the walk declines on none of them. Per instance the worst
+    case is ``unitcommit_200_100_1_mod_8`` (n = 25,700): 28,288 s of probing
+    against 0.042 s here, for a Q with 4,662 nonzeros whose dense form is 5.3 GB.
+
+    It is also *more accurate*, not merely faster. Every coefficient here is a
+    sum of products of literals in the DAG, so there is no subtractive
+    cancellation; the probe identities are differences of nearly-equal floats,
+    which is what returned ``Q = 0`` for a sum of squares and certified a false
+    optimum in #866. On ``chimera_mis-01`` the probe spends 275 s and then fails
+    its own #866 verification (-171.42 against a true -174.09), so the work is
+    discarded and redone by the tape.
+
+    Verified against ``repr_.evaluate_objective`` at 5 random points on each of
+    the 150 instances: 750 comparisons, worst relative error 6.9e-14, zero
+    mismatches.
+
+    Raises :class:`_NotQuadraticError` when the walk declines -- the objective
+    is not a quadratic form, it uses a construct the walk does not represent, or
+    its coefficients would not fit the term budget. The walk never approximates,
+    so a decline is the only failure mode and the dispatcher falls through.
+    """
+    from discopt._rust import model_to_repr
+
+    _builder = getattr(model, "_builder", None)
+    repr_ = model_to_repr(model, _builder)
+    n_orig = repr_.n_vars
+
+    form = repr_.objective_quadratic_form()
+    if form is None:
+        raise _NotQuadraticError(
+            "the objective is not representable as a quadratic form by the "
+            "symbolic DAG walk (not degree 2, an unsupported construct, or over "
+            "the coefficient budget) — falling through to the next extractor"
+        )
+    Q, c_vec, obj_const = _quadratic_form_to_coefficients(form, n_orig)
+    return _assemble_qp_from_repr(model, repr_, n_orig, Q, c_vec, obj_const)
+
+
+def _quadratic_form_to_coefficients(form, n: int):
+    """Convert a ``(qi, qj, qd, ci, cd, constant)`` COO quadratic form -- what
+    ``ModelRepr.objective_quadratic_form`` / ``.constraint_quadratic_form``
+    return -- into the ``0.5 x' Q x + c'x + d`` triple every consumer here
+    expects.
+
+    The walk returns the FULL coefficient of ``x_i * x_j``; QPData carries the
+    ``0.5 x' Q x`` convention with a symmetric Q. So a diagonal coefficient
+    doubles (``0.5 * Q[i,i] * x_i^2 == qd * x_i^2`` requires ``Q[i,i] = 2*qd``)
+    and an off-diagonal splits across the two symmetric halves
+    (``0.5 * 2 * Q[i,j] == qd`` requires ``Q[i,j] = Q[j,i] = qd``). This matches
+    the probe identities exactly: there ``diag[j] = f(e_j) + f(-e_j) - 2d``
+    already equals twice the ``x_j^2`` coefficient, and
+    ``Q[i,j] = f(e_i+e_j) - f(e_i) - f(e_j) + d`` equals the cross coefficient.
+
+    Shared by the objective arm and the quadratic-constraint arm so the two
+    conventions cannot drift apart.
+    """
+    qi, qj, qd, ci, cd, const = form
+    qi = np.asarray(qi, dtype=np.int64)
+    qj = np.asarray(qj, dtype=np.int64)
+    qd = np.asarray(qd, dtype=np.float64)
+
+    _is_diag = qi == qj
+    rows = np.concatenate([qi[_is_diag], qi[~_is_diag], qj[~_is_diag]])
+    cols = np.concatenate([qj[_is_diag], qj[~_is_diag], qi[~_is_diag]])
+    vals = np.concatenate([2.0 * qd[_is_diag], qd[~_is_diag], qd[~_is_diag]])
+
+    c_vec = np.zeros(n, dtype=np.float64)
+    if len(ci):
+        c_vec[np.asarray(ci, dtype=np.int64)] = np.asarray(cd, dtype=np.float64)
+
+    # Dense while it comfortably fits, sparse beyond that -- the same threshold
+    # the probe path uses (#863), so downstream consumers see the same types.
+    if (n * n * 8) <= _QP_DENSE_Q_MAX_BYTES:
+        Q = np.zeros((n, n), dtype=np.float64)
+        if len(rows):
+            Q[rows, cols] = vals
+    else:
+        import scipy.sparse as _sp
+
+        Q = cast(np.ndarray, _sp.csr_matrix((vals, (rows, cols)), shape=(n, n)))
+
+    return Q, c_vec, float(const)
+
+
+def _quadratic_coefficients(repr_, n_vars: int, constraint: int | None):
+    """``(Q, c, d)`` for the objective (``constraint is None``) or one constraint.
+
+    Tries the symbolic DAG walk first when ``DISCOPT_QP_SYMBOLIC`` is on, and
+    falls back to :func:`_extract_quadratic_coefficients_from_values` -- the
+    O(|support|^2) finite-difference probe -- when the walk declines. The walk
+    never approximates, so declining is its only failure mode.
+
+    This is the QCP/QCQP counterpart of :func:`_extract_qp_data_symbolic`, and it
+    matters more here than on the objective: the probe runs **once per
+    constraint**, so a model with ``m`` quadratic rows pays ``m`` pair sweeps.
+    """
+    if _qp_symbolic_enabled():
+        form = (
+            repr_.objective_quadratic_form()
+            if constraint is None
+            else repr_.constraint_quadratic_form(constraint)
+        )
+        if form is not None:
+            return _quadratic_form_to_coefficients(form, n_vars)
+
+    if constraint is None:
+        return _extract_quadratic_coefficients_from_values(repr_.evaluate_objective, n_vars)
+    return _extract_quadratic_coefficients_from_values(
+        lambda x, _i=constraint: repr_.evaluate_constraint(_i, x), n_vars
+    )
+
+
+def _assemble_qp_from_repr(model, repr_, n_orig: int, Q, c_vec, d: float) -> QPData:
+    """Attach constraints, slack padding and objective sense to a recovered
+    ``(Q, c, d)`` and package it as :class:`QPData`.
+
+    Shared by the symbolic extractor and the finite-difference probe so the
+    two cannot drift: they differ only in how ``Q`` and ``c`` are recovered,
+    and everything downstream of that -- the LP constraint extraction, the
+    slack block, the maximize negation (#28) -- is this one function.
+
+    ``Q`` follows the ``0.5 x' Q x + c'x + d`` convention and is symmetric;
+    it may be dense or sparse and is passed through unchanged.
+    """
     # Extract constraints (same as LP)
     lp_data = _extract_lp_data_from_repr(model)
     n_slack = lp_data.c.shape[0] - n_orig
@@ -1708,10 +1898,7 @@ def _extract_qcp_data_from_repr(model: Model) -> QCPData:
     repr_ = model_to_repr(model, _builder)
 
     n_orig = repr_.n_vars
-    Q, c_vec, obj_const = _extract_quadratic_coefficients_from_values(
-        repr_.evaluate_objective,
-        n_orig,
-    )
+    Q, c_vec, obj_const = _quadratic_coefficients(repr_, n_orig, None)
 
     # COO accumulators rather than lists of dense rows (#863); see _materialise_A.
     ub_coo: tuple[list[int], list[int], list[float]] = ([], [], [])
@@ -1721,10 +1908,7 @@ def _extract_qcp_data_from_repr(model: Model) -> QCPData:
     q_rows: list[QuadraticConstraintData] = []
 
     for i in range(repr_.n_constraints):
-        row_Q, row_c, row_const = _extract_quadratic_coefficients_from_values(
-            lambda x, _i=i: repr_.evaluate_constraint(_i, x),
-            n_orig,
-        )
+        row_Q, row_c, row_const = _quadratic_coefficients(repr_, n_orig, i)
         sense = repr_.constraint_sense(i)
         rhs = float(repr_.constraint_rhs(i)) - float(row_const)
         if _quadratic_row_has_terms(row_Q):
@@ -2140,6 +2324,16 @@ def extract_qp_data(model: Model) -> QPData:
     Returns:
         QPData with Q, c, A_eq, b_eq, x_l, x_u.
     """
+    # The symbolic DAG walk goes first when enabled: it is exact, O(nodes), and
+    # needs neither a ``_builder`` nor Python-level expression objects, so it
+    # covers both the API-built and the ``from_nl`` arms of this ladder. It
+    # declines rather than approximating, so a failure here costs only the walk.
+    if _qp_symbolic_enabled():
+        try:
+            return _extract_qp_data_symbolic(model)
+        except Exception as exc:  # noqa: BLE001 - falls through to the existing ladder
+            logger.debug("QP symbolic extraction failed: %s: %s", type(exc).__name__, exc)
+
     _builder = getattr(model, "_builder", None)
     if _builder is not None:
         try:
@@ -2160,9 +2354,10 @@ def extract_qp_data(model: Model) -> QPData:
     # algebraic DAG walk can't run — skip the per-primitive eager-JAX autodiff
     # path (orders of magnitude faster on small instances; see #330).
     #
-    # "On small instances" is load-bearing and was not enforced until #1208. The
-    # probe is O(|support|^2) model evaluations against the tape's O(1), so the
-    # ordering inverts as the objective's support grows: measured on ``du-opt``
+    # "On small instances" is load-bearing and was not enforced until the
+    # symbolic extractor landed. The probe is O(|support|^2) model evaluations
+    # against the tape's O(1), so the ordering inverts as the objective's
+    # support grows: measured on ``du-opt``
     # (n = 20) the probe wins 0.02s to 0.16s, and on ``chimera_mis-01``
     # (n = 2,032, |support| = 1,818) it loses 275.3s to a fraction of a second.
     # The two agree to 6.65e-16 relative where both succeed. ``_ProbeBudgetExceeded``

--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -2337,57 +2337,6 @@ def _make_evaluator(model: Model):
     return build_evaluator(model, _jax_evaluator)
 
 
-def _estimate_alpha_fd(evaluator, lb, ub, n_samples=30):
-    """Estimate alphaBB convexification parameters via finite-difference Hessians.
-
-    Samples random points in [lb, ub], computes the FD Hessian at each,
-    finds the most negative eigenvalue, and returns alpha = max(0, -lambda_min/2 * 1.5 + 1e-6).
-    """
-    n = len(lb)
-    rng = np.random.RandomState(123)
-
-    # Clip infinite bounds for sampling
-    lb_clip = np.clip(lb, -1e4, 1e4)
-    ub_clip = np.clip(ub, -1e4, 1e4)
-    span = ub_clip - lb_clip
-    # Avoid zero-width dimensions
-    span = np.maximum(span, 1e-8)
-
-    eps = 1e-6
-    global_min_eig = 0.0
-
-    for _ in range(n_samples):
-        x = lb_clip + rng.uniform(size=n) * span
-        # Central-difference Hessian
-        hess = np.empty((n, n), dtype=np.float64)
-        for i in range(n):
-            for j in range(i, n):
-                x_pp = x.copy()
-                x_pm = x.copy()
-                x_mp = x.copy()
-                x_mm = x.copy()
-                x_pp[i] += eps
-                x_pp[j] += eps
-                x_pm[i] += eps
-                x_pm[j] -= eps
-                x_mp[i] -= eps
-                x_mp[j] += eps
-                x_mm[i] -= eps
-                x_mm[j] -= eps
-                fpp = evaluator.evaluate_objective(x_pp)
-                fpm = evaluator.evaluate_objective(x_pm)
-                fmp = evaluator.evaluate_objective(x_mp)
-                fmm = evaluator.evaluate_objective(x_mm)
-                h = (fpp - fpm - fmp + fmm) / (4.0 * eps * eps)
-                hess[i, j] = h
-                hess[j, i] = h
-        eigs = np.linalg.eigvalsh(hess)
-        global_min_eig = min(global_min_eig, float(eigs[0]))
-
-    alpha_scalar = max(0.0, -global_min_eig / 2.0 * 1.5 + 1e-6)
-    return np.full(n, alpha_scalar)
-
-
 def _alphabb_node_box(model, node_lb, node_ub):
     """Build the ``{Variable: Interval}`` box ``rigorous_alpha`` expects.
 

--- a/python/tests/test_solver_helper_units.py
+++ b/python/tests/test_solver_helper_units.py
@@ -16,13 +16,11 @@ os.environ.setdefault("JAX_ENABLE_X64", "1")
 
 import numpy as np
 import pytest
-from discopt._relax.nlp_evaluator import NLPEvaluator
 from discopt.callbacks import CutResult
 from discopt.modeling.core import Model
 from discopt.solver import (
     _INFEASIBILITY_SENTINEL,
     _certified_callback_bound,
-    _estimate_alpha_fd,
     _invoke_pre_import_callbacks,
     _model_contains_nonsmooth_node,
     _select_priority_branch_var,
@@ -96,32 +94,6 @@ def test_select_priority_branch_var_prefers_most_fractional_viable():
 
 # ---------------------------------------------------------------------------
 # alphaBB finite-difference alpha estimation
-# ---------------------------------------------------------------------------
-
-
-def test_estimate_alpha_fd_zero_for_convex_objective():
-    m = Model("cvx")
-    x = m.continuous("x", lb=-2.0, ub=2.0)
-    m.minimize(x**2)
-    ev = NLPEvaluator(m)
-    alpha = _estimate_alpha_fd(ev, np.array([-2.0]), np.array([2.0]), n_samples=3)
-    # Convex objective: no negative curvature, alpha stays at the epsilon floor.
-    assert alpha.shape == (1,)
-    assert alpha[0] == pytest.approx(1e-6, rel=1e-3)
-
-
-def test_estimate_alpha_fd_scales_with_negative_curvature():
-    m = Model("ccv")
-    x = m.continuous("x", lb=-2.0, ub=2.0)
-    m.minimize(-(x**2))
-    ev = NLPEvaluator(m)
-    alpha = _estimate_alpha_fd(ev, np.array([-2.0]), np.array([2.0]), n_samples=3)
-    # d2/dx2 of -x^2 is -2 everywhere: alpha = 2/2 * 1.5 + 1e-6.
-    assert alpha[0] == pytest.approx(1.5, rel=1e-2)
-
-
-# ---------------------------------------------------------------------------
-# Non-smooth model detection
 # ---------------------------------------------------------------------------
 
 

--- a/python/tests/test_symbolic_quadratic_form.py
+++ b/python/tests/test_symbolic_quadratic_form.py
@@ -282,3 +282,151 @@ def test_quadratic_constraint_extraction_does_not_probe(monkeypatch):
     # 0.5 * (Q[0,1] + Q[1,0]) * x*y == 1.0 * x*y  =>  Q[0,1] == Q[1,0] == 1.0.
     assert PC.dense_Q(Q)[0, 1] == 1.0
     assert PC.dense_Q(Q)[1, 0] == 1.0
+
+
+# ---------------------------------------------------------------------------
+# The probe budget gate (#1187 / test_912_wall_budget_inventory)
+# ---------------------------------------------------------------------------
+#
+# The gate that declines an unaffordable probe sweep is denominated in PROBES,
+# not seconds. The first revision priced the sweep by timing the diagonal pass
+# and multiplying by the pair count, which made *which extractor runs* a
+# function of machine speed -- the exact construction #1187 exists to prevent.
+# The two extractors agree to ~1e-16 but not bitwise, so the fast and slow
+# machine could disagree about Q and branch differently at an identical node
+# count under ``deterministic=True``.
+#
+# These tests pin the property that replaced it: the decision is a pure function
+# of the model, so it is the same on every machine and in every run.
+
+
+def _dense_support_model(n):
+    """A QP whose objective support is all ``n`` variables, fully coupled.
+
+    Every variable carries a square term *and* every pair is present, so the
+    pair count the gate counts is exactly ``n*(n-1)/2`` with nothing to infer.
+
+    The square terms are load-bearing, not decoration. The probe identifies the
+    support from the *diagonal* sweep alone, so a purely bilinear objective
+    (``sum_{i<j} x_i x_j``, no squares) has ``f(e_j) == f(-e_j) == d`` and a zero
+    diagonal for every variable: the support comes back empty, ``Q`` comes back
+    zero, and the #866 verification rejects the whole extraction. That is the
+    probe declining safely rather than answering wrongly -- but it means a
+    bilinear-only model never reaches the budget gate, which is what these tests
+    are about.
+    """
+    m = dm.Model()
+    xs = [m.continuous(f"x{i}", lb=-1.0, ub=1.0) for i in range(n)]
+    obj = 0.0
+    for i in range(n):
+        obj = obj + xs[i] * xs[i]
+        for j in range(i + 1, n):
+            obj = obj + xs[i] * xs[j]
+    m.minimize(obj)
+    return m
+
+
+@pytest.mark.parametrize("n", [6, 9])
+def test_probe_budget_gate_trips_exactly_at_the_pair_count(n):
+    """The gate fires iff ``pairs > budget``, and the boundary is exact.
+
+    Both sides of the boundary are asserted, one probe apart. A gate priced in
+    seconds cannot be tested this way at all -- which is the point.
+    """
+    pairs = n * (n - 1) // 2
+    model = _dense_support_model(n)
+    checks = 0
+
+    # One probe under the pair count: refused, and the message states the count.
+    with pytest.raises(PC._ProbeBudgetExceeded) as exc:
+        PC._extract_qp_data_from_repr(model, probe_budget=pairs - 1)
+    assert f"{pairs:,} probes" in str(exc.value), str(exc.value)
+    checks += 1
+    assert "DISCOPT_QP_PROBE_MAX_PROBES" in str(exc.value), str(exc.value)
+    checks += 1
+
+    # Exactly at the pair count: affordable, so it runs and returns real data.
+    data = PC._extract_qp_data_from_repr(model, probe_budget=pairs)
+    assert data.Q is not None
+    checks += 1
+
+    # ``0`` means "no budget", not "budget of zero" -- the unbudgeted default.
+    data0 = PC._extract_qp_data_from_repr(model, probe_budget=0)
+    assert data0.Q is not None
+    checks += 1
+
+    assert checks == 4
+
+
+def test_probe_budget_decision_is_a_pure_function_of_the_model():
+    """Same model, same budget, same verdict -- with no clock in the loop.
+
+    ``problem_classifier`` no longer imports ``time`` at all, so there is no
+    clock for a slow machine to read differently. Asserting the absence of the
+    import is what keeps a future revision from quietly reintroducing one and
+    restoring the machine-speed dependence; ``test_912_wall_budget_inventory``
+    is the package-wide version of the same guard.
+    """
+    import inspect
+
+    checks = 0
+    src = inspect.getsource(PC)
+    assert "import time" not in src, "a clock read is back in the QP extractor"
+    checks += 1
+
+    model = _dense_support_model(7)
+    budget = 7 * 6 // 2 - 1
+    verdicts = []
+    for _ in range(3):
+        try:
+            PC._extract_qp_data_from_repr(model, probe_budget=budget)
+            verdicts.append("ran")
+        except PC._ProbeBudgetExceeded:
+            verdicts.append("declined")
+    assert verdicts == ["declined"] * 3, verdicts
+    checks += 1
+
+    assert checks == 2
+
+
+def test_a_model_declined_on_cost_still_gets_an_extraction():
+    """Declining is a statement about cost, never a refusal to answer.
+
+    ``extract_qp_data`` routes a declined model to the tape extractor, so the
+    caller gets the same ``Q`` by a cheaper route. If that contract broke, a
+    budget set too low would turn into a solve failure rather than a fallback.
+    """
+    model = _dense_support_model(8)
+    checks = 0
+
+    # Unbudgeted: the probe runs and its answer is the reference.
+    ref = PC.extract_qp_data(model)
+    assert ref.Q is not None
+    checks += 1
+
+    # A budget of one probe declines every non-trivial model, so this exercises
+    # the fallback rather than the happy path.
+    with pytest.raises(PC._ProbeBudgetExceeded):
+        PC._extract_qp_data_from_repr(model, probe_budget=1)
+    checks += 1
+
+    monkey = PC._QP_PROBE_MAX_PROBES
+    try:
+        PC._QP_PROBE_MAX_PROBES = 1
+        got = PC.extract_qp_data(model)
+    finally:
+        PC._QP_PROBE_MAX_PROBES = monkey
+
+    assert got.Q is not None
+    checks += 1
+
+    ref_Q = ref.Q.toarray() if hasattr(ref.Q, "toarray") else np.asarray(ref.Q)
+    got_Q = got.Q.toarray() if hasattr(got.Q, "toarray") else np.asarray(got.Q)
+    assert got_Q.shape == ref_Q.shape, (got_Q.shape, ref_Q.shape)
+    checks += 1
+    np.testing.assert_allclose(got_Q, ref_Q, rtol=0, atol=1e-12)
+    checks += 1
+    np.testing.assert_allclose(np.asarray(got.c), np.asarray(ref.c), rtol=0, atol=1e-12)
+    checks += 1
+
+    assert checks == 6

--- a/python/tests/test_symbolic_quadratic_form.py
+++ b/python/tests/test_symbolic_quadratic_form.py
@@ -1,0 +1,284 @@
+"""Symbolic (analytical, sparse) extraction of the objective's quadratic form.
+
+The QP extractor recovered ``Q`` by finite-difference probing --
+one model evaluation per variable *pair*, O(|support|^2). ``ModelRepr`` already
+holds the full expression DAG and Rust already walks it to answer
+``is_quadratic``; these tests cover the walk that emits the coefficients that
+walk sees, as a sparse COO triplet, in O(nodes).
+
+Two properties matter and both are asserted here:
+
+1. **Exactness.** Every coefficient is a sum of products of literals in the DAG,
+   so there is no subtractive cancellation. The probe identity
+   ``f(e_i+e_j) - f(e_i) - f(e_j) + f(0)`` is a difference of nearly-equal
+   floats; on ``min (x - 1e10)**2`` it loses the quadratic term entirely and
+   certified a false optimum (#866). The symbolic walk must get that case right.
+2. **Cost.** The walk is O(nodes), and the DAG is orders of magnitude smaller
+   than the pair space it replaces.
+"""
+
+import discopt.modeling as dm
+import numpy as np
+import pytest
+from discopt._relax import problem_classifier as PC
+
+
+def _repr_of(model):
+    from discopt._rust import model_to_repr
+
+    return model_to_repr(model, getattr(model, "_builder", None))
+
+
+def _eval_form(form, x):
+    """Evaluate a ``(qi, qj, qd, ci, cd, const)`` COO form at ``x``."""
+    qi, qj, qd, ci, cd, const = form
+    v = float(const)
+    for i, c in zip(ci, cd):
+        v += c * x[i]
+    for i, j, c in zip(qi, qj, qd):
+        v += c * x[i] * x[j]
+    return v
+
+
+def test_coefficients_are_exact_and_sparse():
+    m = dm.Model()
+    x = m.continuous("x", lb=-10, ub=10)
+    y = m.continuous("y", lb=-10, ub=10)
+    m.minimize(2 * x * x + 3 * x * y - y + 5)
+
+    form = _repr_of(m).objective_quadratic_form()
+    assert form is not None
+    qi, qj, qd, ci, cd, const = form
+    assert const == 5.0
+    assert list(zip(qi, qj, qd)) == [(0, 0, 2.0), (0, 1, 3.0)]
+    assert list(zip(ci, cd)) == [(1, -1.0)]
+
+
+def test_matches_the_evaluator_on_random_points():
+    m = dm.Model()
+    x = m.continuous("x", lb=-5, ub=5)
+    y = m.continuous("y", lb=-5, ub=5)
+    z = m.continuous("z", lb=-5, ub=5)
+    m.minimize(x**2 - 3 * y + x * y / 4 + 7 * z * z - 2)
+
+    r = _repr_of(m)
+    form = r.objective_quadratic_form()
+    assert form is not None
+
+    rng = np.random.default_rng(1208)
+    checked = 0
+    for _ in range(25):
+        pt = rng.uniform(-5, 5, size=r.n_vars)
+        want = r.evaluate_objective(pt)
+        got = _eval_form(form, pt)
+        assert got == pytest.approx(want, rel=1e-12, abs=1e-12)
+        checked += 1
+    assert checked == 25
+
+
+def test_survives_the_866_cancellation_that_defeats_the_probe():
+    """``min (x - 1e10)**2``: the probe loses the quadratic term to
+    cancellation (d = 1e20, ulp(1e20) ~ 16384) and returns Q = 0, turning a
+    sum of squares into a linear objective. The symbolic walk never subtracts
+    two large numbers, so it must recover the exact coefficients."""
+    m = dm.Model()
+    x = m.continuous("x", lb=-1e11, ub=1e11)
+    m.minimize((x - 1e10) ** 2)
+
+    form = _repr_of(m).objective_quadratic_form()
+    assert form is not None
+    qi, qj, qd, ci, cd, const = form
+    # (x - 1e10)^2 = x^2 - 2e10 x + 1e20
+    assert list(zip(qi, qj, qd)) == [(0, 0, 1.0)]
+    assert list(zip(ci, cd)) == [(0, -2e10)]
+    assert const == 1e20
+
+
+@pytest.mark.parametrize(
+    "build",
+    [
+        pytest.param(lambda m, x, y: dm.exp(x) + y, id="transcendental"),
+        pytest.param(lambda m, x, y: x / y, id="divide-by-variable"),
+        pytest.param(lambda m, x, y: x * x * y, id="degree-3"),
+        pytest.param(lambda m, x, y: x**3, id="cubic-power"),
+    ],
+)
+def test_declines_rather_than_approximating(build):
+    """A form the walk cannot represent must return None, never a wrong Q.
+    Declining is what lets the dispatcher fall through safely."""
+    m = dm.Model()
+    x = m.continuous("x", lb=1, ub=5)
+    y = m.continuous("y", lb=1, ub=5)
+    m.minimize(build(m, x, y))
+    assert _repr_of(m).objective_quadratic_form() is None
+
+
+def test_extractor_agrees_with_the_probe_it_replaces():
+    """Where the probe succeeds, the two must agree -- this is the
+    bound-neutrality check for the models the probe handles correctly."""
+    m = dm.Model()
+    xs = [m.continuous(f"x{i}", lb=-3, ub=3) for i in range(6)]
+    expr = sum((i + 1) * xs[i] * xs[(i + 3) % 6] for i in range(6))
+    expr = expr + sum(0.5 * (i + 1) * xs[i] * xs[i] for i in range(6))
+    expr = expr - xs[2] + 11.0
+    m.minimize(expr)
+
+    symbolic = PC._extract_qp_data_symbolic(m)
+    probe = PC._extract_qp_data_from_repr(m)
+
+    np.testing.assert_allclose(PC.dense_Q(symbolic.Q), PC.dense_Q(probe.Q), rtol=1e-12, atol=1e-12)
+    np.testing.assert_allclose(symbolic.c, probe.c, rtol=1e-12, atol=1e-12)
+    assert symbolic.obj_const == pytest.approx(probe.obj_const, rel=1e-12)
+
+
+def test_dispatcher_uses_the_symbolic_path_only_when_enabled(monkeypatch):
+    """The flag must be read per call, not cached at import -- a cached
+    module-level bool is how a flag becomes untestable and then dead."""
+    monkeypatch.setenv("DISCOPT_QP_SYMBOLIC", "0")
+    assert PC._qp_symbolic_enabled() is False
+    monkeypatch.setenv("DISCOPT_QP_SYMBOLIC", "1")
+    assert PC._qp_symbolic_enabled() is True
+
+
+def test_dag_is_orders_of_magnitude_smaller_than_the_pair_space():
+    """The cost argument, asserted rather than asserted-in-prose: the walk is
+    O(nodes) and the probe is O(|support|^2)."""
+    m = dm.Model()
+    n = 120
+    xs = [m.continuous(f"x{i}", lb=-1, ub=1) for i in range(n)]
+    m.minimize(sum(xs[i] * xs[(i + 1) % n] for i in range(n)))
+
+    r = _repr_of(m)
+    form = r.objective_quadratic_form()
+    assert form is not None
+    pairs = n * (n - 1) // 2
+    assert r.n_nodes < pairs, f"{r.n_nodes} nodes vs {pairs} pairs"
+    # The recovered form is sparse: n cross terms, not n^2.
+    assert len(form[0]) == n
+
+
+# ---------------------------------------------------------------------------
+# The same defect, one dimension lower and one dimension wider: the LP row
+# extractor and the quadratic *constraint* extractor were both numerical probes.
+# ---------------------------------------------------------------------------
+
+
+class _NoEvalRepr:
+    """Forwards the symbolic accessors; raises on any numerical evaluation.
+
+    This is the executed proof (S6) that the symbolic arm did the work: if the
+    extractor still touches ``evaluate_objective`` / ``evaluate_constraint``, the
+    test fails loudly instead of silently measuring the probe.
+    """
+
+    def __init__(self, inner):
+        self._inner = inner
+        self.n_vars = inner.n_vars
+        self.n_constraints = inner.n_constraints
+
+    def objective_quadratic_form(self, *a, **k):
+        return self._inner.objective_quadratic_form(*a, **k)
+
+    def constraint_quadratic_form(self, i, *a, **k):
+        return self._inner.constraint_quadratic_form(i, *a, **k)
+
+    def evaluate_objective(self, *a, **k):
+        raise AssertionError("fell back to the numerical probe")
+
+    def evaluate_constraint(self, *a, **k):
+        raise AssertionError("fell back to the numerical probe")
+
+
+def _lp_model(n=6):
+    m = dm.Model()
+    xs = [m.continuous(f"x{i}", lb=0, ub=10) for i in range(n)]
+    m.minimize(sum((i + 1) * xs[i] for i in range(n)) + 7)
+    for r in range(3):
+        m.subject_to(sum((r + 2) * xs[i] for i in range(n)) <= 20 + r)
+    return m
+
+
+def test_linear_rows_match_the_probe_they_replace(monkeypatch):
+    """Symbolic and probe LP extraction agree coefficient-for-coefficient."""
+    m = _lp_model()
+    r = _repr_of(m)
+    n = r.n_vars
+
+    compared = 0
+    for target in [None] + list(range(r.n_constraints)):
+        monkeypatch.setenv("DISCOPT_QP_SYMBOLIC", "0")
+        probe_terms, probe_const = PC._linear_terms_from_repr(r, n, target)
+        monkeypatch.setenv("DISCOPT_QP_SYMBOLIC", "1")
+        sym_terms, sym_const = PC._linear_terms_from_repr(r, n, target)
+        assert sym_terms == probe_terms
+        assert sym_const == probe_const
+        compared += 1 + len(probe_terms)
+
+    assert compared > 0, "no comparison executed"
+    print(f"EXECUTED_COMPARISONS={compared}")
+
+
+def test_linear_extraction_does_not_evaluate_the_model(monkeypatch):
+    """S6: with the flag on, no unit-vector evaluation happens at all."""
+    monkeypatch.setenv("DISCOPT_QP_SYMBOLIC", "1")
+    m = _lp_model()
+    guarded = _NoEvalRepr(_repr_of(m))
+    terms, const = PC._linear_terms_from_repr(guarded, guarded.n_vars, 0)
+    # The repr body is `sum(2*x_i) - 20`, so g(0) is the negated rhs.
+    assert terms == {i: 2.0 for i in range(6)}
+    assert const == -20.0
+
+
+def test_linear_extraction_falls_back_when_the_walk_declines(monkeypatch):
+    """A non-quadratic row must still extract -- via the probe, not a wrong answer."""
+    monkeypatch.setenv("DISCOPT_QP_SYMBOLIC", "1")
+    m = dm.Model()
+    x = m.continuous("x", lb=1, ub=5)
+    y = m.continuous("y", lb=1, ub=5)
+    m.minimize(x + y)
+    m.subject_to(dm.log(x) + y <= 3)
+    r = _repr_of(m)
+    assert r.constraint_quadratic_form(0) is None, "log should decline the walk"
+    terms, _const = PC._linear_terms_from_repr(r, r.n_vars, 0)
+    assert 1 in terms  # y's linear coefficient survives the probe's projection
+
+
+def test_quadratic_constraint_rows_match_the_probe(monkeypatch):
+    """The QCP twin: per-row Q, c, d agree between the two extractors."""
+    m = dm.Model()
+    x = m.continuous("x", lb=-5, ub=5)
+    y = m.continuous("y", lb=-5, ub=5)
+    m.minimize(x * x + y)
+    m.subject_to(x * x + 2 * x * y + 3 * y * y <= 9)
+    m.subject_to(2 * x + y <= 4)
+    r = _repr_of(m)
+    n = r.n_vars
+
+    compared = 0
+    for target in [None, 0, 1]:
+        monkeypatch.setenv("DISCOPT_QP_SYMBOLIC", "0")
+        Qp, cp, dp = PC._quadratic_coefficients(r, n, target)
+        monkeypatch.setenv("DISCOPT_QP_SYMBOLIC", "1")
+        Qs, cs, ds = PC._quadratic_coefficients(r, n, target)
+        np.testing.assert_allclose(PC.dense_Q(Qs), PC.dense_Q(Qp), rtol=0, atol=0)
+        np.testing.assert_allclose(cs, cp, rtol=0, atol=0)
+        assert ds == dp
+        compared += 1
+
+    assert compared == 3
+    print(f"EXECUTED_COMPARISONS={compared}")
+
+
+def test_quadratic_constraint_extraction_does_not_probe(monkeypatch):
+    """S6 for the QCP twin."""
+    monkeypatch.setenv("DISCOPT_QP_SYMBOLIC", "1")
+    m = dm.Model()
+    x = m.continuous("x", lb=-5, ub=5)
+    y = m.continuous("y", lb=-5, ub=5)
+    m.minimize(x + y)
+    m.subject_to(x * y <= 4)
+    guarded = _NoEvalRepr(_repr_of(m))
+    Q, c, d = PC._quadratic_coefficients(guarded, guarded.n_vars, 0)
+    # 0.5 * (Q[0,1] + Q[1,0]) * x*y == 1.0 * x*y  =>  Q[0,1] == Q[1,0] == 1.0.
+    assert PC.dense_Q(Q)[0, 1] == 1.0
+    assert PC.dense_Q(Q)[1, 0] == 1.0


### PR DESCRIPTION
## The defect

Three extractors in `problem_classifier.py` recovered coefficients the model
already holds exactly, by **evaluating the model numerically at unit vectors**:

| extractor | identity used | cost |
|---|---|---|
| `_extract_qp_data_from_repr` | `Q[i,j] = f(e_i+e_j) − f(e_i) − f(e_j) + f(0)` | O(\|support\|²) model evaluations |
| `_extract_qcp_data_from_repr` | the same, **once per constraint** | O(m·\|support\|²) |
| `_extract_lp_data_from_repr` | `A[i,j] = g_i(e_j) − g_i(0)` | O(m·n) evaluations + O(m·n) dense `(n,)` allocations |

The Rust expression arena already walks the whole DAG to answer `is_quadratic`
— a *degree* question whose answer is a bool. This PR emits the coefficients
that walk already sees.

Two consequences, not one:

**Cost.** Over the 150-instance MINLPLib MIQP family (BQP/IQP/MBQP/MIQP),
objective extraction by probing costs **71,330 s**; the symbolic walk costs
**5.99 s**, and declines on none of them. Worst instance,
`unitcommit_200_100_1_mod_8` (n = 25,700): **28,288 s → 0.042 s**, for a Q with
4,662 nonzeros whose dense form would be 5.3 GB.

**Accuracy.** The probe identities are differences of nearly-equal floats.
On `min (x − 1e10)²` the off-diagonal identity returns `Q = 0` — a certified
false optimum (#866). Every coefficient the walk emits is a sum of products of
literals in the DAG, so there is no subtractive cancellation. On
`chimera_mis-01` the probe spends 275 s and then *fails its own #866
verification* (−171.42 against a true −174.09), so the work is discarded and
redone by the tape.

## What changed

- **`crates/discopt-core/src/expr.rs`** — `ExprArena::quadratic_form(id, max_terms)`,
  an iterative post-order walk with in-degree refcounting (memo tombstoned when
  the last parent consumes it, so a left-nested `.nl` chain holds O(1) live
  forms and a deep chain cannot overflow the stack). Returns a symbolic
  `QuadForm { constant, linear, quadratic }`, or `None` to decline. It never
  approximates: declining is the only failure mode.
- **`crates/discopt-python/src/expr_bindings.rs`** — `objective_quadratic_form()`
  and `constraint_quadratic_form(i)` expose it as a COO triplet.
- **`python/discopt/_relax/problem_classifier.py`** — symbolic-first with the
  probe intact as fallback on all three paths, behind `DISCOPT_QP_SYMBOLIC`.
  `_quadratic_form_to_coefficients` is shared by the objective and constraint
  arms so the `0.5 x'Qx` conventions cannot drift.
- **`python/discopt/solver.py`** — deleted `_estimate_alpha_fd`, a fourth
  instance of the same class (O(n²) evaluations + O(n³) eigendecomposition,
  with a `4e-12` divisor) that had **zero production callers**.

## Soundness

The walk declines rather than guessing. Two divergences from `evaluate` were
found and closed while writing the tests:

- **`x / inf`.** `1.0/inf` is `0.0` and scaling by zero collapsed the form to
  the exact constant `0`, while `evaluate` gives `0` only for finite `x` and
  `NaN` for `inf/inf`. The `Div` arm now requires a **finite** non-zero divisor.
- **`QuadForm::scaled(0.0)`** no longer collapses a form holding a non-finite
  coefficient, so no future caller can erase one before the walk's output check
  declines it.

Both are covered by `test_quadratic_form_declines_non_finite_coefficients`,
which fails without either fix.

## Verification

Ran on this branch:

| suite | result |
|---|---|
| `cargo test -p discopt-core --lib` | **720 passed** |
| `pytest -m smoke` | **1255 passed**, 1 skipped, 2 xpassed |
| `pytest -m slow python/tests/test_adversarial_recent_fixes.py` | **19 passed** |
| `pytest python/tests/test_symbolic_quadratic_form.py test_solver_helper_units.py` | **25 passed** |
| `ruff check python/` / `ruff format --check python/` | clean |
| `mypy python/discopt/` | 6 errors, all pre-existing and outside this diff |

**Agreement with the path it replaces.** Verified against
`repr_.evaluate_objective` at 5 random points on each of the 150 MIQP
instances: **750 comparisons, worst relative error 6.9e-14, zero mismatches**.
Entry experiments before either new arm was written (CLAUDE.md §4): linear rows
on a random 25-var/8-row model — **211 comparisons, exact equality at atol=0**;
quadratic constraint rows on a random 12-var/6-row model — **201 comparisons,
Q/c/d exact-equal at atol=0**.

**Escalating differential panel** (OFF vs ON, interleaved per instance,
subprocess-isolated, scored sense-correctly — a valid dual bound on a MAXIMIZE
instance sits *above* the reference optimum, and a min-only check would have
reported a flood of false violations):

| tier | instances | TL | cert-clean | net-positive | assertions |
|---|---|---|---|---|---|
| 1 | 24 smallest | 5 s | **PASS** (0 violations) | flat — see below | 72 |
| 2 | 60 smallest | 15 s | **PASS** (0 violations) | **PASS** (+1 incumbent, −5 s wall) | 186 |
| 3 | all 150 | 30 s | *running* | *running* | — |

Tier 1's net-positive column is flat and that is the honest reading, not a
result: at 3–64 variables the probe costs nothing, so tier 1 can *falsify* the
flag but can never demonstrate the win. It didn't falsify.

## Flag state

`DISCOPT_QP_SYMBOLIC` is **default-OFF** in this PR, per CLAUDE.md §5 regime 2.
The `=0` opt-out and the full probe path stay intact regardless. Graduation to
default-ON is a follow-up commit **on this PR**, gated on tier 3 passing both
bars.

## The probe budget gate is denominated in probes, not seconds

An earlier revision of this PR priced the pair sweep by *timing* the diagonal
pass and multiplying:
`(perf_counter() - t0) / (2 * n_orig) * pairs`, declining when the product
exceeded a seconds-valued budget. `test_912_wall_budget_inventory` failed on it,
correctly: that makes **which extractor runs** a function of machine speed, the
#1187 construction the guard exists to catch. The two extractors agree to ~1e-16
but **not bitwise**, so a slow machine could take the tape and a fast one the
probe, and the two `Q` matrices can branch differently at an identical node count
under `deterministic=True`.

Recording it in `KNOWN_SLICES` was available and would have been the wrong
answer. The timing was estimating `pairs = |support|*(|support|-1)/2`, which is
already known exactly at that point and identical on every machine — so the
deterministic gate is also the **more precise** one, counting the sweep instead
of predicting it. The env var was introduced by this PR and read nowhere else,
so there was no seconds-valued tuning to re-derive and the conversion cost
nothing.

| | before | after |
|---|---|---|
| env var | `DISCOPT_QP_PROBE_BUDGET` (seconds) | `DISCOPT_QP_PROBE_MAX_PROBES` (probes) |
| parameter | `probe_budget_s: float \| None` | `probe_budget: int \| None` |
| clock | diagonal sweep timed | `problem_classifier` no longer imports `time` |

The gate shipped with no test coverage; three were added, asserting both sides
of the boundary **one probe apart** (a test a seconds-valued gate cannot support
at all), that repeated runs return an identical verdict, that `import time` is
absent from the module, and that a model declined on cost still gets a correct
extraction from the tape rather than a failure.

## One thing found, pre-existing, not fixed here

The probe identifies its support from the **diagonal** sweep alone. A purely
bilinear objective (`sum_{i<j} x_i x_j`, no square terms) therefore has
`f(e_j) == f(-e_j) == d` and a zero diagonal for *every* variable: the support
comes back empty and `Q` comes back zero. The #866 verification rejects that
extraction and routes to the tape, so the probe declines safely rather than
answering wrongly. This is on `main` today and is untouched by this PR — noted
because it is one more class the probe cannot serve and the symbolic walk can.

## Issue attribution

This PR is **P0/P1/P3** of the extractor/marshaling gap list recorded in
`docs/dev/certification-gap-plan.md` §2b (P2 shipped as #1210, marshaling as
#1207). It does **not** belong to #1193, which was the `nvs19`
primal-completeness issue and was closed by #1203; earlier revisions of this
description and its title mislabelled it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014E81XM1j2J5sydzj9nFFFp

