### PR TITLE
fix(test): size the deep-sum export timeout for an instrumented run

### DIFF
--- a/python/tests/test_1215_deep_sum_export.py
+++ b/python/tests/test_1215_deep_sum_export.py
@@ -65,6 +65,14 @@ SHAPES = {
 }
 
 
+# The n=20000 MPS cases cost 8-18 s uninstrumented but 35-74 s under
+# `--cov` (measured, M4 Pro), and CI's coverage lane runs `--timeout=120` on a
+# slower runner -- so the default timeout was deciding this test rather than the
+# assertion, exactly what the `python-correctness-slow` lane's `--timeout=1800`
+# comment in `ci.yml` warns against. The assertion is unchanged and the sizes are
+# untouched (`test_the_old_failure_point_is_actually_crossed` pins them); only the
+# hang backstop is sized for an instrumented run.
+@pytest.mark.timeout(600)
 @pytest.mark.parametrize("writer", sorted(WRITERS))
 @pytest.mark.parametrize("shape", sorted(SHAPES))
 @pytest.mark.parametrize("n", SIZES)


### PR DESCRIPTION
## `main` is red after #1220; this greens it

#1220 merged with every PR check green and turned `main` red on the merge commit
`2ac42ab2`. `main` was green on the three commits before it (`682417e7`,
`aa33a26e`, `d8a41078`).

### Why the PR could not have caught it

The `Python coverage (3.12, ubuntu)` lane is the only one that runs these tests
under `--cov`, and its `if` runs it on `main` pushes or on a PR carrying the
`coverage` label. #1220 had neither, so the lane was **skipped on every
pre-merge run** — it shows as `skipping` in that PR's checks — and the failure
could only appear after the merge. Coverage itself was never the problem: the
run reports `Required test coverage of 85% reached. Total coverage: 85.46%`.

Two parametrisations exceeded the lane's `--timeout=120`:

```
FAILED test_1215_deep_sum_export.py::test_a_deep_sum_exports[20000-mixed signs-mps]
FAILED test_1215_deep_sum_export.py::test_a_deep_sum_exports[20000-sum objective-mps]
       Failed: Timeout (>120.0s) from pytest-timeout
```

### The cause is instrumentation cost, not a defect

Measured on an M4 Pro, same two cases:

| | uninstrumented | under `--cov` | factor |
|---|---|---|---|
| `[20000-mixed signs-mps]` | 18.4 s | 73.7 s | 4.0x |
| `[20000-sum objective-mps]` | 8.3 s | 35.2 s | 4.2x |

Both pass locally even instrumented; CI's runner is slower again, which pushes
the larger case past 120 s there. The export is correct — it is the 120 s
backstop that was deciding the result, which is what `ci.yml`'s own
`--timeout=1800` rationale warns against:

> the per-test timeout must not be what decides a quality bar, because then the
> bar measures the runner.

### The change

`@pytest.mark.timeout(600)` on `test_a_deep_sum_exports`; a mark overrides the
CLI `--timeout`. 600 s is ~8x the measured instrumented cost, so a real hang is
still caught.

Deliberately unchanged: the assertion, `SIZES = (800, 2000, 20000)`, and
`test_the_old_failure_point_is_actually_crossed`, which asserts
`max(SIZES) > sys.getrecursionlimit()` so the sizes cannot be quietly lowered to
make this cheap. Shrinking `n` would have greened CI by deleting the coverage of
the deep-sum path #1215 exists to protect — so that route was not taken.

### Verified

- **Reproduced before fixing.** Pre-fix at `--timeout=5` → `FAILED` in 5.28 s at
  `mps.py:161`. Post-fix, same flag → `2 passed in 27.0 s`. Since the tests take
  8–18 s, passing under a 5 s CLI flag proves the mark overrides it.
- **CI lane simulated:** `--timeout=120 --cov=discopt` over the whole file →
  **39 passed in 114.31 s**.
- `ruff check` / `ruff format --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0115eE146uMqL5w3mDqKgYSD
