### PR TITLE
perf(nlp): P2 -- the cut-augmented evaluator reports sparse structure

### DIFF
--- a/python/discopt/solver.py
+++ b/python/discopt/solver.py
@@ -2231,6 +2231,90 @@ class _AugmentedEvaluator:
         m_orig = self._ev.n_constraints
         return self._ev.evaluate_lagrangian_hessian(x, obj_factor, lambda_[:m_orig])
 
+    # ---- sparse-structure protocol -------------------------------------
+    #
+    # This class enumerates its members explicitly (see ``timing_bucket``), so
+    # before this block it silently omitted ``has_sparse_structure``. The
+    # ``hasattr`` probe in ``nlp_ipopt._IpoptCallbacks.__init__`` then read
+    # False, and every derivative callback on a cut-augmented node fell to the
+    # dense arm: ``jacobianstructure`` built an ``m x n`` meshgrid and the
+    # Hessian was materialized ``n x n`` -- even though the wrapped tape
+    # evaluator returns analytical sparse COO for both. POUNCE is the consumer
+    # (``_solve_batch_pounce`` builds ``_IpoptCallbacks`` for ``pounce.Problem``),
+    # not cyipopt, which only runs under ``nlp_solver="ipopt"``.
+    #
+    # Forwarding the flag alone would be WRONG, not merely incomplete: the
+    # augmented constraint vector has ``n_cuts`` more rows than the wrapped
+    # evaluator's Jacobian structure describes, so the solver would receive a
+    # Jacobian silently missing every cut row. The structure must be extended,
+    # which is what these methods do.
+
+    def has_sparse_structure(self) -> bool:
+        """True when the wrapped evaluator can report a sparsity pattern.
+
+        The cut block is exactly representable either way -- ``self._A`` is a
+        constant matrix whose nonzero pattern is fixed for the life of this
+        wrapper -- so the answer is entirely the wrapped evaluator's.
+        """
+        return bool(hasattr(self._ev, "has_sparse_structure") and self._ev.has_sparse_structure())
+
+    def _cut_jacobian_coo(self):
+        """``(rows, cols, vals)`` for the cut block, in the augmented row space.
+
+        Cut ``k`` occupies augmented row ``n_constraints_original + k``. Only
+        the structural nonzeros of ``self._A`` are reported: the cut rows are
+        linear with constant coefficients, so this pattern is exact and does
+        not change across iterations, which is what the solver requires.
+        """
+        if not hasattr(self, "_cut_coo_cache"):
+            r, c = np.nonzero(self._A)
+            self._cut_coo_cache = (
+                r.astype(np.int64) + self._ev.n_constraints,
+                c.astype(np.int64),
+                np.asarray(self._A[r, c], dtype=np.float64),
+            )
+        return self._cut_coo_cache
+
+    def jacobian_structure(self):
+        """Jacobian sparsity as COO ``(rows, cols)``, cut rows appended."""
+        rows, cols = self._ev.jacobian_structure()
+        if self._n_cuts == 0:
+            return rows, cols
+        cr, cc, _ = self._cut_jacobian_coo()
+        return np.concatenate([rows, cr]), np.concatenate([cols, cc])
+
+    def evaluate_jacobian_values(self, x):
+        """Jacobian values in ``jacobian_structure`` order, cut values appended.
+
+        The cut values are the constant coefficients themselves -- a cut is
+        ``a^T x - b``, whose gradient is ``a`` and does not depend on ``x``.
+        """
+        vals = self._ev.evaluate_jacobian_values(x)
+        if self._n_cuts == 0:
+            return vals
+        _, _, cv = self._cut_jacobian_coo()
+        return np.concatenate([np.asarray(vals, dtype=np.float64), cv])
+
+    def hessian_structure(self):
+        """Lower-triangle Hessian sparsity, unchanged by the cuts.
+
+        Cuts are linear, so they contribute nothing to the Lagrangian Hessian
+        and add no structural nonzeros -- the same reasoning
+        ``evaluate_lagrangian_hessian`` already relies on.
+        """
+        return self._ev.hessian_structure()
+
+    def evaluate_hessian_values(self, x, obj_factor, lambda_):
+        """Lagrangian Hessian values; the cut multipliers are dropped.
+
+        ``lambda_`` arrives in the augmented row space, so it is truncated to
+        the wrapped evaluator's rows exactly as in
+        :meth:`evaluate_lagrangian_hessian`. Dropping the tail is correct
+        rather than approximate: a linear row's Hessian is zero whatever its
+        multiplier.
+        """
+        return self._ev.evaluate_hessian_values(x, obj_factor, lambda_[: self._ev.n_constraints])
+
     def get_augmented_constraint_bounds(self, original_bounds):
         """Return constraint bounds extended with cut bounds (all <= 0)."""
         if self._n_cuts == 0:

--- a/python/tests/test_solver_bound_units.py
+++ b/python/tests/test_solver_bound_units.py
@@ -188,3 +188,101 @@ def test_compute_alphabb_bound_is_sound_lower_bound():
     # Unbounded box -> abstain with -inf, never a fabricated bound.
     bound_inf = _compute_alphabb_bound(ev, m, expr, np.array([-np.inf]), np.array([np.inf]))
     assert bound_inf == -np.inf
+
+
+def _cut_augmented_case():
+    """A constrained model plus two cuts, and the augmented evaluator over them."""
+    m = _constrained_model()
+    ev = NLPEvaluator(m)
+    pool = CutPool()
+    pool.add(LinearCut(coeffs=np.array([1.0, 1.0]), rhs=3.0, sense="<="))
+    pool.add(LinearCut(coeffs=np.array([1.0, -1.0]), rhs=-1.0, sense=">="))
+    return ev, _AugmentedEvaluator(ev, pool)
+
+
+def test_augmented_evaluator_reports_sparse_structure_including_cut_rows():
+    """The cut proxy must implement the sparse-structure protocol (#1193, P2).
+
+    ``_AugmentedEvaluator`` enumerates its members explicitly, and before this
+    it omitted ``has_sparse_structure``. ``_IpoptCallbacks`` probes for that
+    attribute with ``hasattr``, so every derivative callback on a cut-augmented
+    node fell to the dense arm: an ``m x n`` meshgrid for the Jacobian pattern
+    and a dense ``n x n`` Lagrangian Hessian, even though the wrapped tape
+    evaluator returns analytical sparse COO for both.
+
+    Forwarding the flag alone would be unsound rather than merely incomplete:
+    the augmented constraint vector carries ``n_cuts`` extra rows that the
+    wrapped evaluator's pattern does not describe. This test therefore asserts
+    the reconstructed dense Jacobian -- not just the flag.
+    """
+    checks = 0
+    ev, aug = _cut_augmented_case()
+
+    assert ev.has_sparse_structure(), "wrapped evaluator must be sparse for this test to bite"
+    checks += 1
+    assert aug.has_sparse_structure() is True
+    checks += 1
+
+    x = np.array([2.0, 0.5])
+    rows, cols = aug.jacobian_structure()
+    vals = aug.evaluate_jacobian_values(x)
+    assert len(rows) == len(cols) == len(vals)
+    checks += 1
+
+    # Every augmented row must be described, cut rows included.
+    assert set(np.unique(rows)) >= set(range(aug.n_constraints))
+    checks += 1
+
+    # The COO triple must reconstruct the dense Jacobian exactly.
+    dense = np.zeros((aug.n_constraints, aug.n_variables))
+    dense[rows, cols] = vals
+    np.testing.assert_allclose(dense, np.asarray(aug.evaluate_jacobian(x)))
+    checks += 1
+
+    # Hessian: cuts are linear, so structure and values are the wrapped ones,
+    # with the cut multipliers truncated away.
+    lam = np.array([0.3, 0.1, 0.2])
+    hrows, hcols = aug.hessian_structure()
+    hvals = aug.evaluate_hessian_values(x, 1.0, lam)
+    h_ref = np.asarray(ev.evaluate_lagrangian_hessian(x, 1.0, lam[:1]))
+    np.testing.assert_allclose(hvals, h_ref[hrows, hcols])
+    checks += 1
+
+    assert checks == 6, f"expected 6 executed assertions, ran {checks}"
+
+
+def test_ipopt_callbacks_take_the_sparse_arm_for_a_cut_augmented_node():
+    """The consumer must reconstruct the same Jacobian through the sparse arm.
+
+    This is the end the fix is for: ``_IpoptCallbacks`` is what POUNCE is
+    handed (``_solve_batch_pounce``), and its ``_use_sparse`` flag is decided
+    once from ``has_sparse_structure``.
+    """
+    from discopt.solvers.nlp_ipopt import _IpoptCallbacks
+
+    checks = 0
+    _, aug = _cut_augmented_case()
+    cb = _IpoptCallbacks(aug)
+    assert cb._use_sparse is True
+    checks += 1
+
+    x = np.array([2.0, 0.5])
+    rows, cols = cb.jacobianstructure()
+    vals = cb.jacobian(x)
+    dense = np.zeros((aug.n_constraints, aug.n_variables))
+    dense[rows, cols] = vals
+    np.testing.assert_allclose(dense, np.asarray(aug.evaluate_jacobian(x)))
+    checks += 1
+
+    # The sparse arm must not be a dense meshgrid in disguise.
+    assert len(rows) <= aug.n_constraints * aug.n_variables
+    checks += 1
+
+    lam = np.array([0.3, 0.1, 0.2])
+    hrows, hcols = cb.hessianstructure()
+    hvals = cb.hessian(x, lam, 1.0)
+    h_ref = np.asarray(aug.evaluate_lagrangian_hessian(x, 1.0, lam))
+    np.testing.assert_allclose(hvals, h_ref[hrows, hcols])
+    checks += 1
+
+    assert checks == 4, f"expected 4 executed assertions, ran {checks}"

--- a/scratchpad/1193/p2_census.py
+++ b/scratchpad/1193/p2_census.py
@@ -1,0 +1,47 @@
+"""Structural census for #1193 P2: dense-arm vs sparse-arm callback sizes.
+
+Deterministic (counts, not timings), so it is valid under load. Exits non-zero
+if it measured nothing (CLAUDE.md §6).
+"""
+import glob, os, sys
+import numpy as np
+
+import discopt.solver as S
+from discopt._relax.cutting_planes import CutPool, LinearCut
+from discopt._relax.nlp_evaluator import NLPEvaluator
+from discopt.modeling.core import from_nl
+
+WT = "/Users/jkitchin/projects/discopt/wt-p2/"
+assert S.__file__.startswith(WT), S.__file__
+assert hasattr(S._AugmentedEvaluator, "has_sparse_structure"), "unpatched solver.py loaded"
+
+ROOT = os.path.expanduser("~/Dropbox/projects/discopt-minlp-benchmark/minlplib/nl")
+names = sys.argv[1:]
+compared = 0
+print(f"{'instance':<28} {'n':>6} {'m_aug':>6} {'jac dense':>12} {'jac sparse':>11} "
+      f"{'hess dense':>12} {'hess sparse':>12}")
+for nm in names:
+    p = os.path.join(ROOT, nm + ".nl")
+    if not os.path.exists(p):
+        print(f"{nm}: MISSING", flush=True)
+        continue
+    m = from_nl(p)
+    ev = NLPEvaluator(m)
+    n = ev.n_variables
+    rng = np.random.default_rng(0)
+    pool = CutPool()
+    for _ in range(10):                     # a plausible root cut round
+        c = np.zeros(n); c[rng.integers(0, n, size=min(5, n))] = 1.0
+        pool.add(LinearCut(coeffs=c, rhs=1.0, sense="<="))
+    aug = S._AugmentedEvaluator(ev, pool)
+    assert aug.has_sparse_structure(), f"{nm}: wrapped evaluator is not sparse"
+    m_aug = aug.n_constraints
+    jr, jc = aug.jacobian_structure()
+    hr, hc = aug.hessian_structure()
+    print(f"{nm:<28} {n:>6} {m_aug:>6} {m_aug*n:>12,} {len(jr):>11,} "
+          f"{n*(n+1)//2:>12,} {len(hr):>12,}", flush=True)
+    compared += 1
+
+print(f"instances compared: {compared}")
+if compared == 0:
+    sys.exit(6)


### PR DESCRIPTION
## What this is

The second item (**P2**) from the numerical-probing / dense-fallback audit
recorded in `docs/dev/certification-gap-plan.md` §2b. P0 and P1 are PR #1209;
P3 was deleted there. This is the last open row of that table.

## The defect

`_AugmentedEvaluator` (`python/discopt/solver.py`) wraps the node NLP evaluator
when cuts are injected. It enumerates its members explicitly rather than
delegating through `__getattr__` — deliberately, as its own `timing_bucket`
docstring explains — and it did not enumerate `has_sparse_structure`.

`_IpoptCallbacks` decides once per solve:

```python
self._use_sparse = (
    hasattr(evaluator, "has_sparse_structure") and evaluator.has_sparse_structure()
)
```

So on a cut-augmented node the probe read `False` and every derivative callback
took the dense arm — `jacobianstructure` built an `m × n` meshgrid,
`hessianstructure` returned the whole lower triangle — while the wrapped tape
evaluator was sitting on analytical sparse COO for both. The consumer is
**POUNCE** (`_solve_batch_pounce` builds `_IpoptCallbacks` for `pounce.Problem`);
cyipopt only enters under `nlp_solver="ipopt"`.

**This is not a one-line forward.** Forwarding the flag alone would be *unsound*:
the augmented constraint vector has `n_cuts` more rows than the wrapped
evaluator's pattern describes, so the solver would receive a Jacobian silently
missing every cut row. The structure has to be extended, which is what the fix
does.

## The fix

- `has_sparse_structure()` — answers with the wrapped evaluator's answer. The
  cut block is exactly representable either way.
- `jacobian_structure()` / `evaluate_jacobian_values(x)` — the wrapped COO with
  the cut block appended at rows `n_constraints_original + k`. The cut pattern
  is exact and constant (the pool is snapshotted in `__init__`; a cut
  `aᵀx − b` has gradient `a`), so the values *are* the coefficients and the
  triple is cached once.
- `hessian_structure()` / `evaluate_hessian_values(x, obj_factor, lambda_)` —
  forwarded with `lambda_` truncated to the wrapped rows, exactly as
  `evaluate_lagrangian_hessian` already does. A linear row contributes zero to
  the Lagrangian Hessian whatever its multiplier, so this is exact, not an
  approximation.

Behavior with an empty cut pool is byte-identical to before (the `_n_cuts == 0`
arms return the wrapped values unchanged).

## Measurement

Structural census, `scratchpad/1193/p2_census.py` — **counts, not timings**, so
the numbers are load-independent and reproducible. 10 cuts on a root pool:

| instance | n | m_aug | jac dense | jac sparse | hess dense | hess sparse |
|---|---:|---:|---:|---:|---:|---:|
| carton9 | 360 | 903 | 325,080 | 4,935 | 64,980 | 400 |
| syn15m03hfsg | 453 | 778 | 352,434 | 1,724 | 102,831 | 424 |
| portfol_classical200_2 | 600 | 413 | 247,800 | 41,250 | 180,300 | 400 |
| waterund28 | 760 | 550 | 418,000 | 7,010 | 289,180 | 3,400 |
| crudeoil_lee1_09 | 963 | 2362 | 2,274,606 | 12,488 | 464,166 | 1,397 |

`elec100` is the honest counter-case and is in the script's output: its Hessian
is genuinely dense (45,150 entries either way), so it gains nothing there — the
Jacobian still drops 33,000 → 350.

This is a **per-callback** count, paid on every IPM iteration of every
cut-augmented node NLP.

## Scope

This path fires only when cuts are actually injected —
`cutting_planes: bool = False` is the default — so it is not on the default
solve path. It is not behind a flag because it is not bound-changing: the
Jacobian and Hessian delivered to POUNCE are numerically identical to the dense
ones, which is what the tests assert.

## Tests

Two new tests in `python/tests/test_solver_bound_units.py`, both with executed-
assertion counters (§6):

- `test_augmented_evaluator_reports_sparse_structure_including_cut_rows` —
  reconstructs the dense augmented Jacobian from the COO triple and asserts
  elementwise equality against `evaluate_jacobian(x)`, and the same for the
  Hessian against `evaluate_lagrangian_hessian`. It asserts the *numbers*, not
  just the flag.
- `test_ipopt_callbacks_take_the_sparse_arm_for_a_cut_augmented_node` — the
  same round-trip through the real consumer, `_IpoptCallbacks`.

Both fail on `origin/main` (`AttributeError: '_AugmentedEvaluator' object has no
attribute 'has_sparse_structure'` and `assert False is True` on `_use_sparse`)
and pass with the change. Verified by checking out `origin/main`'s `solver.py`
under the new tests and back.

## Verification run

- `pytest python/tests/test_cutting_planes.py python/tests/test_solver_bound_units.py python/tests/test_75_jax_free_solve_path.py` — 88 passed
- `pytest -m smoke` — 1255 passed, 1 skipped, 2 xpassed
- `pytest -m slow python/tests/test_adversarial_recent_fixes.py` — 19 passed
- Rust untouched, so no `cargo test`.
- §8 note, because it bit twice. The first test run imported `discopt` from a
  *sibling worktree* (the editable install points elsewhere) and reported a bogus
  `AttributeError` against code that already had the fix. Setting `PYTHONPATH`
  fixed the Python side, but pointing the extension at the sibling's
  `_rust.abi3.so` was then caught by
  `test_rust_extension_not_shadowed.py::test_the_imported_extension_is_the_one_on_disk`
  — which is exactly its job. Resolved properly by building this worktree's own
  extension (`cargo build --release -p discopt-python`, no `maturin develop`, so
  no other worktree's install was disturbed). Every measurement above asserts
  both `__file__` and the `has_sparse_structure` marker before it runs.

Part of the P0-P3 extractor/marshaling gap list recorded in
`docs/dev/certification-gap-plan.md` §2b (this PR is **P2**). It does **not**
belong to #1193, which was the `nvs19` primal-completeness issue and was
closed by #1203; an earlier revision of this description mislabelled it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014E81XM1j2J5sydzj9nFFFp

