### PR TITLE
fix(#1218): diagnose value() on a non-variable, refuse GDP/SOS rows in the exporters

### DIFF
--- a/python/discopt/export/_common.py
+++ b/python/discopt/export/_common.py
@@ -21,7 +21,15 @@ from dataclasses import dataclass, field
 
 import numpy as np
 
-from discopt.modeling.core import Constraint, Model, Variable
+from discopt.modeling.core import (
+    Constraint,
+    Model,
+    Variable,
+    _DisjunctiveConstraint,
+    _IndicatorConstraint,
+    _LogicalConstraint,
+    _SOSConstraint,
+)
 
 
 def has_builder_only_rows(model: Model) -> bool:
@@ -216,3 +224,79 @@ def iter_all_rows(model: Model) -> tuple[list[Constraint], list[LinearRow]]:
     expr_rows = [c for c in model._constraints if isinstance(c, Constraint)]
     builder_rows = iter_builder_linear_rows(model)
     return expr_rows, builder_rows
+
+
+# ── Relations no exporter here can carry (#1218) ─────────────────────────────
+#
+# Every writer in this package emits ordinary algebraic rows: a body, a sense and
+# a right-hand side, plus variable bounds. A disjunction, an indicator, an SOS
+# set and a propositional clause are *structure* -- none of them is such a row,
+# and none of the writers emits the SOS/indicator sections some of these formats
+# define. Each of them nevertheless walked ``model._constraints`` assuming
+# ``Constraint``, so a GDP or MPEC model died inside the writer on
+# ``AttributeError: '_DisjunctiveConstraint' object has no attribute 'rhs'``
+# (``.body`` for LP/MPS/GAMS) -- an internal error where the real answer is that
+# the model needs a further lowering first. The table maps each IR type to how it
+# reads in the model and to that lowering, so the refusal names both.
+_GDP_REMEDY = (
+    "Lower it to algebra first and export the lowered model:\n"
+    "    from discopt._relax.gdp_reformulate import reformulate_gdp\n"
+    "    lowered = reformulate_gdp(model, method='big-m')   # or method='hull'\n"
+    "(the lowering adds selector binaries and needs finite bounds on the "
+    "variables of each disjunct)."
+)
+
+_UNREPRESENTABLE_RELATIONS: dict[type, tuple[str, str]] = {
+    _DisjunctiveConstraint: (
+        "a disjunctive constraint (Model.either_or / Model.if_else, GDP)",
+        _GDP_REMEDY,
+    ),
+    _IndicatorConstraint: (
+        "an indicator constraint (Model.if_then)",
+        _GDP_REMEDY,
+    ),
+    _SOSConstraint: (
+        "an SOS constraint (Model.sos1 / Model.sos2)",
+        "No SOS section is emitted by this writer. " + _GDP_REMEDY,
+    ),
+    _LogicalConstraint: (
+        "a propositional-logic constraint over BooleanVars",
+        _GDP_REMEDY,
+    ),
+}
+
+
+def refuse_non_algebraic_relations(model: Model, fmt: str) -> None:
+    """Refuse a relation the writer cannot carry, by name, before writing a row.
+
+    Parameters
+    ----------
+    model : Model
+        The model about to be exported.
+    fmt : str
+        The target format, as it appears at the head of the error message
+        (``".nl"``, ``"LP"``, ``"MPS"``, ``"GAMS"``).
+
+    Raises
+    ------
+    ValueError
+        On the first non-``Constraint`` relation in ``model._constraints``,
+        naming what it is and the lowering that makes the model exportable.
+    """
+    for con in model._constraints:
+        if isinstance(con, Constraint):
+            continue
+        what, remedy = _UNREPRESENTABLE_RELATIONS.get(
+            type(con),
+            (
+                f"a non-algebraic relation ({type(con).__name__})",
+                "Reformulate it into ordinary algebraic constraints before exporting.",
+            ),
+        )
+        name = getattr(con, "name", None)
+        where = f" named {name!r}" if name else ""
+        raise ValueError(
+            f"{fmt} export: the model carries {what}{where}. This writer emits "
+            "ordinary algebraic rows and variable bounds only, so there is "
+            f"nothing faithful to write. {remedy}"
+        )

--- a/python/discopt/export/gams.py
+++ b/python/discopt/export/gams.py
@@ -13,6 +13,7 @@ from pathlib import Path
 
 import numpy as np
 
+from discopt.export._common import refuse_non_algebraic_relations
 from discopt.modeling.core import (
     BinaryOp,
     Constant,
@@ -91,6 +92,10 @@ def to_gams(
     # NOTE: the LP and MPS writers deliberately do *not* do this — see the comment
     # on their ``model.validate()`` calls.
     model.validate(for_solve=False)
+    # A disjunction/indicator/SOS/logic row is not an algebraic row; refuse it
+    # by name rather than die on ``con.body`` in the equation writer (#1218).
+    # This writer emits plain GAMS equations, not an EMP/JAMS disjunctive model.
+    refuse_non_algebraic_relations(model, "GAMS")
     writer = _GamsWriter(model, model_type)
     text = writer.write()
     if path is not None:

--- a/python/discopt/export/lp.py
+++ b/python/discopt/export/lp.py
@@ -12,7 +12,11 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from discopt.export._common import builder_objective, iter_builder_linear_rows
+from discopt.export._common import (
+    builder_objective,
+    iter_builder_linear_rows,
+    refuse_non_algebraic_relations,
+)
 from discopt.export._extract import (
     extract_linear_terms,
     extract_quadratic_terms,
@@ -55,6 +59,9 @@ def to_lp(model: Model, path: str | Path | None = None) -> str | None:
     # that into a loud error; do not relax it without teaching the row builder
     # below to fold ``con.rhs`` in.
     model.validate()
+    # A disjunction/indicator/SOS/logic row is not an algebraic row; refuse it
+    # by name rather than die on ``con.body`` in the row loop below (#1218).
+    refuse_non_algebraic_relations(model, "LP")
     flat_vars = flatten_variables(model)
     var_names = [name for name, _, _, _, _ in flat_vars]
     mvars = model._variables

--- a/python/discopt/export/mps.py
+++ b/python/discopt/export/mps.py
@@ -14,7 +14,11 @@ from pathlib import Path
 
 import numpy as np
 
-from discopt.export._common import builder_objective, iter_builder_linear_rows
+from discopt.export._common import (
+    builder_objective,
+    iter_builder_linear_rows,
+    refuse_non_algebraic_relations,
+)
 from discopt.export._extract import (
     extract_linear_terms,
     extract_quadratic_terms,
@@ -57,6 +61,9 @@ def to_mps(model: Model, path: str | Path | None = None) -> str | None:
     # refusal turns that into a loud error; do not relax it without teaching the
     # row builder below to fold ``con.rhs`` in.
     model.validate()
+    # A disjunction/indicator/SOS/logic row is not an algebraic row; refuse it
+    # by name rather than die on ``con.body`` in the row loop below (#1218).
+    refuse_non_algebraic_relations(model, "MPS")
     flat_vars = flatten_variables(model)
     var_names = [name for name, _, _, _, _ in flat_vars]
 

--- a/python/discopt/export/nl.py
+++ b/python/discopt/export/nl.py
@@ -30,6 +30,7 @@ from typing import Any, Union, cast
 
 import numpy as np
 
+from discopt.export._common import refuse_non_algebraic_relations
 from discopt.modeling.core import (
     BinaryOp,
     Constant,
@@ -174,6 +175,7 @@ class _NLWriter:
         self._niv = 0  # linear integer vars
 
     def write(self) -> str:
+        self._refuse_unrepresentable_relations()
         self._build_var_map()
         self._decompose_expressions()
         self._reorder_vars_canonical()
@@ -188,6 +190,21 @@ class _NLWriter:
         self._write_J_sections(buf)
         self._write_G_section(buf)
         return buf.getvalue()
+
+    # ── Refuse relations the format cannot carry ──
+
+    def _refuse_unrepresentable_relations(self):
+        """Refuse a non-algebraic relation by name, before any row is written.
+
+        Without this the disjunctive/SOS rows a GDP or an MPEC complementarity
+        encoding leaves on the model reached ``_decompose_expressions`` and died
+        on ``float(con.rhs)`` with ``AttributeError: '_DisjunctiveConstraint'
+        object has no attribute 'rhs'`` (#1218) -- an internal error from deep
+        inside the writer, where the real answer is that ``.nl`` has no such row
+        and the model needs a further lowering first. Shared with the LP/MPS/GAMS
+        writers, which walk ``model._constraints`` the same way.
+        """
+        refuse_non_algebraic_relations(self.model, ".nl")
 
     # ── Build flat variable map ──
 

--- a/python/discopt/modeling/argmin.py
+++ b/python/discopt/modeling/argmin.py
@@ -45,9 +45,10 @@ land on a different branch.
 
 ``argmin_kkt(model, inner, bind=...)`` -- **lower** the follower.  Its variables
 become real variables of the outer model and its KKT conditions become real
-constraints, so the Rust tape, FBBT, a **global certificate** and ``.nl`` export
-all come back.  The price is that KKT conditions characterize a follower's optimum
-only when the follower is **convex in its own variables**, so the lowering runs
+constraints, so the Rust tape, FBBT, a **global certificate** and (on the
+``method="strong_duality"`` arm) ``.nl`` export all come back.  The price is that
+KKT conditions characterize a follower's optimum only when the follower is
+**convex in its own variables**, so the lowering runs
 :class:`discopt.bilevel.BilevelProblem`'s convexity certifier and refuses anything
 it cannot prove -- including the projection follower above, whose nonlinear
 equality is exactly what makes the hand-written version unsound.  There is no flag
@@ -57,7 +58,7 @@ For ``.nl`` export specifically, use ``method="strong_duality"``: it emits pure
 algebra (stationarity, primal/dual feasibility, and the single bilinear equality
 ``Σ μ_i g_i == 0``).  The ``"kkt"`` arm's complementarity conditions go through the
 GDP/SOS1 encodings, which discopt solves and certifies but which have no ``.nl``
-form.
+form -- exporting such a model is refused by name (#1218), never approximated.
 
 Soundness gates (all refuse rather than approximate)
 ----------------------------------------------------
@@ -708,6 +709,14 @@ def argmin(
         variable order (a vector inner variable contributes its elements in
         ``ravel`` order).  Use it anywhere an expression is allowed.
 
+        It is an **expression, not a variable**: the follower is solved inside
+        the node, so ``y*`` is not a column of the outer model and
+        ``result.value(v)`` refuses it (#1218).  Recover it by calling the layer
+        at the solution -- ``dm.argmin_layer(inner, [q])(jnp.array([p_star]))``,
+        which re-solves the follower at that parameter value -- or use
+        :func:`argmin_kkt`, whose follower variables are real variables of the
+        outer model and which ``result.value(v[0])`` reads directly.
+
     Raises
     ------
     ValueError
@@ -728,10 +737,18 @@ def argmin(
     >>> m.minimize((v[0] + 0.9) ** 2)                       # doctest: +SKIP
     >>> result = m.solve()                                  # doctest: +SKIP
 
+    The leader's own variables are read as usual; the follower's solution is not
+    a variable, so it is recovered by evaluating the layer at the answer:
+
+    >>> import jax.numpy as jnp                             # doctest: +SKIP
+    >>> p_star = float(result.value(p))                     # doctest: +SKIP
+    >>> y_star = dm.argmin_layer(inner, [q])(jnp.array([p_star]))  # doctest: +SKIP
+
     See Also
     --------
-    argmin_kkt : the lowered arm -- a certified, ``.nl``-exportable reformulation
-        for a follower that can be *proved* convex in its own variables.
+    argmin_kkt : the lowered arm -- a certified reformulation (``.nl``-exportable
+        on its ``method="strong_duality"`` arm) for a follower that can be
+        *proved* convex in its own variables.
 
     Notes
     -----
@@ -914,7 +931,16 @@ def argmin_kkt(
     behind an opaque node, its variables become real variables of ``model`` and its
     optimality conditions become real constraints. What that buys is everything the
     opaque node forecloses -- the Rust tape, FBBT, a **global certificate**, and
-    ``.nl`` export, so the same formulation can be handed to another solver.
+    (with ``method="strong_duality"``) ``.nl`` export, so the same formulation can
+    be handed to another solver.
+
+    ``.nl`` export is scoped to ``method="strong_duality"`` because that arm emits
+    pure algebra. The default ``method="kkt"`` encodes complementarity as
+    disjunctive (``mpec_method="gdp"``) or SOS1 rows, which discopt solves and
+    certifies but which the ``.nl`` format has no row for -- exporting such a model
+    is refused by name (#1218), not silently approximated. Lowering it with
+    :func:`discopt._relax.gdp_reformulate.reformulate_gdp` first also produces an
+    exportable model, at the price of big-M selector binaries.
 
     What it costs is generality, and the cost is not negotiable: KKT conditions
     characterize a follower's optimum only when the follower is **convex in its own
@@ -973,7 +999,14 @@ def argmin_kkt(
     --------
     >>> v = dm.argmin_kkt(m, inner, bind={q: p}, multiplier_ub=100.0)  # doctest: +SKIP
     >>> m.minimize((v[0] - 2.0) ** 2)                                  # doctest: +SKIP
-    >>> m.to_nl("leader.nl")   # an ordinary algebraic model            # doctest: +SKIP
+    >>> result = m.solve()          # certified, and v[0] is a Variable  # doctest: +SKIP
+
+    For ``.nl`` export, take the strong-duality arm -- the ``"kkt"`` default's
+    complementarity rows are disjunctive/SOS1 and have no ``.nl`` form:
+
+    >>> v = dm.argmin_kkt(m, inner, bind={q: p}, method="strong_duality")  # doctest: +SKIP
+    >>> m.minimize((v[0] - 2.0) ** 2)                                      # doctest: +SKIP
+    >>> m.to_nl("leader.nl")   # an ordinary algebraic model               # doctest: +SKIP
     """
     from discopt.bilevel import BilevelProblem
 

--- a/python/discopt/modeling/core.py
+++ b/python/discopt/modeling/core.py
@@ -2221,6 +2221,42 @@ _NON_GAP_CERTIFICATE_STATUSES = frozenset({"infeasible"})
 from discopt.status import is_local_status as _is_local_status  # noqa: E402
 
 
+def _value_not_a_variable_message(node: Any) -> str:
+    """Why ``SolveResult.value(node)`` cannot serve a non-``Variable`` argument.
+
+    ``result.x`` is keyed by variable name, so anything that is not a column of
+    the solved model has no entry in it. Looking the argument's ``.name`` up
+    anyway raised a bare ``KeyError`` on the node's display name (#1218) -- an
+    internal error where the honest answer is structural: an expression is
+    computed FROM the solution, it is not part of it.
+    """
+    if isinstance(node, CustomCall):
+        return (
+            f"value() takes a model Variable; {node.name!r} is an opaque custom "
+            "block (a CustomCall). Its body is traced and evaluated inside the "
+            "objective/constraints -- it is not a column of the model, so the "
+            "solution has no entry for it. If it came from dm.argmin(): the "
+            "follower's y* is recovered either by calling the layer at the "
+            "solution (phi = dm.argmin_layer(inner, [q]); phi(jnp.array([p*]))), "
+            "or by using dm.argmin_kkt(model, inner, ...) instead, which lowers "
+            "the follower so its variables ARE model variables and "
+            "result.value(v[0]) works."
+        )
+    if isinstance(node, Expression):
+        return (
+            f"value() takes a model Variable; got a {type(node).__name__} "
+            "expression. Only variables have entries in result.x -- an "
+            "expression is computed from them. Read the variables it is built "
+            "from (result.value(x)) and combine them, or add the quantity to "
+            "the model as a named variable fixed by an equality constraint."
+        )
+    return (
+        f"value() takes a model Variable; got {type(node).__name__}. Pass the "
+        "Variable object returned by model.continuous()/integer()/binary(), or "
+        "any handle that names one of the solved model's variables."
+    )
+
+
 @dataclass
 class SolveResult:
     """
@@ -2540,7 +2576,13 @@ class SolveResult:
         Parameters
         ----------
         var : Variable
-            A variable from the solved model.
+            A variable from the solved model (or any handle naming one, such as
+            an :class:`~discopt.modeling.indexed.IndexedVar`). Only *variables*
+            have entries in the solution: an expression built from them (a sum,
+            a product, an opaque :func:`~discopt.modeling.core.custom` /
+            :func:`~discopt.modeling.argmin.argmin` node) is not a column of the
+            model, and is refused with the reason rather than raising a bare
+            ``KeyError`` on its display name (#1218).
 
         Returns
         -------
@@ -2551,10 +2593,28 @@ class SolveResult:
         ------
         ValueError
             If no feasible solution is available.
+        TypeError
+            If *var* is an expression rather than a variable.
+        KeyError
+            If *var* names no variable of the solved model.
         """
         if self.x is None:
             raise ValueError("No solution available")
-        return self.x[var.name]
+        # Resolve by name first: the lookup is what it always was, so every
+        # handle that names a column of the solved model -- Variable, IndexedVar,
+        # anything else carrying its name -- keeps working. Only a lookup that
+        # WOULD have raised reaches the diagnosis below.
+        name = getattr(var, "name", None)
+        if isinstance(name, str) and name in self.x:
+            return self.x[name]
+        if not isinstance(var, Variable):
+            raise TypeError(_value_not_a_variable_message(var))
+        known = ", ".join(sorted(self.x)[:12]) or "(none)"
+        raise KeyError(
+            f"No variable named {var.name!r} in this solution -- it is not a "
+            "variable of the model that was solved (a variable of a different "
+            f"Model, or one dropped before the solve). Solution variables: {known}."
+        )
 
     def explain(self, llm: bool = False, model: str | None = None) -> str:
         """Get a human-readable explanation of the solve result.

--- a/python/tests/test_1218_result_value_diagnostics.py
+++ b/python/tests/test_1218_result_value_diagnostics.py
@@ -1,0 +1,88 @@
+"""``SolveResult.value`` says why a lookup failed, instead of ``KeyError`` (#1218).
+
+``result.x`` is keyed by variable name, so anything that is not a column of the
+solved model has no entry in it. Looking the argument's ``.name`` up anyway gave
+the user a bare ``KeyError`` on the node's *display* name -- the reported case
+was ``KeyError: 'argmin'`` from ``result.value(v)`` on a ``dm.argmin`` block,
+where the honest answer is structural: the follower is solved inside an opaque
+node, so its ``y*`` is not a variable of the outer model at all.
+
+The diagnosis must not cost the lookups that already worked: ``result.value``
+resolves by name first, so every handle naming a real column (a ``Variable``, an
+``IndexedVar``, anything else carrying the name) keeps working untouched, and
+only a lookup that WOULD have raised reaches the new message.
+"""
+
+from __future__ import annotations
+
+import discopt.modeling as dm
+import numpy as np
+import pytest
+from discopt.modeling.core import SolveResult
+
+pytestmark = pytest.mark.unit
+
+
+def _result(**x) -> SolveResult:
+    return SolveResult(status="optimal", x=dict(x), objective=0.0)
+
+
+def test_a_plain_variable_still_resolves():
+    m = dm.Model("m")
+    x = m.continuous("x", lb=0.0, ub=1.0)
+    assert _result(x=np.array([0.25])).value(x) == pytest.approx(np.array([0.25]))
+
+
+def test_an_indexed_container_still_resolves():
+    """``IndexedVar`` is not a ``Variable``; it names one, and that is enough."""
+    m = dm.Model("m")
+    s = m.set("S", [10, 20, 30])
+    y = m.continuous("y", lb=1.0, ub=5.0, over=s)
+    assert not isinstance(y, dm.Variable)
+
+    got = np.asarray(_result(y=np.ones(3)).value(y), dtype=float).ravel()
+    assert got.size == 3
+
+
+def test_an_opaque_custom_node_is_refused_with_the_reason():
+    import jax.numpy as jnp
+
+    m = dm.Model("m")
+    x = m.continuous("x", lb=0.0, ub=1.0)
+    node = dm.custom(lambda t: jnp.sin(t), name="argmin")(x)
+
+    with pytest.raises(TypeError) as exc:
+        _result(x=np.array([0.25])).value(node)
+    message = str(exc.value)
+    assert "argmin" in message  # which node
+    assert "CustomCall" in message  # what it is
+    assert "argmin_layer" in message and "argmin_kkt" in message  # what to do
+
+
+def test_an_ordinary_expression_is_refused_with_the_reason():
+    m = dm.Model("m")
+    x = m.continuous("x", lb=0.0, ub=1.0)
+
+    with pytest.raises(TypeError, match="expression"):
+        _result(x=np.array([0.25])).value(x + 1.0)
+
+
+def test_a_variable_of_another_model_says_which_variable():
+    other = dm.Model("other")
+    stranger = other.continuous("stranger", lb=0.0, ub=1.0)
+
+    with pytest.raises(KeyError) as exc:
+        _result(x=np.array([0.25])).value(stranger)
+    message = str(exc.value)
+    assert "stranger" in message
+    assert "not a variable of the model" in message
+    assert "Solution variables: x." in message  # and what the solution does carry
+
+
+def test_no_solution_still_reports_no_solution_first():
+    m = dm.Model("m")
+    x = m.continuous("x", lb=0.0, ub=1.0)
+    empty = SolveResult(status="infeasible", x=None)
+
+    with pytest.raises(ValueError, match="No solution available"):
+        empty.value(x)

--- a/python/tests/test_argmin_block.py
+++ b/python/tests/test_argmin_block.py
@@ -531,3 +531,200 @@ def test_unbound_inner_parameters_are_frozen_at_their_value():
     r = m.solve()
     # y* = 3 q, so the leader drives q to 0.5.
     assert float(np.asarray(r.value(p)).ravel()[0]) == pytest.approx(0.5, abs=1e-4)
+
+
+# ---------------------------------------------------------------------------
+# Follow-ups from the #1216 verification pass (#1218)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.slow
+def test_value_of_the_opaque_node_explains_itself_and_names_the_recovery():
+    """`result.value(v)` on an `argmin` node is refused, not a bare KeyError.
+
+    The node is a `CustomCall`, so the follower's y* is genuinely not a column
+    of the outer model -- but the failure used to be `KeyError: 'argmin'` from
+    the name lookup (#1218). It now says what the node is and how to get y*,
+    and this test runs that recovery route so the advice cannot rot.
+    """
+    import jax.numpy as jnp
+
+    inner, q = _convex_follower()
+    m = Model("leader")
+    p = m.continuous("p", lb=-2.0, ub=2.0)
+    v = dm.argmin(inner, bind={q: p})
+    m.minimize(_leader_with(v, p))
+    r = m.solve()
+
+    with pytest.raises(TypeError) as exc:
+        r.value(v)
+    message = str(exc.value)
+    assert "argmin" in message
+    assert "argmin_layer" in message and "argmin_kkt" in message
+
+    # The leader's own variables are unaffected, and the documented recovery
+    # returns the follower's minimizer at the leader's answer.
+    p_star = float(np.asarray(r.value(p)).ravel()[0])
+    y_star = np.asarray(dm.argmin_layer(inner, [q])(jnp.array([p_star])))
+    assert y_star[0] == pytest.approx(p_star, abs=1e-5)
+
+
+@pytest.mark.slow
+@pytest.mark.parametrize("mpec_method", ["gdp", "sos1"])
+def test_kkt_default_refuses_nl_export_by_name(mpec_method):
+    """`method="kkt"` encodes complementarity as rows `.nl` has no form for.
+
+    The docstring's `.nl` promise is scoped to `method="strong_duality"`
+    (`test_lowered_arm_exports_to_nl` is the positive case). The default arm
+    used to die inside the writer with `AttributeError: '_DisjunctiveConstraint'
+    object has no attribute 'rhs'` (#1218); it now refuses by name.
+    """
+    inner, q = _convex_follower()
+    m = Model("leader")
+    p = m.continuous("p", lb=-2.0, ub=2.0)
+    v = dm.argmin_kkt(m, inner, bind={q: p}, mpec_method=mpec_method, multiplier_ub=100.0)
+    m.minimize(_leader_with(v, p))
+
+    with pytest.raises(ValueError, match="nl export"):
+        m.to_nl()
+
+
+# ---------------------------------------------------------------------------
+# The soundness gates, driven at points a solver could return (#1218 item 3)
+#
+# POUNCE is an interior-point method: it stops a barrier's width from a bound,
+# so a returned point that is EXACTLY degenerate, or that is a stationary point
+# with indefinite reduced curvature, is not reachable by asking it nicely. The
+# gates still have to hold there -- that is the whole claim of the block over
+# the hand-written-KKT route -- so the inner solve is replaced by one returning
+# a chosen point, and the gates are run against the REAL evaluator of a real
+# inner model at that point.
+# ---------------------------------------------------------------------------
+
+
+def _stub_inner_solve(monkeypatch, point, multipliers=None):
+    """Make the inner NLP solve return ``point`` (a function of the parameter).
+
+    Returns a one-element list holding the call count, so a test can assert the
+    stub actually ran rather than pass vacuously.
+    """
+    import discopt.solvers.nlp_pounce as nlp_pounce
+    from discopt.solvers import NLPResult, SolveStatus
+
+    calls = [0]
+
+    def fake_solve_nlp(ev, x0, options=None):
+        calls[0] += 1
+        x = np.asarray(point(), dtype=float)
+        mult = None if multipliers is None else np.asarray(multipliers(), dtype=float)
+        return NLPResult(
+            status=SolveStatus.OPTIMAL,
+            x=x,
+            objective=float(ev.evaluate_objective(x)),
+            multipliers=mult,
+            iterations=1,
+        )
+
+    monkeypatch.setattr(nlp_pounce, "solve_nlp", fake_solve_nlp)
+    return calls
+
+
+def _concave_inner() -> tuple[Model, dm.Parameter]:
+    """``min -(y - q)^2``: ``y = q`` is stationary, and is the MAXIMIZER."""
+    inner = Model("concave")
+    y = inner.continuous("y", lb=-5.0, ub=5.0)
+    q = inner.parameter("q", value=0.0)
+    inner.minimize(-(y - q) * (y - q))
+    return inner, q
+
+
+@pytest.mark.unit
+def test_verify_minimizer_refuses_a_stationary_point_that_is_not_a_minimizer():
+    """Gate 3: a KKT point with indefinite reduced curvature evaluates to NaN.
+
+    This is exactly the failure the hand-written-KKT route suffers -- a
+    stationary point served as if it were an argmin -- so the block refuses it
+    rather than differentiate it.
+    """
+    import jax.numpy as jnp
+
+    mp = pytest.MonkeyPatch()
+    try:
+        calls = _stub_inner_solve(mp, point=lambda: [0.3])
+        inner, q = _concave_inner()
+        phi = dm.argmin_layer(inner, [q], verify_minimizer=True)
+        with pytest.warns(RuntimeWarning, match="positive semidefinite"):
+            out = np.asarray(phi(jnp.array([0.3])))
+    finally:
+        mp.undo()
+
+    assert calls[0] == 1, "the stubbed inner solve never ran"
+    assert not np.isfinite(out).all()
+
+
+@pytest.mark.unit
+def test_verify_minimizer_off_returns_the_same_point_the_gate_refuses():
+    """The pair of the test above: the gate, not the arithmetic, is the refusal.
+
+    Without it the block would return the maximizer as though it were an argmin,
+    which is what makes ``_reduced_hessian_psd`` a correctness guard rather than
+    a diagnostic. If it ever returned ``True`` unconditionally, the test above
+    would report this value instead of NaN.
+    """
+    import jax.numpy as jnp
+
+    mp = pytest.MonkeyPatch()
+    try:
+        calls = _stub_inner_solve(mp, point=lambda: [0.3])
+        inner, q = _concave_inner()
+        phi = dm.argmin_layer(inner, [q], verify_minimizer=False)
+        out = np.asarray(phi(jnp.array([0.3])))
+    finally:
+        mp.undo()
+
+    assert calls[0] == 1, "the stubbed inner solve never ran"
+    assert out[0] == pytest.approx(0.3, abs=1e-12)
+
+
+@pytest.mark.unit
+def test_degenerate_active_set_warns_once_and_still_returns_the_point():
+    """Gate 2: an active row with a ~zero multiplier is warned, not hidden.
+
+    ``min (y - q)^2 s.t. y <= q`` is degenerate for EVERY ``q``: the constraint
+    passes through the unconstrained optimum, so it is active with multiplier
+    zero and ``dx*/dp`` is one-sided there. The block still returns the point --
+    the sensitivity is a subgradient, not a wrong number -- and warns once per
+    block, so a second parameter value does not re-warn.
+    """
+    import jax.numpy as jnp
+
+    p_values = [0.5, 1.5]
+    current = {"p": p_values[0]}
+
+    mp = pytest.MonkeyPatch()
+    try:
+        calls = _stub_inner_solve(mp, point=lambda: [current["p"]], multipliers=lambda: [0.0])
+        inner = Model("degenerate")
+        y = inner.continuous("y", lb=-5.0, ub=5.0)
+        q = inner.parameter("q", value=p_values[0])
+        inner.minimize((y - q) * (y - q))
+        inner.subject_to(y <= q)
+        phi = dm.argmin_layer(inner, [q])
+
+        with pytest.warns(RuntimeWarning, match="degenerate active set"):
+            first = np.asarray(phi(jnp.array([p_values[0]])))
+
+        import warnings as _warnings
+
+        current["p"] = p_values[1]
+        with _warnings.catch_warnings(record=True) as caught:
+            _warnings.simplefilter("always")
+            second = np.asarray(phi(jnp.array([p_values[1]])))
+        repeats = [w for w in caught if issubclass(w.category, RuntimeWarning)]
+    finally:
+        mp.undo()
+
+    assert calls[0] == 2, f"expected two stubbed inner solves, ran {calls[0]}"
+    assert first[0] == pytest.approx(p_values[0], abs=1e-12)
+    assert second[0] == pytest.approx(p_values[1], abs=1e-12)
+    assert repeats == [], "the degeneracy warning repeated; it is warn-once per block"

--- a/python/tests/test_nl_writer.py
+++ b/python/tests/test_nl_writer.py
@@ -783,3 +783,81 @@ class TestNLWriterDeepNesting:
         lin_part = sum(coeff * x[idx] for idx, coeff in writer._obj_linear.items())
         expected = float(compile_expression(m._objective.expression, m)(x))
         np.testing.assert_allclose(lin_part + nl_part, expected, atol=1e-9)
+
+
+class TestNLWriterRefusesNonAlgebraicRelations:
+    """A relation the format has no row for is refused by name (#1218).
+
+    ``.nl`` is algebra plus variable/row bounds: a disjunction, an indicator, an
+    SOS set and a propositional clause are structure, and this writer emits no
+    suffixes. Before #1218 such a model reached ``_decompose_expressions`` and
+    died on ``float(con.rhs)`` with ``AttributeError: '_DisjunctiveConstraint'
+    object has no attribute 'rhs'`` -- an internal error where the honest answer
+    is that the model needs a further lowering first.
+    """
+
+    @staticmethod
+    def _base() -> tuple:
+        m = dm.Model("gdp")
+        x = m.continuous("x", lb=0, ub=10)
+        m.minimize(x)
+        return m, x
+
+    def test_disjunction_is_refused_by_name(self):
+        m, x = self._base()
+        m.either_or([[x <= 3], [x >= 7]], name="operating_mode")
+        with pytest.raises(ValueError, match="disjunctive constraint") as exc:
+            m.to_nl()
+        message = str(exc.value)
+        assert "operating_mode" in message  # which relation
+        assert "reformulate_gdp" in message  # and what to do about it
+
+    def test_indicator_is_refused_by_name(self):
+        m, x = self._base()
+        y = m.binary("y")
+        m.if_then(y, [x >= 4], name="unit_on")
+        with pytest.raises(ValueError, match="indicator constraint"):
+            m.to_nl()
+
+    def test_sos_is_refused_by_name(self):
+        m, x = self._base()
+        z = m.continuous("z", lb=0, ub=10)
+        m.sos1([x, z], name="pick_one")
+        with pytest.raises(ValueError, match="SOS constraint"):
+            m.to_nl()
+
+    def test_logical_constraint_is_refused_by_name(self):
+        m, _x = self._base()
+        y = m.boolean("choice", shape=(2,))
+        m.logical(y[0].implies(y[1]))
+        with pytest.raises(ValueError, match="propositional-logic constraint"):
+            m.to_nl()
+
+    @pytest.mark.parametrize("fmt", ["to_nl", "to_lp", "to_mps", "to_gams"])
+    def test_every_writer_in_the_package_refuses_the_same_way(self, fmt):
+        """The LP/MPS/GAMS writers walk ``model._constraints`` the same way.
+
+        They died on ``con.body`` rather than ``con.rhs``, but it is the same
+        defect and the same answer, so the refusal is shared (#1218).
+        """
+        m, x = self._base()
+        m.either_or([[x <= 3], [x >= 7]], name="operating_mode")
+        with pytest.raises(ValueError, match="disjunctive constraint"):
+            getattr(m, fmt)()
+
+    def test_the_refusal_names_a_remedy_that_works(self):
+        """The lowering the message points at produces an exportable model.
+
+        An error that names a fix nobody verified is a worse error. This runs
+        the message's own advice and exports the result.
+        """
+        from discopt._relax.gdp_reformulate import reformulate_gdp
+
+        m, x = self._base()
+        m.either_or([[x <= 3], [x >= 7]], name="operating_mode")
+        nl = reformulate_gdp(m, method="big-m").to_nl()
+        assert nl.startswith("g3")
+        # The lowering introduced selector binaries, so the exported model is a
+        # MILP over more columns than the source model's single x.
+        n_vars = int(nl.split("\n")[1].split()[0])
+        assert n_vars > len(m._variables)


### PR DESCRIPTION
## Summary

All three follow-ups from #1218's verification pass. Closes #1218.

**1. `result.value(v)` on an `argmin` node raised a bare `KeyError`.** The node is a
`CustomCall`, so the follower's `y*` genuinely is not a column of the outer model — but
`KeyError: 'argmin'` from `self.x[var.name]` said none of that. `SolveResult.value` now
resolves **by name first** (so every handle that names a real column keeps working —
`Variable`, `IndexedVar`, anything else carrying the name) and only a lookup that *would*
have raised reaches the new diagnosis: for an opaque node, what it is and both recovery
routes (`argmin_layer` at the solution, or `argmin_kkt`, whose follower variables are real
variables); for an ordinary expression, that only variables have entries in `result.x`; for
a `Variable` of another model, which variable and what the solution does carry.
`argmin`'s Returns section states the limitation and its example now shows the recovery.

**2. `argmin_kkt`'s documented `.nl` example raised `AttributeError`.** `to_nl()` on a model
carrying a disjunctive/indicator/SOS/logic row died in `_decompose_expressions` on
`float(con.rhs)` with `AttributeError: '_DisjunctiveConstraint' object has no attribute
'rhs'`. That is the shape of **every** writer in `discopt/export/` — LP, MPS and GAMS die
the same way on `con.body` — so the refusal is one shared helper,
`_common.refuse_non_algebraic_relations`, called by all four. It names the relation, its
name in the model, and the lowering that makes the model exportable; a test runs that
lowering and exports the result, so the remedy cannot rot. Refusing is the right answer:
none of these writers emits an SOS/indicator section, and lowering silently would change
the model. `argmin_kkt`'s docstring promised `.nl` export unconditionally while its default
`method="kkt"` encodes complementarity as exactly those rows — the promise is now scoped to
`method="strong_duality"` in the function docstring, the module docstring and the example.

**3. `verify_minimizer` and the degeneracy warning had no tests** (`grep -rn
verify_minimizer python/tests/` was empty). POUNCE is an interior-point method, so a point
that is exactly degenerate, or a stationary point with indefinite reduced curvature, is not
reachable by asking it nicely — the inner solve is stubbed to return such a point and the
gates run against the **real** evaluator of a real inner model there. The PSD gate is tested
as a pair (verify on → NaN, verify off → the maximizer it refuses), so
`_reduced_hessian_psd` returning `True` unconditionally fails the suite.

## Correctness

No solver math changed. Two failure modes became loud refusals; one lookup gained a
diagnosis on a path that previously raised anyway. No relaxation, bound, cut or certificate
is touched, and no guard was loosened — the `.nl`/LP/MPS/GAMS refusal is new *strictness*,
and `value()`'s lookup semantics are byte-identical for every argument that resolved before
(a regression during development, where an `IndexedVar` stopped resolving, is what motivated
the name-first ordering; it is covered by a test).

- [x] Cannot produce a false certificate (no solver-math change)
- [x] No validation, fallback, or safety guard was weakened to make a check pass

## Tests run (state the result — numbers, not adjectives)

- [x] `pytest -m smoke python/tests` → 1253 passed, 7 skipped, 2 xpassed (282 s)
- [x] `pytest -m slow python/tests/test_adversarial_recent_fixes.py` → 19 passed (158 s)
- [x] `cargo test -p discopt-core` → N/A (no Rust change)
- [x] `ruff check python/` / `ruff format --check python/` → clean
- Targeted: `pytest -m "" test_argmin_block.py test_nl_writer.py
  test_1218_result_value_diagnostics.py test_export_cli_roundtrip.py test_cli.py
  test_native_nlp_equivalence.py test_nl_reconstruction.py` → 223 passed, 4 skipped, 1 xfailed
- Wider export/GDP slice: `pytest -m "" -k "gdp or sos or export or mps or lp_ or gams"` →
  1983 passed, 2 failed. Both failures are environment, not this change, and reproduce on
  the unpatched tree: `test_neglog_interior_stall_not_false_optimal[ipopt]` (no `cyipopt`
  installed) and `test_solve_degrades_to_jax_when_pounce_is_missing` (300 s pytest timeout
  in the JAX fallback; verified failing identically with the patch stashed).

## Regression test

Each new regression test was run against the unpatched source and fails there:

- `test_nl_writer.py::TestNLWriterRefusesNonAlgebraicRelations` — disjunction, indicator,
  SOS and logic refused by name; the same refusal across `to_nl`/`to_lp`/`to_mps`/`to_gams`;
  plus `test_the_refusal_names_a_remedy_that_works`, which runs the lowering the message
  names and exports the result.
- `test_1218_result_value_diagnostics.py` — the opaque node, an ordinary expression and a
  foreign variable each get their reason; a plain `Variable` and an `IndexedVar` still
  resolve; no-solution still reports no solution first.
- `test_argmin_block.py::test_value_of_the_opaque_node_explains_itself_and_names_the_recovery`
  and `::test_kkt_default_refuses_nl_export_by_name[gdp|sos1]`.
- The three gate tests (`verify_minimizer` on/off pair, degenerate-active-set warn-once) are
  new coverage of existing behaviour and pass before and after, as coverage tests should.

- [x] Added a regression test that fails before / passes after

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DTMMofkWbgXQZrx5edioGp

---
_Generated by [Claude Code](https://claude.ai/code/session_01DTMMofkWbgXQZrx5edioGp)_