### PR TITLE
fix(export): #1222 nlvo is ASL's prefix bound; emit the .nl x section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,7 +57,48 @@ The release procedure that produces these entries is documented in
   follower goes through `dm.argmin`, which solves rather than reformulates and
   reports its answer as local.
 
+- **`.nl` export writes the `x` (initial primal guess) section** (#1222). The
+  writer never emitted one — the module docstring listed the section, no code
+  wrote it, and on round-trip 202 of 202 corpus instances that carried an `x`
+  block lost it. `m.to_nl(path, initial_point={x: 2.5, z: [...]})` (and
+  `discopt.export.nl.to_nl(..., initial_point=...)`) now writes it. The guess
+  takes the same `{Variable: value}` form as `solve(initial_solution=...)` and
+  goes through `validate_initial_solution`, so values are bound-clamped and
+  integrality-rounded with a warning rather than written as given. Only
+  variables the caller actually supplied get an entry — a partial section is
+  what AMPL itself writes (`ex1221.nl` declares 5 variables and an `x2` block)
+  — so no starting value is invented for the rest. Without the argument no
+  section is written, exactly as before.
+
 ### Fixed
+
+- **`.nl` header under-declared `nlvo`, so an ASL solver silently answered a
+  different problem** (#1222). Header line 4 is `nlvc nlvo nlvb`, and the
+  writer put the *raw* count of variables appearing nonlinearly in objectives
+  in the `nlvo` field. ASL sizes its nonlinear-column prefix as
+  `max(nlvc, nlvo)` and reads the objective-only nonlinear block as the columns
+  in `[nlvc, nlvo)`, so `nlvo` is a **prefix bound**: with the canonical
+  `[both | cons-only | objs-only | linear]` column order this writer already
+  emits, it has to be `nlvc + |objs-only|` whenever an objective-only nonlinear
+  variable exists. The raw count truncated that prefix on any model with both
+  cons-only and objs-only nonlinear variables, and every column past the
+  truncation was mis-assigned — with no error and no warning. On `fuel` (AMPL
+  writes `3 6 0`, discopt wrote `3 3 0`) Ipopt reported
+  `Optimal Solution Found.` with objective 7269.45 instead of 8457.69; patching
+  only that one field made the two files agree bit-for-bit.
+
+  The correction is conditional, *not* the unconditional
+  `nlvc + nlvo - nlvb` — a model with a linear objective must keep `nlvo = 0`
+  however large `nlvc` is, which is the common case. Measured by round-tripping
+  the AMPL-written corpus in `python/tests/data/minlplib_nl` and comparing
+  header line 4 against AMPL's own: the new conditional form reproduces AMPL on
+  **66/66** instances (0 differ), the old raw count on 61/66, and the
+  unconditional form on 37/66 — it breaks all 29 linear-objective instances.
+
+  In-repo benchmark numbers are unaffected — the runner hands external solvers
+  the original corpus `.nl`, never a rewrite — and discopt's own reader took
+  `max(nlvc, nlvo)` the same way the writer wrote it, which is why the defect
+  was invisible from inside.
 
 - **`pounce_sensitivity` ignored the active set** (#1216). The KKT sensitivity
   system was assembled over *all* constraint rows, i.e. as though every constraint

--- a/python/discopt/export/nl.py
+++ b/python/discopt/export/nl.py
@@ -15,7 +15,7 @@ opcodes. Key sections:
   k section:          Jacobian column counts (cumulative)
   J sections:         linear terms in constraints (Jacobian)
   G sections:         linear terms in objective (gradient)
-  x section:          initial point (optional)
+  x section:          initial point (written when one is supplied)
 
 Reference: Gay, D.M. "Hooking Your Solver to AMPL" (2003).
 Inspired by Pyomo's NLv2Writer (pyomo/repn/plugins/nl_writer.py).
@@ -52,6 +52,8 @@ from discopt.modeling.core import (
 def to_nl(
     model: Model,
     path: Union[str, Path, None] = None,
+    *,
+    initial_point: Union[dict, None] = None,
 ) -> Union[str, None]:
     """Export a discopt Model to AMPL .nl text format.
 
@@ -62,6 +64,14 @@ def to_nl(
     path : str or Path, optional
         If provided, write the .nl string to this file and return ``None``.
         Otherwise return the .nl string.
+    initial_point : dict, optional
+        ``{Variable: value}`` starting guess, in the same form
+        :meth:`Model.solve`'s ``initial_solution`` takes. Written as the ``.nl``
+        ``x`` section so the reading solver starts from it; variables left out
+        of the dict are left out of the section (no guess is invented for them).
+        Values are validated, bound-clamped and integrality-rounded by
+        :func:`discopt.warm_start.validate_initial_solution` first. Omitted (or
+        ``{}``) writes no ``x`` section at all.
 
     Returns
     -------
@@ -74,7 +84,7 @@ def to_nl(
     # would block a correct export over a defect that only affects solving.
     # Measured: ``Constraint(w, ">=", 5.0)`` emits ``r`` entry ``2 5.0``.
     model.validate(for_solve=False)
-    writer = _NLWriter(model)
+    writer = _NLWriter(model, initial_point=initial_point)
     text = writer.write()
     if path is not None:
         Path(path).write_text(text)
@@ -144,9 +154,41 @@ def _elem(arr: np.ndarray, idx: Any) -> Expression:
     return cast(Expression, arr[idx])
 
 
+def _keyed_initial_point(model: Model, initial_point: dict) -> dict[tuple[str, int], float]:
+    """Validate a ``{Variable: value}`` guess and key it by ``(name, element)``.
+
+    :func:`~discopt.warm_start.validate_initial_solution` returns one flat
+    vector in ``model._variables`` declaration order, filling *every* slot —
+    unprovided variables get the bound midpoint. That default is right for a
+    warm start and wrong for an ``x`` section, where an entry is a statement
+    about a variable the caller actually chose: only the columns whose variable
+    appears in *initial_point* are carried over, so the export never invents a
+    guess. Re-keying by ``(name, element)`` lets the writer translate to final
+    ``.nl`` column indices after :meth:`_NLWriter._reorder_vars_canonical` has
+    permuted them.
+    """
+    from discopt.warm_start import validate_initial_solution
+
+    x_flat = validate_initial_solution(model, initial_point)
+    keyed: dict[tuple[str, int], float] = {}
+    offset = 0
+    for var in model._variables:
+        if var in initial_point:
+            for elem in range(var.size):
+                keyed[(var.name, elem)] = float(x_flat[offset + elem])
+        offset += var.size
+    return keyed
+
+
 class _NLWriter:
-    def __init__(self, model: Model):
+    def __init__(self, model: Model, initial_point: Union[dict, None] = None):
         self.model = model
+        # (name, element) -> initial value, for the optional x section. Empty
+        # when the caller supplied no guess, in which case no x section is
+        # written (the pre-#1222 behaviour, which was the only behaviour).
+        self._initial_point: dict[tuple[str, int], float] = (
+            _keyed_initial_point(model, initial_point) if initial_point else {}
+        )
         # Flatten all variables to a single indexed list
         # .nl format: continuous first, then binary, then integer (at end)
         self._flat_vars: list[tuple[Variable, int]] = []  # (var, element_idx)
@@ -186,6 +228,7 @@ class _NLWriter:
         self._write_O_section(buf)
         self._write_r_section(buf)
         self._write_b_section(buf)
+        self._write_x_section(buf)
         self._write_k_section(buf)
         self._write_J_sections(buf)
         self._write_G_section(buf)
@@ -328,13 +371,48 @@ class _NLWriter:
 
         # Stash header counts (line 4: nlvc/nlvo totals + nlvb; line 6: discrete).
         self._nlvc_total = len(nl_cons)
-        self._nlvo_total = len(nl_objs)
+        self._nlvo_total = self._nlvo_prefix_bound(nl_cons, nl_objs, nl_both)
         self._nlvb = len(nl_both)
         self._nlvbi = len(both_disc)
         self._nlvci = len(cons_disc)
         self._nlvoi = len(objs_disc)
         self._nbv = len(lin_bin)
         self._niv = len(lin_int)
+
+    @staticmethod
+    def _nlvo_prefix_bound(nl_cons: set[int], nl_objs: set[int], nl_both: set[int]) -> int:
+        """Header ``nlvo``: the ASL **prefix bound**, not the raw objective count.
+
+        ASL sizes its nonlinear-column prefix as ``max(nlvc, nlvo)`` and reads
+        the objective-only nonlinear block as the columns in ``[nlvc, nlvo)``.
+        The canonical variable order this writer emits is
+        ``[both | cons-only | objs-only | linear]`` (see
+        :meth:`_reorder_vars_canonical`), so when an objective-only nonlinear
+        variable exists that block starts at ``nlvc`` and ``nlvo`` has to be
+        ``nlvc + |objs-only|`` — i.e. the *end* of the block, counted from
+        column 0. Writing the raw ``len(nl_objs)`` instead under-declares the
+        prefix whenever there are also cons-only nonlinear variables, ASL
+        truncates it, and every column past the truncation is mis-assigned:
+        the reader silently solves a different problem (issue #1222; Ipopt
+        reported ``Optimal Solution Found.`` with objective 7269.45 instead of
+        8457.69 on ``fuel``).
+
+        When there is *no* objective-only nonlinear variable the two readings
+        coincide at ``len(nl_objs)`` (``== |both|``, and ``0`` for a model with
+        a linear objective) and ``nlvo`` must **not** be inflated to ``nlvc`` —
+        the unconditional ``len(nl_cons) + len(nl_objs) - len(nl_both)``
+        proposed in #1222 gets that case wrong. Measured by round-tripping the
+        AMPL-written corpus in ``python/tests/data/minlplib_nl`` and comparing
+        header line 4 against AMPL's own: this conditional form reproduces AMPL
+        on 66/66 instances, the raw count on 61/66, the unconditional form on
+        37/66 (it breaks all 29 linear-objective instances).
+
+        Reference: Gay, D.M. "Writing .nl Files" (2005), §"Variable ordering".
+        """
+        objs_only = len(nl_objs) - len(nl_both)
+        if objs_only:
+            return len(nl_cons) + objs_only
+        return len(nl_objs)
 
     # ── Jacobian sparsity (union of linear + nonlinear vars per constraint) ──
 
@@ -1057,6 +1135,32 @@ class _NLWriter:
                 buf.write(f"1 {ub}\n")  # ub only
             else:
                 buf.write("3\n")  # free
+
+    # ── x section (initial primal guess) ──
+
+    def _write_x_section(self, buf: io.StringIO):
+        """Initial primal guess: ``x<count>`` then one ``<column> <value>`` line.
+
+        Optional in the format and written only when the caller supplied an
+        initial point — a model with no guess emits no section, as before. The
+        section is a partial map: AMPL itself writes only the variables that
+        have a starting value (``ex1221.nl`` declares 5 variables and an ``x2``
+        block), so an absent column simply means "no guess for this one".
+
+        Columns are the *final* ``.nl`` indices, resolved through
+        ``_var_index`` after :meth:`_reorder_vars_canonical` — indexing is
+        direct rather than ``.get(...)``: every key came from
+        ``model._variables``, so a miss is a writer bug and must surface as a
+        ``KeyError`` instead of silently dropping a starting value.
+        """
+        if not self._initial_point:
+            return
+        entries = sorted(
+            (self._var_index[key], value) for key, value in self._initial_point.items()
+        )
+        buf.write(f"x{len(entries)}\n")
+        for idx, value in entries:
+            buf.write(f"{idx} {value}\n")
 
     # ── k section (Jacobian column counts) ──
 

--- a/python/discopt/modeling/core.py
+++ b/python/discopt/modeling/core.py
@@ -5916,7 +5916,11 @@ class Model:
 
         return to_gams(self, path, model_type)
 
-    def to_nl(self, path: Union[str, None] = None) -> Union[str, None]:
+    def to_nl(
+        self,
+        path: Union[str, None] = None,
+        initial_point: Optional[dict] = None,
+    ) -> Union[str, None]:
         """Export the model to AMPL .nl text format.
 
         Supports all model types including MINLP with nonlinear expressions.
@@ -5927,6 +5931,11 @@ class Model:
         ----------
         path : str, optional
             File path to write. If ``None``, return the .nl string.
+        initial_point : dict, optional
+            ``{Variable: value}`` starting guess (same form as
+            :meth:`solve`'s ``initial_solution``), written as the ``.nl`` ``x``
+            section. Variables omitted from the dict get no entry. Without it
+            no ``x`` section is written.
 
         Returns
         -------
@@ -5935,7 +5944,7 @@ class Model:
         """
         from discopt.export.nl import to_nl
 
-        return to_nl(self, path)
+        return to_nl(self, path, initial_point=initial_point)
 
     def _check_name(self, name: str):
         """Ensure a variable/parameter name is unique and not compiler-reserved.

--- a/python/tests/test_1222_nl_header_nlvo_x_section.py
+++ b/python/tests/test_1222_nl_header_nlvo_x_section.py
@@ -1,0 +1,206 @@
+"""Regression tests for issue #1222 — the .nl writer's header and ``x`` section.
+
+Two defects, both invisible to a round-trip through discopt's *own* reader
+(which mirrored the writer's mistake) and therefore both checked here against
+an external oracle instead:
+
+1. **Header line 4 ``nlvo``** was the raw count of variables appearing
+   nonlinearly in objectives. ASL sizes its nonlinear-column prefix as
+   ``max(nlvc, nlvo)`` and reads objective-only nonlinear columns from
+   ``[nlvc, nlvo)``, so whenever a model had *both* cons-only and objs-only
+   nonlinear variables the declared prefix was short and the reader
+   mis-assigned columns — a silent wrong answer (Ipopt printed
+   ``Optimal Solution Found.`` for a different problem). The oracle here is the
+   corpus itself: every file in ``data/minlplib_nl`` was written by AMPL, so
+   its own header line 4 is ground truth for the model it encodes.
+
+2. **The ``x`` section** (initial primal guess) was never emitted — the module
+   docstring listed it, no code wrote it.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import discopt.modeling as dm
+import pytest
+
+pytestmark = pytest.mark.unit
+
+CORPUS = Path(__file__).parent / "data" / "minlplib_nl"
+
+# The five in-repo instances whose AMPL header line 4 the pre-fix writer got
+# wrong. Listed by name only to make the regression legible in a failure
+# report; the parametrized corpus test below covers all 66 files, so the fix is
+# not keyed to these names.
+KNOWN_NLVO_DISAGREEMENTS = (
+    "casctanks.nl",
+    "contvar.nl",
+    "heatexch_gen2.nl",
+    "heatexch_gen3.nl",
+    "st_e11.nl",
+)
+
+
+def _header_line(text: str, index: int) -> list[int]:
+    """Numeric fields of header line *index* (comment stripped)."""
+    return [int(tok) for tok in text.splitlines()[index].split("#")[0].split()]
+
+
+def _nlvar_line(text: str) -> list[int]:
+    """Header line 4: ``nlvc nlvo nlvb``, zero-padded to three fields."""
+    fields = _header_line(text, 4)
+    return fields + [0] * (3 - len(fields))
+
+
+def _corpus_files() -> list[Path]:
+    return sorted(CORPUS.glob("*.nl"))
+
+
+class TestNlvoPrefixBound:
+    """Header line 4 must carry ASL's prefix bound, not the raw objective count."""
+
+    @pytest.mark.parametrize("path", _corpus_files(), ids=lambda p: p.name)
+    def test_roundtrip_matches_ampl_header(self, path: Path):
+        """``to_nl(from_nl(f))`` reproduces AMPL's own ``nlvc nlvo nlvb``.
+
+        AMPL wrote these files, so the comparison is against an external
+        oracle rather than against discopt's own reading of its own output.
+        """
+        original = path.read_text(encoding="latin-1")
+        exported = dm.from_nl(str(path)).to_nl()
+        assert _nlvar_line(exported) == _nlvar_line(original), (
+            f"{path.name}: header line 4 disagrees with the AMPL original"
+        )
+
+    def test_corpus_is_present_and_covers_the_defect(self):
+        """Guard the parametrization: an empty corpus would make it a no-op."""
+        names = {p.name for p in _corpus_files()}
+        assert len(names) >= 60, f"corpus unexpectedly small: {len(names)} files"
+        missing = set(KNOWN_NLVO_DISAGREEMENTS) - names
+        assert not missing, f"instances that exercised the defect are gone: {missing}"
+
+    def test_objective_only_nonlinear_var_extends_the_prefix(self):
+        """The ``fuel`` shape: cons-only *and* objs-only nonlinear variables.
+
+        ``a`` is nonlinear in the constraint only, ``b`` in the objective only.
+        The canonical column order is ``[both | cons-only | objs-only | linear]``
+        = ``[a | b | ...]``, so the objective-only block ends at column 2 and
+        ``nlvo`` must be 2 — the raw count (1) would truncate ASL's prefix to
+        one column and hand the objective's nonlinear variable to the wrong
+        column.
+        """
+        m = dm.Model("objs_only")
+        a = m.continuous("a", lb=0, ub=10)
+        b = m.continuous("b", lb=0, ub=10)
+        m.minimize(b * b + a)
+        m.subject_to(a * a + b <= 5)
+        nlvc, nlvo, nlvb = _nlvar_line(m.to_nl())
+        assert (nlvc, nlvb) == (1, 0)
+        assert nlvo == 2
+
+    def test_no_objective_nonlinearity_leaves_nlvo_zero(self):
+        """A linear objective keeps ``nlvo = 0`` however large ``nlvc`` is.
+
+        This is the case the unconditional ``nlvc + nlvo - nlvb`` correction
+        proposed in #1222 gets wrong (it would declare ``nlvo = nlvc``); it is
+        also the common case — that form breaks 29 of the 66 corpus
+        instances.
+        """
+        m = dm.Model("linear_obj")
+        a = m.continuous("a", lb=0, ub=10)
+        b = m.continuous("b", lb=0, ub=10)
+        m.minimize(a + b)
+        m.subject_to(a * b <= 5)
+        assert _nlvar_line(m.to_nl()) == [2, 0, 0]
+
+    def test_objective_nonlinear_vars_subset_of_constraints(self):
+        """No objs-only variable: ``nlvo`` stays at the both-count, not ``nlvc``."""
+        m = dm.Model("subset")
+        a = m.continuous("a", lb=0, ub=10)
+        b = m.continuous("b", lb=0, ub=10)
+        m.minimize(a * a + b)
+        m.subject_to(a * b <= 5)
+        nlvc, nlvo, nlvb = _nlvar_line(m.to_nl())
+        assert (nlvc, nlvb) == (2, 1)
+        assert nlvo == 1
+
+
+class TestInitialPointSection:
+    """The ``x`` section is emitted when — and only when — a guess is supplied."""
+
+    @staticmethod
+    def _x_block(text: str) -> list[str]:
+        """The ``x`` section's lines, or ``[]`` when there is none."""
+        lines = text.splitlines()
+        for i, line in enumerate(lines):
+            if line.startswith("x") and line[1:].strip().isdigit():
+                count = int(line[1:].strip())
+                return lines[i : i + 1 + count]
+        return []
+
+    def _model(self):
+        m = dm.Model("x_section")
+        x = m.continuous("x", lb=0, ub=10)
+        n = m.integer("n", lb=0, ub=5)
+        z = m.continuous("z", shape=(3,), lb=0, ub=1)
+        m.minimize(x * x + n + z[0])
+        m.subject_to(x * n + z[1] <= 4)
+        return m, x, n, z
+
+    def test_no_section_without_an_initial_point(self):
+        m, _x, _n, _z = self._model()
+        assert self._x_block(m.to_nl()) == []
+        assert self._x_block(m.to_nl(initial_point={})) == []
+
+    def test_section_carries_only_the_supplied_variables(self):
+        """A partial guess writes a partial section — no invented midpoints."""
+        m, x, _n, z = self._model()
+        block = self._x_block(m.to_nl(initial_point={x: 2.5, z: [0.1, 0.2, 0.3]}))
+        assert block[0] == "x4"
+        # x is nonlinear in both -> column 0; z is linear -> columns 2..4
+        # (column 1 is the integer n, deliberately absent: no guess was given).
+        assert [line.split()[0] for line in block[1:]] == ["0", "2", "3", "4"]
+        assert [float(line.split()[1]) for line in block[1:]] == [2.5, 0.1, 0.2, 0.3]
+
+    def test_columns_follow_the_canonical_reorder(self):
+        """Entries use final ``.nl`` columns, not declaration order.
+
+        ``lin`` is declared first but is linear, so the canonical reorder sends
+        it behind the nonlinear ``nl``. A guess keyed to ``lin`` must land on
+        the reordered column, not on column 0.
+        """
+        m = dm.Model("reorder")
+        lin = m.continuous("lin", lb=0, ub=10)
+        nl = m.continuous("nl", lb=0, ub=10)
+        m.minimize(nl * nl + lin)
+        block = self._x_block(m.to_nl(initial_point={lin: 4.0}))
+        assert block == ["x1", "1 4.0"]
+
+    def test_values_are_validated_against_bounds_and_integrality(self):
+        """Out-of-bounds / fractional guesses are clamped and rounded, with a warning."""
+        m, x, n, _z = self._model()
+        with pytest.warns(UserWarning):
+            block = self._x_block(m.to_nl(initial_point={x: 99.0, n: 2.4}))
+        values = {line.split()[0]: float(line.split()[1]) for line in block[1:]}
+        assert values["0"] == 10.0  # clamped to ub
+        assert values["1"] == 2.0  # rounded to the nearest integer
+
+    def test_rejects_a_variable_from_another_model(self):
+        """A foreign Variable is refused loudly rather than silently dropped."""
+        m, _x, _n, _z = self._model()
+        other = dm.Model("other")
+        stranger = other.continuous("stranger", lb=0, ub=1)
+        with pytest.raises(ValueError, match="not part of this model"):
+            m.to_nl(initial_point={stranger: 0.5})
+
+    def test_rust_parser_reads_a_file_carrying_an_x_section(self, tmp_path):
+        """The emitted section must not break discopt's own reader."""
+        m, x, n, _z = self._model()
+        path = tmp_path / "with_x.nl"
+        m.to_nl(str(path), initial_point={x: 1.5, n: 3})
+        assert "\nx2\n" in path.read_text()
+        reparsed = dm.from_nl(str(path))
+        # The reader splits blocks into scalars, so compare scalar counts.
+        assert sum(v.size for v in reparsed._variables) == sum(v.size for v in m._variables)
+        assert len(reparsed._constraints) == len(m._constraints)


### PR DESCRIPTION
## Summary

Closes #1222.

Two pre-existing defects in the `.nl` writer, both invisible from inside discopt
because its own reader mirrored the writer's mistake.

**1 — `nlvo` under-declared in header line 4 (silent wrong answer).** Line 4 is
`nlvc nlvo nlvb`, and the writer put the *raw* count of variables appearing
nonlinearly in objectives in the `nlvo` field. ASL sizes its nonlinear-column
prefix as `max(nlvc, nlvo)` and reads the objective-only nonlinear block as the
columns in `[nlvc, nlvo)`, so `nlvo` is a **prefix bound**: with the canonical
`[both | cons-only | objs-only | linear]` column order this writer already
emits, it has to be `nlvc + |objs-only|` whenever an objective-only nonlinear
variable exists. The raw count truncated the prefix on any model carrying *both*
cons-only and objs-only nonlinear variables, and every column past the
truncation was mis-assigned — no error, no warning. On `fuel` (AMPL writes
`3 6 0`, discopt wrote `3 3 0`) the issue measured Ipopt reporting
`Optimal Solution Found.` with objective 7269.45 instead of 8457.69.

**The one-line fix proposed in the issue is wrong, and this PR does not use it.**
`len(nl_cons) + len(nl_objs) - len(nl_both)` is right for the disagreeing
instances but breaks every model with a linear objective, which must keep
`nlvo = 0` however large `nlvc` is. Measured on one harness — round-trip the
AMPL-written corpus in `python/tests/data/minlplib_nl`, compare header line 4
against AMPL's own value:

| `nlvo` formula | matches AMPL |
|---|---:|
| **conditional prefix bound (shipped)** | **66/66** |
| raw `len(nl_objs)` (previous behaviour) | 61/66 |
| unconditional `nlvc + nlvo - nlvb` (#1222's proposal) | 37/66 — breaks all 29 linear-objective instances |

The 5 instances the old writer got wrong are `casctanks`, `contvar`,
`heatexch_gen2`, `heatexch_gen3`, `st_e11` (7.6% of the in-repo corpus,
consistent with the issue's 8.6% over the full snapshot). `nlvc` and `nlvb`
agreed before and still agree.

**2 — the `x` (initial primal guess) section was never emitted.** The module
docstring listed the section; no code wrote it.
`m.to_nl(path, initial_point={x: 2.5, z: [...]})` and
`discopt.export.nl.to_nl(..., initial_point=...)` now write it. The guess takes
the same `{Variable: value}` form as `solve(initial_solution=...)` and goes
through `validate_initial_solution`, so values are bound-clamped and
integrality-rounded (each warned) rather than written as given. Only variables
the caller actually supplied get an entry — a partial section is what AMPL
itself writes (`ex1221.nl` declares 5 variables and an `x2` block) — so the
export never invents a starting value. Without the argument no section is
written, exactly as before.

### Not in this PR, and why

- **Round-trip preservation of a corpus `x` block** (the issue's "202 of 202
  lost"). The Rust parser reads the `x` section into a local that is discarded
  (`nl_parser.rs:834` `_x0`); carrying it to Python means a new field on
  `ModelRepr`, which has **172 struct-literal construction sites**, and a
  decision at every presolve transform about what happens to a point whose
  variables were eliminated or reindexed — silently carrying a stale `x0`
  through presolve would be a new correctness hazard. That is its own change,
  filed as a follow-up rather than widened into here.
- **The Rust `.nl` writer in #1220 needs the same two changes ported.** That
  writer is byte-identical to the *old* Python writer on 1570/1570 instances,
  so it inherits both defects; `nl_writer.rs` does not exist on `main` yet, so
  it cannot be patched from here. #1220's own byte-parity test will fail at
  merge time until the `nlvo` rule and the `x` section are ported — that
  failure is the intended signal, not a surprise.
- **An ASL readback test gated on `ipopt`.** The issue suggests one; no
  ASL-linked solver is installed in this container (`ipopt`, `couenne`,
  `bonmin`, `scip`, `baron`, `ampl` all absent), so I could not run the
  instrument I would be shipping. Rather than add a test that has never
  executed anywhere (CLAUDE.md §6), the regression gate here compares against
  the AMPL-written corpus headers — the external oracle that actually isolates
  this defect.

## Correctness

The writer only produces files for *other* solvers; discopt's solve path never
reads its own `.nl` output, so no bound, cut, or relaxation is touched and no
certificate can change. Verified rather than asserted: read → write → read over
all 66 corpus instances, fingerprinting the recovered model (scalar variable
count, variable types, finite-bound sum, row count) plus a hash of the written
bytes with header line 4 masked out — **identical fingerprint on both arms**
(`277bd50aee5e…`). The change is confined to that one header field.

The direction of the fix is toward soundness: the previous file made an external
ASL solver answer a different problem and say `Optimal Solution Found.`

- [x] Cannot produce a false certificate (no solver-math change; export-only,
      and the corrected header removes a silent wrong answer from third-party
      readers)
- [x] No validation, fallback, or safety guard was weakened to make a check pass

## Tests run (state the result — numbers, not adjectives)

- [x] `pytest -m smoke` → **1209 passed, 21 skipped, 2 xpassed** (345 s)
- [x] `pytest -m slow python/tests/test_adversarial_recent_fixes.py` → **19 passed**
- [x] `cargo test -p discopt-core` → N/A, no Rust touched
- [x] `ruff check python/` / `ruff format --check python/` → clean (989 files)
- [x] `mypy python/discopt/export/nl.py` → `Success: no issues found`
- [x] `pytest python/tests/test_nl_writer.py test_nl_parser.py test_export.py test_export_cli_roundtrip.py test_binary_nl_parsing.py test_nl_parser_objonly_integers.py` → **172 passed, 8 skipped, 1 xfailed**

## Regression test

`python/tests/test_1222_nl_header_nlvo_x_section.py` — **76 tests, 12 of them
fail before this change and pass after** (verified by stashing the two source
files and re-running, not by assuming).

- `TestNlvoPrefixBound::test_roundtrip_matches_ampl_header` is parametrized over
  all 66 corpus files and compares against **AMPL's own header**, so it is an
  external-oracle check, not a round-trip through our own reader (which is why
  this defect survived). `test_corpus_is_present_and_covers_the_defect` guards
  the parametrization against silently degrading to zero cases.
- Three synthetic cases pin the *rule* rather than the instances: an
  objective-only nonlinear variable alongside a cons-only one (the `fuel`
  shape), a linear objective with a large `nlvc` (the case the issue's proposed
  one-liner breaks), and objective-nonlinear variables that are a subset of the
  constraint-nonlinear ones.
- `TestInitialPointSection` covers: no section without a guess (including
  `initial_point={}`), a partial section carrying only supplied variables,
  columns resolved through the canonical reorder rather than declaration order,
  bound clamping / integrality rounding, a foreign `Variable` refused loudly,
  and the Rust parser reading back a file that carries the section.

- [x] Added a regression test that fails before / passes after

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011H3zJQrWcY7BMkuMkDyavw


---
_Generated by [Claude Code](https://claude.ai/code/session_011H3zJQrWcY7BMkuMkDyavw)_