### PR TITLE
feat(nl): #1225 carry a .nl file's initial point through the reader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,45 @@ The release procedure that produces these entries is documented in
   follower goes through `dm.argmin`, which solves rather than reformulates and
   reports its answer as local.
 
+- **`from_nl` keeps a `.nl` file's initial point, so a round-trip preserves it**
+  (#1225). #1222's writer half shipped in #1224; this is the reader half. The
+  Rust parser filled a dense `vec![0.0; n_vars]` named `_x0` that nothing ever
+  read, so all 202 corpus instances carrying an `x` block lost it on
+  `to_nl(from_nl(f))`. `from_nl` now attaches the segment to the `Model` and
+  `to_nl()` writes it back with no argument: **51/51** of the in-repo corpus's
+  text-format files with an `x` block round-trip, both the values (against the
+  AMPL original) and the column each value lands on (against the writer's own
+  canonical reorder). The binary (`b3`) encoding comes along for free — the
+  transcoder already carried the segment.
+
+  The point rides **alongside** `ModelRepr`, not inside it — a new
+  `ParsedNl { model, complementarities, initial_point }` from the parser and a
+  field on `PyModelRepr`, following the route `complementarities` already takes.
+  That is the design point, not a convenience: an initial point is indexed *by
+  column*, and every presolve transform may remove, fix or renumber columns, so
+  a field on `ModelRepr` would have to be remapped correctly by each of ~20
+  transforms or be silently stale. Out here a transform's output starts from an
+  empty point by construction (tested for `substitute`, `eliminate_variables`
+  and `reformulate_polynomial`), and the 172 `ModelRepr` construction sites stay
+  untouched.
+
+  New API: `Model.set_initial_point({Variable: value})` attaches one explicitly
+  (validated, bound-clamped and integrality-rounded like
+  `solve(initial_solution=...)`), and `Model.initial_point` reads it back as
+  `{Variable: {element: value}}` — element-keyed because the segment is a
+  *partial* map and "this element has no guess" has no array encoding that is not
+  a sentinel. A point read from a file is attached **verbatim**, unclamped, so
+  the export reproduces its source; only the setter validates, because only the
+  setter takes user input. `to_nl(initial_point=...)` still wins over the
+  attached point, and `initial_point={}` suppresses the section entirely.
+
+  **The solve path deliberately does not read it.** Warm starting stays
+  `solve(initial_solution=...)`: wiring a file's `x` segment into it would change
+  how every `.nl`-read model is solved, which is a measured decision of its own,
+  not a side effect of fixing the reader. Verified rather than asserted — a
+  20-instance corpus panel is bit-identical across the change: same status, same
+  objective bits, same `node_count` on 20/20.
+
 - **`.nl` export writes the `x` (initial primal guess) section** (#1222). The
   writer never emitted one — the module docstring listed the section, no code
   wrote it, and on round-trip 202 of 202 corpus instances that carried an `x`

--- a/crates/discopt-core/src/nl_parser.rs
+++ b/crates/discopt-core/src/nl_parser.rs
@@ -737,7 +737,30 @@ fn parse_opcode(
 /// Complementarity (type-5) rows are recovered but discarded here; use
 /// [`parse_nl_with_complementarity`] to also receive the recovered pairs.
 pub fn parse_nl(content: &str) -> Result<ModelRepr, NlParseError> {
-    parse_nl_with_complementarity(content).map(|(model, _compl)| model)
+    parse_nl_full(content).map(|parsed| parsed.model)
+}
+
+/// Everything a text-mode `.nl` file carries, including the parts that are
+/// deliberately **not** fields of [`ModelRepr`].
+///
+/// `ModelRepr` is the input to every presolve transform, and those transforms
+/// remove, fix and reindex columns. Data indexed *by column* — the `x` segment's
+/// starting point — would therefore be silently invalidated by any of them, so
+/// it rides alongside the model rather than inside it and cannot be carried
+/// through a transform by accident (the same reason `complementarities` lives
+/// out here; see `ModelRepr`'s own note).
+pub struct ParsedNl {
+    /// The model itself.
+    pub model: ModelRepr,
+    /// Complementarity (type-5) relations recovered from the `r` segment. Their
+    /// `body` ids reference `model.arena`.
+    pub complementarities: Vec<ComplementarityRepr>,
+    /// `(column, value)` pairs from the `x` segment, sorted by column with one
+    /// entry per column. Sparse on purpose: the segment is a *partial* map (AMPL
+    /// writes `x2` for a 5-column problem in `ex1221.nl`), and a dense vector
+    /// cannot tell "starting value 0.0" from "no starting value". Empty when the
+    /// file has no `x` segment.
+    pub initial_point: Vec<(usize, f64)>,
 }
 
 /// Parse a text-mode .nl file, returning the model together with any
@@ -750,6 +773,12 @@ pub fn parse_nl(content: &str) -> Result<ModelRepr, NlParseError> {
 pub fn parse_nl_with_complementarity(
     content: &str,
 ) -> Result<(ModelRepr, Vec<ComplementarityRepr>), NlParseError> {
+    parse_nl_full(content).map(|parsed| (parsed.model, parsed.complementarities))
+}
+
+/// Parse a text-mode .nl file into a [`ParsedNl`] — the model plus the
+/// column-indexed and relation data that does not belong inside `ModelRepr`.
+pub fn parse_nl_full(content: &str) -> Result<ParsedNl, NlParseError> {
     let mut reader = LineReader::new(content);
     let header = parse_header(&mut reader)?;
 
@@ -831,7 +860,11 @@ pub fn parse_nl_with_complementarity(
     let mut g_terms: Vec<Vec<(usize, f64)>> = vec![Vec::new(); n_objectives.max(1)];
 
     // Initial point
-    let mut _x0: Vec<f64> = vec![0.0; n_vars];
+    // `x` segment entries, sparse `(column, value)`: see `ParsedNl::initial_point`
+    // for why this is not a dense `vec![0.0; n_vars]` (which is what it used to be,
+    // discarded under a leading underscore — the initial point never left the
+    // parser, so a round-trip dropped it; #1225).
+    let mut initial_point: Vec<(usize, f64)> = Vec::new();
 
     // Determine variable types from header counts.
     // In .nl format the variables are ordered:
@@ -969,8 +1002,11 @@ pub fn parse_nl_with_complementarity(
                     if pts.len() >= 2 {
                         let vi = parse_usize(pts[0])?;
                         let val = parse_f64(pts[1])?;
+                        // An out-of-range column cannot be represented; ASL
+                        // ignores it too. Keeping the guard preserves the
+                        // existing tolerance for such a file.
                         if vi < n_vars {
-                            _x0[vi] = val;
+                            initial_point.push((vi, val));
                         }
                     }
                 }
@@ -1459,7 +1495,23 @@ pub fn parse_nl_with_complementarity(
         variables,
         n_vars,
     };
-    Ok((model, complementarities))
+    // One entry per column, ordered. The segment is a write sequence, so a
+    // repeated column takes its LAST value; `sort_by_key` is stable, which keeps
+    // the duplicates in file order for the fold below.
+    initial_point.sort_by_key(|&(vi, _)| vi);
+    let mut unique: Vec<(usize, f64)> = Vec::with_capacity(initial_point.len());
+    for entry in initial_point {
+        match unique.last_mut() {
+            Some(last) if last.0 == entry.0 => *last = entry,
+            _ => unique.push(entry),
+        }
+    }
+
+    Ok(ParsedNl {
+        model,
+        complementarities,
+        initial_point: unique,
+    })
 }
 
 /// Check if an ExprId is a zero constant.
@@ -1881,7 +1933,7 @@ fn transcode_binary_nl(bytes: &[u8]) -> Result<String, NlParseError> {
 /// than a confusing UTF-8 decode error, since binary bodies embed raw IEEE-754
 /// doubles that are not valid UTF-8).
 pub fn parse_nl_file(path: &str) -> Result<ModelRepr, NlParseError> {
-    parse_nl_file_with_complementarity(path).map(|(model, _compl)| model)
+    parse_nl_file_full(path).map(|parsed| parsed.model)
 }
 
 /// Parse a .nl file, returning the model together with any complementarity
@@ -1890,6 +1942,13 @@ pub fn parse_nl_file(path: &str) -> Result<ModelRepr, NlParseError> {
 pub fn parse_nl_file_with_complementarity(
     path: &str,
 ) -> Result<(ModelRepr, Vec<ComplementarityRepr>), NlParseError> {
+    parse_nl_file_full(path).map(|parsed| (parsed.model, parsed.complementarities))
+}
+
+/// Parse a `.nl` file (text or binary) into a [`ParsedNl`]. Binary input is
+/// transcoded to text first, so both encodings yield the same `ParsedNl` —
+/// including the `x` segment, which the transcoder already carries over.
+pub fn parse_nl_file_full(path: &str) -> Result<ParsedNl, NlParseError> {
     let bytes = std::fs::read(path)
         .map_err(|e| NlParseError::Parse(format!("failed to read file '{path}': {e}")))?;
 
@@ -1899,7 +1958,7 @@ pub fn parse_nl_file_with_complementarity(
     // two encodings of one model build byte-identical `ModelRepr`s.
     if let Some(b'b') = bytes.iter().find(|b| !b.is_ascii_whitespace()) {
         let text = transcode_binary_nl(&bytes)?;
-        return parse_nl_with_complementarity(&text);
+        return parse_nl_full(&text);
     }
 
     let content = std::str::from_utf8(&bytes).map_err(|e| {
@@ -1907,7 +1966,7 @@ pub fn parse_nl_file_with_complementarity(
             "failed to read file '{path}': not valid UTF-8 text .nl ({e})"
         ))
     })?;
-    parse_nl_with_complementarity(content)
+    parse_nl_full(content)
 }
 
 // ─────────────────────────────────────────────────────────────
@@ -2314,6 +2373,47 @@ mod tests {
     }
 
     // ─── Test: header parsing ─────────────────────────────
+
+    // ─── Tests: the `x` segment (initial point), #1225 ────
+
+    #[test]
+    fn test_initial_point_is_captured_sparsely() {
+        // linear_nl()'s x segment gives BOTH columns the value 0.0 — the case a
+        // dense `vec![0.0; n_vars]` could not tell from "no starting value".
+        let parsed = parse_nl_full(&linear_nl()).unwrap();
+        assert_eq!(parsed.initial_point, vec![(0, 0.0), (1, 0.0)]);
+    }
+
+    #[test]
+    fn test_initial_point_empty_when_segment_absent() {
+        let nl = linear_nl().replace("x2\n0 0\n1 0\n", "");
+        assert!(!nl.contains("x2"), "fixture still carries an x segment");
+        let parsed = parse_nl_full(&nl).unwrap();
+        assert!(parsed.initial_point.is_empty());
+    }
+
+    #[test]
+    fn test_initial_point_partial_segment_names_only_its_columns() {
+        let nl = linear_nl().replace("x2\n0 0\n1 0\n", "x1\n1 2.5\n");
+        let parsed = parse_nl_full(&nl).unwrap();
+        assert_eq!(parsed.initial_point, vec![(1, 2.5)]);
+    }
+
+    #[test]
+    fn test_initial_point_repeated_column_takes_the_last_value() {
+        // The segment is a write sequence, so a later line wins.
+        let nl = linear_nl().replace("x2\n0 0\n1 0\n", "x3\n1 1\n0 7\n1 9\n");
+        let parsed = parse_nl_full(&nl).unwrap();
+        assert_eq!(parsed.initial_point, vec![(0, 7.0), (1, 9.0)]);
+    }
+
+    #[test]
+    fn test_initial_point_out_of_range_column_dropped() {
+        // Column 5 does not exist in a 2-variable problem; ASL ignores it too.
+        let nl = linear_nl().replace("x2\n0 0\n1 0\n", "x2\n5 3\n1 4\n");
+        let parsed = parse_nl_full(&nl).unwrap();
+        assert_eq!(parsed.initial_point, vec![(1, 4.0)]);
+    }
 
     #[test]
     fn test_parse_linear_header() {

--- a/crates/discopt-python/src/expr_bindings.rs
+++ b/crates/discopt-python/src/expr_bindings.rs
@@ -22,18 +22,23 @@ pub struct PyModelRepr {
     /// Complementarity relations recovered from a `.nl` file (empty for models
     /// built any other way). Their `body` ids reference `inner.arena` (#658).
     complementarities: Vec<ComplementarityRepr>,
+    /// `(column, value)` starting-point entries from a `.nl` file's `x` segment
+    /// (empty for models built any other way, and for every model a transform
+    /// below produces). Indexed **by column**, which is why it sits out here
+    /// rather than in `ModelRepr`: every presolve transform may remove, fix or
+    /// renumber columns, so a transform's output must start from empty instead
+    /// of inheriting indices that no longer mean anything (#1225).
+    initial_point: Vec<(usize, f64)>,
 }
 
 impl PyModelRepr {
-    /// Create a PyModelRepr carrying complementarity relations recovered from a
-    /// `.nl` parse (crate-internal). Pass an empty vector for models with none.
-    pub(crate) fn from_model_repr_with_complementarity(
-        model: ModelRepr,
-        complementarities: Vec<ComplementarityRepr>,
-    ) -> Self {
+    /// Create a PyModelRepr from a `.nl` parse, carrying the recovered
+    /// complementarity relations and `x`-segment starting point (crate-internal).
+    pub(crate) fn from_parsed_nl(parsed: discopt_core::nl_parser::ParsedNl) -> Self {
         Self {
-            inner: model,
-            complementarities,
+            inner: parsed.model,
+            complementarities: parsed.complementarities,
+            initial_point: parsed.initial_point,
         }
     }
 }
@@ -112,6 +117,19 @@ impl PyModelRepr {
     /// Variable upper bounds (flat).
     fn var_ub(&self, index: usize) -> Vec<f64> {
         self.inner.variables[index].ub.clone()
+    }
+
+    /// `.nl` `x`-segment starting point as `[(column, value), ...]`, sorted by
+    /// column, one entry per column.
+    ///
+    /// A *partial* map, deliberately: the segment names only the columns the
+    /// file gave a starting value for, and a dense vector could not tell
+    /// "starting value 0.0" from "no starting value". Empty for a model that
+    /// did not come from a `.nl` file and for every model a transform on this
+    /// class produces — those renumber columns, so inheriting the entries would
+    /// mean inheriting stale indices (#1225).
+    fn initial_point(&self) -> Vec<(usize, f64)> {
+        self.initial_point.clone()
     }
 
     /// Tighten variable block `block_idx`'s element-wise bounds by
@@ -532,6 +550,7 @@ impl PyModelRepr {
             PyModelRepr {
                 inner: new_model,
                 complementarities: Vec::new(),
+                initial_point: Vec::new(),
             },
             dict.into(),
         ))
@@ -561,6 +580,7 @@ impl PyModelRepr {
             PyModelRepr {
                 inner: new_model,
                 complementarities: Vec::new(),
+                initial_point: Vec::new(),
             },
             dict.into(),
         ))
@@ -952,6 +972,7 @@ impl PyModelRepr {
             PyModelRepr {
                 inner: result.model,
                 complementarities: Vec::new(),
+                initial_point: Vec::new(),
             },
             stats.into(),
         ))
@@ -974,8 +995,11 @@ impl PyModelRepr {
         if !self.complementarities.is_empty() {
             return Ok((
                 PyModelRepr {
+                    // Refusal path: the model is returned unchanged, columns and
+                    // all, so the starting point is still valid and is kept.
                     inner: self.inner.clone(),
                     complementarities: self.complementarities.clone(),
+                    initial_point: self.initial_point.clone(),
                 },
                 PySubstitutionChain {
                     models: vec![self.inner.clone()],
@@ -991,6 +1015,7 @@ impl PyModelRepr {
             PyModelRepr {
                 inner: reduced,
                 complementarities: Vec::new(),
+                initial_point: Vec::new(),
             },
             PySubstitutionChain {
                 models,
@@ -1381,6 +1406,7 @@ pub fn model_to_repr(
     Ok(PyModelRepr {
         inner,
         complementarities: Vec::new(),
+        initial_point: Vec::new(),
     })
 }
 

--- a/crates/discopt-python/src/nl_bindings.rs
+++ b/crates/discopt-python/src/nl_bindings.rs
@@ -17,11 +17,9 @@ use crate::expr_bindings::PyModelRepr;
 ///     PyModelRepr wrapping the parsed model.
 #[pyfunction]
 pub fn parse_nl_file(path: &str) -> PyResult<PyModelRepr> {
-    let (model, compl) = nl_parser::parse_nl_file_with_complementarity(path)
+    let parsed = nl_parser::parse_nl_file_full(path)
         .map_err(|e| PyErr::new::<pyo3::exceptions::PyValueError, _>(format!("{e}")))?;
-    Ok(PyModelRepr::from_model_repr_with_complementarity(
-        model, compl,
-    ))
+    Ok(PyModelRepr::from_parsed_nl(parsed))
 }
 
 /// Parse .nl content from a string and return a PyModelRepr.
@@ -33,9 +31,7 @@ pub fn parse_nl_file(path: &str) -> PyResult<PyModelRepr> {
 ///     PyModelRepr wrapping the parsed model.
 #[pyfunction]
 pub fn parse_nl_string(content: &str) -> PyResult<PyModelRepr> {
-    let (model, compl) = nl_parser::parse_nl_with_complementarity(content)
+    let parsed = nl_parser::parse_nl_full(content)
         .map_err(|e| PyErr::new::<pyo3::exceptions::PyValueError, _>(format!("{e}")))?;
-    Ok(PyModelRepr::from_model_repr_with_complementarity(
-        model, compl,
-    ))
+    Ok(PyModelRepr::from_parsed_nl(parsed))
 }

--- a/python/discopt/export/nl.py
+++ b/python/discopt/export/nl.py
@@ -70,8 +70,13 @@ def to_nl(
         ``x`` section so the reading solver starts from it; variables left out
         of the dict are left out of the section (no guess is invented for them).
         Values are validated, bound-clamped and integrality-rounded by
-        :func:`discopt.warm_start.validate_initial_solution` first. Omitted (or
-        ``{}``) writes no ``x`` section at all.
+        :func:`discopt.warm_start.validate_initial_solution` first.
+
+        ``None`` (the default) writes the point **attached to the model** —
+        ``from_nl`` attaches a source file's ``x`` segment (#1225), and
+        :meth:`Model.set_initial_point` attaches one explicitly — or no section
+        at all when the model carries none. Passing ``{}`` writes no section
+        even when the model does carry one; an explicit argument always wins.
 
     Returns
     -------
@@ -184,11 +189,18 @@ class _NLWriter:
     def __init__(self, model: Model, initial_point: Union[dict, None] = None):
         self.model = model
         # (name, element) -> initial value, for the optional x section. Empty
-        # when the caller supplied no guess, in which case no x section is
-        # written (the pre-#1222 behaviour, which was the only behaviour).
-        self._initial_point: dict[tuple[str, int], float] = (
-            _keyed_initial_point(model, initial_point) if initial_point else {}
-        )
+        # means no x section is written (the pre-#1222 behaviour, which was the
+        # only behaviour). ``None`` falls back to the point attached to the
+        # model -- what ``from_nl`` read out of a source file, or what
+        # ``set_initial_point`` put there -- so a read/write round-trip keeps it
+        # (#1225); an explicit argument wins, and an explicit ``{}`` suppresses
+        # the section even for a model that carries a point.
+        if initial_point is None:
+            self._initial_point: dict[tuple[str, int], float] = dict(model._initial_point)
+        elif initial_point:
+            self._initial_point = _keyed_initial_point(model, initial_point)
+        else:
+            self._initial_point = {}
         # Flatten all variables to a single indexed list
         # .nl format: continuous first, then binary, then integer (at end)
         self._flat_vars: list[tuple[Variable, int]] = []  # (var, element_idx)

--- a/python/discopt/modeling/core.py
+++ b/python/discopt/modeling/core.py
@@ -2929,6 +2929,14 @@ class Model:
         # default, so it never changes behaviour with the flag off.
         self._zero_spanning_factor_auxes: set[str] = set()
         self._builder = None  # Optional PyModelBuilder, lazy-initialized
+        # Starting point for the model's variables, keyed ``(var name, element)``
+        # -> value (#1225). A *partial* map: only elements someone actually gave
+        # a value for appear, so an absent key means "no guess" rather than
+        # "guess 0.0". Populated by ``from_nl`` from a ``.nl`` file's ``x``
+        # segment and by ``set_initial_point``; read back by ``to_nl`` when no
+        # explicit ``initial_point=`` is passed. It is a hint for an exporter,
+        # not solver input — nothing on the solve path reads it.
+        self._initial_point: dict[tuple[str, int], float] = {}
         self._aux_counter = 0  # monotonic suffix for if_else auxiliary names
         # Complementarity conditions added via ``complementarity()``/``mcp()``;
         # recorded for introspection and bound tightening (see ``discopt.mpec``),
@@ -5916,6 +5924,55 @@ class Model:
 
         return to_gams(self, path, model_type)
 
+    def set_initial_point(self, mapping: dict) -> None:
+        """Attach a starting point to the model, for export.
+
+        Parameters
+        ----------
+        mapping : dict
+            ``{Variable: value}`` in the same form :meth:`solve`'s
+            ``initial_solution`` and :meth:`to_nl`'s ``initial_point`` take
+            (scalars, lists or arrays, matching each variable's shape). Values
+            are validated, bound-clamped and integrality-rounded by
+            :func:`discopt.warm_start.validate_initial_solution`, each with a
+            warning. Replaces any point already attached; ``{}`` clears it.
+
+        Notes
+        -----
+        The point is a hint carried to the exporters -- :meth:`to_nl` writes it
+        as the ``.nl`` ``x`` segment. Nothing on the solve path reads it; warm
+        starting is still ``solve(initial_solution=...)``, deliberately, so that
+        reading a model from a file does not silently change how it is solved
+        (#1225).
+
+        A point attached by :func:`from_nl` instead carries the source file's
+        values **verbatim**, unclamped, so a round-trip reproduces the file; only
+        this setter validates, because only this setter takes user input.
+        """
+        from discopt.export.nl import _keyed_initial_point
+
+        self._initial_point = _keyed_initial_point(self, mapping) if mapping else {}
+
+    @property
+    def initial_point(self) -> dict:
+        """The attached starting point as ``{Variable: {element: value}}``.
+
+        Element-keyed rather than array-valued because the point is a *partial*
+        map: a ``.nl`` ``x`` segment names only the columns it has a value for
+        (AMPL writes an ``x2`` block for the 5-variable ``ex1221``), and there is
+        no array encoding of "this element has no guess" that is not a sentinel.
+        A scalar variable reads as ``{var: {0: value}}``. Empty when no point is
+        attached. The returned dict is a fresh copy; mutate it and nothing
+        happens -- use :meth:`set_initial_point`.
+        """
+        by_var: dict = {}
+        for var in self._variables:
+            for elem in range(var.size):
+                value = self._initial_point.get((var.name, elem))
+                if value is not None:
+                    by_var.setdefault(var, {})[elem] = value
+        return by_var
+
     def to_nl(
         self,
         path: Union[str, None] = None,
@@ -5934,8 +5991,10 @@ class Model:
         initial_point : dict, optional
             ``{Variable: value}`` starting guess (same form as
             :meth:`solve`'s ``initial_solution``), written as the ``.nl`` ``x``
-            section. Variables omitted from the dict get no entry. Without it
-            no ``x`` section is written.
+            section. Variables omitted from the dict get no entry. Leave it
+            ``None`` to write the point attached to the model (by
+            :func:`from_nl` or :meth:`set_initial_point`), or pass ``{}`` to
+            write no ``x`` section even when one is attached.
 
         Returns
         -------
@@ -6395,6 +6454,13 @@ def model_from_repr(rep, name: str) -> Model:
 
     Complementarity relations are **not** reconstructed here — they live
     outside ``ModelRepr`` and are threaded separately by :func:`from_nl`.
+
+    The ``x``-segment starting point *is* attached here (#1225). It lives
+    outside ``ModelRepr`` for the same reason as the complementarities, and for
+    a *reduced* ``rep`` it is empty by construction — the Rust side gives every
+    transform's output an empty point rather than letting it inherit column
+    indices the transform renumbered — so this is uniform without being wrong
+    for the presolve caller.
     """
     from discopt._relax.nl_reconstruction import reconstruct_dag
 
@@ -6448,7 +6514,50 @@ def model_from_repr(rep, name: str) -> Model:
         elif sense == "==":
             m.subject_to(body_expr == rhs)
 
+    _attach_repr_initial_point(m, rep)
+
     return m
+
+
+def _attach_repr_initial_point(m: Model, rep) -> None:
+    """Attach ``rep``'s column-indexed starting point to ``m``'s variables.
+
+    ``rep.initial_point()`` is ``[(column, value), …]`` over the *flat* scalar
+    column space. Variables were created above in block order, so that space is
+    the model's own flat variable vector (the contract stated in
+    :func:`model_from_repr`'s docstring) and a running offset resolves each
+    column to its ``(variable, element)``.
+
+    Values are carried **verbatim** — no bound clamping, no integrality
+    rounding. They are a faithful copy of what the source file said, and
+    re-exporting them has to reproduce it; the clamping belongs to
+    :meth:`Model.set_initial_point`, which takes user input instead.
+
+    A column outside the model's variables would mean the parser and this
+    builder disagree about the column space, so it raises rather than being
+    skipped: silently dropping it would attach a starting point that is quietly
+    missing entries.
+    """
+    entries = rep.initial_point()
+    if not entries:
+        return
+
+    # Flat column -> (variable, element), built once.
+    columns: list[tuple[str, int]] = []
+    for var in m._variables:
+        for elem in range(var.size):
+            columns.append((var.name, elem))
+
+    keyed: dict[tuple[str, int], float] = {}
+    for column, value in entries:
+        if not 0 <= column < len(columns):
+            raise ValueError(
+                f"initial-point column {column} is outside the model's "
+                f"{len(columns)} scalar variables; the .nl parser and the model "
+                "builder disagree about the column space"
+            )
+        keyed[columns[column]] = float(value)
+    m._initial_point = keyed
 
 
 def from_nl(path: str) -> Model:

--- a/python/tests/test_1225_nl_initial_point_roundtrip.py
+++ b/python/tests/test_1225_nl_initial_point_roundtrip.py
@@ -1,0 +1,273 @@
+"""Regression tests for issue #1225 — the ``.nl`` ``x`` segment survives a read.
+
+#1224 taught the *writer* to emit an ``x`` (initial primal guess) section. The
+*reader* still threw the section away: the Rust parser filled a dense
+``vec![0.0; n_vars]`` named ``_x0`` that nothing read, so every one of the 202
+corpus instances carrying an ``x`` block lost it on round-trip.
+
+The point is now carried alongside the model — sparse ``(column, value)`` pairs
+on ``PyModelRepr``, not a field of ``ModelRepr`` — so no presolve transform can
+inherit column indices it renumbered. ``from_nl`` attaches it to the ``Model``
+and ``to_nl`` writes it back.
+
+The oracle is the original AMPL-written file in ``data/minlplib_nl``: its own
+``x`` segment is what the round-trip has to reproduce.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import discopt.modeling as dm
+import pytest
+from discopt.export.nl import _NLWriter
+from discopt.modeling.core import _attach_repr_initial_point
+
+pytestmark = pytest.mark.unit
+
+CORPUS = Path(__file__).parent / "data" / "minlplib_nl"
+X_HEADER = re.compile(r"^x(\d+)\s*$")
+
+
+def _file_x_entries(text: str) -> dict[int, float] | None:
+    """A ``.nl`` text's own ``x`` segment as ``{column: value}``, else ``None``.
+
+    ``None`` (no segment) and ``{}`` (an ``x0`` segment) are deliberately
+    distinct — the tests below assert on the difference.
+    """
+    lines = text.splitlines()
+    for i, line in enumerate(lines):
+        match = X_HEADER.match(line)
+        if match:
+            count = int(match.group(1))
+            entries = {}
+            for row in lines[i + 1 : i + 1 + count]:
+                column, value = row.split()[:2]
+                entries[int(column)] = float(value)
+            return entries
+    return None
+
+
+def _text_corpus_files() -> list[Path]:
+    """Corpus files in text (``g``) format — the binary one has its own test."""
+    return [
+        p
+        for p in sorted(CORPUS.glob("*.nl"))
+        if p.read_text(encoding="latin-1").lstrip().startswith("g")
+    ]
+
+
+def _files_with_x() -> list[Path]:
+    return [p for p in _text_corpus_files() if _file_x_entries(p.read_text(encoding="latin-1"))]
+
+
+def _files_without_x() -> list[Path]:
+    return [
+        p for p in _text_corpus_files() if _file_x_entries(p.read_text(encoding="latin-1")) is None
+    ]
+
+
+class TestCorpusRoundTrip:
+    """``to_nl(from_nl(f))`` reproduces the file's own ``x`` segment."""
+
+    def test_corpus_covers_the_defect(self):
+        """Guard the parametrization: an empty split would make it all a no-op."""
+        with_x, without_x = _files_with_x(), _files_without_x()
+        assert len(with_x) >= 40, f"only {len(with_x)} corpus files carry an x segment"
+        assert without_x, "no corpus file lacks an x segment; the negative arm is vacuous"
+
+    @pytest.mark.parametrize("path", _files_with_x(), ids=lambda p: p.name)
+    def test_reader_attaches_the_files_own_entries(self, path: Path):
+        """The attached point equals the file's ``x`` segment, value for value.
+
+        ``from_nl`` names flat column *i* ``x{i}``, so the file's column keys map
+        onto variable names exactly and the comparison needs no permutation.
+        """
+        original = _file_x_entries(path.read_text(encoding="latin-1"))
+        model = dm.from_nl(str(path))
+        assert model._initial_point == {(f"x{col}", 0): val for col, val in original.items()}
+
+    @pytest.mark.parametrize("path", _files_with_x(), ids=lambda p: p.name)
+    def test_writer_reemits_every_entry_on_the_right_column(self, path: Path):
+        """Re-export puts each value on the column the writer assigns its variable.
+
+        The exported column is *not* the source column: the writer reorders
+        variables into the canonical ``[both | cons-only | objs-only | linear]``
+        sequence. What must hold is that each value still travels with its own
+        variable, which is what the writer's own ``_var_index`` permutation says.
+        """
+        model = dm.from_nl(str(path))
+        writer = _NLWriter(model)
+        exported = _file_x_entries(writer.write())
+        expected = {writer._var_index[key]: val for key, val in model._initial_point.items()}
+        assert exported == expected
+
+    @pytest.mark.parametrize("path", _files_without_x(), ids=lambda p: p.name)
+    def test_file_without_the_segment_attaches_nothing(self, path: Path):
+        model = dm.from_nl(str(path))
+        assert model._initial_point == {}
+        assert _file_x_entries(model.to_nl()) is None
+
+    def test_binary_nl_file_carries_its_segment_too(self):
+        """The binary (``b3``) encoding round-trips through the transcoder."""
+        binary = [p for p in sorted(CORPUS.glob("*.nl")) if p.read_bytes().lstrip()[:1] == b"b"]
+        assert binary, "no binary-format .nl in the corpus; this arm is vacuous"
+        for path in binary:
+            model = dm.from_nl(str(path))
+            assert model._initial_point, f"{path.name}: binary x segment was dropped"
+            assert _file_x_entries(model.to_nl())
+
+
+class TestAttachedPointSemantics:
+    """How the attached point interacts with ``to_nl`` and the public setter."""
+
+    def _model(self):
+        m = dm.Model("attached")
+        x = m.continuous("x", lb=0, ub=10)
+        y = m.continuous("y", lb=0, ub=10)
+        m.minimize(x * x + y)
+        m.subject_to(x + y >= 1)
+        return m, x, y
+
+    def test_explicit_argument_wins_over_the_attached_point(self):
+        m, x, y = self._model()
+        m.set_initial_point({x: 1.0, y: 2.0})
+        block = _file_x_entries(m.to_nl(initial_point={x: 9.0}))
+        assert block == {0: 9.0}  # y's attached 2.0 is not written
+
+    def test_empty_dict_suppresses_the_attached_point(self):
+        m, x, y = self._model()
+        m.set_initial_point({x: 1.0})
+        assert _file_x_entries(m.to_nl()) == {0: 1.0}
+        assert _file_x_entries(m.to_nl(initial_point={})) is None
+
+    def test_setter_validates_and_property_is_element_keyed(self):
+        m = dm.Model("setter")
+        x = m.continuous("x", lb=0, ub=5)
+        n = m.integer("n", lb=0, ub=4)
+        z = m.continuous("z", shape=(2,), lb=0, ub=1)
+        m.minimize(x + n + z[0])
+        with pytest.warns(UserWarning):
+            m.set_initial_point({x: 99.0, n: 2.4, z: [0.25, 0.75]})
+        assert m.initial_point == {x: {0: 5.0}, n: {0: 2.0}, z: {0: 0.25, 1: 0.75}}
+
+    def test_setter_with_empty_mapping_clears(self):
+        m, x, _y = self._model()
+        m.set_initial_point({x: 1.0})
+        m.set_initial_point({})
+        assert m.initial_point == {}
+        assert _file_x_entries(m.to_nl()) is None
+
+    def test_property_returns_a_copy(self):
+        m, x, _y = self._model()
+        m.set_initial_point({x: 1.0})
+        m.initial_point.clear()
+        assert m.initial_point == {x: {0: 1.0}}
+
+    def test_a_files_values_are_attached_verbatim_not_clamped(self, tmp_path):
+        """A source file's guess is copied as-is, so the round-trip reproduces it.
+
+        Only :meth:`Model.set_initial_point` clamps, because only it takes user
+        input. Here the file starts ``x0`` at 500 with an upper bound of 100 —
+        AMPL-written files do carry such starts, and silently moving the value to
+        the bound would make the export disagree with its source.
+        """
+        source = tmp_path / "out_of_bounds.nl"
+        source.write_text(_MINIMAL_NL_WITH_X.replace("0 1.5\n", "0 500\n"))
+        model = dm.from_nl(str(source))
+        assert model._initial_point == {("x0", 0): 500.0}
+        assert _file_x_entries(model.to_nl()) == {0: 500.0}
+
+
+class TestTransformsDropThePoint:
+    """A transform renumbers columns, so its output must start from empty."""
+
+    def _repr_with_point(self):
+        from discopt._rust import parse_nl_file
+
+        path = CORPUS / "alan.nl"
+        rep = parse_nl_file(str(path))
+        assert rep.initial_point(), "fixture carries no initial point"
+        return rep
+
+    def test_substitute_output_has_no_point(self):
+        reduced, _chain = self._repr_with_point().substitute(4)
+        assert reduced.initial_point() == []
+
+    def test_eliminate_variables_output_has_no_point(self):
+        eliminated, _stats = self._repr_with_point().eliminate_variables()
+        assert eliminated.initial_point() == []
+
+    def test_reformulate_polynomial_output_has_no_point(self):
+        reformed, _stats = self._repr_with_point().reformulate_polynomial()
+        assert reformed.initial_point() == []
+
+    def test_out_of_range_column_raises_rather_than_being_skipped(self):
+        """A column past the model's variables means the two disagree — refuse.
+
+        Unreachable from the parser (it drops such a column itself), so this
+        pins the helper's own invariant: never attach a quietly incomplete point.
+        """
+
+        class _Rep:
+            def initial_point(self):
+                return [(0, 1.0), (7, 2.0)]
+
+        m = dm.Model("range")
+        m.continuous("a", lb=0, ub=1)
+        with pytest.raises(ValueError, match="outside the model's"):
+            _attach_repr_initial_point(m, _Rep())
+
+
+class TestSolveIsUnaffected:
+    """The point is an export hint: the solve path must not read it."""
+
+    def test_attached_point_does_not_change_the_solve(self):
+        def build():
+            m = dm.Model("solve_hint")
+            x = m.continuous("x", lb=-3, ub=3)
+            y = m.continuous("y", lb=-3, ub=3)
+            m.minimize((x - 1) ** 2 + (y + 1) ** 2)
+            m.subject_to(x + y <= 2)
+            return m, x, y
+
+        plain, _x, _y = build()
+        hinted, hx, hy = build()
+        # A start pinned to the far corner of the box, away from the optimum.
+        hinted.set_initial_point({hx: -3.0, hy: 3.0})
+
+        base = plain.solve()
+        with_hint = hinted.solve()
+        assert with_hint.objective == pytest.approx(base.objective, rel=1e-12, abs=1e-12)
+        assert with_hint.node_count == base.node_count
+
+
+# A 1-variable, 1-constraint text .nl with an x segment, used by the
+# verbatim-attachment test above. Bounds are [0, 100]; the x value is patched in.
+_MINIMAL_NL_WITH_X = """g3 1 1 0	# problem minimal
+ 1 1 1 0 0	# vars, constraints, objectives
+ 0 0	# nonlinear constraints, objectives
+ 0 0	# network constraints
+ 0 0 0	# nonlinear vars in cons, objs, both
+ 0 0 0 1 0	# flags
+ 0 0 0 0 0	# nbv niv nlvbi nlvci nlvoi
+ 1 1	# Jacobian, gradient nonzeros
+ 0 0	# max name lengths
+ 0 0 0 0 0	# common expressions
+C0
+n0
+O0 0
+n0
+r
+1 10.0
+b
+0 0.0 100.0
+x1
+0 1.5
+k0
+J0 1
+0 1.0
+G0 1
+0 1.0
+"""


### PR DESCRIPTION
## Summary

Closes #1225. The reader half of #1222's defect 2; #1224 (merged) was the writer half.

The `x` (initial primal guess) segment was parsed into a dense
`vec[0.0; n_vars]` named `_x0` that nothing ever read, so all 202 corpus
instances carrying an `x` block lost it on `to_nl(from_nl(f))`. `from_nl` now
attaches the segment to the `Model` and `to_nl()` writes it back with no
argument.

### The design point: alongside `ModelRepr`, not inside it

The issue framed a field on `ModelRepr` as the way in, and flagged the two
costs: 172 struct-literal construction sites, and a remap-or-drop decision at
every presolve transform. **Both disappear** if the point rides alongside the
model instead — the route `complementarities` already takes in this codebase:

- `crates/discopt-core/src/nl_parser.rs` gains
  `ParsedNl { model, complementarities, initial_point }` plus
  `parse_nl_full` / `parse_nl_file_full`. The existing
  `parse_nl*`/`parse_nl*_with_complementarity` signatures are unchanged and now
  delegate, so nothing downstream breaks.
- `PyModelRepr` carries `initial_point` next to `complementarities`, exposed as
  `rep.initial_point() -> [(column, value), …]`.

An initial point is indexed **by column**, and every presolve transform may
remove, fix or renumber columns. On `ModelRepr` it would have to be remapped
correctly by each of ~20 transforms or be silently stale — a stale column index
is exactly the quietly-invalid data CLAUDE.md §3 says to refuse. Out here every
transform's output starts from an empty point *by construction*, and the 172
`ModelRepr` sites stay untouched. The one exception is deliberate and
commented: `substitute`'s refusal branch returns the model unchanged, columns
and all, so the point is still valid there and is carried.

Tested, not assumed: `substitute`, `eliminate_variables` and
`reformulate_polynomial` each return `initial_point() == []`.

### Representation

`(column, value)` pairs, sorted, one entry per column — sparse on purpose. The
segment is a *partial* map (AMPL writes an `x2` block for the 5-variable
`ex1221`), and a dense vector cannot tell "starting value 0.0" from "no
starting value"; `linear_nl()`'s fixture, whose `x` segment sets both columns
to 0.0, is the case that distinguishes them. A repeated column takes its last
value (the segment is a write sequence); an out-of-range column is dropped, as
ASL drops it.

### New API

- `Model.set_initial_point({Variable: value})` — attaches one explicitly,
  validated / bound-clamped / integrality-rounded like
  `solve(initial_solution=...)`, each with a warning. `{}` clears.
- `Model.initial_point` → `{Variable: {element: value}}`, element-keyed because
  the segment is partial and "this element has no guess" has no array encoding
  that is not a sentinel. Returns a copy.
- A point read from a **file** is attached **verbatim, unclamped**, so the
  export reproduces its source (an AMPL-written start can sit outside its
  bounds). Only the setter validates, because only the setter takes user input.
  Both are documented as such.
- `to_nl(initial_point=...)` still wins over the attached point;
  `initial_point={}` writes no section even when one is attached.

### What is NOT done, deliberately

**The solve path does not read the point.** The issue floats feeding it to the
warm start "in the same change". Doing that would change how *every* `.nl`-read
model is solved — a behaviour change across the whole benchmark corpus, which
under CLAUDE.md §5 needs its own measured panel, not a side effect of fixing
the reader. Warm starting stays `solve(initial_solution=...)`. The panel below
is the evidence that this PR does not touch it.

## Correctness

Bound-neutral by construction (nothing on the solve path reads the point) and
**verified by measurement** rather than assertion: a 20-instance corpus solve
panel, with both arms rebuilt from source, is bit-identical —

- same `status` on 20/20
- same objective, compared as raw IEEE-754 bits, on 20/20
- same `node_count` on 20/20 (`alan` 13, `ex1221` 5, `nvs09` 31, `syn05hfsg`
  277, …)

The reader refuses rather than skips: a column outside the model's variables
means the parser and the model builder disagree about the column space, so
`_attach_repr_initial_point` raises instead of attaching a quietly incomplete
point.

- [x] Cannot produce a false certificate (no solver-math change; the solve path
      does not read the attached point, confirmed by a bit-identical 20-instance
      panel)
- [x] No validation, fallback, or safety guard was weakened to make a check pass

## Tests run (state the result — numbers, not adjectives)

- [x] `pytest -m smoke` → **1209 passed, 21 skipped, 2 xpassed** (324 s)
- [x] `pytest -m slow python/tests/test_adversarial_recent_fixes.py` → **19 passed**
- [x] `cargo test -p discopt-core` → **725 passed, 0 failed** (720 before + 5 new)
- [x] `ruff check python/` / `ruff format --check python/` → clean (990 files); `cargo fmt --check` clean
- [x] `mypy python/discopt/export/nl.py python/discopt/modeling/core.py` → `Success: no issues found in 2 source files`
- [x] nl/export suites (`test_nl_writer`, `test_nl_parser`, `test_export`, `test_export_cli_roundtrip`, `test_binary_nl_parsing`, `test_nl_parser_objonly_integers`, `test_nl_complementarity`, `test_nl_reconstruction`) → **216 passed, 8 skipped, 1 xfailed**

## Regression test

`python/tests/test_1225_nl_initial_point_roundtrip.py` — **129 tests**, plus 5
Rust tests in `nl_parser.rs`.

**Fail-before measured against a full revert *and rebuild*** (CLAUDE.md §8 — the
Rust getter does not exist on the merge base, so a Python-only stash would not
have been a baseline): on the rebuilt baseline all **51/51** reader comparisons
and all **51/51** writer comparisons fail, and `Model.set_initial_point` /
`Model.initial_point` do not exist. After restoring and rebuilding, 0 fail.

- Corpus arms, parametrized per file and guarded by
  `test_corpus_covers_the_defect` so an empty split cannot pass vacuously:
  *reader* — the attached point equals the AMPL file's own `x` entries
  (51 files); *writer* — each value is re-emitted on the column the writer's
  canonical reorder assigns its variable, which is **not** the source column
  (51 files); *negative* — the 14 files without a segment attach nothing and
  export none; *binary* — the `b3`-format instance carries its segment too.
- Semantics: explicit argument wins, `{}` suppresses, setter validates and
  clamps, property is element-keyed and returns a copy, and a file's
  out-of-bounds start is attached verbatim.
- Transforms: `substitute` / `eliminate_variables` / `reformulate_polynomial`
  outputs carry no point; the out-of-range-column guard raises.
- `TestSolveIsUnaffected`: a model with a point pinned to the far corner of its
  box solves to the same objective and the same `node_count` as the same model
  without one.
- Rust: sparse capture (including the both-columns-zero case a dense vector
  could not represent), absent segment, partial segment, repeated column
  (last wins), out-of-range column dropped.

- [x] Added a regression test that fails before / passes after

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011H3zJQrWcY7BMkuMkDyavw


---
_Generated by [Claude Code](https://claude.ai/code/session_011H3zJQrWcY7BMkuMkDyavw)_