### PR TITLE
fix(correctness): FBBT read a 3.2e-9 rounding residual as a proof of infeasibility

### DIFF
--- a/crates/discopt-core/src/lp/simplex/presolve.rs
+++ b/crates/discopt-core/src/lp/simplex/presolve.rs
@@ -39,6 +39,7 @@ const INF: f64 = 1e20;
 ///     further and it fails identically at round 4 with a 7.1e-07 gap;
 ///   - refusing only the sub-tolerance tightenings still leaves a 3.2e-9
 ///     crossing from the tightenings that do clear the bar.
+///
 /// Refusing the junk movements is what stops the compounding; judging
 /// emptiness at the same scale is what stops a residual wobble being read as a
 /// proof. Together the box survives and 602 columns still fix.

--- a/crates/discopt-core/src/lp/simplex/presolve.rs
+++ b/crates/discopt-core/src/lp/simplex/presolve.rs
@@ -18,6 +18,41 @@ use crate::lp::simplex::sparse::SparseCols;
 
 const INF: f64 = 1e20;
 
+/// Feasibility tolerance for propagation: the smallest bound movement FBBT is
+/// allowed to believe, and the slack on its empty-box proof.
+///
+/// This is a **feasibility** tolerance, not the LP pivot tolerance the callers
+/// pass in `tol` (1e-9). A derived bound carries the rounding error of every
+/// earlier tightening baked into the incoming `lo`/`hi`, which the per-row
+/// `res_err` budget below does *not* model — it covers only the current row's
+/// own summation. Over a few rounds that inherited error compounds.
+///
+/// Instance #2122 (`ref/HiGHS/check/instances/2122.lp`, 1473x2328 after
+/// slacks): by round 2 the drift on column 51 — true value exactly 0, box
+/// [0, 8700] — had reached `lo=3.25e-09 > hi=2.58e-11`, a gap of 3.2e-9 on row
+/// data of magnitude 1e4 (3e-13 relative, ~1400 eps). Against `tol=1e-9` that
+/// read as a *proof* of infeasibility and the solver returned `infeasible` for
+/// a problem whose optimum is 187616.11.
+///
+/// Both uses matter, and neither suffices alone (measured on #2122):
+///   - loosening only the empty-box test lets the same drift accumulate
+///     further and it fails identically at round 4 with a 7.1e-07 gap;
+///   - refusing only the sub-tolerance tightenings still leaves a 3.2e-9
+///     crossing from the tightenings that do clear the bar.
+/// Refusing the junk movements is what stops the compounding; judging
+/// emptiness at the same scale is what stops a residual wobble being read as a
+/// proof. Together the box survives and 602 columns still fix.
+///
+/// Both directions are strictly conservative: refusing a tightening only ever
+/// keeps points, and a looser empty-box test only ever prunes less, so neither
+/// can produce a false optimal or an invalid bound.
+///
+/// HiGHS makes the same distinction — `mip_feasibility_tolerance` (1e-6) for
+/// propagation, with `adjustedLb`/`adjustedUb` refusing movements below it and
+/// snapping a bound that would cross its opposite
+/// (`ref/HiGHS/highs/mip/HighsDomain.cpp:1293-1350`).
+const FEAS_TOL: f64 = 1e-6;
+
 /// Tightened bounds plus an infeasibility flag.
 pub struct PresolveResult {
     /// Tightened lower bounds (length `n`).
@@ -248,15 +283,18 @@ fn fbbt_row(
                 new_hi = (new_hi + round_tol).floor();
             }
         }
-        if new_lo > lo[k] + tol {
+        // Accept only movements large enough to be real (see `FEAS_TOL`). The
+        // caller's `tol` still applies when it is the coarser of the two.
+        let feas = tol.max(FEAS_TOL);
+        if new_lo > lo[k] + feas {
             lo[k] = new_lo;
             changed = true;
         }
-        if new_hi < hi[k] - tol {
+        if new_hi < hi[k] - feas {
             hi[k] = new_hi;
             changed = true;
         }
-        if lo[k] > hi[k] + tol {
+        if lo[k] > hi[k] + feas {
             return None;
         }
     }
@@ -276,6 +314,86 @@ mod tests {
         u: &'a [f64],
     ) -> LpView<'a> {
         LpView { a, m, n, c, l, u }
+    }
+
+    /// #2122 regression: real MIP data is inconsistent at the 1e-9 level, and
+    /// propagation must not read that as a proof of infeasibility.
+    ///
+    /// These six rows and five columns are the reduced core of the root box of
+    /// `2122.lp` (HiGHS's own instance collection; optimum 187616.11), found by
+    /// greedy deletion from the 1473x2328 standard form. Written out:
+    ///
+    /// ```text
+    ///   x0 = 222.34033333
+    ///   x1 = 1714.007
+    ///   x2 = x0
+    ///   1.01333353535354 * (x1 - x2) = 1511.55585690236
+    ///   x0 + x3 = 14501,  x2 + x4 = 14501
+    /// ```
+    ///
+    /// The last equality re-derives `x1` as 1714.006999996697 — 3.4e-9 below
+    /// the value the second row fixes it to. That is the instance's own data
+    /// residual, five orders below any feasibility tolerance; HiGHS solves the
+    /// problem to a certified optimum. Against the LP pivot tolerance (1e-9)
+    /// FBBT instead concluded `lo > hi` and reported the whole problem
+    /// infeasible.
+    ///
+    /// Both halves of the fix are load-bearing here, and each was measured
+    /// insufficient alone on the full instance: refusing sub-`FEAS_TOL`
+    /// movements stops the drift compounding, and judging emptiness at the
+    /// same scale stops the residue being read as a proof.
+    #[test]
+    fn tiny_data_residual_is_not_a_proof_of_infeasibility() {
+        const N: usize = 5;
+        let rows: [(&[(usize, f64)], f64); 6] = [
+            (&[(0, 1.0)], 222.34033333),
+            (&[(1, -1.0)], -1714.007),
+            (&[(0, -1.0), (2, 1.0)], 0.0),
+            (
+                &[(1, 1.01333353535354), (2, -1.01333353535354)],
+                1511.55585690236,
+            ),
+            (&[(0, 1.0), (3, 1.0)], 14501.0),
+            (&[(2, 1.0), (4, 1.0)], 14501.0),
+        ];
+        let m = rows.len();
+        let mut a = vec![0.0; m * N];
+        let mut b = vec![0.0; m];
+        for (i, (nz, bi)) in rows.iter().enumerate() {
+            for &(j, v) in nz.iter() {
+                a[i * N + j] = v;
+            }
+            b[i] = *bi;
+        }
+        let c = [0.0; N];
+        let l = [0.0; N];
+        let u = [8700.0, INF, 8700.0, INF, INF];
+        let is_int = [false; N];
+
+        let r = tighten_bounds(&view(&a, m, N, &c, &l, &u), &b, &is_int, 1e-9);
+        assert!(
+            !r.infeasible,
+            "FBBT reported infeasible on a 3.4e-9 data residual: x1 in [{}, {}]",
+            r.l[1], r.u[1]
+        );
+        // The contraction is still useful: every column pins down to its value.
+        for k in 0..N {
+            assert!(
+                r.u[k] - r.l[k] < 1e-6,
+                "column {k} did not fix: [{}, {}]",
+                r.l[k],
+                r.u[k]
+            );
+        }
+        assert!((r.l[0] - 222.34033333).abs() < 1e-6);
+        assert!((r.l[1] - 1714.007).abs() < 1e-6);
+
+        // The CSC entry must agree (the T3b4 parity contract).
+        let csc = SparseCols::from_dense(&a, m, N);
+        let rc = tighten_bounds_csc(&csc, m, N, &l, &u, &b, &is_int, 1e-9);
+        assert!(!rc.infeasible);
+        assert_eq!(r.l, rc.l);
+        assert_eq!(r.u, rc.u);
     }
 
     #[test]

--- a/crates/discopt-core/src/nl_writer.rs
+++ b/crates/discopt-core/src/nl_writer.rs
@@ -365,10 +365,7 @@ fn write_expr(
                 }
             }
             c if c >= OP_FUNC_BASE
-                && matches!(
-                    c - OP_FUNC_BASE,
-                    FUNC_LOG1P | FUNC_SIGMOID | FUNC_SOFTPLUS
-                ) =>
+                && matches!(c - OP_FUNC_BASE, FUNC_LOG1P | FUNC_SIGMOID | FUNC_SOFTPLUS) =>
             {
                 // Each is prefix tokens followed by the single argument, so the
                 // argument subtree is simply pushed last -- no trailing text.
@@ -969,7 +966,10 @@ mod func_table_tests {
             }
         }
         // Prove the loop ran: an empty ALL would pass every assertion above.
-        assert_eq!(admitted, 18, "expected 18 expanded functions, saw {admitted}");
+        assert_eq!(
+            admitted, 18,
+            "expected 18 expanded functions, saw {admitted}"
+        );
     }
 
     #[test]

--- a/crates/discopt-python/src/expr_bindings.rs
+++ b/crates/discopt-python/src/expr_bindings.rs
@@ -666,7 +666,7 @@ impl PyModelRepr {
             self.n_builder_constraints,
             &initial_point,
         )
-            .map_err(|e| pyo3::exceptions::PyValueError::new_err(format!("cannot write .nl: {e}")))
+        .map_err(|e| pyo3::exceptions::PyValueError::new_err(format!("cannot write .nl: {e}")))
     }
 
     /// How many leading constraints came from the Rust model builder.


### PR DESCRIPTION
## The bug

Root-node FBBT returned `infeasible` on `ref/HiGHS/check/instances/2122.lp`, a
problem HiGHS proves optimal at **187616.11**. A false infeasible is the §1
hard-gate failure: the solver's product is its certificate.

## Root cause

`fbbt_row` judged *both* "is this tightening real?" and "is this box empty?"
against the caller's `tol`. Every production call site passes `simplex.tol`
= **1e-9**, which is an **LP pivot** tolerance, not a feasibility tolerance.

A derived bound carries the rounding error of every *earlier* tightening baked
into the incoming `lo`/`hi`. The per-row `res_err = 8*eps*max_abs_term` budget
models only the current row's own summation, so that inherited error is
unmodelled and compounds across rounds.

On 2122 (1473x2328 after slacks) it reached, by round 2 on column 51 — a
continuous variable whose true optimal value is exactly 0, in a declared box of
`[0, 8700]`:

```
lo = 3.2477659329307093e-09  >  hi = 2.5758950528143077e-11
```

A gap of **3.2e-9** on row data of magnitude 1e4: 3e-13 relative, ~1400 eps.
Against `tol = 1e-9` that read as a *proof* that the box was empty.

## The fix

Introduce `FEAS_TOL = 1e-6` in `presolve.rs` and use it for both the accept test
and the empty-box test (`tol.max(FEAS_TOL)`, so a coarser caller `tol` still
wins).

The entry experiment (CLAUDE.md §4) was run before the implementation and
**falsified each half alone** on the real instance:

| variant | result on 2122 |
|---|---|
| loosen only the empty-box test to 1e-6 | still infeasible — the same drift accumulates further and fails identically at **round 4** with a **7.1e-07** gap |
| refuse only sub-feastol tightenings | still infeasible — a **3.2e-9** crossing survives from the tightenings that do clear the bar |
| **both** | box survives; **602** columns still fix, **2097** tightenings |

Refusing the junk movements is what stops the compounding; judging emptiness at
the same scale is what stops a residual wobble being read as a proof.

**Neither direction can be unsound.** Refusing a tightening only ever *keeps*
points; a looser empty-box test only ever *prunes less*. So neither can produce
a false optimal or an invalid bound — this change is one-directional.

HiGHS draws the same line: `mip_feasibility_tolerance` 1e-6 for propagation vs
`small_matrix_value` 1e-9 (`ref/HiGHS/highs/mip/HighsMipSolverData.cpp:697-698`),
with `adjustedLb`/`adjustedUb` refusing sub-feastol movements and snapping a
bound that would cross its opposite
(`ref/HiGHS/highs/mip/HighsDomain.cpp:1293-1350`).

## Regression test

`tiny_data_residual_is_not_a_proof_of_infeasibility` is the **reduced core of
2122's own root box** — 6 rows x 5 cols carrying the instance's real
coefficients, found by a two-sided greedy reducer:

```
x0 = 222.34033333 ;  x1 = 1714.007 ;  x2 = x0
1.01333353535354 (x1 - x2) = 1511.55585690236
x0 + x3 = 14501 ;  x2 + x4 = 14501
```

The last equality re-derives `x1` as `1714.006999996697`, **3.38e-09** below the
value the second row fixes it to — the instance's own data residual. It fails
before this change with

```
FBBT reported infeasible on a 3.4e-9 data residual:
x1 in [1714.006999999997, 1714.006999996697]
```

and passes after. It also asserts `tighten_bounds_csc` stays bit-identical to
`tighten_bounds` (the T3b4 parity contract).

A randomized property test was written first and **discarded as vacuous**
(0/60 reproduced): with `b = A x` computed in the same floating point there is
no data residual to accumulate. That is the #727 RLT lesson — a synthetic proxy
that is a no-op on the real class.

## Verification

- `cargo test --release -p discopt-core` — **742 passed, 0 failed**
- `pytest -m smoke` — **1443 passed, 1 skipped**, 183.8 s
- `pytest -m slow python/tests/test_adversarial_recent_fixes.py` — **19 passed**, 145.3 s
- 46-instance **interleaved** differential panel, `main` vs this branch, 15 s/arm,
  both builds pinned by `sys.path` and proved by a *behavioral* marker per §8
  (`prefix` vs `fixed`; the baseline arm asserts the marker **absent**):

| arm | proved | nodes (all) | wall (all) |
|---|---|---|---|
| `main` | 32/46 | 4,600,323 | 211.2 s |
| this branch | **33/46** | 4,596,120 | 217.5 s |

  Paired node ratio over the 32 instances **both** arms prove: geomean
  **1.000x**, W/L/T **0/0/32**, 95% CI [1.000, 1.000] — node-identical
  everywhere, which is the expected shape: the change is inert except where the
  drift actually crossed. The one extra instance proved is 2122 itself
  (`main=infeasible n=0` -> `fix=optimal obj 187612.944 bound 187612.94
  n=19583, 3.50 s`), which also accounts for the wall delta.

- 2122's incumbent independently feasibility-verified: `A_ub` 2.92e-07, `A_eq`
  3.33e-09, lb 8.31e-10, ub 2.36e-11, integrality 1.19e-11; the reported
  objective equals the recomputed `c.x`; -1.69e-05 relative to HiGHS, inside the
  matched `gap_tol` 1e-4.

## Cert gate: the two remaining panel hits are not this change

The gate reports three violations across both arms. Two are unrelated to this
branch and are **bit-identical on `main`**:

1. `2122 main FALSE INFEASIBLE` — the bug this PR fixes. Gone on this branch.
2. `issue-2388 INFEASIBLE INCUMBENT` on **both** arms — a **separate,
   pre-existing** defect found by this panel. The returned incumbent has the
   `INF` sentinel `1e20` in 8 of its 42 structural entries — `x5 x6 x17 x18 x27
   x28 x37 x38`, all free columns, parked nonbasic at the sentinel upper bound.
   The sentinels cancel pairwise in most rows, so the point passes the solver's
   own residual check, but `c43: x17 - x37 >= 10.2` evaluates to `1e20 - 1e20`
   `= 0` and is violated by exactly **10.2**. The reported objective is 0.0 —
   which matches the true optimum — only because those columns have zero cost.
   This is the `INF`-sentinel class the repo CLAUDE.md already warns about, in
   the *solution readback* rather than in FBBT. **Not addressed here**; filed
   separately.

   (The gate printed `viol=174` for this instance. That magnitude was an
   artifact of the *verifier*: scipy's sparse matvec contracts to FMA, so
   `c41`'s `-a*1e20 + a*1e20` returns the rounding residual of the first product
   instead of 0 — the dense dot of the same row gives exactly 0. The `c43`
   violation of 10.2 is FMA-independent and is the real one.)
3. `issue-2173 oracle-suspect` on both arms — previously established as an error
   in the oracle, not in discopt.

So relative to `main` this branch strictly removes one certificate violation and
introduces none.

## Not included, deliberately

HiGHS also requires `relativeImprove >= 0.3` before accepting a tightening on a
**continuous** column. Measured on 2122 it costs tightenings (1996 / 568 fixed,
vs 2097 / 602 without it). That is a *performance* tradeoff, not a correctness
one, and folding it in would have made the panel above uninterpretable. Left for
a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0115eE146uMqL5w3mDqKgYSD
